### PR TITLE
[Scheduler] add dependency on symfony/messenger

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/ChainMessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/ChainMessageGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\Scheduler\Generator;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ChainMessageGenerator implements MessageGeneratorInterface
+{
+    /**
+     * @param MessageGeneratorInterface[] $generators
+     */
+    public function __construct(private iterable $generators)
+    {
+    }
+
+    public function getMessages(): iterable
+    {
+        foreach ($this->generators as $generator) {
+            yield from $generator->getMessages();
+        }
+    }
+}

--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Scheduler\Generator;
 
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Scheduler\Messenger\ScheduledStamp;
 use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
@@ -29,6 +31,7 @@ final class MessageGenerator implements MessageGeneratorInterface
         private readonly Schedule $schedule,
         string|CheckpointInterface $checkpoint,
         private readonly ClockInterface $clock = new Clock(),
+        private readonly ?string $name = null,
     ) {
         $this->waitUntil = new \DateTimeImmutable('@0');
         if (\is_string($checkpoint)) {
@@ -70,7 +73,7 @@ final class MessageGenerator implements MessageGeneratorInterface
             }
 
             if ($yield) {
-                yield $message;
+                yield Envelope::wrap($message, [new ScheduledStamp($this->name, $trigger, $time, $nextTime)]);
                 $this->checkpoint->save($time, $index);
             }
         }

--- a/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
+++ b/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
@@ -12,10 +12,18 @@
 namespace Symfony\Component\Scheduler\Messenger;
 
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
 /**
  * @experimental
  */
 final class ScheduledStamp implements NonSendableStampInterface
 {
+    public function __construct(
+        public readonly ?string $name,
+        public readonly TriggerInterface $trigger,
+        public readonly \DateTimeImmutable $runAt,
+        public readonly \DateTimeImmutable $nextRun,
+    ) {
+    }
 }

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -29,7 +29,7 @@ class SchedulerTransport implements TransportInterface
     public function get(): iterable
     {
         foreach ($this->messageGenerator->getMessages() as $message) {
-            yield Envelope::wrap($message, [new ScheduledStamp()]);
+            yield Envelope::wrap($message);
         }
     }
 

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransportFactory.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransportFactory.php
@@ -48,7 +48,7 @@ class SchedulerTransportFactory implements TransportFactoryInterface
         $schedule = $this->scheduleProviders->get($scheduleName)->getSchedule();
         $checkpoint = new Checkpoint('scheduler_checkpoint_'.$scheduleName, $schedule->getLock(), $schedule->getState());
 
-        return new SchedulerTransport(new MessageGenerator($schedule, $checkpoint, $this->clock));
+        return new SchedulerTransport(new MessageGenerator($schedule, $checkpoint, $this->clock, $scheduleName));
     }
 
     public function supports(string $dsn, array $options): bool

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportFactoryTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportFactoryTest.php
@@ -36,8 +36,8 @@ class SchedulerTransportFactoryTest extends TestCase
         $defaultRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'default']);
         $customRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'custom']);
 
-        $default = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$defaultRecurringMessage]))->getSchedule(), 'default', $clock));
-        $custom = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$customRecurringMessage]))->getSchedule(), 'custom', $clock));
+        $default = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$defaultRecurringMessage]))->getSchedule(), 'default', $clock, 'default'));
+        $custom = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$customRecurringMessage]))->getSchedule(), 'custom', $clock, 'custom'));
 
         $factory = new SchedulerTransportFactory(
             new Container([

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\Generator\MessageGeneratorInterface;
-use Symfony\Component\Scheduler\Messenger\ScheduledStamp;
 use Symfony\Component\Scheduler\Messenger\SchedulerTransport;
 
 class SchedulerTransportTest extends TestCase
@@ -33,7 +32,6 @@ class SchedulerTransportTest extends TestCase
 
         foreach ($transport->get() as $envelope) {
             $this->assertInstanceOf(Envelope::class, $envelope);
-            $this->assertNotNull($envelope->last(ScheduledStamp::class));
             $this->assertSame(array_shift($messages), $envelope->getMessage());
         }
 

--- a/src/Symfony/Component/Scheduler/Tests/SchedulerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/SchedulerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Symfony\Component\Scheduler\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\Scheduler;
+
+class SchedulerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_run(): void
+    {
+        $handler = new Handler();
+        $schedule = (new Schedule())->add(RecurringMessage::every('1 microseconds', new Message()));
+        $scheduler = new Scheduler([Message::class => $handler], [$schedule]);
+        $handler->scheduler = $scheduler;
+
+        $scheduler->run(['sleep' => 0]);
+
+        $this->assertSame(3, $handler->count);
+    }
+}
+
+class Message
+{
+}
+
+class Handler
+{
+    public int $count = 0;
+    public Scheduler $scheduler;
+
+    public function __invoke(Message $message): void
+    {
+        if (3 === ++$this->count) {
+            $this->scheduler->stop();
+        }
+    }
+}

--- a/src/Symfony/Component/Scheduler/composer.json
+++ b/src/Symfony/Component/Scheduler/composer.json
@@ -21,14 +21,14 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/clock": "^6.3"
+        "symfony/clock": "^6.3",
+        "symfony/messenger": "^6.3"
     },
     "require-dev": {
         "dragonmantank/cron-expression": "^3",
         "symfony/cache": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/lock": "^5.4|^6.0",
-        "symfony/messenger": "^6.3"
+        "symfony/lock": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Scheduler\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50085, Fix #49864, Helps with #49838, #49865
| License       | MIT
| Doc PR        | n/a

I think we should create a _hard_ dependency on `symfony/messenger`. This makes adding messenger-related features much easier. When using standalone, I've made the fact that messenger is used under the hood _completely_ transparent.

- 2d05655f18f88b939792cb43ab285560e6368141: switches the `Scheduler` to use messenger's `Worker` under the hood
- 8a9e1af95bb679bf5a4261cabde159e20039f354: Adds useful context to the `ScheduleStamp` (schedule name, trigger, current run time, next run time). This could be moved to a followup PR but wanted to demonstrate how much easier it is to add this context with the hard dep.

/cc @upyx, any objections here? 
