### PR TITLE
Check if trace.curlCommand is defined in profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -91,7 +91,7 @@
                                                 Profile
                                             </th>
                                         {% endif %}
-                                        {% if trace.curlCommand is not null %}
+                                        {% if trace.curlCommand is defined and trace.curlCommand %}
                                             <th>
                                                 <button class="btn btn-sm hidden" title="Copy as cURL" data-clipboard-text="{{ trace.curlCommand }}">Copy as cURL</button>
                                             </th>
@@ -107,7 +107,7 @@
                                     {% endif %}
                                     <tr>
                                         <th class="font-normal">Response</th>
-                                        <td{% if trace.curlCommand %} colspan="2"{% endif %}>
+                                        <td{% if trace.curlCommand is defined and trace.curlCommand %} colspan="2"{% endif %}>
                                             {% if trace.http_code >= 500 %}
                                                 {% set responseStatus = 'error' %}
                                             {% elseif trace.http_code >= 400 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Tickets       | 
| License       | MIT
| Doc PR        | 

We'll get a `Key "curlCommand" for array with keys "method, url, options, content, http_code, info" does not exist.` `RuntimeError` otherwise, if this key does not exist :) 