### PR TITLE
[Scheduler] Fix CallbackTriggerTest fail on AppVeyor

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/CallbackTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/CallbackTriggerTest.php
@@ -19,7 +19,7 @@ class CallbackTriggerTest extends TestCase
     public function testToString()
     {
         $trigger = new CallbackTrigger(fn () => null);
-        $this->assertMatchesRegularExpression('/^\d{32}$/', (string) $trigger);
+        $this->assertMatchesRegularExpression('/^[\da-f]{32}$/', (string) $trigger);
 
         $trigger = new CallbackTrigger(fn () => null, '');
         $this->assertSame('', (string) $trigger);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        |

A test fails on AppVeyor since `spl_object_hash` can return an hexadecimal value. This PR fixes it.

![image](https://user-images.githubusercontent.com/6114779/234876513-069d1de6-469a-492d-8806-3be3510fddd9.png)
