### PR TITLE
[Mailer][RemoteEvent] Enhance webhook reason with Mailgun data

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php
@@ -39,7 +39,7 @@ final class MailgunPayloadConverter implements PayloadConverterInterface
 
             $event = new MailerDeliveryEvent($name, $payload['id'], $payload);
             // reason is only available on failed messages
-            $event->setReason($payload['reason'] ?? '');
+            $event->setReason($this->getReason($payload));
         } else {
             $name = match ($payload['event']) {
                 'clicked' => MailerEngagementEvent::CLICK,
@@ -71,5 +71,20 @@ final class MailgunPayloadConverter implements PayloadConverterInterface
         }
 
         return MailerDeliveryEvent::BOUNCE;
+    }
+
+    private function getReason(array $payload): string
+    {
+        if ('' !== $payload['delivery-status']['description']) {
+            return $payload['delivery-status']['description'];
+        }
+        if ('' !== $payload['delivery-status']['message']) {
+            return $payload['delivery-status']['message'];
+        }
+        if ('' !== $payload['reason']) {
+            return $payload['reason'];
+        }
+
+        return '';
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/delivered_messages.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/delivered_messages.php
@@ -7,5 +7,6 @@ $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
 $wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521472262.908181));
+$wh->setReason('OK');
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/permanent_failure.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/permanent_failure.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
 $wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521233195.375624));
-$wh->setReason('bounce');
+$wh->setReason('No Such User Here');
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/suppression_failure.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/suppression_failure.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
 $wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521233195.375624));
-$wh->setReason('suppress-bounce');
+$wh->setReason('Not delivering to previously bounced address');
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/temporary_failure.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/temporary_failure.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
 $wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521472262.908181));
-$wh->setReason('generic');
+$wh->setReason("4.2.2 The email account that you tried to reach is over quota. Please direct\n4.2.2 the recipient to\n4.2.2  https://support.example.com/mail/?p=422");
 
 return $wh;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | 

The `$payload['reason']` gives a poorly actionable explanation of the event.

I propose to leverage data in `$payload['delivery-status']` when available to enrich the output from the Webhook parsing.
