### PR TITLE
46867 - add more helpful property path accessor exceptions

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataAccessor/PropertyPathAccessor.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataAccessor/PropertyPathAccessor.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Exception\AccessException;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PropertyAccess\Exception\AccessException as PropertyAccessException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -60,7 +61,11 @@ class PropertyPathAccessor implements DataAccessorInterface
         // If the data is identical to the value in $data, we are
         // dealing with a reference
         if (!\is_object($data) || !$form->getConfig()->getByReference() || $value !== $this->getPropertyValue($data, $propertyPath)) {
-            $this->propertyAccessor->setValue($data, $propertyPath, $value);
+            try {
+                $this->propertyAccessor->setValue($data, $propertyPath, $value);
+            } catch (NoSuchPropertyException $e) {
+                throw new NoSuchPropertyException($e->getMessage().' Make the property public, add a setter, or set the "mapped" field option in the form type to be false.', 0, $e);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch? | 6.3
| Bug fix? | no
| New feature? | no
| Deprecations? | no
| Tickets | https://github.com/symfony/symfony/issues/46867
| License | MIT
| Doc PR | none

Dear reviewers,

This small modification adds more helpful exceptions when properties cannot be accessed/set
using forms. Only one file was modified, so it should be relatively easy to review. Please feel free to leave a comment if you have any questions about what I'm doing here, and thanks for your work as a reviewer on an open-source project!

All the best,

Patrick