### PR TITLE
Allow sending scheduled messages through the slack API

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -90,6 +90,16 @@ class SlackOptions implements MessageOptionsInterface
     /**
      * @return $this
      */
+    public function postAt(\DateTime $timestamp): static
+    {
+        $this->options['post_at'] = $timestamp->getTimestamp();
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function block(SlackBlockInterface $block): static
     {
         if (\count($this->options['blocks'] ?? []) >= self::MAX_BLOCKS) {

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -76,6 +76,10 @@ final class SlackTransport extends AbstractTransport
         $options['text'] = $message->getSubject();
 
         $apiMethod = $message->getOptions() instanceof UpdateMessageSlackOptions ? 'chat.update' : 'chat.postMessage';
+        if (\array_key_exists('post_at', $options)) {
+            $apiMethod = 'chat.scheduleMessage';
+        }
+
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/'.$apiMethod, [
             'json' => array_filter($options),
             'auth_bearer' => $this->accessToken,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | /
| License       | MIT
| Doc PR        | TODO

Add option post_at to the Slack Notifier bridge, this allows for easy scheduling of Slack messages. 


