### PR TITLE
[Security] Fix return type of AuthenticationSuccessHandlerInterface::onAuthenticationSuccess()

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
@@ -31,7 +31,7 @@ interface AuthenticationSuccessHandlerInterface
      * is called by authentication listeners inheriting from
      * AbstractAuthenticationListener.
      *
-     * @return Response
+     * @return Response|null
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Relates to #48288

Note that callers of this method are already null-aware.