### PR TITLE
Fix registering traceable voters, argument resolvers and normalizers

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -56,7 +56,7 @@ class AddSecurityVotersPass implements CompilerPassInterface
             }
 
             if ($debug) {
-                $voterServices[] = new Reference($debugVoterServiceId = 'debug.security.voter.'.$voterServiceId);
+                $voterServices[] = new Reference($debugVoterServiceId = '.debug.security.voter.'.$voterServiceId);
 
                 $container
                     ->register($debugVoterServiceId, TraceableVoter::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -91,11 +91,11 @@ class AddSecurityVotersPassTest extends TestCase
         $compilerPass = new AddSecurityVotersPass();
         $compilerPass->process($container);
 
-        $def1 = $container->getDefinition('debug.security.voter.voter1');
+        $def1 = $container->getDefinition('.debug.security.voter.voter1');
         $this->assertNull($def1->getDecoratedService(), 'voter1: should not be decorated');
         $this->assertEquals(new Reference('voter1'), $def1->getArgument(0), 'voter1: wrong argument');
 
-        $def2 = $container->getDefinition('debug.security.voter.voter2');
+        $def2 = $container->getDefinition('.debug.security.voter.voter2');
         $this->assertNull($def2->getDecoratedService(), 'voter2: should not be decorated');
         $this->assertEquals(new Reference('voter2'), $def2->getArgument(0), 'voter2: wrong argument');
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
@@ -43,30 +43,30 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
         $namedResolvers = $this->findAndSortTaggedServices(new TaggedIteratorArgument('controller.targeted_value_resolver', 'name', needsIndexes: true), $container);
         $resolvers = $this->findAndSortTaggedServices(new TaggedIteratorArgument('controller.argument_value_resolver', 'name', needsIndexes: true), $container);
 
-        foreach ($resolvers as $name => $resolverReference) {
-            $id = (string) $resolverReference;
-
-            if ($definitions[$id]->hasTag('controller.targeted_value_resolver')) {
+        foreach ($resolvers as $name => $resolver) {
+            if ($definitions[(string) $resolver]->hasTag('controller.targeted_value_resolver')) {
                 unset($resolvers[$name]);
             } else {
-                $namedResolvers[$name] ??= clone $resolverReference;
+                $namedResolvers[$name] ??= clone $resolver;
             }
         }
 
-        $resolvers = array_values($resolvers);
-
         if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class) && $container->has('debug.stopwatch')) {
-            foreach ($resolvers + $namedResolvers as $resolverReference) {
-                $id = (string) $resolverReference;
-                $container->register("debug.$id", TraceableValueResolver::class)
-                    ->setDecoratedService($id)
-                    ->setArguments([new Reference("debug.$id.inner"), new Reference('debug.stopwatch')]);
+            foreach ($resolvers as $name => $resolver) {
+                $resolvers[$name] = new Reference('.debug.value_resolver.'.$resolver);
+                $container->register('.debug.value_resolver.'.$resolver, TraceableValueResolver::class)
+                    ->setArguments([$resolver, new Reference('debug.stopwatch')]);
+            }
+            foreach ($namedResolvers as $name => $resolver) {
+                $namedResolvers[$name] = new Reference('.debug.value_resolver.'.$resolver);
+                $container->register('.debug.value_resolver.'.$resolver, TraceableValueResolver::class)
+                    ->setArguments([$resolver, new Reference('debug.stopwatch')]);
             }
         }
 
         $container
             ->getDefinition('argument_resolver')
-            ->replaceArgument(1, new IteratorArgument($resolvers))
+            ->replaceArgument(1, new IteratorArgument(array_values($resolvers)))
             ->setArgument(2, new ServiceLocatorArgument($namedResolvers))
         ;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ControllerArgumentValueResolverPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ControllerArgumentValueResolverPassTest.php
@@ -62,9 +62,9 @@ class ControllerArgumentValueResolverPassTest extends TestCase
         ];
 
         $expected = [
-            new Reference('n1'),
-            new Reference('n2'),
-            new Reference('n3'),
+            new Reference('.debug.value_resolver.n1'),
+            new Reference('.debug.value_resolver.n2'),
+            new Reference('.debug.value_resolver.n3'),
         ];
 
         $definition = new Definition(ArgumentResolver::class, [null, []]);
@@ -81,9 +81,9 @@ class ControllerArgumentValueResolverPassTest extends TestCase
         (new ControllerArgumentValueResolverPass())->process($container);
         $this->assertEquals($expected, $definition->getArgument(1)->getValues());
 
-        $this->assertTrue($container->hasDefinition('debug.n1'));
-        $this->assertTrue($container->hasDefinition('debug.n2'));
-        $this->assertTrue($container->hasDefinition('debug.n3'));
+        $this->assertTrue($container->hasDefinition('.debug.value_resolver.n1'));
+        $this->assertTrue($container->hasDefinition('.debug.value_resolver.n2'));
+        $this->assertTrue($container->hasDefinition('.debug.value_resolver.n3'));
 
         $this->assertTrue($container->hasDefinition('n1'));
         $this->assertTrue($container->hasDefinition('n2'));

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -104,17 +104,15 @@ class SerializerPassTest extends TestCase
         $serializerPass = new SerializerPass();
         $serializerPass->process($container);
 
-        $traceableNormalizerDefinition = $container->getDefinition('debug.n');
-        $traceableEncoderDefinition = $container->getDefinition('debug.e');
+        $traceableNormalizerDefinition = $container->getDefinition('.debug.serializer.normalizer.n');
+        $traceableEncoderDefinition = $container->getDefinition('.debug.serializer.encoder.e');
 
         $this->assertEquals(TraceableNormalizer::class, $traceableNormalizerDefinition->getClass());
-        $this->assertEquals(['n', null, 0], $traceableNormalizerDefinition->getDecoratedService());
-        $this->assertEquals(new Reference('debug.n.inner'), $traceableNormalizerDefinition->getArgument(0));
+        $this->assertEquals(new Reference('n'), $traceableNormalizerDefinition->getArgument(0));
         $this->assertEquals(new Reference('serializer.data_collector'), $traceableNormalizerDefinition->getArgument(1));
 
         $this->assertEquals(TraceableEncoder::class, $traceableEncoderDefinition->getClass());
-        $this->assertEquals(['e', null, 0], $traceableEncoderDefinition->getDecoratedService());
-        $this->assertEquals(new Reference('debug.e.inner'), $traceableEncoderDefinition->getArgument(0));
+        $this->assertEquals(new Reference('e'), $traceableEncoderDefinition->getArgument(0));
         $this->assertEquals(new Reference('serializer.data_collector'), $traceableEncoderDefinition->getArgument(1));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

By using service decoration to trace voters, resolvers and normalizers, we break the possibility to register them under several tags. We also make it harder to decorate them for end users. But adding observability to those doesn't require adding side effect to service definitions. Instead, we can and should use regular decoration.