### PR TITLE
[FrameworkBundle] Add --show-aliases option to debug:router command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -47,6 +47,7 @@ CHANGELOG
  * Deprecate the `Http\Client\HttpClient` service, use `Psr\Http\Client\ClientInterface` instead
  * Add `stop_worker_on_signals` configuration option to `messenger` to define signals which would stop a worker
  * Add support for `--all` option to clear all cache pools with `cache:pool:clear` command
+ * Add `--show-aliases` option to `debug:router` command
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -56,6 +56,7 @@ class RouterDebugCommand extends Command
             ->setDefinition([
                 new InputArgument('name', InputArgument::OPTIONAL, 'A route name'),
                 new InputOption('show-controllers', null, InputOption::VALUE_NONE, 'Show assigned controllers in overview'),
+                new InputOption('show-aliases', null, InputOption::VALUE_NONE, 'Show aliases in overview'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, sprintf('The output format ("%s")', implode('", "', $this->getAvailableFormatOptions())), 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw route(s)'),
             ])
@@ -92,6 +93,7 @@ EOF
                     'format' => $input->getOption('format'),
                     'raw_text' => $input->getOption('raw'),
                     'show_controllers' => $input->getOption('show-controllers'),
+                    'show_aliases' => $input->getOption('show-aliases'),
                     'output' => $io,
                 ]);
 
@@ -120,6 +122,7 @@ EOF
                 'format' => $input->getOption('format'),
                 'raw_text' => $input->getOption('raw'),
                 'show_controllers' => $input->getOption('show-controllers'),
+                'show_aliases' => $input->getOption('show-aliases'),
                 'output' => $io,
                 'container' => $container,
             ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -260,6 +260,19 @@ abstract class Descriptor implements DescriptorInterface
         return $tag;
     }
 
+    /**
+     * @return array<string, string[]>
+     */
+    protected function getReverseAliases(RouteCollection $routes): array
+    {
+        $reverseAliases = [];
+        foreach ($routes->getAliases() as $name => $alias) {
+            $reverseAliases[$alias->getId()][] = $name;
+        }
+
+        return $reverseAliases;
+    }
+
     public static function getClassDescription(string $class, string &$resolvedClass = null): string
     {
         $resolvedClass = $class;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -37,6 +37,9 @@ class JsonDescriptor extends Descriptor
         $data = [];
         foreach ($routes->all() as $name => $route) {
             $data[$name] = $this->getRouteData($route);
+            if (($showAliases ??= $options['show_aliases'] ?? false) && $aliases = ($reverseAliases ??= $this->getReverseAliases($routes))[$name] ?? []) {
+                $data[$name]['aliases'] = $aliases;
+            }
         }
 
         $this->writeData($data, $options);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -39,6 +39,9 @@ class MarkdownDescriptor extends Descriptor
                 $this->write("\n\n");
             }
             $this->describeRoute($route, ['name' => $name]);
+            if (($showAliases ??= $options['show_aliases'] ?? false) && $aliases = ($reverseAliases ??= $this->getReverseAliases($routes))[$name] ?? []) {
+                $this->write(sprintf("- Aliases: \n%s", implode("\n", array_map(static fn (string $alias): string => sprintf('    - %s', $alias), $aliases))));
+            }
         }
         $this->write("\n");
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -53,6 +53,10 @@ class TextDescriptor extends Descriptor
             $tableHeaders[] = 'Controller';
         }
 
+        if ($showAliases = $options['show_aliases'] ?? false) {
+            $tableHeaders[] = 'Aliases';
+        }
+
         $tableRows = [];
         foreach ($routes->all() as $name => $route) {
             $controller = $route->getDefault('_controller');
@@ -67,6 +71,10 @@ class TextDescriptor extends Descriptor
 
             if ($showControllers) {
                 $row[] = $controller ? $this->formatControllerLink($controller, $this->formatCallable($controller), $options['container'] ?? null) : '';
+            }
+
+            if ($showAliases) {
+                $row[] = implode('|', ($reverseAliases ??= $this->getReverseAliases($routes))[$name] ?? []);
             }
 
             $tableRows[] = $row;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -96,6 +96,20 @@ class RouterDebugCommandTest extends AbstractWebTestCase
         $this->assertSame($expectedSuggestions, $tester->complete($input));
     }
 
+    /**
+     * @testWith    ["txt"]
+     *              ["xml"]
+     *              ["json"]
+     *              ["md"]
+     */
+    public function testShowAliases(string $format)
+    {
+        $tester = $this->createCommandTester();
+
+        $this->assertSame(0, $tester->execute(['--show-aliases' => true, '--format' => $format]));
+        $this->assertStringContainsString('my_custom_alias', $tester->getDisplay());
+    }
+
     public static function provideCompletionSuggestions()
     {
         yield 'option --format' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RouterDebug/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RouterDebug/routing.yml
@@ -13,3 +13,6 @@ routerdebug_session_logout:
 routerdebug_test:
     path:     /test
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SessionController::welcomeAction }
+
+my_custom_alias:
+    alias: routerdebug_test


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Add the `--show-aliases` option to display all the route aliases, for example:

![Screenshot from 2023-04-21 18-55-11](https://user-images.githubusercontent.com/3658119/233692506-d137cbb5-67b7-42df-8ce8-76326749534c.png)