### PR TITLE
[HttpClient] Fix global state preventing two CurlHttpClient instances from working together

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -36,6 +36,7 @@ final class CurlClientState extends ClientState
     public $execCounter = \PHP_INT_MIN;
     /** @var LoggerInterface|null */
     public $logger;
+    public $performing = false;
 
     public static $curlVersion;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix -
| License       | MIT
| Doc PR        | -

Spotted while working on #49911