### PR TITLE
Add remaining missing return types to safe methods

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -386,7 +386,7 @@ index 8bfaa0a22c..745ba6aff3 100644
      {
          $this->debug = $debug;
 diff --git a/src/Symfony/Bridge/Twig/Command/DebugCommand.php b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
-index fe581b5987..8109e7c68d 100644
+index 43e4d9c9f1..ea0116870b 100644
 --- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
 +++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
 @@ -63,5 +63,5 @@ class DebugCommand extends Command
@@ -397,7 +397,7 @@ index fe581b5987..8109e7c68d 100644
      {
          $this
 diff --git a/src/Symfony/Bridge/Twig/Command/LintCommand.php b/src/Symfony/Bridge/Twig/Command/LintCommand.php
-index fa8effc12a..deced50a90 100644
+index e059740a13..e7d6fbdd05 100644
 --- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
 +++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
 @@ -52,5 +52,5 @@ class LintCommand extends Command
@@ -1500,7 +1500,7 @@ index 00e912686b..58872ec2bc 100644
      {
          if (!$container->hasDefinition('console.command.cache_pool_prune')) {
 diff --git a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
-index 2ee96e9b37..f49ed24f68 100644
+index 200406a564..0bad73fe6a 100644
 --- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
 +++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
 @@ -81,5 +81,5 @@ trait FilesystemCommonTrait
@@ -5038,28 +5038,10 @@ index 9e107401a2..7f92321a2b 100644
 +    protected function registerFunctions(): void
      {
          $this->addFunction(ExpressionFunction::fromPhp('constant'));
-diff --git a/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php b/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
-index fec02abaae..7d02544275 100644
---- a/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
-+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
-@@ -41,5 +41,5 @@ class ConditionalNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         if ($this->nodes['expr1']->evaluate($functions, $values)) {
 diff --git a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php b/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
-index d4ab3e0922..811fec7e2e 100644
+index 33323f388f..811fec7e2e 100644
 --- a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
 +++ b/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
-@@ -41,5 +41,5 @@ class FunctionNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         $arguments = [$values];
 @@ -54,5 +54,5 @@ class FunctionNode extends Node
       * @return array
       */
@@ -5106,17 +5088,6 @@ index f6fff09b1e..4661f7d165 100644
 +    protected function isHash(array $value): bool
      {
          $expectedKey = 0;
-diff --git a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php b/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
-index 580ee13095..55e2121fcf 100644
---- a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
-+++ b/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
-@@ -46,5 +46,5 @@ class UnaryNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         $value = $this->nodes['node']->evaluate($functions, $values);
 diff --git a/src/Symfony/Component/ExpressionLanguage/ParsedExpression.php b/src/Symfony/Component/ExpressionLanguage/ParsedExpression.php
 index 239624ec2c..3b497d5ccf 100644
 --- a/src/Symfony/Component/ExpressionLanguage/ParsedExpression.php
@@ -10730,7 +10701,7 @@ index cf41e0c507..61f7397734 100644
 +    public function createNewToken(PersistentTokenInterface $token): void;
  }
 diff --git a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
-index 4416cda616..0fcf4303e0 100644
+index 10cb8f776e..0da1b3330e 100644
 --- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
 +++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
 @@ -57,5 +57,5 @@ abstract class AbstractToken implements TokenInterface, \Serializable
@@ -11173,17 +11144,6 @@ index 91271d14a3..100c2fb549 100644
 -    public function start(Request $request, AuthenticationException $authException = null);
 +    public function start(Request $request, AuthenticationException $authException = null): Response;
  }
-diff --git a/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php b/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
-index 46a25eed07..b3e25f1af3 100644
---- a/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
-+++ b/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
-@@ -32,5 +32,5 @@ final class LazyResponseEvent extends RequestEvent
-     }
- 
--    public function setResponse(Response $response)
-+    public function setResponse(Response $response): void
-     {
-         $this->stopPropagation();
 diff --git a/src/Symfony/Component/Security/Http/Event/LoginFailureEvent.php b/src/Symfony/Component/Security/Http/Event/LoginFailureEvent.php
 index 3b7c5086f2..97fb99f0b5 100644
 --- a/src/Symfony/Component/Security/Http/Event/LoginFailureEvent.php
@@ -11238,17 +11198,6 @@ index fc56733efa..8538f5f821 100644
 +    protected function callListeners(RequestEvent $event, iterable $listeners): void
      {
          foreach ($listeners as $listener) {
-diff --git a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
-index ad343ef085..9a1a2563c4 100644
---- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
-+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
-@@ -65,5 +65,5 @@ class AccessListener extends AbstractListener
-      * @throws AccessDeniedException
-      */
--    public function authenticate(RequestEvent $event)
-+    public function authenticate(RequestEvent $event): void
-     {
-         $request = $event->getRequest();
 diff --git a/src/Symfony/Component/Security/Http/Firewall/FirewallListenerInterface.php b/src/Symfony/Component/Security/Http/Firewall/FirewallListenerInterface.php
 index be200c0d12..69483f8f1d 100644
 --- a/src/Symfony/Component/Security/Http/Firewall/FirewallListenerInterface.php

--- a/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
@@ -71,7 +71,7 @@ class NotifierHandler extends AbstractHandler
         $this->notifier->send($notification, ...$this->notifier->getAdminRecipients());
     }
 
-    private function getHighestRecord(array $records)
+    private function getHighestRecord(array $records): array
     {
         $highestRecord = null;
         foreach ($records as $record) {

--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -126,7 +126,7 @@ trait ServerLogHandlerTrait
         return new VarDumperFormatter();
     }
 
-    private static function nullErrorHandler()
+    private static function nullErrorHandler(): void
     {
     }
 

--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -305,7 +305,7 @@ EOF
         return $loaderPaths;
     }
 
-    private function getMetadata(string $type, mixed $entity)
+    private function getMetadata(string $type, mixed $entity): mixed
     {
         if ('globals' === $type) {
             return $entity;

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -143,7 +143,7 @@ EOF
         return $filesInfo;
     }
 
-    protected function findFiles(string $filename)
+    protected function findFiles(string $filename): iterable
     {
         if (is_file($filename)) {
             return [$filename];
@@ -172,7 +172,7 @@ EOF
         return ['template' => $template, 'file' => $file, 'valid' => true];
     }
 
-    private function display(InputInterface $input, OutputInterface $output, SymfonyStyle $io, array $files)
+    private function display(InputInterface $input, OutputInterface $output, SymfonyStyle $io, array $files): int
     {
         return match ($this->format) {
             'txt' => $this->displayTxt($output, $io, $files),
@@ -205,7 +205,7 @@ EOF
         return min($errors, 1);
     }
 
-    private function displayJson(OutputInterface $output, array $filesInfo)
+    private function displayJson(OutputInterface $output, array $filesInfo): int
     {
         $errors = 0;
 
@@ -224,7 +224,7 @@ EOF
         return min($errors, 1);
     }
 
-    private function renderException(SymfonyStyle $output, string $template, Error $exception, string $file = null, GithubActionReporter $githubReporter = null)
+    private function renderException(SymfonyStyle $output, string $template, Error $exception, string $file = null, GithubActionReporter $githubReporter = null): void
     {
         $line = $exception->getTemplateLine();
 

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -99,7 +99,7 @@ final class WorkflowExtension extends AbstractExtension
      *                                                Use a string (the place name) to get place metadata
      *                                                Use a Transition instance to get transition metadata
      */
-    public function getMetadata(object $subject, string $key, string|Transition $metadataSubject = null, string $name = null)
+    public function getMetadata(object $subject, string $key, string|Transition $metadataSubject = null, string $name = null): mixed
     {
         return $this
             ->workflowRegistry

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -237,7 +237,7 @@ EOF
         return $availableBundles;
     }
 
-    private function getConfig(ExtensionInterface $extension, ContainerBuilder $container, bool $resolveEnvs = false)
+    private function getConfig(ExtensionInterface $extension, ContainerBuilder $container, bool $resolveEnvs = false): mixed
     {
         return $container->resolveEnvPlaceholders(
             $container->getParameterBag()->resolveValue(

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -120,9 +120,9 @@ abstract class Descriptor implements DescriptorInterface
      * Common options are:
      * * name: name of listened event
      */
-    abstract protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = []);
+    abstract protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = []): void;
 
-    abstract protected function describeCallable(mixed $callable, array $options = []);
+    abstract protected function describeCallable(mixed $callable, array $options = []): void;
 
     protected function formatValue(mixed $value): string
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -336,7 +336,7 @@ class MarkdownDescriptor extends Descriptor
         }
     }
 
-    protected function describeCallable(mixed $callable, array $options = [])
+    protected function describeCallable(mixed $callable, array $options = []): void
     {
         $string = '';
 
@@ -359,7 +359,9 @@ class MarkdownDescriptor extends Descriptor
                 }
             }
 
-            return $this->write($string."\n");
+            $this->write($string."\n");
+
+            return;
         }
 
         if (\is_string($callable)) {
@@ -375,7 +377,9 @@ class MarkdownDescriptor extends Descriptor
                 $string .= "\n- Static: yes";
             }
 
-            return $this->write($string."\n");
+            $this->write($string."\n");
+
+            return;
         }
 
         if ($callable instanceof \Closure) {
@@ -383,7 +387,9 @@ class MarkdownDescriptor extends Descriptor
 
             $r = new \ReflectionFunction($callable);
             if (str_contains($r->name, '{closure}')) {
-                return $this->write($string."\n");
+                $this->write($string."\n");
+
+                return;
             }
             $string .= "\n".sprintf('- Name: `%s`', $r->name);
 
@@ -394,14 +400,18 @@ class MarkdownDescriptor extends Descriptor
                 }
             }
 
-            return $this->write($string."\n");
+            $this->write($string."\n");
+
+            return;
         }
 
         if (method_exists($callable, '__invoke')) {
             $string .= "\n- Type: `object`";
             $string .= "\n".sprintf('- Name: `%s`', $callable::class);
 
-            return $this->write($string."\n");
+            $this->write($string."\n");
+
+            return;
         }
 
         throw new \InvalidArgumentException('Callable is not describable.');

--- a/src/Symfony/Bundle/SecurityBundle/Debug/TraceableListenerTrait.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/TraceableListenerTrait.php
@@ -30,12 +30,12 @@ trait TraceableListenerTrait
     /**
      * Proxies all method calls to the original listener.
      */
-    public function __call(string $method, array $arguments)
+    public function __call(string $method, array $arguments): mixed
     {
         return $this->listener->{$method}(...$arguments);
     }
 
-    public function getWrappedListener()
+    public function getWrappedListener(): mixed
     {
         return $this->listener;
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php
@@ -233,7 +233,7 @@ class ContentSecurityPolicyHandler
         return false;
     }
 
-    private function getDirectiveFallback(array $directiveSet, string $type)
+    private function getDirectiveFallback(array $directiveSet, string $type): ?array
     {
         if (\in_array($type, ['script-src-elem', 'style-src-elem'], true) || !isset($directiveSet['default-src'])) {
             // Let the browser fallback on it's own

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -83,7 +83,7 @@ final class LockRegistry
         return $previousFiles;
     }
 
-    public static function compute(callable $callback, ItemInterface $item, bool &$save, CacheInterface $pool, \Closure $setMetadata = null, LoggerInterface $logger = null)
+    public static function compute(callable $callback, ItemInterface $item, bool &$save, CacheInterface $pool, \Closure $setMetadata = null, LoggerInterface $logger = null): mixed
     {
         if ('\\' === \DIRECTORY_SEPARATOR && null === self::$lockedFiles) {
             // disable locking on Windows by default
@@ -146,6 +146,9 @@ final class LockRegistry
         return null;
     }
 
+    /**
+     * @return resource|false
+     */
     private static function open(int $key)
     {
         if (null !== $h = self::$openedFiles[$key] ?? null) {

--- a/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
@@ -91,7 +91,7 @@ class DefaultMarshaller implements MarshallerInterface
     /**
      * @internal
      */
-    public static function handleUnserializeCallback(string $class)
+    public static function handleUnserializeCallback(string $class): never
     {
         throw new \DomainException('Class not found: '.$class);
     }

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -367,7 +367,7 @@ trait AbstractAdapterTrait
     /**
      * @internal
      */
-    public static function handleUnserializeCallback(string $class)
+    public static function handleUnserializeCallback(string $class): never
     {
         throw new \DomainException('Class not found: '.$class);
     }

--- a/src/Symfony/Component/Cache/Traits/ContractsTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ContractsTrait.php
@@ -59,7 +59,7 @@ trait ContractsTrait
         return $previousWrapper;
     }
 
-    private function doGet(AdapterInterface $pool, string $key, callable $callback, ?float $beta, array &$metadata = null)
+    private function doGet(AdapterInterface $pool, string $key, callable $callback, ?float $beta, array &$metadata = null): mixed
     {
         if (0 > $beta ??= 1.0) {
             throw new InvalidArgumentException(sprintf('Argument "$beta" provided to "%s::get()" must be a positive number, %f given.', static::class, $beta));

--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -23,7 +23,7 @@ trait FilesystemCommonTrait
     private string $directory;
     private string $tmpSuffix;
 
-    private function init(string $namespace, ?string $directory)
+    private function init(string $namespace, ?string $directory): void
     {
         if (!isset($directory[0])) {
             $directory = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'symfony-cache';
@@ -161,7 +161,7 @@ trait FilesystemCommonTrait
     /**
      * @internal
      */
-    public static function throwError(int $type, string $message, string $file, int $line)
+    public static function throwError(int $type, string $message, string $file, int $line): never
     {
         throw new \ErrorException($message, 0, $type, $file, $line);
     }

--- a/src/Symfony/Component/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/Descriptor.php
@@ -50,25 +50,25 @@ abstract class Descriptor implements DescriptorInterface
     /**
      * Describes an InputArgument instance.
      */
-    abstract protected function describeInputArgument(InputArgument $argument, array $options = []);
+    abstract protected function describeInputArgument(InputArgument $argument, array $options = []): void;
 
     /**
      * Describes an InputOption instance.
      */
-    abstract protected function describeInputOption(InputOption $option, array $options = []);
+    abstract protected function describeInputOption(InputOption $option, array $options = []): void;
 
     /**
      * Describes an InputDefinition instance.
      */
-    abstract protected function describeInputDefinition(InputDefinition $definition, array $options = []);
+    abstract protected function describeInputDefinition(InputDefinition $definition, array $options = []): void;
 
     /**
      * Describes a Command instance.
      */
-    abstract protected function describeCommand(Command $command, array $options = []);
+    abstract protected function describeCommand(Command $command, array $options = []): void;
 
     /**
      * Describes an Application instance.
      */
-    abstract protected function describeApplication(Application $application, array $options = []);
+    abstract protected function describeApplication(Application $application, array $options = []): void;
 }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -183,7 +183,7 @@ final class ProgressBar
         $this->messages[$name] = $message;
     }
 
-    public function getMessage(string $name = 'message')
+    public function getMessage(string $name = 'message'): string
     {
         return $this->messages[$name];
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
@@ -47,10 +47,12 @@ final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
         }
     }
 
-    private static function registerForAutoconfiguration(ContainerBuilder $container, \ReflectionClass $class, \ReflectionAttribute $attribute)
+    private static function registerForAutoconfiguration(ContainerBuilder $container, \ReflectionClass $class, \ReflectionAttribute $attribute): void
     {
         if (self::$registerForAutoconfiguration) {
-            return (self::$registerForAutoconfiguration)($container, $class, $attribute);
+            (self::$registerForAutoconfiguration)($container, $class, $attribute);
+
+            return;
         }
 
         $parseDefinitions = new \ReflectionMethod(YamlFileLoader::class, 'parseDefinitions');
@@ -79,6 +81,6 @@ final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
             );
         };
 
-        return (self::$registerForAutoconfiguration)($container, $class, $attribute);
+        (self::$registerForAutoconfiguration)($container, $class, $attribute);
     }
 }

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -483,7 +483,7 @@ class ErrorHandler
      *
      * @internal
      */
-    public function handleException(\Throwable $exception)
+    public function handleException(\Throwable $exception): void
     {
         $handlerException = null;
 
@@ -534,7 +534,9 @@ class ErrorHandler
 
         try {
             if (null !== $exceptionHandler) {
-                return $exceptionHandler($exception);
+                $exceptionHandler($exception);
+
+                return;
             }
             $handlerException ??= $exception;
         } catch (\Throwable $handlerException) {

--- a/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
@@ -40,7 +40,7 @@ class ConditionalNode extends Node
         ;
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): mixed
     {
         if ($this->nodes['expr1']->evaluate($functions, $values)) {
             return $this->nodes['expr2']->evaluate($functions, $values);

--- a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
@@ -40,7 +40,7 @@ class FunctionNode extends Node
         $compiler->raw($function['compiler'](...$arguments));
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): mixed
     {
         $arguments = [$values];
         foreach ($this->nodes['arguments']->nodes as $node) {

--- a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
@@ -45,7 +45,7 @@ class UnaryNode extends Node
         ;
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): mixed
     {
         $value = $this->nodes['node']->evaluate($functions, $values);
 

--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -123,6 +123,9 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
         return $this->info + $this->response->getInfo();
     }
 
+    /**
+     * @return resource
+     */
     public function toStream(bool $throw = true)
     {
         if ($throw) {

--- a/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
@@ -100,6 +100,9 @@ trait CommonResponseTrait
         return $content;
     }
 
+    /**
+     * @return resource
+     */
     public function toStream(bool $throw = true)
     {
         if ($throw) {

--- a/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
@@ -95,9 +95,9 @@ abstract class AbstractDataGenerator
      */
     abstract protected function scanLocales(LocaleScanner $scanner, string $sourceDir): array;
 
-    abstract protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir);
+    abstract protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir): void;
 
-    abstract protected function preGenerate();
+    abstract protected function preGenerate(): void;
 
     abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale): ?array;
 

--- a/src/Symfony/Component/Intl/Data/Util/ArrayAccessibleResourceBundle.php
+++ b/src/Symfony/Component/Intl/Data/Util/ArrayAccessibleResourceBundle.php
@@ -32,7 +32,7 @@ class ArrayAccessibleResourceBundle implements \ArrayAccess, \IteratorAggregate,
         $this->bundleImpl = $bundleImpl;
     }
 
-    public function get(int|string $offset)
+    public function get(int|string $offset): mixed
     {
         $value = $this->bundleImpl->get($offset);
 

--- a/src/Symfony/Component/Intl/Data/Util/RecursiveArrayAccess.php
+++ b/src/Symfony/Component/Intl/Data/Util/RecursiveArrayAccess.php
@@ -20,7 +20,7 @@ use Symfony\Component\Intl\Exception\OutOfBoundsException;
  */
 class RecursiveArrayAccess
 {
-    public static function get(mixed $array, array $indices)
+    public static function get(mixed $array, array $indices): mixed
     {
         foreach ($indices as $index) {
             // Use array_key_exists() for arrays, isset() otherwise

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -82,7 +82,7 @@ final class Dsn
         return $this->port ?? $default;
     }
 
-    public function getOption(string $key, mixed $default = null)
+    public function getOption(string $key, mixed $default = null): mixed
     {
         return $this->options[$key] ?? $default;
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Tests\Transport;
 
-use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -60,7 +59,7 @@ class DoctrineIntegrationTest extends TestCase
             ->setParameter('body', '{"message": "Hi i am delayed"}')
             ->execute();
 
-        $available_at = new \DateTimeImmutable($stmt instanceof Result || $stmt instanceof DriverResult ? $stmt->fetchOne() : $stmt->fetchColumn());
+        $available_at = new \DateTimeImmutable($stmt instanceof Result ? $stmt->fetchOne() : $stmt->fetchColumn());
 
         $now = new \DateTimeImmutable('now + 60 seconds');
         $this->assertGreaterThan($now, $available_at);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportFactoryTest.php
@@ -72,6 +72,7 @@ class DoctrineTransportFactoryTest extends TestCase
         $schemaManager->method('createSchemaConfig')->willReturn($schemaConfig);
         $driverConnection->method('getSchemaManager')->willReturn($schemaManager);
         $driverConnection->method('getDatabasePlatform')->willReturn($platform);
+        $driverConnection->method('executeStatement')->willReturn(1);
         $registry = $this->createMock(ConnectionRegistry::class);
 
         $registry->expects($this->once())

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -31,6 +31,7 @@ class PostgreSqlConnectionTest extends TestCase
         $this->expectExceptionMessage('Cannot serialize '.PostgreSqlConnection::class);
 
         $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
 
         $connection = new PostgreSqlConnection([], $driverConnection);
         serialize($connection);
@@ -42,6 +43,7 @@ class PostgreSqlConnectionTest extends TestCase
         $this->expectExceptionMessage('Cannot unserialize '.PostgreSqlConnection::class);
 
         $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
 
         $connection = new PostgreSqlConnection([], $driverConnection);
         $connection->__wakeup();
@@ -50,6 +52,7 @@ class PostgreSqlConnectionTest extends TestCase
     public function testListenOnConnection()
     {
         $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
 
         $driverConnection
             ->expects(self::any())
@@ -112,6 +115,7 @@ class PostgreSqlConnectionTest extends TestCase
     public function testGetExtraSetupSql()
     {
         $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
         $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
 
         $table = new Table('queue_table');
@@ -128,6 +132,7 @@ class PostgreSqlConnectionTest extends TestCase
     public function testTransformTableNameWithSchemaToValidProcedureName()
     {
         $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
         $connection = new PostgreSqlConnection(['table_name' => 'schema.queue_table'], $driverConnection);
 
         $table = new Table('schema.queue_table');
@@ -141,6 +146,7 @@ class PostgreSqlConnectionTest extends TestCase
     public function testGetExtraSetupSqlWrongTable()
     {
         $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
         $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
 
         $table = new Table('queue_table');

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -208,7 +208,7 @@ abstract class AbstractFailedMessagesCommand extends Command
         }
     }
 
-    protected function interactiveChooseFailureTransport(SymfonyStyle $io)
+    protected function interactiveChooseFailureTransport(SymfonyStyle $io): string
     {
         $failedTransports = array_keys($this->failureTransports->getProvidedServices());
         $question = new ChoiceQuestion('Select failed transport:', $failedTransports, 0);

--- a/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
@@ -69,7 +69,7 @@ final class HandlerDescriptor
         return $this->batchHandler;
     }
 
-    public function getOption(string $option)
+    public function getOption(string $option): mixed
     {
         return $this->options[$option] ?? null;
     }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -112,7 +112,7 @@ class PhpSerializer implements SerializerInterface
     /**
      * @internal
      */
-    public static function handleUnserializeCallback(string $class)
+    public static function handleUnserializeCallback(string $class): never
     {
         throw new MessageDecodingFailedException(sprintf('Message class "%s" not found during decoding.', $class));
     }

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -264,7 +264,7 @@ final class Headers
         return $arr;
     }
 
-    public function getHeaderBody(string $name)
+    public function getHeaderBody(string $name): mixed
     {
         return $this->has($name) ? $this->get($name)->getBody() : null;
     }

--- a/src/Symfony/Component/Notifier/Transport/Dsn.php
+++ b/src/Symfony/Component/Notifier/Transport/Dsn.php
@@ -79,12 +79,12 @@ final class Dsn
         return $this->port ?? $default;
     }
 
-    public function getOption(string $key, mixed $default = null)
+    public function getOption(string $key, mixed $default = null): mixed
     {
         return $this->options[$key] ?? $default;
     }
 
-    public function getRequiredOption(string $key)
+    public function getRequiredOption(string $key): mixed
     {
         if (!\array_key_exists($key, $this->options) || '' === trim($this->options[$key])) {
             throw new MissingRequiredOptionException($key);

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -912,7 +912,7 @@ class Process implements \IteratorAggregate
      *
      * @internal
      */
-    public function addOutput(string $line)
+    public function addOutput(string $line): void
     {
         $this->lastOutputTime = microtime(true);
 
@@ -926,7 +926,7 @@ class Process implements \IteratorAggregate
      *
      * @internal
      */
-    public function addErrorOutput(string $line)
+    public function addErrorOutput(string $line): void
     {
         $this->lastOutputTime = microtime(true);
 

--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -44,7 +44,7 @@ final class Window implements LimiterStateInterface
         return $this->intervalInSeconds;
     }
 
-    public function add(int $hits = 1, float $now = null)
+    public function add(int $hits = 1, float $now = null): void
     {
         $now ??= microtime(true);
         if (($now - $this->timer) > $this->intervalInSeconds) {

--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -86,7 +86,7 @@ class CompiledRoute implements \Serializable
     /**
      * @internal
      */
-    final public function unserialize(string $serialized)
+    final public function unserialize(string $serialized): void
     {
         $this->__unserialize(unserialize($serialized, ['allowed_classes' => false]));
     }

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -102,7 +102,7 @@ class Route implements \Serializable
     /**
      * @internal
      */
-    final public function unserialize(string $serialized)
+    final public function unserialize(string $serialized): void
     {
         $this->__unserialize(unserialize($serialized));
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -172,7 +172,7 @@ abstract class AbstractToken implements TokenInterface, \Serializable
     /**
      * @internal
      */
-    final public function unserialize(string $serialized)
+    final public function unserialize(string $serialized): void
     {
         $this->__unserialize(unserialize($serialized));
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -137,7 +137,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         return true;
     }
 
-    public function setTranslator(TranslatorInterface $translator)
+    public function setTranslator(TranslatorInterface $translator): void
     {
         $this->translator = $translator;
     }

--- a/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
@@ -31,7 +31,7 @@ final class LazyResponseEvent extends RequestEvent
         $this->event = $event;
     }
 
-    public function setResponse(Response $response)
+    public function setResponse(Response $response): never
     {
         $this->stopPropagation();
         $this->event->stopPropagation();

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -60,11 +60,9 @@ class AccessListener extends AbstractListener
     /**
      * Handles access authorization.
      *
-     * @void
-     *
      * @throws AccessDeniedException
      */
-    public function authenticate(RequestEvent $event)
+    public function authenticate(RequestEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -251,7 +251,7 @@ class ContextListener extends AbstractListener
         throw new \RuntimeException(sprintf('There is no user provider for user "%s". Shouldn\'t the "supportsClass()" method of your user provider return true for this classname?', $userClass));
     }
 
-    private function safelyUnserialize(string $serializedToken)
+    private function safelyUnserialize(string $serializedToken): mixed
     {
         $token = null;
         $prevUnserializeHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
@@ -323,7 +323,7 @@ class ContextListener extends AbstractListener
     /**
      * @internal
      */
-    public static function handleUnserializeCallback(string $class)
+    public static function handleUnserializeCallback(string $class): never
     {
         throw new \ErrorException('Class not found: '.$class, 0x37313BC);
     }

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -225,7 +225,7 @@ class ExceptionListener
         }
     }
 
-    private function throwUnauthorizedException(AuthenticationException $authException)
+    private function throwUnauthorizedException(AuthenticationException $authException): never
     {
         $this->logger?->notice(sprintf('No Authentication entry point configured, returning a %s HTTP response. Configure "entry_point" on the firewall "%s" if you want to modify the response.', Response::HTTP_UNAUTHORIZED, $this->firewallName));
 

--- a/src/Symfony/Component/Translation/Provider/Dsn.php
+++ b/src/Symfony/Component/Translation/Provider/Dsn.php
@@ -79,12 +79,12 @@ final class Dsn
         return $this->port ?? $default;
     }
 
-    public function getOption(string $key, mixed $default = null)
+    public function getOption(string $key, mixed $default = null): mixed
     {
         return $this->options[$key] ?? $default;
     }
 
-    public function getRequiredOption(string $key)
+    public function getRequiredOption(string $key): mixed
     {
         if (!\array_key_exists($key, $this->options) || '' === trim($this->options[$key])) {
             throw new MissingRequiredOptionException($key);

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -99,7 +99,7 @@ class Parser
         return $data;
     }
 
-    private function doParse(string $value, int $flags)
+    private function doParse(string $value, int $flags): mixed
     {
         $this->currentLineNb = -1;
         $this->currentLine = '';
@@ -503,7 +503,7 @@ class Parser
         return empty($data) ? null : $data;
     }
 
-    private function parseBlock(int $offset, string $yaml, int $flags)
+    private function parseBlock(int $offset, string $yaml, int $flags): mixed
     {
         $skippedLineNumbers = $this->skippedLineNumbers;
 

--- a/src/Symfony/Component/Yaml/Tag/TaggedValue.php
+++ b/src/Symfony/Component/Yaml/Tag/TaggedValue.php
@@ -31,7 +31,7 @@ final class TaggedValue
         return $this->tag;
     }
 
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Ref #47551
| License       | MIT
| Doc PR        | -

This adds return types to remaining methods that are safe to receive a return type (final, internal or private ones), except from methods of `DataCollector` classes (which are missing quite a lot of types). I couldn't figure out whether they all return `Data`, the actual value or a union of both, so I've left them out for now.

Asides from these, we're missing 121 more return types on "non-safe" methods. If I have time, I'll create some smaller PRs for them to allow easier reviews.

<details>
<summary>Full list</summary>

```120 missing return types on interfaces

Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass::process
Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser::getMetadata
Symfony\Bridge\Monolog\Handler\ConsoleHandler::setOutput
Symfony\Bridge\Monolog\Handler\ConsoleHandler::onCommand
Symfony\Bridge\Monolog\Handler\ConsoleHandler::onTerminate
Symfony\Bridge\Monolog\Handler\ServerLogHandler::createSocket
Symfony\Bundle\FrameworkBundle\Command\AbstractConfigCommand::listBundles
Symfony\Bundle\FrameworkBundle\Command\AbstractConfigCommand::validateConfiguration
Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration::addHttpClientRetrySection
Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration::addRemoteEventSection
Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension::registerWebhookConfiguration
Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension::registerRemoteEventConfiguration
Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension::createContextListener
Symfony\Component\BrowserKit\AbstractBrowser::getScript
Symfony\Component\Cache\Adapter\ArrayAdapter::freeze
Symfony\Component\Cache\Adapter\ArrayAdapter::unfreeze
Symfony\Component\Cache\Adapter\MemcachedAdapter::checkResultCode
Symfony\Component\Cache\DependencyInjection\CachePoolPass::process
Symfony\Component\Config\Definition\BaseNode::validateType
Symfony\Component\Config\Definition\PrototypedArrayNode::addChild
Symfony\Component\Config\FileLocator::locate
Symfony\Component\Config\Loader\FileLoader::setCurrentDir
Symfony\Component\Config\Loader\FileLoader::import
Symfony\Component\Config\Loader\FileLoader::doImport
Symfony\Component\Config\ResourceCheckerConfigCache::safelyUnserialize
Symfony\Component\Console\Command\LockableTrait::release
Symfony\Component\Console\Formatter\OutputFormatter::formatAndWrap
Symfony\Component\Console\Helper\Helper::formatTime
Symfony\Component\Console\Helper\Table::setStyleDefinition
Symfony\Component\Console\Helper\Table::render
Symfony\Component\Console\Helper\Table::renderRowSeparator
Symfony\Component\Console\Helper\Table::renderRow
Symfony\Component\Console\Helper\Table::calculateNumberOfColumns
Symfony\Component\Console\Helper\Table::calculateColumnsWidth
Symfony\Component\Console\Helper\Table::cleanup
Symfony\Component\Console\Input\Input::parse
Symfony\Component\Console\Input\Input::getStream
Symfony\Component\Console\Output\Output::doWrite
Symfony\Component\DependencyInjection\Argument\ReferenceSetArgumentTrait::setValues
Symfony\Component\DependencyInjection\Container::make
Symfony\Component\DependencyInjection\Container::load
Symfony\Component\DependencyInjection\Extension\Extension::getXsdValidationBasePath
Symfony\Component\DependencyInjection\Extension\Extension::getNamespace
Symfony\Component\DependencyInjection\Extension\Extension::getConfiguration
Symfony\Component\DependencyInjection\Loader\YamlFileLoader::parseDefinition
Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::clear
Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::add
Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::set
Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::deprecate
Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::remove
Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::isResolved
Symfony\Component\DomCrawler\AbstractUriElement::setNode
Symfony\Component\DomCrawler\Field\FormField::initialize
Symfony\Component\ExpressionLanguage\Compiler::getFunction
Symfony\Component\ExpressionLanguage\Node\Node::toArray
Symfony\Component\ExpressionLanguage\Parser::parseExpression
Symfony\Component\ExpressionLanguage\Parser::getPrimary
Symfony\Component\ExpressionLanguage\SerializedParsedExpression::getNodes
Symfony\Component\Filesystem\Filesystem::linkException
Symfony\Component\Form\AbstractType::getBlockPrefix
Symfony\Component\Form\AbstractType::getParent
Symfony\Component\Form\ButtonBuilder::setFormFactory
Symfony\Component\Form\Extension\Core\DataAccessor\PropertyPathAccessor::getPropertyValue
Symfony\Component\Form\Extension\Core\Type\ChoiceType::buildForm
Symfony\Component\Form\Extension\Core\Type\ChoiceType::buildView
Symfony\Component\Form\Extension\Core\Type\ChoiceType::finishView
Symfony\Component\Form\Extension\Core\Type\ChoiceType::configureOptions
Symfony\Component\Form\Extension\Core\Type\ChoiceType::addSubForms
Symfony\Component\Form\Extension\Core\Type\ChoiceType::addSubForm
Symfony\Component\Form\Extension\Core\Type\DateType::buildForm
Symfony\Component\Form\Extension\Core\Type\DateType::finishView
Symfony\Component\Form\Extension\Core\Type\DateType::configureOptions
Symfony\Component\Form\Extension\Core\Type\FileType::buildForm
Symfony\Component\Form\Extension\Core\Type\FileType::buildView
Symfony\Component\Form\Extension\Core\Type\FileType::finishView
Symfony\Component\Form\Extension\Core\Type\FileType::configureOptions
Symfony\Component\Form\Extension\Core\Type\MoneyType::getPattern
Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationPathIterator::mapsForm
Symfony\Component\HttpClient\Response\StreamWrapper::stream_cast
Symfony\Component\HttpFoundation\Request::prepareRequestUri
Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension::loadInternal
Symfony\Component\Ldap\Security\LdapUserProvider::getAttributeValue
Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetApiTransport::castCustomHeader
Symfony\Component\Mime\Email::ensureValidity
Symfony\Component\Process\Exception\ProcessFailedException::getProcess
Symfony\Component\Process\Exception\ProcessTimedOutException::getProcess
Symfony\Component\Process\Exception\ProcessTimedOutException::getExceededTimeout
Symfony\Component\Process\Process::start
Symfony\Component\Process\Process::checkTimeout
Symfony\Component\Process\Process::setOptions
Symfony\Component\Process\Process::updateStatus
Symfony\Component\Process\Process::readPipesForOutput
Symfony\Component\Process\Process::readPipes
Symfony\Component\Process\Process::resetProcessData
Symfony\Component\Process\Process::requireProcessIsStarted
Symfony\Component\Process\Process::requireProcessIsTerminated
Symfony\Component\Routing\Loader\AnnotationClassLoader::configureRoute
Symfony\Component\Routing\Matcher\UrlMatcher::getExpressionLanguage
Symfony\Component\Routing\Router::getRouteCollection
Symfony\Component\Security\Core\User\InMemoryUserProvider::createUser
Symfony\Component\Security\Http\Firewall::getSubscribedEvents
Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::supportsNormalization
Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::normalize
Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::instantiateObject
Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::supportsDenormalization
Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::denormalize
Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::setAttributeValue
Symfony\Component\Translation\Catalogue\AbstractOperation::processDomain
Symfony\Component\Translation\Command\XliffLintCommand::display
Symfony\Component\Translation\Command\XliffLintCommand::displayJson
Symfony\Component\Translation\Command\XliffLintCommand::getDirectoryIterator
Symfony\Component\Translation\Command\XliffLintCommand::isReadable
Symfony\Component\Translation\Extractor\PhpExtractor::seekToNextRelevantToken
Symfony\Component\Translation\Extractor\PhpExtractor::skipMethodArgument
Symfony\Component\Translation\Extractor\PhpExtractor::parseTokens
Symfony\Component\Translation\Util\ArrayConverter::getElementByPath
Symfony\Component\Validator\Constraints\IsbnValidator::getMessage
Symfony\Component\Validator\Exception\ValidationFailedException::getValue
Symfony\Component\VarDumper\Test\VarDumperTestTrait::assertDumpEquals
Symfony\Component\VarDumper\Test\VarDumperTestTrait::assertDumpMatchesFormat
```

</details>