### PR TITLE
[HttpClient] Add `JsonMockResponse`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `UriTemplateHttpClient` to use URI templates as specified in the RFC 6570
  * Add `ServerSentEvent::getArrayData()` to get the Server-Sent Event's data decoded as an array when it's a JSON payload
  * Allow array of urls as `base_uri` option value in `RetryableHttpClient` to retry on a new url each time
+ * Add `JsonMockResponse`, a `MockResponse` shortcut that automatically encodes the passed body to JSON and sets the content type to `application/json` by default
 
 6.2
 ---

--- a/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+
+class JsonMockResponse extends MockResponse
+{
+    public function __construct(mixed $body = [], array $info = [])
+    {
+        try {
+            $json = json_encode($body, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new InvalidArgumentException('JSON encoding failed: '.$e->getMessage(), $e->getCode());
+        }
+
+        $info['response_headers']['content-type'] ??= 'application/json';
+
+        parent::__construct($json, $info);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/Response/JsonMockResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/JsonMockResponseTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Response;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+final class JsonMockResponseTest extends TestCase
+{
+    public function testDefaults()
+    {
+        $client = new MockHttpClient(new JsonMockResponse());
+        $response = $client->request('GET', 'https://symfony.com');
+
+        $this->assertSame([], $response->toArray());
+        $this->assertSame('application/json', $response->getHeaders()['content-type'][0]);
+    }
+
+    public function testInvalidBody()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('JSON encoding failed: Malformed UTF-8 characters, possibly incorrectly encoded');
+
+        new JsonMockResponse("\xB1\x31");
+    }
+
+    public function testJsonEncodeArray()
+    {
+        $client = new MockHttpClient(new JsonMockResponse([
+            'foo' => 'bar',
+            'ccc' => 123,
+        ]));
+        $response = $client->request('GET', 'https://symfony.com');
+
+        $this->assertSame([
+            'foo' => 'bar',
+            'ccc' => 123,
+        ], $response->toArray());
+        $this->assertSame('application/json', $response->getHeaders()['content-type'][0]);
+    }
+
+    public function testJsonEncodeString()
+    {
+        $client = new MockHttpClient(new JsonMockResponse('foobarccc'));
+        $response = $client->request('GET', 'https://symfony.com');
+
+        $this->assertSame('"foobarccc"', $response->getContent());
+        $this->assertSame('application/json', $response->getHeaders()['content-type'][0]);
+    }
+
+    /**
+     * @dataProvider responseHeadersProvider
+     */
+    public function testResponseHeaders(string $expectedContentType, array $responseHeaders)
+    {
+        $client = new MockHttpClient(new JsonMockResponse([
+            'foo' => 'bar',
+        ], [
+            'response_headers' => $responseHeaders,
+            'http_code' => 201,
+        ]));
+        $response = $client->request('GET', 'https://symfony.com');
+
+        $this->assertSame($expectedContentType, $response->getHeaders()['content-type'][0]);
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    public static function responseHeadersProvider(): array
+    {
+        return [
+            ['application/json', []],
+            ['application/json', ['x-foo' => 'ccc']],
+            ['application/problem+json', ['content-type' => 'application/problem+json']],
+            ['application/problem+json', ['x-foo' => 'ccc', 'content-type' => 'application/problem+json']],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This tiny DX feature eases the creation of mocked JSON responses which is a common and repetitive use case. 

Before:
```php
new MockResponse(json_encode([
    'foo' => 'bar'
]), [
    'response_headers' => [
        'content-type' => 'application/json',
    ],
]);
```

After:
```php
new JsonMockResponse([
    'foo' => 'bar'
]);
```