### PR TITLE
[VarDumper] show uninitialized properties

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -361,7 +361,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
                             $withChildren = false;
                             $cut = -1;
                         } else {
-                            $cut = $this->dumpChildren($dumper, $cursor, $refs, $children, $cut, $item->type, null !== $item->class);
+                            $cut = $this->dumpChildren($dumper, $cursor, $refs, $children, $cut, $item->type, $item->attr, null !== $item->class);
                         }
                     } elseif ($children && 0 <= $cut) {
                         $cut += \count($children);
@@ -392,7 +392,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return int The final number of removed items
      */
-    private function dumpChildren(DumperInterface $dumper, Cursor $parentCursor, array &$refs, array $children, int $hashCut, int $hashType, bool $dumpKeys): int
+    private function dumpChildren(DumperInterface $dumper, Cursor $parentCursor, array &$refs, array $children, int $hashCut, int $hashType, array $hashAttributes, bool $dumpKeys): int
     {
         $cursor = clone $parentCursor;
         ++$cursor->depth;
@@ -409,6 +409,13 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
 
                 return $hashCut >= 0 ? $hashCut + $cursor->hashLength - $cursor->hashIndex : $hashCut;
             }
+        }
+
+        // Add uninitialized properties
+        foreach ($hashAttributes["uninitialized"] as $propName => $propType) {
+            $string = "⚠ uninitialized($propType)";
+            $cursor->hashKey = $dumpKeys ? $propName : null;
+            $this->dumpItem($dumper, $cursor, $refs, $string);
         }
 
         return $hashCut;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix #https://github.com/symfony/symfony/issues/50054
| License       | MIT
| Doc PR        | -

First commit for the feature. Please review this pull request and help me doing this in a good way :pray: 

I am not sure if it's good to store uninitialized properties to the attr of the stub. Any better ideas ?


Missing:
- tests
- updating CHANGELOG.md