### PR TITLE
[Contracts] Fix ServiceLocatorTestCase name

### DIFF
--- a/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
+++ b/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 
-abstract class ServiceLocatorTest extends TestCase
+abstract class ServiceLocatorTestCase extends TestCase
 {
     protected function getServiceLocator(array $factories): ContainerInterface
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The original change in 5.4 uses the correct name (#50104), but it seems like the `Case` suffix was lost during the merge from 5.4 into 6.2.