### PR TITLE
[Routing] Add FQCN and FQCN::method aliases when applicable

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add FQCN and FQCN::method aliases for routes loaded from attributes/annotations when applicable
+
 6.2
 ---
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableMethodController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableMethodController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class InvokableMethodController
+{
+    /**
+     * @Route("/here", name="lol", methods={"GET", "POST"}, schemes={"https"})
+     */
+    public function __invoke()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/InvokableMethodController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/InvokableMethodController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class InvokableMethodController
+{
+    #[Route(path: '/here', name: 'lol', methods: ["GET", "POST"], schemes: ['https'])]
+    public function __invoke()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTestCase.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Alias;
 use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\AbstractClassController;
 
@@ -55,6 +56,7 @@ abstract class AnnotationClassLoaderTestCase extends TestCase
         $routes = $this->loader->load($this->getNamespace().'\ActionPathController');
         $this->assertCount(1, $routes);
         $this->assertEquals('/path', $routes->get('action')->getPath());
+        $this->assertEquals(new Alias('action'), $routes->getAlias($this->getNamespace().'\ActionPathController::action'));
     }
 
     public function testRequirementsWithoutPlaceholderName()
@@ -72,6 +74,19 @@ abstract class AnnotationClassLoaderTestCase extends TestCase
         $this->assertEquals('/here', $routes->get('lol')->getPath());
         $this->assertEquals(['GET', 'POST'], $routes->get('lol')->getMethods());
         $this->assertEquals(['https'], $routes->get('lol')->getSchemes());
+        $this->assertEquals(new Alias('lol'), $routes->getAlias($this->getNamespace().'\InvokableController'));
+        $this->assertEquals(new Alias('lol'), $routes->getAlias($this->getNamespace().'\InvokableController::__invoke'));
+    }
+
+    public function testInvokableMethodControllerLoader()
+    {
+        $routes = $this->loader->load($this->getNamespace().'\InvokableMethodController');
+        $this->assertCount(1, $routes);
+        $this->assertEquals('/here', $routes->get('lol')->getPath());
+        $this->assertEquals(['GET', 'POST'], $routes->get('lol')->getMethods());
+        $this->assertEquals(['https'], $routes->get('lol')->getSchemes());
+        $this->assertEquals(new Alias('lol'), $routes->getAlias($this->getNamespace().'\InvokableMethodController'));
+        $this->assertEquals(new Alias('lol'), $routes->getAlias($this->getNamespace().'\InvokableMethodController::__invoke'));
     }
 
     public function testInvokableLocalizedControllerLoading()
@@ -119,6 +134,8 @@ abstract class AnnotationClassLoaderTestCase extends TestCase
         $this->assertSame(['put', 'post'], array_keys($routes->all()));
         $this->assertEquals('/the/path', $routes->get('put')->getPath());
         $this->assertEquals('/the/path', $routes->get('post')->getPath());
+        $this->assertEquals(new Alias('post'), $routes->getAlias($this->getNamespace().'\MethodActionControllers::post'));
+        $this->assertEquals(new Alias('put'), $routes->getAlias($this->getNamespace().'\MethodActionControllers::put'));
     }
 
     public function testInvokableClassRouteLoadWithMethodAnnotation()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/49981
| License       | MIT
| Doc PR        | -

See https://github.com/symfony/symfony/issues/49981, I think it's a great idea :smiley:

* We add an FQCN alias only if the target class has an `__invoke` method that adds a route AND if the target class added 1 route exactly.
* We add a FQCN::method alias for every method that defines only one route.