### PR TITLE
[Mailer] Add X-Infobip-Track header to be able to disable tracking

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Infobip/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add reporting behavior thanks to new attributes support
+ * Add header to disable tracking that is enabled by default on API V3
 
 6.2
 ---

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
@@ -409,7 +409,8 @@ class InfobipApiTransportTest extends TestCase
             ->addTextHeader('X-Infobip-IntermediateReport', 'true')
             ->addTextHeader('X-Infobip-NotifyUrl', 'https://foo.bar')
             ->addTextHeader('X-Infobip-NotifyContentType', 'application/json')
-            ->addTextHeader('X-Infobip-MessageId', 'RANDOM-CUSTOM-ID');
+            ->addTextHeader('X-Infobip-MessageId', 'RANDOM-CUSTOM-ID')
+            ->addTextHeader('X-Infobip-Track', 'false');
 
         $sentMessage = $this->transport->send($email);
 
@@ -421,6 +422,7 @@ class InfobipApiTransportTest extends TestCase
             X-Infobip-NotifyUrl: https://foo.bar
             X-Infobip-NotifyContentType: application/json
             X-Infobip-MessageId: RANDOM-CUSTOM-ID
+            X-Infobip-Track: false
             %a
             TXT,
             $sentMessage->toString()

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
@@ -38,6 +38,7 @@ final class InfobipApiTransport extends AbstractApiTransport
         'X-Infobip-NotifyUrl' => 'notifyUrl',
         'X-Infobip-NotifyContentType' => 'notifyContentType',
         'X-Infobip-MessageId' => 'messageId',
+        'X-Infobip-Track' => 'track',
     ];
 
     private string $key;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | symfony/symfony-docs#18169

# 📍 Context

This PR add a new header to disable tracking that is now enabled by default with the Infobip API V3 (email).

# ➕ New feature

New payload attribute was added allowing end users to disable tracking.

| Attribute | Type | Description |
| --- | --- | --- |
| X-Infobip-Track | boolean | Enable or disable open and click tracking. | 