### PR TITLE
[DependencyInjection] Do not ignore tags `name` attribute when it does not define their name

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -336,13 +336,14 @@ class XmlFileLoader extends FileLoader
         $tags = $this->getChildren($service, 'tag');
 
         foreach ($tags as $tag) {
-            if ('' === $tagName = $tag->childElementCount || '' === $tag->nodeValue ? $tag->getAttribute('name') : $tag->nodeValue) {
+            $tagNameComesFromAttribute = $tag->childElementCount || '' === $tag->nodeValue;
+            if ('' === $tagName = $tagNameComesFromAttribute ? $tag->getAttribute('name') : $tag->nodeValue) {
                 throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', (string) $service->getAttribute('id'), $file));
             }
 
             $parameters = $this->getTagAttributes($tag, sprintf('The attribute name of tag "%s" for service "%s" in %s must be a non-empty string.', $tagName, (string) $service->getAttribute('id'), $file));
             foreach ($tag->attributes as $name => $node) {
-                if ('name' === $name) {
+                if ($tagNameComesFromAttribute && 'name' === $name) {
                     continue;
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/tag_with_name_attribute.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/tag_with_name_attribute.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="foo" class="BarClass">
+            <tag name="name_attribute">tag_name</tag>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -1194,4 +1194,14 @@ class XmlFileLoaderTest extends TestCase
            ['bar8', new IteratorArgument(['item.1', 'item.2', ['item.3.1', 'item.3.2']])],
         ];
     }
+
+    public function testTagNameAttribute()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('tag_with_name_attribute.xml');
+
+        $definition = $container->getDefinition('foo');
+        $this->assertSame([['name' => 'name_attribute']], $definition->getTag('tag_name'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50081
| License       | MIT
| Doc PR        | N/A

Tags `name` attribute is ignored using XML if the tag name is its node content. That means `<tag name="name_attribute">tag_name</tag>` will return a `tag_name` tag without any attribute.

This seems to be a regression from #36586.