### PR TITLE
[VarDumper] Use native `never` return type for `dd` function

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -32,10 +32,7 @@ if (!function_exists('dump')) {
 }
 
 if (!function_exists('dd')) {
-    /**
-     * @return never
-     */
-    function dd(...$vars): void
+    function dd(...$vars): never
     {
         if (!in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && !headers_sent()) {
             header('HTTP/1.1 500 Internal Server Error');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      |no
| New feature?  |no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 


The native never return type was introduced in PHP 8.1 so we can use it.

https://www.php.net/manual/en/language.types.never.php

