### PR TITLE
[Dotenv] Add comment to `parse()` method

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -222,6 +222,8 @@ final class Dotenv
      * @param string $data The data to be parsed
      * @param string $path The original file name where data where stored (used for more meaningful error messages)
      *
+     * @return the array with all parsed data from env file
+     *
      * @throws FormatException when a file has a syntax error
      */
     public function parse(string $data, string $path = '.env'): array

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -222,7 +222,7 @@ final class Dotenv
      * @param string $data The data to be parsed
      * @param string $path The original file name where data where stored (used for more meaningful error messages)
      *
-     * @return the array with all parsed data from env file
+     * @return array the array with all parsed data from env file
      *
      * @throws FormatException when a file has a syntax error
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| Deprecations? | no
| License       | MIT

Add a way to get parsed values for the given `.env` file. Help to parse env files without needing to change `$_ENV` variables.