### PR TITLE
Add new twig bridge function to generate impersonation path

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -69,12 +69,22 @@ final class SecurityExtension extends AbstractExtension
         return $this->impersonateUrlGenerator->generateExitPath($exitTo);
     }
 
+    public function getImpersonatePath(string $identifier = null): string
+    {
+        if (null === $this->impersonateUrlGenerator) {
+            return '';
+        }
+
+        return $this->impersonateUrlGenerator->generateImpersonationPath($identifier);
+    }
+
     public function getFunctions(): array
     {
         return [
             new TwigFunction('is_granted', $this->isGranted(...)),
             new TwigFunction('impersonation_exit_url', $this->getImpersonateExitUrl(...)),
             new TwigFunction('impersonation_exit_path', $this->getImpersonateExitPath(...)),
+            new TwigFunction('impersonation_path', $this->getImpersonatePath(...)),
         ];
     }
 }

--- a/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 
 /**
- * Provides generator functions for the impersonate url exit.
+ * Provides generator functions for the impersonation urls.
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Damien Fayet <damienf1521@gmail.com>
@@ -36,9 +36,14 @@ class ImpersonateUrlGenerator
         $this->firewallMap = $firewallMap;
     }
 
+    public function generateImpersonationPath(string $identifier = null): string
+    {
+        return $this->buildPath(null, $identifier);
+    }
+
     public function generateExitPath(string $targetUri = null): string
     {
-        return $this->buildExitPath($targetUri);
+        return $this->buildPath($targetUri);
     }
 
     public function generateExitUrl(string $targetUri = null): string
@@ -47,7 +52,7 @@ class ImpersonateUrlGenerator
             return '';
         }
 
-        return $request->getUriForPath($this->buildExitPath($targetUri));
+        return $request->getUriForPath($this->buildPath($targetUri));
     }
 
     private function isImpersonatedUser(): bool
@@ -55,19 +60,23 @@ class ImpersonateUrlGenerator
         return $this->tokenStorage->getToken() instanceof SwitchUserToken;
     }
 
-    private function buildExitPath(string $targetUri = null): string
+    private function buildPath(string $targetUri = null, string $identifier = SwitchUserListener::EXIT_VALUE): string
     {
-        if (null === ($request = $this->requestStack->getCurrentRequest()) || !$this->isImpersonatedUser()) {
+        if (null === ($request = $this->requestStack->getCurrentRequest())) {
+            return '';
+        }
+
+        if (!$this->isImpersonatedUser() && $identifier == SwitchUserListener::EXIT_VALUE){
             return '';
         }
 
         if (null === $switchUserConfig = $this->firewallMap->getFirewallConfig($request)->getSwitchUser()) {
-            throw new \LogicException('Unable to generate the impersonate exit URL without a firewall configured for the user switch.');
+            throw new \LogicException('Unable to generate the impersonate URLs without a firewall configured for the user switch.');
         }
 
         $targetUri ??= $request->getRequestUri();
 
-        $targetUri .= (parse_url($targetUri, \PHP_URL_QUERY) ? '&' : '?').http_build_query([$switchUserConfig['parameter'] => SwitchUserListener::EXIT_VALUE], '', '&');
+        $targetUri .= (parse_url($targetUri, \PHP_URL_QUERY) ? '&' : '?').http_build_query([$switchUserConfig['parameter'] => $identifier], '', '&');
 
         return $targetUri;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

# Before this PR
So we already have impersonation features in Symfony (https://symfony.com/doc/current/security/impersonating_user.html) and we have two twig helper functions `impersonation_exit_url` and `impersonation_exit_path ` which both work with the configuration parameter for the switch user. 

If the developer changes the switch parameter (`_switch_user`), then these helper functions will dynamically update the `_switch_user=_exit` type urls/paths.

However, to switch TO a user, hand crafted urls with `?_switch_user=MYIDENTIFIER` like `http://example.com/somewhere?_switch_user=thomas` need to be hand crafted currently. 

# The problem

if we now go and change `_switch_user` to be something else, like `_want_to_be_this_user ` in the Symfony configuration (Because the boss told us to do that), then all our exit path/urls will dynamically update, but our hard coded ?_switch_user=MYIDENTIFIER` will stop working.

# The solution this PR provides

The solution this PR provides is to provide a new Twig Helper function for the impersonation path only, taking into account the configured value in Symfony config of the parameter (default is still `_switch_user ` but can be anything like `_want_to_be_this_user` as per the docs) 

This new twig function can be used as such:

```twig
<a href="{{ impersonation_path('mike') }}">Impersonate Mike</a>
```

This would output `?_want_to_be_this_user=mike` or if the default parameter still used would be `?_switch_user=mike`

The PR repurposes the existing code to generate the paths and is backward compatible. 
