### PR TITLE
[Scheduler] Make `MessageGenerator` yield some scheduling context

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/MessageContext.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageContext.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Generator;
+
+use Symfony\Component\Scheduler\Trigger\TriggerInterface;
+
+/**
+ * @author Tugdual Saunier <tugdual@saunier.tech>
+ *
+ * @experimental
+ */
+final class MessageContext
+{
+    public function __construct(
+        public readonly TriggerInterface $trigger,
+        public readonly \DateTimeImmutable $triggeredAt,
+        public readonly \DateTimeImmutable|null $nextTriggerAt = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -70,7 +70,7 @@ final class MessageGenerator implements MessageGeneratorInterface
             }
 
             if ($yield) {
-                yield $message;
+                yield (new MessageContext($trigger, $time, $nextTime)) => $message;
                 $this->checkpoint->save($time, $index);
             }
         }

--- a/src/Symfony/Component/Scheduler/Generator/MessageGeneratorInterface.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGeneratorInterface.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\Scheduler\Generator;
 interface MessageGeneratorInterface
 {
     /**
-     * @return iterable<object>
+     * @return iterable<MessageContext, object>
      */
     public function getMessages(): iterable;
 }

--- a/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
+++ b/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
@@ -12,10 +12,14 @@
 namespace Symfony\Component\Scheduler\Messenger;
 
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Scheduler\Generator\MessageContext;
 
 /**
  * @experimental
  */
 final class ScheduledStamp implements NonSendableStampInterface
 {
+    public function __construct(public readonly MessageContext $messageContext)
+    {
+    }
 }

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -28,8 +28,8 @@ class SchedulerTransport implements TransportInterface
 
     public function get(): iterable
     {
-        foreach ($this->messageGenerator->getMessages() as $message) {
-            yield Envelope::wrap($message, [new ScheduledStamp()]);
+        foreach ($this->messageGenerator->getMessages() as $context => $message) {
+            yield Envelope::wrap($message, [new ScheduledStamp($context)]);
         }
     }
 

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -14,9 +14,11 @@ namespace Symfony\Component\Scheduler\Tests\Messenger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Scheduler\Exception\LogicException;
+use Symfony\Component\Scheduler\Generator\MessageContext;
 use Symfony\Component\Scheduler\Generator\MessageGeneratorInterface;
 use Symfony\Component\Scheduler\Messenger\ScheduledStamp;
 use Symfony\Component\Scheduler\Messenger\SchedulerTransport;
+use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
 class SchedulerTransportTest extends TestCase
 {
@@ -26,9 +28,15 @@ class SchedulerTransportTest extends TestCase
             (object) ['id' => 'first'],
             (object) ['id' => 'second'],
         ];
-        $generator = $this->createConfiguredMock(MessageGeneratorInterface::class, [
+        $generator = $this->createMock(MessageGeneratorInterface::class, [
             'getMessages' => $messages,
         ]);
+        $generator->method('getMessages')->willReturnCallback(function () use ($messages): \Generator {
+            $trigger = $this->createMock(TriggerInterface::class);
+            $triggerAt = new \DateTimeImmutable('2020-02-20T02:00:00', new \DateTimeZone('UTC'));
+            yield (new MessageContext($trigger, $triggerAt)) => $messages[0];
+            yield (new MessageContext($trigger, $triggerAt)) => $messages[1];
+        });
         $transport = new SchedulerTransport($generator);
 
         foreach ($transport->get() as $envelope) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50085, "replaces" #50096?, could help with #49864
| License       | MIT
| Doc PR        | no doc yet for Scheduler

This PR introduces a new `MessageContext` that `MessageGenerator` should use as key when yielding messages to provide more context about the scheduled message.
The consumer of the scheduled messages can decide to use it or not.
The PR also adds the wiring to add this context to the `ScheduledStamp` when using Scheduler within Messenger.
This allows to add more context but without introducing a hard dependency on Messenger.

/cc @kbond 

Note: this PR is not adding the scheduler name (cf #49864) because I don't know exactly where to wire it yet but I don't see anything preventing it to be added to the context once we know where it should belong. 