### PR TITLE
[Routing] Prevent duplicated methods and schemes in Route

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -183,8 +183,8 @@ abstract class AnnotationClassLoader implements LoaderInterface
         $defaults = array_replace($globals['defaults'], $annot->getDefaults());
         $requirements = array_replace($globals['requirements'], $requirements);
         $options = array_replace($globals['options'], $annot->getOptions());
-        $schemes = array_merge($globals['schemes'], $annot->getSchemes());
-        $methods = array_merge($globals['methods'], $annot->getMethods());
+        $schemes = array_unique(array_merge($globals['schemes'], $annot->getSchemes()));
+        $methods = array_unique(array_merge($globals['methods'], $annot->getMethods()));
 
         $host = $annot->getHost() ?? $globals['host'];
         $condition = $annot->getCondition() ?? $globals['condition'];

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/GlobalDefaultsClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/GlobalDefaultsClass.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("/defaults", locale="g_locale", format="g_format")
+ * @Route("/defaults", methods="GET", schemes="https", locale="g_locale", format="g_format")
  */
 class GlobalDefaultsClass
 {
@@ -29,6 +29,20 @@ class GlobalDefaultsClass
      * @Route("/specific-format", name="specific_format", format="s_format")
      */
     public function format()
+    {
+    }
+
+    /**
+     * @Route("/redundant-method", name="redundant_method", methods="GET")
+     */
+    public function redundantMethod()
+    {
+    }
+
+    /**
+     * @Route("/redundant-scheme", name="redundant_scheme", methods="https")
+     */
+    public function redundantScheme()
     {
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/GlobalDefaultsClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/GlobalDefaultsClass.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
 
 use Symfony\Component\Routing\Annotation\Route;
 
-#[Route(path: '/defaults', locale: 'g_locale', format: 'g_format')]
+#[Route(path: '/defaults', methods: ['GET'], schemes: ['https'], locale: 'g_locale', format: 'g_format')]
 class GlobalDefaultsClass
 {
     #[Route(path: '/specific-locale', name: 'specific_locale', locale: 's_locale')]
@@ -23,6 +23,16 @@ class GlobalDefaultsClass
 
     #[Route(path: '/specific-format', name: 'specific_format', format: 's_format')]
     public function format()
+    {
+    }
+
+    #[Route(path: '/redundant-method', name: 'redundant_method',  methods: ['GET'])]
+    public function redundantMethod()
+    {
+    }
+
+    #[Route(path: '/redundant-scheme', name: 'redundant_scheme', schemes: ['https'])]
+    public function redundantScheme()
     {
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTestCase.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTestCase.php
@@ -149,7 +149,7 @@ abstract class AnnotationClassLoaderTestCase extends TestCase
     public function testGlobalDefaultsRoutesLoadWithAnnotation()
     {
         $routes = $this->loader->load($this->getNamespace().'\GlobalDefaultsClass');
-        $this->assertCount(2, $routes);
+        $this->assertCount(4, $routes);
 
         $specificLocaleRoute = $routes->get('specific_locale');
 
@@ -162,6 +162,9 @@ abstract class AnnotationClassLoaderTestCase extends TestCase
         $this->assertSame('/defaults/specific-format', $specificFormatRoute->getPath());
         $this->assertSame('g_locale', $specificFormatRoute->getDefault('_locale'));
         $this->assertSame('s_format', $specificFormatRoute->getDefault('_format'));
+
+        $this->assertSame(['GET'], $routes->get('redundant_method')->getMethods());
+        $this->assertSame(['https'], $routes->get('redundant_scheme')->getSchemes());
     }
 
     public function testUtf8RoutesLoadWithAnnotation()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

Methods and schemes can be "duplicated" if declared globally on the controller and also on the method. It impacts the `debug:router` command displaying `GET|GET` for the methods column for example.
