### PR TITLE
[Security] Added error code to `UserPassword` constraint

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTestCase.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTestCase.php
@@ -87,6 +87,7 @@ abstract class UserPasswordValidatorTestCase extends ConstraintValidatorTestCase
         $this->validator->validate('secret', $constraint);
 
         $this->buildViolation('myMessage')
+            ->setCode(UserPassword::INVALID_PASSWORD_ERROR)
             ->assertRaised();
     }
 
@@ -109,6 +110,7 @@ abstract class UserPasswordValidatorTestCase extends ConstraintValidatorTestCase
         $this->validator->validate($password, $constraint);
 
         $this->buildViolation('myMessage')
+            ->setCode(UserPassword::INVALID_PASSWORD_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
@@ -20,6 +20,12 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class UserPassword extends Constraint
 {
+    public const INVALID_PASSWORD_ERROR = '2d2a8bb4-ddc8-45e4-9b0f-8670d3a3e290';
+
+    protected const ERROR_NAMES = [
+        self::INVALID_PASSWORD_ERROR => 'INVALID_PASSWORD_ERROR',
+    ];
+
     public $message = 'This value should be the user\'s current password.';
     public $service = 'security.validator.user_password';
 

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -41,7 +41,9 @@ class UserPasswordValidator extends ConstraintValidator
         }
 
         if (null === $password || '' === $password) {
-            $this->context->addViolation($constraint->message);
+            $this->context->buildViolation($constraint->message)
+                ->setCode(UserPassword::INVALID_PASSWORD_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -59,7 +61,9 @@ class UserPasswordValidator extends ConstraintValidator
         $hasher = $this->hasherFactory->getPasswordHasher($user);
 
         if (null === $user->getPassword() || !$hasher->verify($user->getPassword(), $password, $user instanceof LegacyPasswordAuthenticatedUserInterface ? $user->getSalt() : null)) {
-            $this->context->addViolation($constraint->message);
+            $this->context->buildViolation($constraint->message)
+                ->setCode(UserPassword::INVALID_PASSWORD_ERROR)
+                ->addViolation();
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Improved UserPassword constraint so the violation will contain `INVALID_PASSWORD_ERROR` error code instead of `null` when password is invalid.
