### PR TITLE
[Console] Fix the usage of the zsh completion through the fpath discovery

### DIFF
--- a/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
+++ b/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
@@ -48,7 +48,7 @@ final class DumpCompletionCommand extends Command
         $shell = $this->guessShell();
         [$rcFile, $completionFile] = match ($shell) {
             'fish' => ['~/.config/fish/config.fish', "/etc/fish/completions/$commandName.fish"],
-            'zsh' => ['~/.zshrc', '$fpath[1]/'.$commandName],
+            'zsh' => ['~/.zshrc', '$fpath[1]/_'.$commandName],
             default => ['~/.bashrc', "/etc/bash_completion.d/$commandName"],
         };
 

--- a/src/Symfony/Component/Console/Resources/completion.zsh
+++ b/src/Symfony/Component/Console/Resources/completion.zsh
@@ -1,3 +1,5 @@
+#compdef {{ COMMAND_NAME }}
+
 # This file is part of the Symfony package.
 #
 # (c) Fabien Potencier <fabien@symfony.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Zsh completion files registered through the fpath discovery mecanism have 2 requirements:

- the file name must have a `_` prefix
- the file must start with a `#compdef` comment describing the registration for that file.

The file can then either execute the completion logic directly or call `compdef` to register a function for completion. Keeping the second approach allows to use the same generated script for the global use case than for a sourced configuration script.
