### PR TITLE
[BrowserKit][HttpClient] [BrowserKit, HttpClient] Minor updates in the default user agents

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -1,12 +1,6 @@
 UPGRADE FROM 6.2 to 6.3
 =======================
 
-BrowserKit
-----------
-
- * The default user agent has been renamed from `Symfony BrowserKit` to `SymfonyBrowserKit`
-   to comply with the RFC 9110 specification
-
 Console
 -------
 
@@ -75,8 +69,8 @@ HttpClient
 ----------
 
  * The default user agents have been renamed from `Symfony HttpClient/Amp`, `Symfony HttpClient/Curl`
-   and `Symfony HttpClient/Native` to `SymfonyHttpClient (Amp)`, `SymfonyHttpClient (Curl)`
-   and `SymfonyHttpClient (Native)` respectively to comply with the RFC 9110 specification
+   and `Symfony HttpClient/Native` to `Symfony HttpClient (Amp)`, `Symfony HttpClient (Curl)`
+   and `Symfony HttpClient (Native)` respectively to comply with the RFC 9110 specification
 
 HttpFoundation
 --------------

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -132,7 +132,7 @@ abstract class AbstractBrowser
     public function setServerParameters(array $server)
     {
         $this->server = array_merge([
-            'HTTP_USER_AGENT' => 'SymfonyBrowserKit',
+            'HTTP_USER_AGENT' => 'Symfony BrowserKit',
         ], $server);
     }
 

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -508,7 +508,7 @@ class AbstractBrowserTest extends TestCase
     {
         $headers = [
             'HTTP_HOST' => 'www.example.com',
-            'HTTP_USER_AGENT' => 'SymfonyBrowserKit',
+            'HTTP_USER_AGENT' => 'Symfony BrowserKit',
             'CONTENT_TYPE' => 'application/vnd.custom+xml',
             'HTTPS' => false,
         ];
@@ -535,7 +535,7 @@ class AbstractBrowserTest extends TestCase
     {
         $headers = [
             'HTTP_HOST' => 'www.example.com:8080',
-            'HTTP_USER_AGENT' => 'SymfonyBrowserKit',
+            'HTTP_USER_AGENT' => 'Symfony BrowserKit',
             'HTTPS' => false,
             'HTTP_REFERER' => 'http://www.example.com:8080/',
         ];
@@ -755,7 +755,7 @@ class AbstractBrowserTest extends TestCase
     {
         $client = $this->getBrowser();
         $this->assertSame('', $client->getServerParameter('HTTP_HOST'));
-        $this->assertSame('SymfonyBrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
+        $this->assertSame('Symfony BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
         $this->assertSame('testvalue', $client->getServerParameter('testkey', 'testvalue'));
     }
 
@@ -764,7 +764,7 @@ class AbstractBrowserTest extends TestCase
         $client = $this->getBrowser();
 
         $this->assertSame('', $client->getServerParameter('HTTP_HOST'));
-        $this->assertSame('SymfonyBrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
+        $this->assertSame('Symfony BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
 
         $client->setServerParameter('HTTP_HOST', 'testhost');
         $this->assertSame('testhost', $client->getServerParameter('HTTP_HOST'));
@@ -778,7 +778,7 @@ class AbstractBrowserTest extends TestCase
         $client = $this->getBrowser();
 
         $this->assertSame('', $client->getServerParameter('HTTP_HOST'));
-        $this->assertSame('SymfonyBrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
+        $this->assertSame('Symfony BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
 
         $client->request('GET', 'https://www.example.com/https/www.example.com', [], [], [
             'HTTP_HOST' => 'testhost',
@@ -788,7 +788,7 @@ class AbstractBrowserTest extends TestCase
         ]);
 
         $this->assertSame('', $client->getServerParameter('HTTP_HOST'));
-        $this->assertSame('SymfonyBrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
+        $this->assertSame('Symfony BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
 
         $this->assertSame('https://www.example.com/https/www.example.com', $client->getRequest()->getUri());
 

--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -42,7 +42,7 @@ class HttpBrowserTest extends AbstractBrowserTest
 
     public static function validContentTypes()
     {
-        $defaultHeaders = ['user-agent' => 'SymfonyBrowserKit', 'host' => 'example.com'];
+        $defaultHeaders = ['user-agent' => 'Symfony BrowserKit', 'host' => 'example.com'];
         yield 'GET/HEAD' => [
             ['GET', 'http://example.com/', ['key' => 'value']],
             ['GET', 'http://example.com/', ['headers' => $defaultHeaders, 'body' => '', 'max_redirects' => 0]],

--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -98,7 +98,7 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
         }
 
         if (!isset($options['normalized_headers']['user-agent'])) {
-            $options['headers'][] = 'User-Agent: SymfonyHttpClient (Amp)';
+            $options['headers'][] = 'User-Agent: Symfony HttpClient (Amp)';
         }
 
         if (0 < $options['max_duration']) {

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -93,7 +93,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         $url = implode('', $url);
 
         if (!isset($options['normalized_headers']['user-agent'])) {
-            $options['headers'][] = 'User-Agent: SymfonyHttpClient (Curl)';
+            $options['headers'][] = 'User-Agent: Symfony HttpClient (Curl)';
         }
 
         $curlopts = [

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -191,7 +191,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
         $this->logger?->info(sprintf('Request: "%s %s"', $method, implode('', $url)));
 
         if (!isset($options['normalized_headers']['user-agent'])) {
-            $options['headers'][] = 'User-Agent: SymfonyHttpClient (Native)';
+            $options['headers'][] = 'User-Agent: Symfony HttpClient (Native)';
         }
 
         if (0 < $options['max_duration']) {

--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -193,7 +193,7 @@ class HttpClientDataCollectorTest extends TestCase
   --url %1$shttp://localhost:8057/json%1$s \\
   --header %1$sAccept: */*%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
-  --header %1$sUser-Agent: SymfonyHttpClient (Native)%1$s',
+  --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s',
         ];
         yield 'GET with base uri' => [
             [
@@ -209,7 +209,7 @@ class HttpClientDataCollectorTest extends TestCase
   --url %1$shttp://localhost:8057/json/1%1$s \\
   --header %1$sAccept: */*%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
-  --header %1$sUser-Agent: SymfonyHttpClient (Native)%1$s',
+  --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s',
         ];
         yield 'GET with resolve' => [
             [
@@ -229,7 +229,7 @@ class HttpClientDataCollectorTest extends TestCase
   --url %1$shttp://localhost:8057/json%1$s \\
   --header %1$sAccept: */*%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
-  --header %1$sUser-Agent: SymfonyHttpClient (Native)%1$s',
+  --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s',
         ];
         yield 'POST with string body' => [
             [
@@ -247,7 +247,7 @@ class HttpClientDataCollectorTest extends TestCase
   --header %1$sContent-Length: 9%1$s \\
   --header %1$sContent-Type: application/x-www-form-urlencoded%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
-  --header %1$sUser-Agent: SymfonyHttpClient (Native)%1$s \\
+  --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s \\
   --data %1$sfoobarbaz%1$s',
         ];
         yield 'POST with array body' => [
@@ -285,7 +285,7 @@ class HttpClientDataCollectorTest extends TestCase
   --header %1$sContent-Type: application/x-www-form-urlencoded%1$s \\
   --header %1$sContent-Length: 211%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
-  --header %1$sUser-Agent: SymfonyHttpClient (Native)%1$s \\
+  --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s \\
   --data %1$sfoo=fooval%1$s --data %1$sbar=barval%1$s --data %1$sbaz=bazval%1$s --data %1$sfoobar[baz]=bazval%1$s --data %1$sfoobar[qux]=quxval%1$s --data %1$sbazqux[0]=bazquxval1%1$s --data %1$sbazqux[1]=bazquxval2%1$s --data %1$sobject[fooprop]=foopropval%1$s --data %1$sobject[barprop]=barpropval%1$s --data %1$stostring=tostringval%1$s',
         ];
 
@@ -312,7 +312,7 @@ class HttpClientDataCollectorTest extends TestCase
   --url %1$shttp://localhost:8057/?foo=fooval&bar=newbarval&foobar[baz]=bazval&foobar[qux]=quxval&bazqux[0]=bazquxval1&bazqux[1]=bazquxval2%1$s \\
   --header %1$sAccept: */*%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
-  --header %1$sUser-Agent: SymfonyHttpClient (Native)%1$s',
+  --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s',
             ];
             yield 'POST with json' => [
                 [
@@ -336,7 +336,7 @@ class HttpClientDataCollectorTest extends TestCase
   --header %1$sAccept: */*%1$s \\
   --header %1$sContent-Length: 120%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
-  --header %1$sUser-Agent: SymfonyHttpClient (Native)%1$s \\
+  --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s \\
   --data %1$s{"foo":{"bar":"baz","qux":[1.1,1.0],"fred":["\u003Cfoo\u003E","\u0027bar\u0027","\u0022baz\u0022","\u0026blong\u0026"]}}%1$s',
             ];
         }
@@ -368,7 +368,7 @@ class HttpClientDataCollectorTest extends TestCase
   --header %1$sAccept: */*%1$s \\
   --header %1$sAuthorization: Basic Zm9vOmJhcg==%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
-  --header %1$sUser-Agent: SymfonyHttpClient (Native)%1$s', '\\' === \DIRECTORY_SEPARATOR ? '"' : "'"), $curlCommand
+  --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s', '\\' === \DIRECTORY_SEPARATOR ? '"' : "'"), $curlCommand
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

After merging #50053 I realized that some of my changes were not really needed.

According to the spec, the user agent _"consists of one or more product identifiers, each followed by zero or more comments"_

For example this user agent:

```
Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405
```

`Mozilla/5.0` is the product and version
`AppleWebKit/531.21.10` is a subproduct and its own version
In both cases the version is optional.

So, our user agent `Symfony BrowserKit` is correct:

* `Symfony` is the product, without version (completely legal)
* `BrowserKit` is the subproduct, and omits its version (legal too)

The real issue was with user agents like `Symfony HttpClient/Amp`, because `/Amp` would be interpreted as the version of the `HttpClient`, which is wrong (the version is `6.2`, `6.3`, etc.). The `Amp` text is a detail about a product, so it's common to wrap it in parenthesis.

So, sorry for the noise and I think this time this is fully correct. Thanks.