### PR TITLE
[HttpKernel] Enhance MapQueryString adding validation group

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Attribute;
 
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 
 /**
  * Controller parameter tag to map the query string of the request to typed object and validate it.
@@ -22,7 +23,8 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValue
 class MapQueryString extends ValueResolver
 {
     public function __construct(
-        public readonly array $context = [],
+        public readonly array $serializationContext = [],
+        public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
     ) {
         parent::__construct($resolver);

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -120,7 +120,7 @@ final class RequestPayloadValueResolver implements ValueResolverInterface
             return null;
         }
 
-        return $this->serializer->denormalize($data, $type, null, self::CONTEXT_DENORMALIZE + $attribute->context);
+        return $this->serializer->denormalize($data, $type, null, self::CONTEXT_DENORMALIZE + $attribute->serializationContext);
     }
 
     private function mapRequestPayload(Request $request, string $type, MapRequestPayload $attribute): ?object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | continuity of #50029 and #49138
| License       | MIT
| Doc PR        | n/a

- Introduces `$validationGroups` property to the `MapQueryString` attribute to work as same as in `MapRequestPayload`
- Renames `MapQueryString` property `$context` to `$serializationContext` to harmonize with `MapRequestPayload`

```php
# src/Controller/HelloController.php

namespace App\Controller;

use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\HttpKernel\Attribute\AsController;
use Symfony\Component\HttpKernel\Attribute\MapQueryString;
use Symfony\Component\Routing\Annotation\Route;

#[AsController]
final class HelloController
{
    #[Route('/hello', methods: ['GET'])]
    public function __invoke(
        #[MapQueryString(validationGroups: 'strict')] MyObject $object,
    ): Response {
        // ...
    }
}
```