### PR TITLE
[Validator] Update the name of a password strength level

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
@@ -26,7 +26,7 @@ final class PasswordStrength extends Constraint
 {
     public const STRENGTH_VERY_WEAK = 0;
     public const STRENGTH_WEAK = 1;
-    public const STRENGTH_REASONABLE = 2;
+    public const STRENGTH_MEDIUM = 2;
     public const STRENGTH_STRONG = 3;
     public const STRENGTH_VERY_STRONG = 4;
 
@@ -42,7 +42,7 @@ final class PasswordStrength extends Constraint
 
     public function __construct(array $options = null, int $minScore = null, array $groups = null, mixed $payload = null)
     {
-        $options['minScore'] ??= self::STRENGTH_REASONABLE;
+        $options['minScore'] ??= self::STRENGTH_MEDIUM;
 
         parent::__construct($options, $groups, $payload);
 

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
@@ -82,7 +82,7 @@ final class PasswordStrengthValidator extends ConstraintValidator
         return match (true) {
             $entropy >= 120 => PasswordStrength::STRENGTH_VERY_STRONG,
             $entropy >= 100 => PasswordStrength::STRENGTH_STRONG,
-            $entropy >= 80 => PasswordStrength::STRENGTH_REASONABLE,
+            $entropy >= 80 => PasswordStrength::STRENGTH_MEDIUM,
             $entropy >= 60 => PasswordStrength::STRENGTH_WEAK,
             default => PasswordStrength::STRENGTH_VERY_WEAK,
         };

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
@@ -45,7 +45,7 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
     public static function getValidValues(): iterable
     {
         yield ['How-is-this', PasswordStrength::STRENGTH_WEAK];
-        yield ['Reasonable-pwd', PasswordStrength::STRENGTH_REASONABLE];
+        yield ['Reasonable-pwd', PasswordStrength::STRENGTH_MEDIUM];
         yield ['This 1s a very g00d Pa55word! ;-)', PasswordStrength::STRENGTH_VERY_STRONG];
         yield ['pudding-smack-👌🏼-fox-😎', PasswordStrength::STRENGTH_VERY_STRONG];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

After checking the docs of the new PasswordStrength constraint, I propose to rename the `STRENGTH_REASONABLE` level name.

"Reasonable" is subjective. In a banking app, reasonable can be level 4 (very strong) and in a one-time password that expires in 60 seconds, reasonable can be level 0 (very weak).

I propose to rename it as a more neutral `STRENGTH_MEDIUM` name. Other common names for this are "Moderate" and "Fair".