### PR TITLE
[Cache] Fix success interpretation when pruning cache

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
@@ -82,7 +82,7 @@ class PhpFilesAdapter extends AbstractAdapter implements PruneableInterface
                 }
 
                 if ($time >= $expiresAt) {
-                    $pruned = $this->doUnlink($file) && !file_exists($file) && $pruned;
+                    $pruned = ($this->doUnlink($file) || !file_exists($file)) && $pruned;
                 }
             }
         } finally {

--- a/src/Symfony/Component/Cache/Traits/FilesystemTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemTrait.php
@@ -40,7 +40,7 @@ trait FilesystemTrait
 
             if (($expiresAt = (int) fgets($h)) && $time >= $expiresAt) {
                 fclose($h);
-                $pruned = @unlink($file) && !file_exists($file) && $pruned;
+                $pruned = (@unlink($file) || !file_exists($file)) && $pruned;
             } else {
                 fclose($h);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

As discussed in https://github.com/symfony/symfony/pull/50095 this PR fixes the interpretation when cache-pruning is considered successfull. 

This is changed to use the same semantics used in other places of the codebase, e.g.

https://github.com/symfony/symfony/blob/51666290232ee13165c98fa9e40d3475a3cabfd8/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php#L62
https://github.com/symfony/symfony/blob/51666290232ee13165c98fa9e40d3475a3cabfd8/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php#L74