### PR TITLE
[ErrorHandler] Avoid compile crash while trying to find candidate when a class is not found

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorEnhancer/ClassNotFoundErrorEnhancer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorEnhancer/ClassNotFoundErrorEnhancer.php
@@ -152,6 +152,14 @@ class ClassNotFoundErrorEnhancer implements ErrorEnhancerInterface
             }
         }
 
+        // Symfony may ship some polyfills, like "Normalizer". But if the Intl
+        // extension is already installed, the next require_once will fail with
+        // a compile error because the class is already defined. And this one
+        // does not throw a Throwable. So it's better to skip it here.
+        if (str_contains($file, 'Resources/stubs')) {
+            return null;
+        }
+
         try {
             require_once $file;
         } catch (\Throwable) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

## Before

![image](https://user-images.githubusercontent.com/408368/233658400-7e6fa6e9-3798-4cbb-a5ee-3a81e714d37d.png)


## After

![image](https://user-images.githubusercontent.com/408368/233658515-8f4c1b81-86cf-4d87-a25f-d63b025e37fb.png)


