### PR TITLE
[Serializer] Convert names using denormalize during denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php80ReadonlyDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php80ReadonlyDummy.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class Php80ReadonlyDummy
+{
+    public function __construct(
+        public readonly string $someValue
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -29,6 +30,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableConstructorArgumentDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableOptionalConstructorArgumentDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Php80ReadonlyDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\VariadicConstructorTypedArgsDummy;
@@ -231,6 +233,19 @@ class AbstractNormalizerTest extends TestCase
         $dummy = $normalizer->denormalize(json_decode($data, true), VariadicConstructorTypedArgsDummy::class);
         $this->assertInstanceOf(VariadicConstructorTypedArgsDummy::class, $dummy);
         $this->assertEquals($arr, $dummy->getFoo());
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testWithNameConverter()
+    {
+        $normalizer = new ObjectNormalizer(null, new CamelCaseToSnakeCaseNameConverter());
+
+        $object = new Php80ReadonlyDummy('foo');
+        $this->assertEquals(['some_value' => 'foo'], $normalizer->normalize($object));
+        $this->assertEquals($object, $normalizer->denormalize(['some_value' => 'foo'], Php80ReadonlyDummy::class));
+        $this->assertEquals($object, $normalizer->denormalize(['someValue' => 'foo'], Php80ReadonlyDummy::class));
     }
 
     public static function getNormalizer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Might be related to #49808 
| License       | MIT
| Doc PR        | -

This code is called during denormalization, but it was wrongly calling the normalize function of the name converter. This bug exists since the start of name converters (e14854fe22858648053685f2e5df4493f148eb14). I believe we never caught this bug as the `ObjectNormalizer` would simply set the property using the name converter in the correct direction after initialization.

However, with the recent `readonly` feature this does not work as the constructor sets it to a value and thus the fallback of `ObjectNormalizer` errors with "Cannot modify readonly property".

It might be a bit risky to change this direction in an LTS release, but that is only because people were relying on buggy behavior.