### PR TITLE
[Scheduler] use `spl_object_id` for default `CallbackTrigger` descrip…

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/CallbackTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/CallbackTriggerTest.php
@@ -19,7 +19,7 @@ class CallbackTriggerTest extends TestCase
     public function testToString()
     {
         $trigger = new CallbackTrigger(fn () => null);
-        $this->assertMatchesRegularExpression('/^\d{32}$/', (string) $trigger);
+        $this->assertMatchesRegularExpression('/^\d+$/', (string) $trigger);
 
         $trigger = new CallbackTrigger(fn () => null, '');
         $this->assertSame('', (string) $trigger);

--- a/src/Symfony/Component/Scheduler/Trigger/CallbackTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/CallbackTrigger.php
@@ -24,7 +24,7 @@ final class CallbackTrigger implements TriggerInterface
     public function __construct(callable $callback, string $description = null)
     {
         $this->callback = $callback(...);
-        $this->description = $description ?? spl_object_hash($this->callback);
+        $this->description = $description ?? spl_object_id($this->callback);
     }
 
     public function __toString(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Fixes a brittle test.
