### PR TITLE
[Form] Fix "prototype_data" option creating duplicates instead of new lines

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -23,12 +23,13 @@ class CollectionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $prototypeOptions = null;
+        $resizePrototypeOptions = null;
         if ($options['allow_add'] && $options['prototype']) {
+            $resizePrototypeOptions = array_replace($options['entry_options'], $options['prototype_options']);
             $prototypeOptions = array_replace([
                 'required' => $options['required'],
                 'label' => $options['prototype_name'].'label__',
-            ], array_replace($options['entry_options'], $options['prototype_options']));
+            ], $resizePrototypeOptions);
 
             if (null !== $options['prototype_data']) {
                 $prototypeOptions['data'] = $options['prototype_data'];
@@ -44,7 +45,7 @@ class CollectionType extends AbstractType
             $options['allow_add'],
             $options['allow_delete'],
             $options['delete_empty'],
-            $prototypeOptions
+            $resizePrototypeOptions
         );
 
         $builder->addEventSubscriber($resizeListener);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49961 
| License       | MIT

Fix for issue 49961.

Changed the prototype options passed to the ResizeFormListener to prevent prototype_data from being passed to new fields.