### PR TITLE
[DependencyInjection] More predictable EnvVarProcessor CSV empty string parsing

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -313,7 +313,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if ('csv' === $prefix) {
-            return str_getcsv($env, ',', '"', '');
+            return '' === $env ? [] : str_getcsv($env, ',', '"', '');
         }
 
         if ('trim' === $prefix) {

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -714,7 +714,7 @@ class EnvVarProcessorTest extends TestCase
 CSV;
 
         return [
-            ['', [null]],
+            ['', []],
             [',', ['', '']],
             ['1', ['1']],
             ['1,2," 3 "', ['1', '2', ' 3 ']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Small improvement, that solves problem of getting non-empty array: `[0 => null]`, when parse empty string by csv processor. After this fix '%env(csv:EMPTY_STRING)%' will return `[]`, but not `[0 => null]`.
