### PR TITLE
[HttpClient] Adjust `JsonMockResponse` exception

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
@@ -20,7 +20,7 @@ class JsonMockResponse extends MockResponse
         try {
             $json = json_encode($body, \JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
-            throw new InvalidArgumentException('JSON encoding failed: '.$e->getMessage(), $e->getCode());
+            throw new InvalidArgumentException('JSON encoding failed: '.$e->getMessage(), $e->getCode(), $e);
         }
 
         $info['response_headers']['content-type'] ??= 'application/json';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Minor adjustement of #50044

Set previous exception when throwing InvalidArgumentException as suggested by @stof in https://github.com/symfony/symfony/pull/50044/files#r1172519397