### PR TITLE
Fix the semaphore tests

### DIFF
--- a/src/Symfony/Component/Semaphore/Tests/SemaphoreFactoryTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/SemaphoreFactoryTest.php
@@ -35,8 +35,7 @@ class SemaphoreFactoryTest extends TestCase
                 $keys[] = $key;
 
                 return true;
-            }))
-            ->willReturn(true);
+            }));
 
         $logger = $this->createMock(LoggerInterface::class);
         $factory = new SemaphoreFactory($store);
@@ -64,8 +63,7 @@ class SemaphoreFactoryTest extends TestCase
                 $keys[] = $key;
 
                 return true;
-            }))
-            ->willReturn(true);
+            }));
 
         $logger = $this->createMock(LoggerInterface::class);
         $factory = new SemaphoreFactory($store);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The save method of the store is not meant to return a boolean. And with the new `void` type in the phpdoc, phpunit complains about that.
