### PR TITLE
[HttpFoundation] Clear IpUtils cache to prevent memory leaks

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -75,23 +75,23 @@ class IpUtils
     public static function checkIp4(string $requestIp, string $ip): bool
     {
         $cacheKey = $requestIp.'-'.$ip.'-v4';
-        if (isset(self::$checkedIps[$cacheKey])) {
-            return self::$checkedIps[$cacheKey];
+        if (null !== $cacheValue = self::getCacheResult($cacheKey)) {
+            return $cacheValue;
         }
 
         if (!filter_var($requestIp, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)) {
-            return self::$checkedIps[$cacheKey] = false;
+            return self::setCacheResult($cacheKey, false);
         }
 
         if (str_contains($ip, '/')) {
             [$address, $netmask] = explode('/', $ip, 2);
 
             if ('0' === $netmask) {
-                return self::$checkedIps[$cacheKey] = false !== filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4);
+                return self::setCacheResult($cacheKey, false !== filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4));
             }
 
             if ($netmask < 0 || $netmask > 32) {
-                return self::$checkedIps[$cacheKey] = false;
+                return self::setCacheResult($cacheKey, false);
             }
         } else {
             $address = $ip;
@@ -99,10 +99,10 @@ class IpUtils
         }
 
         if (false === ip2long($address)) {
-            return self::$checkedIps[$cacheKey] = false;
+            return self::setCacheResult($cacheKey, false);
         }
 
-        return self::$checkedIps[$cacheKey] = 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);
+        return self::setCacheResult($cacheKey, 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask));
     }
 
     /**
@@ -120,8 +120,8 @@ class IpUtils
     public static function checkIp6(string $requestIp, string $ip): bool
     {
         $cacheKey = $requestIp.'-'.$ip.'-v6';
-        if (isset(self::$checkedIps[$cacheKey])) {
-            return self::$checkedIps[$cacheKey];
+        if (null !== $cacheValue = self::getCacheResult($cacheKey)) {
+            return $cacheValue;
         }
 
         if (!((\extension_loaded('sockets') && \defined('AF_INET6')) || @inet_pton('::1'))) {
@@ -130,14 +130,14 @@ class IpUtils
 
         // Check to see if we were given a IP4 $requestIp or $ip by mistake
         if (!filter_var($requestIp, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
-            return self::$checkedIps[$cacheKey] = false;
+            return self::setCacheResult($cacheKey, false);
         }
 
         if (str_contains($ip, '/')) {
             [$address, $netmask] = explode('/', $ip, 2);
 
             if (!filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
-                return self::$checkedIps[$cacheKey] = false;
+                return self::setCacheResult($cacheKey, false);
             }
 
             if ('0' === $netmask) {
@@ -145,11 +145,11 @@ class IpUtils
             }
 
             if ($netmask < 1 || $netmask > 128) {
-                return self::$checkedIps[$cacheKey] = false;
+                return self::setCacheResult($cacheKey, false);
             }
         } else {
             if (!filter_var($ip, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
-                return self::$checkedIps[$cacheKey] = false;
+                return self::setCacheResult($cacheKey, false);
             }
 
             $address = $ip;
@@ -160,7 +160,7 @@ class IpUtils
         $bytesTest = unpack('n*', @inet_pton($requestIp));
 
         if (!$bytesAddr || !$bytesTest) {
-            return self::$checkedIps[$cacheKey] = false;
+            return self::setCacheResult($cacheKey, false);
         }
 
         for ($i = 1, $ceil = ceil($netmask / 16); $i <= $ceil; ++$i) {
@@ -168,11 +168,11 @@ class IpUtils
             $left = ($left <= 16) ? $left : 16;
             $mask = ~(0xFFFF >> $left) & 0xFFFF;
             if (($bytesAddr[$i] & $mask) != ($bytesTest[$i] & $mask)) {
-                return self::$checkedIps[$cacheKey] = false;
+                return self::setCacheResult($cacheKey, false);
             }
         }
 
-        return self::$checkedIps[$cacheKey] = true;
+        return self::setCacheResult($cacheKey, true);
     }
 
     /**
@@ -213,5 +213,29 @@ class IpUtils
     public static function isPrivateIp(string $requestIp): bool
     {
         return self::checkIp($requestIp, self::PRIVATE_SUBNETS);
+    }
+
+    private static function getCacheResult(string $cacheKey): ?bool
+    {
+        if (isset(self::$checkedIps[$cacheKey])) {
+            // Move the item last in cache (LRU)
+            $value = self::$checkedIps[$cacheKey];
+            unset(self::$checkedIps[$cacheKey]);
+            self::$checkedIps[$cacheKey] = $value;
+
+            return self::$checkedIps[$cacheKey];
+        }
+
+        return null;
+    }
+
+    private static function setCacheResult(string $cacheKey, bool $result): bool
+    {
+        if (1000 < \count(self::$checkedIps)) {
+            // stop memory leak if there are many keys
+            self::$checkedIps = \array_slice(self::$checkedIps, 500, null, true);
+        }
+
+        return self::$checkedIps[$cacheKey] = $result;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -200,4 +200,23 @@ class IpUtilsTest extends TestCase
             ['2606:4700:20::681a:e06',  false],
         ];
     }
+
+    public function testCacheSizeLimit()
+    {
+        $ref = new \ReflectionClass(IpUtils::class);
+
+        /** @var array */
+        $checkedIps = $ref->getStaticPropertyValue('checkedIps');
+        $this->assertIsArray($checkedIps);
+
+        $maxCheckedIps = 1000;
+
+        for ($i = 1; $i < $maxCheckedIps * 1.5; ++$i) {
+            $ip = '192.168.1.'.str_pad((string) $i, 3, '0');
+
+            IpUtils::checkIp4($ip, '127.0.0.1');
+        }
+
+        $this->assertLessThan($maxCheckedIps, \count($checkedIps));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50032 
| License       | MIT
| Doc PR        | 

Fixes #50032 

IpUtils cache now uses LRU principal