### PR TITLE
[Mailer] Catch Postmark inactive email exceptions

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkTransportFactory.php
@@ -31,7 +31,7 @@ final class PostmarkTransportFactory extends AbstractTransportFactory
             $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
             $port = $dsn->getPort();
 
-            $transport = (new PostmarkApiTransport($user, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            $transport = (new PostmarkApiTransport($user, $this->client, $this->dispatcher, $this->logger, $this->messageBus))->setHost($host)->setPort($port);
         }
 
         if ('postmark+smtp' === $scheme || 'postmark+smtps' === $scheme || 'postmark' === $scheme) {

--- a/src/Symfony/Component/Mailer/Transport/AbstractHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractHttpTransport.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -28,7 +29,7 @@ abstract class AbstractHttpTransport extends AbstractTransport
     protected $port;
     protected $client;
 
-    public function __construct(HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, MessageBusInterface $messageBus = null)
     {
         $this->client = $client;
         if (null === $client) {
@@ -39,7 +40,7 @@ abstract class AbstractHttpTransport extends AbstractTransport
             $this->client = HttpClient::create();
         }
 
-        parent::__construct($dispatcher, $logger);
+        parent::__construct($dispatcher, $logger, $messageBus);
     }
 
     /**

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Event\SentMessageEvent;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\BodyRendererInterface;
 use Symfony\Component\Mime\RawMessage;
@@ -31,13 +32,15 @@ use Symfony\Component\Mime\RawMessage;
 abstract class AbstractTransport implements TransportInterface
 {
     private ?EventDispatcherInterface $dispatcher;
+    protected ?MessageBusInterface $messageBus;
     private LoggerInterface $logger;
     private float $rate = 0;
     private float $lastSent = 0;
 
-    public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, MessageBusInterface $messageBus = null)
     {
         $this->dispatcher = $dispatcher;
+        $this->messageBus = $messageBus;
         $this->logger = $logger ?? new NullLogger();
     }
 

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransportFactory.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Transport;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\IncompleteDsnException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -24,12 +25,14 @@ abstract class AbstractTransportFactory implements TransportFactoryInterface
     protected $dispatcher;
     protected $client;
     protected $logger;
+    protected $messageBus;
 
-    public function __construct(EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null)
+    public function __construct(EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null, MessageBusInterface $messageBus = null)
     {
         $this->dispatcher = $dispatcher;
         $this->client = $client;
         $this->logger = $logger;
+        $this->messageBus = $messageBus;
     }
 
     public function supports(Dsn $dsn): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50165 
| License       | MIT
| Doc PR        | 

When sending an email through Postmark to an email address that has been added to the suppression list, the API call returns an exception.

This PR wants to catch this exception and dispatch a message notifying of a `MailerDeliveryEvent::DROPPED` to simulate a webhook behaviour as for other providers such as Mailgun.
