### PR TITLE
[Translation] Crowdin Bridge: Fix locale vs LanguageId

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -109,6 +109,8 @@ final class CrowdinProvider implements ProviderInterface
         $translatorBag = new TranslatorBag();
         $responses = [];
 
+        $localeLanguageMap = $this->mapLocalesToLanguageId($locales);
+
         foreach ($domains as $domain) {
             $fileId = $this->getFileIdByDomain($fileList, $domain);
 
@@ -118,7 +120,7 @@ final class CrowdinProvider implements ProviderInterface
 
             foreach ($locales as $locale) {
                 if ($locale !== $this->defaultLocale) {
-                    $response = $this->exportProjectTranslations($locale, $fileId);
+                    $response = $this->exportProjectTranslations($localeLanguageMap[$locale], $fileId);
                 } else {
                     $response = $this->downloadSourceFile($fileId);
                 }
@@ -402,5 +404,39 @@ final class CrowdinProvider implements ProviderInterface
         }
 
         return $result;
+    }
+
+    private function mapLocalesToLanguageId(array $locales): array
+    {
+        /**
+         * We cannot query by locales, we need to fetch all and filter out the relevant ones.
+         *
+         * @see https://developer.crowdin.com/api/v2/#operation/api.languages.getMany (Crowdin API)
+         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.languages.getMany (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('GET', '../../languages?limit=500');
+
+        if (200 !== $response->getStatusCode()) {
+            throw new ProviderException('Unable to list set languages.', $response);
+        }
+
+        $localeLanguageMap = [];
+        foreach ($response->toArray()['data'] as $language) {
+            foreach (['locale', 'osxLocale', 'id'] as $key) {
+                if (\in_array($language['data'][$key], $locales)) {
+                    $localeLanguageMap[$language['data'][$key]] = $language['data']['id'];
+                }
+            }
+        }
+
+        if (\count($localeLanguageMap) !== \count($locales)) {
+            $message = implode('", "', array_diff($locales, array_keys($localeLanguageMap)));
+            $message = sprintf('Unable to find all requested locales: "%s" not found.', $message);
+            $this->logger->error($message);
+
+            throw new ProviderException($message, $response);
+        }
+
+        return $localeLanguageMap;
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -632,6 +632,30 @@ XLIFF
                     ],
                 ]));
             },
+            'listLanguages' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/languages?limit=500', $url);
+                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+
+                return new MockResponse(json_encode([
+                    'data' => [
+                        [
+                            'data' => [
+                                'id' => 'en-GB',
+                                'osxLocale' => 'en_GB',
+                                'locale' => 'en-GB',
+                            ],
+                        ],
+                        [
+                            'data' => [
+                                'id' => 'fr',
+                                'osxLocale' => 'fr_FR',
+                                'locale' => 'fr-FR',
+                            ],
+                        ],
+                    ],
+                ]));
+            },
             'exportProjectTranslations' => function (string $method, string $url, array $options = []) use ($expectedTargetLanguageId): ResponseInterface {
                 $this->assertSame('POST', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/translations/exports', $url);
@@ -746,12 +770,37 @@ XLIFF
                     ],
                 ]));
             },
+            'listLanguages' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/languages?limit=500', $url);
+                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+
+                return new MockResponse(json_encode([
+                    'data' => [
+                        [
+                            'data' => [
+                                'id' => 'en',
+                                'osxLocale' => 'en_GB',
+                                'locale' => 'en-GB',
+                            ],
+                        ],
+                        [
+                            'data' => [
+                                'id' => 'fr',
+                                'osxLocale' => 'fr_FR',
+                                'locale' => 'fr-FR',
+                            ],
+                        ],
+                    ],
+                ]));
+            },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12/download', $url);
 
                 return new MockResponse(json_encode(['data' => ['url' => 'https://file.url']]));
             },
+
             'downloadFile' => function (string $method, string $url) use ($responseContent): ResponseInterface {
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://file.url/', $url);
@@ -826,6 +875,30 @@ XLIFF
                     ],
                 ]));
             },
+            'listLanguages' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/languages?limit=500', $url);
+                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+
+                return new MockResponse(json_encode([
+                    'data' => [
+                        [
+                            'data' => [
+                                'id' => 'en',
+                                'osxLocale' => 'en_GB',
+                                'locale' => 'en-GB',
+                            ],
+                        ],
+                        [
+                            'data' => [
+                                'id' => 'fr',
+                                'osxLocale' => 'fr_FR',
+                                'locale' => 'fr-FR',
+                            ],
+                        ],
+                    ],
+                ]));
+            },
             'exportProjectTranslations' => function (string $method, string $url, array $options = []): ResponseInterface {
                 $this->assertSame('POST', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/translations/exports', $url);
@@ -858,6 +931,30 @@ XLIFF
                             'id' => 12,
                             'name' => 'messages.xlf',
                         ]],
+                    ],
+                ]));
+            },
+            'listLanguages' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/languages?limit=500', $url);
+                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+
+                return new MockResponse(json_encode([
+                    'data' => [
+                        [
+                            'data' => [
+                                'id' => 'en',
+                                'osxLocale' => 'en_GB',
+                                'locale' => 'en-GB',
+                            ],
+                        ],
+                        [
+                            'data' => [
+                                'id' => 'fr',
+                                'osxLocale' => 'fr_FR',
+                                'locale' => 'fr-FR',
+                            ],
+                        ],
                     ],
                 ]));
             },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
This is a fix of a problem, where when specifying locale in translations.yaml in accordance to i18n these are not being fetched and downloaded from Crowdin. Even original author typehinted supplying `languageId` into the download function, but simply passed locale without proper mapping. This PR fixes this issue while allowing a fallback 2-letter locale being passed to CrowdIn, but properly querying non-dialect locales for their repsective LanguageIds.
Push works automatically, this fix is being handled by Crowdin apparently during push operations.
-->
