### PR TITLE
Improve type annotation of ContainerInterface::get()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -36,6 +36,12 @@ interface ContainerInterface extends PsrContainerInterface
     public function set(string $id, ?object $service);
 
     /**
+     * @template B of self::*_REFERENCE
+     *
+     * @param B $invalidBehavior
+     *
+     * @psalm-return (B is self::EXCEPTION_ON_INVALID_REFERENCE|self::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE ? object : object|null)
+     *
      * @throws ServiceCircularReferenceException When a circular reference is detected
      * @throws ServiceNotFoundException          When the service is not defined
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Hi! When using Psalm we could improve the type annotations on `ContainerInterface::get() ` to make them understand better the return type, especially:

* can it return `null`?
* Do we know if it will return a specific type or if it could be an `object`

This shows how psalm understands the version of `ContainerInterface::get()` : https://psalm.dev/r/c9cb6f3655

I'm currently introducing this in a project in a Psalm stub, but thought it could be interesting to upstream this change. Is this something that could be integrated in Symfony? I'm not sure what's the policy is about Psalm/PHPStan here

note: I know that there are no guarantee that `$container->get(\DateTimeImmutable::class)` will return `DateTimeImmutable` and that a different service could have been registered with that name. If that's a blocker, we could at least implement the part saying if the method will return `null` or not depending on the second argument.

---

note about PHPStan: I couldn't make it work (yet), here is the playground https://phpstan.org/r/eb1465d2-79cf-4dd1-beb3-5929f565b4a8 I'll try again / ask for help if there's interest in this merge request