### PR TITLE
[Routing] Convert BackedEnums passed as controller action parameters to their value

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -208,7 +208,11 @@ abstract class AnnotationClassLoader implements LoaderInterface
             }
             foreach ($paths as $locale => $path) {
                 if (preg_match(sprintf('/\{%s(?:<.*?>)?\}/', preg_quote($param->name)), $path)) {
-                    $defaults[$param->name] = $param->getDefaultValue();
+                    if (\is_scalar($defaultValue = $param->getDefaultValue()) || null === $defaultValue) {
+                        $defaults[$param->name] = $defaultValue;
+                    } elseif ($defaultValue instanceof \BackedEnum) {
+                        $defaults[$param->name] = $defaultValue->value;
+                    }
                     break;
                 }
             }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/DefaultValueController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/DefaultValueController.php
@@ -3,6 +3,8 @@
 namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
 
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Tests\Fixtures\Enum\TestIntBackedEnum;
+use Symfony\Component\Routing\Tests\Fixtures\Enum\TestStringBackedEnum;
 
 class DefaultValueController
 {
@@ -18,6 +20,20 @@ class DefaultValueController
      * @Route("/hello/{name<\w+>?Symfony}", name="hello_with_default")
      */
     public function hello(string $name = 'World')
+    {
+    }
+
+    /**
+     * @Route("/enum/{default}", name="string_enum_action")
+     */
+    public function stringEnumAction(TestStringBackedEnum $default = TestStringBackedEnum::Diamonds)
+    {
+    }
+
+    /**
+     * @Route("/enum/{default<\d+>}", name="int_enum_action")
+     */
+    public function intEnumAction(TestIntBackedEnum $default = TestIntBackedEnum::Diamonds)
     {
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/DefaultValueController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/DefaultValueController.php
@@ -3,6 +3,8 @@
 namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
 
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Tests\Fixtures\Enum\TestIntBackedEnum;
+use Symfony\Component\Routing\Tests\Fixtures\Enum\TestStringBackedEnum;
 
 class DefaultValueController
 {
@@ -16,6 +18,16 @@ class DefaultValueController
         Route(path: 'hello/{name<\w+>?Symfony}', name: 'hello_with_default'),
     ]
     public function hello(string $name = 'World')
+    {
+    }
+
+    #[Route(path: '/enum/{default}', name: 'string_enum_action')]
+    public function stringEnumAction(TestStringBackedEnum $default = TestStringBackedEnum::Diamonds)
+    {
+    }
+
+    #[Route(path: '/enum/{default<\d+>}', name: 'int_enum_action')]
+    public function intEnumAction(TestIntBackedEnum $default = TestIntBackedEnum::Diamonds)
     {
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTestCase.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTestCase.php
@@ -104,11 +104,13 @@ abstract class AnnotationClassLoaderTestCase extends TestCase
     public function testDefaultValuesForMethods()
     {
         $routes = $this->loader->load($this->getNamespace().'\DefaultValueController');
-        $this->assertCount(3, $routes);
+        $this->assertCount(5, $routes);
         $this->assertEquals('/{default}/path', $routes->get('action')->getPath());
         $this->assertEquals('value', $routes->get('action')->getDefault('default'));
         $this->assertEquals('Symfony', $routes->get('hello_with_default')->getDefault('name'));
         $this->assertEquals('World', $routes->get('hello_without_default')->getDefault('name'));
+        $this->assertEquals('diamonds', $routes->get('string_enum_action')->getDefault('default'));
+        $this->assertEquals(20, $routes->get('int_enum_action')->getDefault('default'));
     }
 
     public function testMethodActionControllers()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49203 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
