### PR TITLE
[ExpressionLanguage] Add `Parser->parseWithoutContext`

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `enum` expression function
  * Deprecate loose comparisons when using the "in" operator; normalize the array parameter
    so it only has the expected types or implement loose matching in your own expression function
+ * Add `parseWithoutContext` to `Parser`, use this function to get the expression's AST without validating names
 
 6.2
 ---

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -14,6 +14,10 @@ namespace Symfony\Component\ExpressionLanguage\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\Lexer;
 use Symfony\Component\ExpressionLanguage\Node;
+use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
+use Symfony\Component\ExpressionLanguage\Node\FunctionNode;
+use Symfony\Component\ExpressionLanguage\Node\NameNode;
+use Symfony\Component\ExpressionLanguage\Node\Node as NodeNode;
 use Symfony\Component\ExpressionLanguage\Parser;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
 
@@ -377,5 +381,15 @@ class ParserTest extends TestCase
                     'around position 5 for expression `[foo: foo]`.',
             ],
         ];
+    }
+
+    public function testParseWithoutContext()
+    {
+        $expression = 'is_granted(\'ROLE_EDIT\', subject)';
+        $expected = new FunctionNode('is_granted', new NodeNode([new ConstantNode('ROLE_EDIT'), new NameNode('subject')]));
+
+        $lexer = new Lexer();
+        $parser = new Parser([]);
+        $this->assertEquals($expected, $parser->parseWithoutContext($lexer->tokenize($expression)));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50105
| License       | MIT
| Doc PR        | symfony/symfony-docs/pull/18298

 - [x] Always add tests and ensure they pass.
 - [x] For new features, provide some code snippets to help understand usage.
 - [x] Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - [x] Never break backward compatibility (see https://symfony.com/bc).
 - [x] Doc PR (https://github.com/symfony/symfony-docs/pull/18298)
 - [ ] Is it possible to backport it to Symfony 5.4 ?

## Code snippet

Let say we want to check that all our `#[Security]` attributes have an `is_granted` call with a subject given.

Note that the following example is for illustration purpose and does not really handle all possible outcomes (for instance `is_granted(.., ..) || is_granted(.., ..)`.

```php
$lexer = new Lexer();
$parser = new Parser([]);

$attributes = /* fetch all `#[Security]` attributes */
foreach ($attributes as $attribute) {
    $intance = $attribute->newInstance();
    $parsed = $parser->parseWithoutContext($instance->getExpression()); // Here we can parse without taking care of the possible symbols
    if (
        $parsed instanceof FunctionNode
        && isset($parsed->nodes['arguments'][1])
        && $parsed->nodes['arguments'][1] instanceof NameNode
    ) {
      continue; // it is an `is_granted` call with a subject
    }

    throw new SecurityException('Attribute with expression `' . $instance->getExpression() . '` does not have a valid `is_granted` call.');
}
```

Other use cases may involve:
- Executing the expression in another language (such as in browser in JavaScript)
- Extracting variable name in a first pass to get their values from a database or something else, then evaluating the expression in a second pass 