### PR TITLE
[Cache] Send Predis SSL options in the $hosts parameter

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -48,4 +48,29 @@ class PredisAdapterTest extends AbstractRedisAdapterTestCase
         ];
         $this->assertSame($params, $connection->getParameters()->toArray());
     }
+
+    public function testCreateSslConnection()
+    {
+        $redisHost = getenv('REDIS_HOST');
+
+        $redis = RedisAdapter::createConnection('rediss://'.$redisHost.'/1?ssl[verify_peer]=0', ['class' => \Predis\Client::class, 'timeout' => 3]);
+        $this->assertInstanceOf(\Predis\Client::class, $redis);
+
+        $connection = $redis->getConnection();
+        $this->assertInstanceOf(StreamConnection::class, $connection);
+
+        $redisHost = explode(':', $redisHost);
+        $params = [
+            'scheme' => 'tls',
+            'host' => $redisHost[0],
+            'port' => (int) ($redisHost[1] ?? 6379),
+            'ssl' => ['verify_peer' => '0'],
+            'persistent' => 0,
+            'timeout' => 3,
+            'read_write_timeout' => 0,
+            'tcp_nodelay' => true,
+            'database' => '1',
+        ];
+        $this->assertSame($params, $connection->getParameters()->toArray());
+    }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -332,6 +332,15 @@ trait RedisTrait
             if (null !== $auth) {
                 $params['parameters']['password'] = $auth;
             }
+
+            if (isset($params['ssl'])) {
+                foreach ($hosts as $i => $host) {
+                    if (!isset($host['ssl'])) {
+                        $hosts[$i]['ssl'] = $params['ssl'];
+                    }
+                }
+            }
+
             if (1 === \count($hosts) && !($params['redis_cluster'] || $params['redis_sentinel'])) {
                 $hosts = $hosts[0];
             } elseif (\in_array($params['failover'], ['slaves', 'distribute'], true) && !isset($params['replication'])) {
@@ -340,7 +349,7 @@ trait RedisTrait
             }
             $params['exceptions'] = false;
 
-            $redis = new $class($hosts, array_diff_key($params, array_diff_key(self::$defaultConnectionOptions, ['ssl' => null])));
+            $redis = new $class($hosts, array_diff_key($params, self::$defaultConnectionOptions));
             if (isset($params['redis_sentinel'])) {
                 $redis->getConnection()->setSentinelTimeout($params['timeout']);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46465
| License       | MIT

Predis accepts SSL options in the `$hosts` parameter, not in the `$params` parameter. From my perspective, this is really only applicable when using `rediss://host:port` style DSNs, where you might want to add `?ssl[verify_peer]=0` or something similar. 

I'm unsure how to write a good test for this, since there doesn't seem to be any standard Redis host with TLS that requires additional options in the test runner. Happy to take suggestions on how to approach a test, if that's deemed necessary. 