### PR TITLE
Fix the list of supported shells for completions in a phar

### DIFF
--- a/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
+++ b/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
@@ -132,8 +132,14 @@ EOH
      */
     private function getSupportedShells(): array
     {
-        return array_map(function ($f) {
-            return pathinfo($f, \PATHINFO_EXTENSION);
-        }, glob(__DIR__.'/../Resources/completion.*'));
+        $shells = [];
+
+        foreach (new \DirectoryIterator(__DIR__.'/../Resources/') as $file) {
+            if (str_starts_with($file->getBasename(), 'completion.') && $file->isFile()) {
+                $shells[] = $file->getExtension();
+            }
+        }
+
+        return $shells;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Using glob inside a phar does not work (it does not find anything). Using a DirectoryIterator on the other hand works with phars. This allows this command to compute the list of supported shells properly when used inside a phar.

Easy way to reproduce the bug: run `composer completion unsupported` (or more realistically `composer completion` in a zsh shell as zsh is not a supported shell in symfony/console 5.4) with composer 2.5.5 and see that you get this error with an empty list of supported shells:

```
Detected shell "unsupported", which is not supported by Symfony shell completion (supported shells: "").
```