### PR TITLE
[HttpKernel] Enhance MapRequestPayload adding format and validation group

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Attribute;
 
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 
 /**
  * Controller parameter tag to map the request content to typed object and validate it.
@@ -22,7 +23,9 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValue
 class MapRequestPayload extends ValueResolver
 {
     public function __construct(
-        public readonly array $context = [],
+        public readonly array|string|null $acceptFormat = null,
+        public readonly array $serializationContext = [],
+        public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
     ) {
         parent::__construct($resolver);

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -43,7 +43,7 @@
         "symfony/translation": "^5.4|^6.0",
         "symfony/translation-contracts": "^2.5|^3",
         "symfony/uid": "^5.4|^6.0",
-        "symfony/validator": "^5.4|^6.0",
+        "symfony/validator": "^6.3",
         "psr/cache": "^1.0|^2.0|^3.0",
         "twig/twig": "^2.13|^3.0.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Implements https://github.com/symfony/symfony/pull/49138#issuecomment-1500267966
| License       | MIT
| Doc PR        | not yet

This PR enhances `MapRequestPayload` (merged via https://github.com/symfony/symfony/pull/49138) by allowing users to restrict format and pick validation groups.

```php
# src/Controller/HelloController.php

namespace App\Controller;

use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\HttpKernel\Attribute\AsController;
use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
use Symfony\Component\Routing\Annotation\Route;
use Symfony\Component\Validator\Constraints as Assert;

#[AsController]
final class HelloController
{
    #[Route('/hello', methods: ['POST'])]
    public function __invoke(
        #[MapRequestPayload(acceptFormat: 'json', validationGroups: 'strict')] MyObject $object,
    ): Response {
        // framework will...
        //     1. deserialized HTTP content from json, and throws exception in case of mismatch
        //     2. validate ONLY constraint in the "strict" group, and throws exception in case of invalidation
    }
}
```