### PR TITLE
[HttpClient] Improve MockHttpClient exception message

### DIFF
--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -72,7 +72,7 @@ class MockHttpClient implements HttpClientInterface, ResetInterface
         } elseif (\is_callable($this->responseFactory)) {
             $response = ($this->responseFactory)($method, $url, $options);
         } elseif (!$this->responseFactory->valid()) {
-            throw new TransportException('The response factory iterator passed to MockHttpClient is empty.');
+            throw new TransportException($this->requestsCount ? 'No more response left in the response factory iterator passed to MockHttpClient: the number of requests exceeds the number of responses.' : 'The response factory iterator passed to MockHttpClient is empty.');
         } else {
             $responseFactory = $this->responseFactory->current();
             $response = \is_callable($responseFactory) ? $responseFactory($method, $url, $options) : $responseFactory;

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -527,4 +527,23 @@ class MockHttpClientTest extends HttpClientTestCase
 
         $this->assertTrue($canceled);
     }
+
+    public function testEmptyResponseFactory()
+    {
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('The response factory iterator passed to MockHttpClient is empty.');
+
+        $client = new MockHttpClient([]);
+        $client->request('GET', 'https://example.com');
+    }
+
+    public function testMoreRequestsThanResponseFactoryResponses()
+    {
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('No more response left in the response factory iterator passed to MockHttpClient: the number of requests exceeds the number of responses.');
+
+        $client = new MockHttpClient([new MockResponse()]);
+        $client->request('GET', 'https://example.com');
+        $client->request('GET', 'https://example.com');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/49874#issuecomment-1491811535
| License       | MIT
| Doc PR        | -

When using `MockHttpClient`, if there are more requests done on the client than the passed available responses, the exception message is misleading.

~Targeting 5.4 since it only changes the exception message :sweat_smile:~