### PR TITLE
[DependencyInjection] Fix support for inner collections when using `<bind>`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -275,7 +275,7 @@
 
   <xsd:complexType name="bind" mixed="true">
     <xsd:choice maxOccurs="unbounded">
-      <xsd:element name="bind" type="argument" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="bind" type="bind_argument" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="service" type="service" />
     </xsd:choice>
     <xsd:attribute name="type" type="argument_type" />
@@ -284,6 +284,24 @@
     <xsd:attribute name="on-invalid" type="invalid_sequence" />
     <xsd:attribute name="method" type="xsd:string" />
     <xsd:attribute name="tag" type="xsd:string" />
+  </xsd:complexType>
+
+  <xsd:complexType name="bind_argument" mixed="true">
+    <xsd:choice minOccurs="0">
+      <xsd:element name="bind" type="bind_argument" maxOccurs="unbounded" />
+      <xsd:element name="service" type="service" />
+      <xsd:element name="exclude" type="xsd:string" maxOccurs="unbounded" />
+    </xsd:choice>
+    <xsd:attribute name="type" type="argument_type" />
+    <xsd:attribute name="id" type="xsd:string" />
+    <xsd:attribute name="key" type="xsd:string" />
+    <xsd:attribute name="index" type="xsd:integer" />
+    <xsd:attribute name="on-invalid" type="invalid_sequence" />
+    <xsd:attribute name="tag" type="xsd:string" />
+    <xsd:attribute name="index-by" type="xsd:string" />
+    <xsd:attribute name="default-index-method" type="xsd:string" />
+    <xsd:attribute name="default-priority-method" type="xsd:string" />
+    <xsd:attribute name="exclude" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="argument" mixed="true">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/bindings_and_inner_collections.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/bindings_and_inner_collections.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="bar1" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar" autowire="true">
+            <bind key="$foo" type="collection">
+                <bind>item.1</bind>
+                <bind>item.2</bind>
+            </bind>
+        </service>
+        <service id="bar2" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar" autowire="true">
+            <bind key="$foo" type="collection">
+                <bind>item.1</bind>
+                <bind>item.2</bind>
+            </bind>
+        </service>
+        <service id="bar3" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar" autowire="true">
+            <bind key="$foo" type="collection">
+                <bind>item.1</bind>
+                <bind>item.2</bind>
+                <bind>item.3</bind>
+                <bind>item.4</bind>
+            </bind>
+        </service>
+        <service id="bar4" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar" autowire="true">
+            <bind key="$foo" type="collection">
+                <bind>item.1</bind>
+                <bind>item.2</bind>
+                <bind key="1">item.3</bind>
+                <bind>item.4</bind>
+            </bind>
+        </service>
+        <service id="bar5" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar" autowire="true">
+            <bind key="$foo" type="collection">
+                <bind>item.1</bind>
+                <bind>item.2</bind>
+                <bind type="collection">
+                    <bind>item.3.1</bind>
+                    <bind>item.3.2</bind>
+                </bind>
+            </bind>
+        </service>
+        <service id="bar6" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar" autowire="true">
+            <bind key="$foo" type="collection">
+                <bind>item.1</bind>
+                <bind type="collection">
+                    <bind>item.2.1</bind>
+                    <bind>item.2.2</bind>
+                </bind>
+                <bind>item.3</bind>
+            </bind>
+        </service>
+        <service id="bar7" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar" autowire="true">
+            <bind key="$foo" type="iterator">
+                <bind>item.1</bind>
+                <bind>item.2</bind>
+            </bind>
+        </service>
+        <service id="bar8" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar" autowire="true">
+            <bind key="$foo" type="iterator">
+                <bind>item.1</bind>
+                <bind>item.2</bind>
+                <bind type="collection">
+                    <bind>item.3.1</bind>
+                    <bind>item.3.2</bind>
+                </bind>
+            </bind>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -1166,4 +1166,32 @@ class XmlFileLoaderTest extends TestCase
         $definition = $container->getDefinition('closure_property')->getProperties()['foo'];
         $this->assertEquals((new Definition('Closure'))->setFactory(['Closure', 'fromCallable'])->addArgument(new Reference('bar')), $definition);
     }
+
+    /**
+     * @dataProvider dataForBindingsAndInnerCollections
+     */
+    public function testBindingsAndInnerCollections($bindName, $expected)
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('bindings_and_inner_collections.xml');
+        (new ResolveBindingsPass())->process($container);
+        $definition = $container->getDefinition($bindName);
+        $actual = $definition->getBindings()['$foo']->getValues()[0];
+        $this->assertEquals($actual, $expected);
+    }
+
+    public function dataForBindingsAndInnerCollections()
+    {
+        return [
+           ['bar1', ['item.1', 'item.2']],
+           ['bar2', ['item.1', 'item.2']],
+           ['bar3', ['item.1', 'item.2', 'item.3', 'item.4']],
+           ['bar4', ['item.1', 'item.3', 'item.4']],
+           ['bar5', ['item.1', 'item.2', ['item.3.1', 'item.3.2']]],
+           ['bar6', ['item.1', ['item.2.1', 'item.2.2'], 'item.3']],
+           ['bar7', new IteratorArgument(['item.1', 'item.2'])],
+           ['bar8', new IteratorArgument(['item.1', 'item.2', ['item.3.1', 'item.3.2']])],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50046
| License       | MIT