### PR TITLE
[Notifier] [SpotHit] Support `smslong` and `smslongnbr` API parameters

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Support `SMSLong` and `SMSLongNBr` API parameters
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/README.md
@@ -6,12 +6,14 @@ Provides [Spot-Hit](https://www.spot-hit.fr/) integration for Symfony Notifier.
 #### DSN example
 
 ```
-SPOTHIT_DSN=spothit://TOKEN@default?from=FROM
+SPOTHIT_DSN=spothit://TOKEN@default?from=FROM&smslong=SMSLONG&smslongnbr=SMSLONGNBR
 ```
 
 where:
  - `TOKEN` is your Spot-Hit API key
  - `FROM` is the custom sender (3-11 letters, default is a 5 digits phone number)
+ - `SMSLONG` (optional) 0 or 1 : allows SMS messages longer than 160 characters
+ - `SMSLONGNBR` (optional) integer : allows to check the size of the long SMS sent. You must send the number of concatenated SMS as a value. If our counter indicates a different number, your message will be rejected.
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
@@ -35,6 +35,8 @@ final class SpotHitTransport extends AbstractTransport
 
     private string $token;
     private ?string $from;
+    private ?bool $smsLong = null;
+    private ?int $smsLongNBr = null;
 
     public function __construct(#[\SensitiveParameter] string $token, string $from = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
@@ -46,7 +48,27 @@ final class SpotHitTransport extends AbstractTransport
 
     public function __toString(): string
     {
-        return sprintf('spothit://%s%s', $this->getEndpoint(), null !== $this->from ? '?from='.$this->from : '');
+        $query = http_build_query([
+            'from' => $this->from,
+            'smslong' => $this->smsLong,
+            'smslongnbr' => $this->smsLongNBr,
+        ]);
+
+        return sprintf('spothit://%s', $this->getEndpoint()).('' !== $query ? '?'.$query : '');
+    }
+
+    public function setSmsLong(?bool $smsLong): self
+    {
+        $this->smsLong = $smsLong;
+
+        return $this;
+    }
+
+    public function setLongNBr(?int $smsLongNBr): self
+    {
+        $this->smsLongNBr = $smsLongNBr;
+
+        return $this;
     }
 
     public function supports(MessageInterface $message): bool
@@ -76,6 +98,8 @@ final class SpotHitTransport extends AbstractTransport
                 'type' => 'premium',
                 'message' => $message->getSubject(),
                 'expediteur' => $message->getFrom() ?: $this->from,
+                'smslong' => $this->smsLong,
+                'smslongnbr' => $this->smsLongNBr,
             ],
         ]);
 

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransportFactory.php
@@ -30,10 +30,12 @@ final class SpotHitTransportFactory extends AbstractTransportFactory
 
         $token = $this->getUser($dsn);
         $from = $dsn->getOption('from');
+        $smsLong = $dsn->getOption('smslong');
+        $smsLongNBr = $dsn->getOption('smslongnbr');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SpotHitTransport($token, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SpotHitTransport($token, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSmsLong($smsLong)->setLongNBr($smsLongNBr);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportFactoryTest.php
@@ -31,11 +31,17 @@ final class SpotHitTransportFactoryTest extends TransportFactoryTestCase
             'spothit://spot-hit.fr?from=MyCompany',
             'spothit://api_token@default?from=MyCompany',
         ];
+        yield [
+            'spothit://spot-hit.fr?from=MyCompany&smslong=1',
+            'spothit://api_token@default?from=MyCompany&smslong=1',
+        ];
     }
 
     public static function supportsProvider(): iterable
     {
         yield [true, 'spothit://api_token@default?from=MyCompany'];
+        yield [true, 'spothit://api_token@default?from=MyCompany&smslong=1'];
+        yield [true, 'spothit://api_token@default?from=MyCompany&smslongnbr=1'];
         yield [false, 'somethingElse://api_token@default?from=MyCompany'];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
| Doc PR        | mandatory for components ?

By default, SMS via Spot Hit are strictly limited to 160 characters maximum. This PR allows to forward the corresponding arguments from the DSN to the API request to unlock this capability