### PR TITLE
[HttpClient][HttpFoundation][HttpKernel][Ldap][Mailer][Mime][Process][Routing][Security][Serializer][Translation][Validator] Add missing return types

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -7188,7 +7188,7 @@ index 9d7012de35..545339d4ef 100644
      {
          unset($this->parameters[$key]);
 diff --git a/src/Symfony/Component/HttpFoundation/Request.php b/src/Symfony/Component/HttpFoundation/Request.php
-index cf7e56f13e..e07d5fab79 100644
+index 633b4a63e2..b69b8cc723 100644
 --- a/src/Symfony/Component/HttpFoundation/Request.php
 +++ b/src/Symfony/Component/HttpFoundation/Request.php
 @@ -269,5 +269,5 @@ class Request
@@ -7275,7 +7275,14 @@ index cf7e56f13e..e07d5fab79 100644
 +    public function setLocale(string $locale): void
      {
          $this->setPhpDefaultLocale($this->locale = $locale);
-@@ -1904,5 +1904,5 @@ class Request
+@@ -1736,5 +1736,5 @@ class Request
+      * @return string
+      */
+-    protected function prepareRequestUri()
++    protected function prepareRequestUri(): string
+     {
+         $requestUri = '';
+@@ -1907,5 +1907,5 @@ class Request
       * @return void
       */
 -    protected static function initializeFormats()
@@ -8225,6 +8232,16 @@ index 1924b1ddb0..62c58c8e8b 100644
 +    public function process(ContainerBuilder $container): void
      {
          $annotatedClasses = [];
+diff --git a/src/Symfony/Component/HttpKernel/DependencyInjection/ConfigurableExtension.php b/src/Symfony/Component/HttpKernel/DependencyInjection/ConfigurableExtension.php
+index 12d468cf04..2ca89c128e 100644
+--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ConfigurableExtension.php
++++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ConfigurableExtension.php
+@@ -38,4 +38,4 @@ abstract class ConfigurableExtension extends Extension
+      * @return void
+      */
+-    abstract protected function loadInternal(array $mergedConfig, ContainerBuilder $container);
++    abstract protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void;
+ }
 diff --git a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
 index dff3e248ae..381db9aa8f 100644
 --- a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
@@ -9845,12 +9862,12 @@ index 70fa786331..f27afd0f01 100644
      {
          if ($container->has('mime_types')) {
 diff --git a/src/Symfony/Component/Mime/Email.php b/src/Symfony/Component/Mime/Email.php
-index 97f5ded24d..05e3ed5202 100644
+index 7f3496d1fc..be6a1eff61 100644
 --- a/src/Symfony/Component/Mime/Email.php
 +++ b/src/Symfony/Component/Mime/Email.php
-@@ -397,5 +397,5 @@ class Email extends Message
-     }
- 
+@@ -400,5 +400,5 @@ class Email extends Message
+      * @return void
+      */
 -    public function ensureValidity()
 +    public function ensureValidity(): void
      {
@@ -10013,18 +10030,36 @@ index b429812176..21aec2b9e8 100644
 +    public function addAllowedTypes(string $option, string|array $allowedTypes): static
      {
          if ($this->locked) {
+diff --git a/src/Symfony/Component/Process/Exception/ProcessFailedException.php b/src/Symfony/Component/Process/Exception/ProcessFailedException.php
+index cf006daebf..51b1ccb810 100644
+--- a/src/Symfony/Component/Process/Exception/ProcessFailedException.php
++++ b/src/Symfony/Component/Process/Exception/ProcessFailedException.php
+@@ -51,5 +51,5 @@ class ProcessFailedException extends RuntimeException
+      * @return Process
+      */
+-    public function getProcess()
++    public function getProcess(): Process
+     {
+         return $this->process;
 diff --git a/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php b/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
-index 27ce7fd430..708e611502 100644
+index e507ca3099..75b5f010b8 100644
 --- a/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
 +++ b/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
-@@ -47,5 +47,5 @@ class ProcessTimedOutException extends RuntimeException
+@@ -42,5 +42,5 @@ class ProcessTimedOutException extends RuntimeException
+      * @return Process
+      */
+-    public function getProcess()
++    public function getProcess(): Process
+     {
+         return $this->process;
+@@ -50,5 +50,5 @@ class ProcessTimedOutException extends RuntimeException
       * @return bool
       */
 -    public function isGeneralTimeout()
 +    public function isGeneralTimeout(): bool
      {
          return self::TYPE_GENERAL === $this->timeoutType;
-@@ -55,5 +55,5 @@ class ProcessTimedOutException extends RuntimeException
+@@ -58,5 +58,5 @@ class ProcessTimedOutException extends RuntimeException
       * @return bool
       */
 -    public function isIdleTimeout()
@@ -10092,6 +10127,38 @@ index ef54a3d2b0..d084e5ba24 100644
 +    public function start(callable $callback = null, array $env = []): void
      {
          if (null === $this->getCommandLine()) {
+diff --git a/src/Symfony/Component/Process/Process.php b/src/Symfony/Component/Process/Process.php
+index 2f4b5a24cc..afe03a912a 100644
+--- a/src/Symfony/Component/Process/Process.php
++++ b/src/Symfony/Component/Process/Process.php
+@@ -292,5 +292,5 @@ class Process implements \IteratorAggregate
+      * @throws LogicException   In case a callback is provided and output has been disabled
+      */
+-    public function start(callable $callback = null, array $env = [])
++    public function start(callable $callback = null, array $env = []): void
+     {
+         if ($this->isRunning()) {
+@@ -1147,5 +1147,5 @@ class Process implements \IteratorAggregate
+      * @throws ProcessTimedOutException In case the timeout was reached
+      */
+-    public function checkTimeout()
++    public function checkTimeout(): void
+     {
+         if (self::STATUS_STARTED !== $this->status) {
+@@ -1188,5 +1188,5 @@ class Process implements \IteratorAggregate
+      * @return void
+      */
+-    public function setOptions(array $options)
++    public function setOptions(array $options): void
+     {
+         if ($this->isRunning()) {
+@@ -1285,5 +1285,5 @@ class Process implements \IteratorAggregate
+      * @return void
+      */
+-    protected function updateStatus(bool $blocking)
++    protected function updateStatus(bool $blocking): void
+     {
+         if (self::STATUS_STARTED !== $this->status) {
 diff --git a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
 index c9125af216..bcd044de52 100644
 --- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -10438,7 +10505,7 @@ index e3fb17e81c..cd27f3e387 100644
      {
          $this->strictRequirements = $enabled;
 diff --git a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
-index b06c649885..e98945cb7d 100644
+index decd2a2b1d..a37965ed5b 100644
 --- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
 +++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
 @@ -96,5 +96,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
@@ -10483,6 +10550,13 @@ index b06c649885..e98945cb7d 100644
 +    protected function createRoute(string $path, array $defaults, array $requirements, array $options, ?string $host, array $schemes, array $methods, ?string $condition): Route
      {
          return new Route($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
+@@ -362,5 +362,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
+      * @return void
+      */
+-    abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot);
++    abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void;
+ 
+     /**
 diff --git a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
 index 24ec21bb5c..1dac35dc8e 100644
 --- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -10563,7 +10637,7 @@ index 417f156415..75d770d852 100644
      {
          $this->request = $request;
 diff --git a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
-index 062be150b8..7c925fbbdb 100644
+index d1cee21377..19e949fbc6 100644
 --- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
 +++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
 @@ -66,5 +66,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
@@ -10580,6 +10654,13 @@ index 062be150b8..7c925fbbdb 100644
 +    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider): void
      {
          $this->expressionLanguageProviders[] = $provider;
+@@ -259,5 +259,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
+      * @return ExpressionLanguage
+      */
+-    protected function getExpressionLanguage()
++    protected function getExpressionLanguage(): ExpressionLanguage
+     {
+         if (null === $this->expressionLanguage) {
 diff --git a/src/Symfony/Component/Routing/RequestContextAwareInterface.php b/src/Symfony/Component/Routing/RequestContextAwareInterface.php
 index 04acbdc800..eedb53c594 100644
 --- a/src/Symfony/Component/Routing/RequestContextAwareInterface.php
@@ -10687,7 +10768,7 @@ index f244e62bed..a5e918317c 100644
      {
          $key = (string) $resource;
 diff --git a/src/Symfony/Component/Routing/Router.php b/src/Symfony/Component/Routing/Router.php
-index b41dd55ef0..c03c3888cd 100644
+index 3fa13457b2..efcbc4219f 100644
 --- a/src/Symfony/Component/Routing/Router.php
 +++ b/src/Symfony/Component/Routing/Router.php
 @@ -121,5 +121,5 @@ class Router implements RouterInterface, RequestMatcherInterface
@@ -10704,28 +10785,28 @@ index b41dd55ef0..c03c3888cd 100644
 +    public function setOption(string $key, mixed $value): void
      {
          if (!\array_key_exists($key, $this->options)) {
-@@ -179,5 +179,5 @@ class Router implements RouterInterface, RequestMatcherInterface
-     }
- 
+@@ -182,5 +182,5 @@ class Router implements RouterInterface, RequestMatcherInterface
+      * @return RouteCollection
+      */
 -    public function getRouteCollection()
 +    public function getRouteCollection(): RouteCollection
      {
          return $this->collection ??= $this->loader->load($this->resource, $this->options['resource_type']);
-@@ -187,5 +187,5 @@ class Router implements RouterInterface, RequestMatcherInterface
+@@ -190,5 +190,5 @@ class Router implements RouterInterface, RequestMatcherInterface
       * @return void
       */
 -    public function setContext(RequestContext $context)
 +    public function setContext(RequestContext $context): void
      {
          $this->context = $context;
-@@ -209,5 +209,5 @@ class Router implements RouterInterface, RequestMatcherInterface
+@@ -212,5 +212,5 @@ class Router implements RouterInterface, RequestMatcherInterface
       * @return void
       */
 -    public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
 +    public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory): void
      {
          $this->configCacheFactory = $configCacheFactory;
-@@ -315,5 +315,5 @@ class Router implements RouterInterface, RequestMatcherInterface
+@@ -318,5 +318,5 @@ class Router implements RouterInterface, RequestMatcherInterface
       * @return void
       */
 -    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
@@ -11064,10 +11145,17 @@ index a493b00e79..377dcacc09 100644
      {
      }
 diff --git a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
-index ed6c2d8b38..7b61505fd5 100644
+index e0aef90a14..651578d1f1 100644
 --- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
 +++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
-@@ -98,5 +98,5 @@ class InMemoryUserProvider implements UserProviderInterface
+@@ -55,5 +55,5 @@ class InMemoryUserProvider implements UserProviderInterface
+      * @throws \LogicException
+      */
+-    public function createUser(UserInterface $user)
++    public function createUser(UserInterface $user): void
+     {
+         if (!$user instanceof InMemoryUser) {
+@@ -100,5 +100,5 @@ class InMemoryUserProvider implements UserProviderInterface
       * @throws UserNotFoundException if user whose given username does not exist
       */
 -    private function getUser(string $username): UserInterface
@@ -11265,7 +11353,7 @@ index 513b6494e5..c0211b6e39 100644
      {
          /** @var IsGranted[] $attributes */
 diff --git a/src/Symfony/Component/Security/Http/Firewall.php b/src/Symfony/Component/Security/Http/Firewall.php
-index fc56733efa..8538f5f821 100644
+index f2f86a5dfa..bd47629587 100644
 --- a/src/Symfony/Component/Security/Http/Firewall.php
 +++ b/src/Symfony/Component/Security/Http/Firewall.php
 @@ -51,5 +51,5 @@ class Firewall implements EventSubscriberInterface
@@ -11282,14 +11370,14 @@ index fc56733efa..8538f5f821 100644
 +    public function onKernelFinishRequest(FinishRequestEvent $event): void
      {
          $request = $event->getRequest();
-@@ -109,5 +109,5 @@ class Firewall implements EventSubscriberInterface
-     }
- 
+@@ -112,5 +112,5 @@ class Firewall implements EventSubscriberInterface
+      * @return array
+      */
 -    public static function getSubscribedEvents()
 +    public static function getSubscribedEvents(): array
      {
          return [
-@@ -120,5 +120,5 @@ class Firewall implements EventSubscriberInterface
+@@ -123,5 +123,5 @@ class Firewall implements EventSubscriberInterface
       * @return void
       */
 -    protected function callListeners(RequestEvent $event, iterable $listeners)
@@ -11521,55 +11609,65 @@ index 61b14a1a80..f745caaada 100644
      {
          if (null !== $object = $this->extractObjectToPopulate($class, $context, self::OBJECT_TO_POPULATE)) {
 diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
-index 16b2bb70af..e1a7dd2df1 100644
+index ed42d56f40..9cf5a883b3 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
-@@ -141,10 +141,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
-      * @param array $context
+@@ -143,5 +143,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      * @return bool
       */
 -    public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */)
 +    public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */): bool
      {
          return \is_object($data) && !$data instanceof \Traversable;
-     }
- 
+@@ -151,5 +151,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      * @return array|string|int|float|bool|\ArrayObject|null
+      */
 -    public function normalize(mixed $object, string $format = null, array $context = [])
 +    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
      {
          if (!isset($context['cache_key'])) {
-@@ -227,5 +227,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
-     }
- 
+@@ -235,5 +235,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      * @return object
+      */
 -    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
 +    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null): object
      {
          if ($this->classDiscriminatorResolver && $mapping = $this->classDiscriminatorResolver->getMappingForClass($class)) {
-@@ -289,5 +289,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -297,5 +297,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
       * @return string[]
       */
 -    abstract protected function extractAttributes(object $object, string $format = null, array $context = []);
 +    abstract protected function extractAttributes(object $object, string $format = null, array $context = []): array;
  
      /**
-@@ -296,15 +296,15 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -304,5 +304,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
       * @return mixed
       */
 -    abstract protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = []);
 +    abstract protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = []): mixed;
  
      /**
-      * @param array $context
+@@ -311,5 +311,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      * @return bool
       */
 -    public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */)
 +    public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */): bool
      {
          return class_exists($type) || (interface_exists($type, false) && null !== $this->classDiscriminatorResolver?->getMappingForClass($type));
-     }
- 
+@@ -319,5 +319,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      * @return mixed
+      */
 -    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
 +    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
      {
          if (!isset($context['cache_key'])) {
+@@ -424,5 +424,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      * @return void
+      */
+-    abstract protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = []);
++    abstract protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = []): void;
+ 
+     /**
 diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
 index 503f3cb518..78f48e086d 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
@@ -11702,9 +11800,30 @@ index 1835568745..2b98fc11d6 100644
      {
          $this->serializer = $serializer;
 diff --git a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
-index df0b6121ea..7441f9fd6e 100644
+index df0b6121ea..37ca485e88 100644
 --- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
 +++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+@@ -592,5 +592,5 @@ class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
+     }
+ 
+-    protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = [])
++    protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = []): void
+     {
+         $object->$attribute = $value;
+@@ -720,5 +720,5 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
+     }
+ 
+-    protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = [])
++    protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = []): void
+     {
+         $object->$attribute = $value;
+@@ -839,5 +839,5 @@ class AbstractObjectNormalizerCollectionDummy extends AbstractObjectNormalizer
+     }
+ 
+-    protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = [])
++    protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = []): void
+     {
+         $object->$attribute = $value;
 @@ -896,5 +896,5 @@ class ArrayDenormalizerDummy implements DenormalizerInterface, SerializerAwareIn
      }
  
@@ -11923,6 +12042,16 @@ index 539bcbce14..a172cd2ed4 100644
 -    public function stream(string|TemplateReferenceInterface $name, array $parameters = []);
 +    public function stream(string|TemplateReferenceInterface $name, array $parameters = []): void;
  }
+diff --git a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+index 65eea0bb9b..12e30f4cf5 100644
+--- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
++++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+@@ -187,4 +187,4 @@ abstract class AbstractOperation implements OperationInterface
+      * @return void
+      */
+-    abstract protected function processDomain(string $domain);
++    abstract protected function processDomain(string $domain): void;
+ }
 diff --git a/src/Symfony/Component/Translation/Catalogue/MergeOperation.php b/src/Symfony/Component/Translation/Catalogue/MergeOperation.php
 index 1b777a8435..804cc138fc 100644
 --- a/src/Symfony/Component/Translation/Catalogue/MergeOperation.php
@@ -11963,7 +12092,7 @@ index c845959f1a..faa5b0b34e 100644
 +    public function deleteCatalogueMetadata(string $key = '', string $domain = 'messages'): void;
  }
 diff --git a/src/Symfony/Component/Translation/Command/XliffLintCommand.php b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
-index 91001c5644..cfeb6c1fdc 100644
+index ba68635db7..fd3b32a02a 100644
 --- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
 +++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
 @@ -54,5 +54,5 @@ class XliffLintCommand extends Command
@@ -12126,7 +12255,7 @@ index 642130af75..c9ae2693a4 100644
 +    public function setPrefix(string $prefix): void;
  }
 diff --git a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
-index 6b59c7cacc..50c1eba7c6 100644
+index 7ff27f7c80..495067ed2e 100644
 --- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
 +++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
 @@ -136,5 +136,5 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
@@ -12143,6 +12272,13 @@ index 6b59c7cacc..50c1eba7c6 100644
 +    public function setPrefix(string $prefix): void
      {
          $this->prefix = $prefix;
+@@ -265,5 +265,5 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
+      * @return void
+      */
+-    protected function parseTokens(array $tokens, MessageCatalogue $catalog, string $filename)
++    protected function parseTokens(array $tokens, MessageCatalogue $catalog, string $filename): void
+     {
+         $tokenIterator = new \ArrayIterator($tokens);
 diff --git a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
 index 7f2f96be64..266c7f48c9 100644
 --- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -12870,7 +13006,7 @@ index 644bbf70cb..4a1336e78b 100644
      {
          if (!$constraint instanceof IsTrue) {
 diff --git a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
-index c6445b16a5..50d738bdc9 100644
+index 3a64f11cf6..b271a2e1df 100644
 --- a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
 +++ b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
 @@ -31,5 +31,5 @@ class IsbnValidator extends ConstraintValidator
@@ -12894,6 +13030,13 @@ index c6445b16a5..50d738bdc9 100644
 +    protected function validateIsbn13(string $isbn): string|bool
      {
          // Error priority:
+@@ -179,5 +179,5 @@ class IsbnValidator extends ConstraintValidator
+      * @return string
+      */
+-    protected function getMessage(Isbn $constraint, string $type = null)
++    protected function getMessage(Isbn $constraint, string $type = null): string
+     {
+         if (null !== $constraint->message) {
 diff --git a/src/Symfony/Component/Validator/Constraints/IsinValidator.php b/src/Symfony/Component/Validator/Constraints/IsinValidator.php
 index 21539cbcb7..86d85efe95 100644
 --- a/src/Symfony/Component/Validator/Constraints/IsinValidator.php
@@ -13213,6 +13356,17 @@ index a7eda1457d..28630f205f 100644
 +    public function getOptions(): array
      {
          return $this->options;
+diff --git a/src/Symfony/Component/Validator/Exception/ValidationFailedException.php b/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
+index 2106e0a0ba..0b64f07c89 100644
+--- a/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
++++ b/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
+@@ -32,5 +32,5 @@ class ValidationFailedException extends RuntimeException
+      * @return mixed
+      */
+-    public function getValue()
++    public function getValue(): mixed
+     {
+         return $this->value;
 diff --git a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
 index f5f084f2ed..b0f6545ab0 100644
 --- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -14693,17 +14847,6 @@ index c1a77ad157..1e926dc83a 100644
 +    public function setParsedLine(int $parsedLine): void
      {
          $this->parsedLine = $parsedLine;
-diff --git a/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php b/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
-index 88f6a0687a..a0f20a6a7c 100644
---- a/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
-+++ b/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
-@@ -16,5 +16,5 @@ use Psr\Container\ContainerInterface;
- use Symfony\Contracts\Service\ServiceLocatorTrait;
- 
--abstract class ServiceLocatorTest extends TestCase
-+abstract class ServiceLocatorTestCase extends TestCase
- {
-     protected function getServiceLocator(array $factories): ContainerInterface
 diff --git a/src/Symfony/Contracts/Translation/LocaleAwareInterface.php b/src/Symfony/Contracts/Translation/LocaleAwareInterface.php
 index db40ba13e0..48928ca959 100644
 --- a/src/Symfony/Contracts/Translation/LocaleAwareInterface.php

--- a/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
+++ b/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
@@ -32,7 +32,7 @@ class StreamWrapper
     /** @var resource|string|null */
     private $content;
 
-    /** @var resource|null */
+    /** @var resource|callable|null */
     private $handle;
 
     private bool $blocking = true;
@@ -266,6 +266,9 @@ class StreamWrapper
         return false;
     }
 
+    /**
+     * @return resource|false
+     */
     public function stream_cast(int $castAs)
     {
         if (\STREAM_CAST_FOR_SELECT === $castAs) {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1732,6 +1732,9 @@ class Request
      * Copyright (c) 2005-2010 Zend Technologies USA Inc. (https://www.zend.com/)
      */
 
+    /**
+     * @return string
+     */
     protected function prepareRequestUri()
     {
         $requestUri = '';

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ConfigurableExtension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ConfigurableExtension.php
@@ -34,6 +34,8 @@ abstract class ConfigurableExtension extends Extension
 
     /**
      * Configures the passed container according to the merged configuration.
+     *
+     * @return void
      */
     abstract protected function loadInternal(array $mergedConfig, ContainerBuilder $container);
 }

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -167,7 +167,7 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
         return new LdapUser($entry, $identifier, $password, $this->defaultRoles, $extraFields);
     }
 
-    private function getAttributeValue(Entry $entry, string $attribute)
+    private function getAttributeValue(Entry $entry, string $attribute): mixed
     {
         if (!$entry->hasAttribute($attribute)) {
             throw new InvalidArgumentException(sprintf('Missing attribute "%s" for user "%s".', $attribute, $entry->getDn()));

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -199,7 +199,7 @@ class MailjetApiTransport extends AbstractApiTransport
         return ($this->host ?: self::HOST).($this->port ? ':'.$this->port : '');
     }
 
-    private function castCustomHeader(string $value, string $type)
+    private function castCustomHeader(string $value, string $type): mixed
     {
         return match ($type) {
             'bool' => filter_var($value, \FILTER_VALIDATE_BOOL),

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -396,6 +396,9 @@ class Email extends Message
         return $this->generateBody();
     }
 
+    /**
+     * @return void
+     */
     public function ensureValidity()
     {
         $this->ensureBodyValid();

--- a/src/Symfony/Component/Process/Exception/ProcessFailedException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessFailedException.php
@@ -47,6 +47,9 @@ class ProcessFailedException extends RuntimeException
         $this->process = $process;
     }
 
+    /**
+     * @return Process
+     */
     public function getProcess()
     {
         return $this->process;

--- a/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
@@ -38,6 +38,9 @@ class ProcessTimedOutException extends RuntimeException
         ));
     }
 
+    /**
+     * @return Process
+     */
     public function getProcess()
     {
         return $this->process;
@@ -59,7 +62,7 @@ class ProcessTimedOutException extends RuntimeException
         return self::TYPE_IDLE === $this->timeoutType;
     }
 
-    public function getExceededTimeout()
+    public function getExceededTimeout(): ?float
     {
         return match ($this->timeoutType) {
             self::TYPE_GENERAL => $this->process->getTimeout(),

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -285,6 +285,8 @@ class Process implements \IteratorAggregate
      * @param callable|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR
      *
+     * @return void
+     *
      * @throws RuntimeException When process can't be launched
      * @throws RuntimeException When process is already running
      * @throws LogicException   In case a callback is provided and output has been disabled
@@ -1140,6 +1142,8 @@ class Process implements \IteratorAggregate
      * In case you run a background process (with the start method), you should
      * trigger this method regularly to ensure the process timeout
      *
+     * @return void
+     *
      * @throws ProcessTimedOutException In case the timeout was reached
      */
     public function checkTimeout()
@@ -1180,6 +1184,8 @@ class Process implements \IteratorAggregate
      *
      * Enabling the "create_new_console" option allows a subprocess to continue
      * to run after the main process exited, on both Windows and *nix
+     *
+     * @return void
      */
     public function setOptions(array $options)
     {
@@ -1275,6 +1281,8 @@ class Process implements \IteratorAggregate
      * Updates the status of the process, reads pipes.
      *
      * @param bool $blocking Whether to use a blocking read call
+     *
+     * @return void
      */
     protected function updateStatus(bool $blocking)
     {
@@ -1323,7 +1331,7 @@ class Process implements \IteratorAggregate
      *
      * @throws LogicException in case output has been disabled or process is not started
      */
-    private function readPipesForOutput(string $caller, bool $blocking = false)
+    private function readPipesForOutput(string $caller, bool $blocking = false): void
     {
         if ($this->outputDisabled) {
             throw new LogicException('Output has been disabled.');
@@ -1358,7 +1366,7 @@ class Process implements \IteratorAggregate
      * @param bool $blocking Whether to use blocking calls or not
      * @param bool $close    Whether to close file handles or not
      */
-    private function readPipes(bool $blocking, bool $close)
+    private function readPipes(bool $blocking, bool $close): void
     {
         $result = $this->processPipes->readAndWrite($blocking, $close);
 
@@ -1407,7 +1415,7 @@ class Process implements \IteratorAggregate
     /**
      * Resets data related to the latest run of the process.
      */
-    private function resetProcessData()
+    private function resetProcessData(): void
     {
         $this->starttime = null;
         $this->callback = null;
@@ -1528,7 +1536,7 @@ class Process implements \IteratorAggregate
      *
      * @throws LogicException if the process has not run
      */
-    private function requireProcessIsStarted(string $functionName)
+    private function requireProcessIsStarted(string $functionName): void
     {
         if (!$this->isStarted()) {
             throw new LogicException(sprintf('Process must be started before calling "%s()".', $functionName));
@@ -1540,7 +1548,7 @@ class Process implements \IteratorAggregate
      *
      * @throws LogicException if the process is not yet terminated
      */
-    private function requireProcessIsTerminated(string $functionName)
+    private function requireProcessIsTerminated(string $functionName): void
     {
         if (!$this->isTerminated()) {
             throw new LogicException(sprintf('Process must be terminated before calling "%s()".', $functionName));

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -358,6 +358,9 @@ abstract class AnnotationClassLoader implements LoaderInterface
         return new Route($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
     }
 
+    /**
+     * @return void
+     */
     abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot);
 
     /**

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -255,6 +255,9 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
         return $defaults;
     }
 
+    /**
+     * @return ExpressionLanguage
+     */
     protected function getExpressionLanguage()
     {
         if (null === $this->expressionLanguage) {

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -178,6 +178,9 @@ class Router implements RouterInterface, RequestMatcherInterface
         return $this->options[$key];
     }
 
+    /**
+     * @return RouteCollection
+     */
     public function getRouteCollection()
     {
         return $this->collection ??= $this->loader->load($this->resource, $this->options['resource_type']);

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -312,7 +312,7 @@ class PhpFileLoaderTest extends TestCase
             $loader = new PhpFileLoader($locator),
             new Psr4DirectoryLoader($locator),
             new class() extends AnnotationClassLoader {
-                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
                 }
@@ -337,7 +337,7 @@ class PhpFileLoaderTest extends TestCase
         new LoaderResolver([
             $loader = new PhpFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
             new class() extends AnnotationClassLoader {
-                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
                 }

--- a/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
@@ -106,7 +106,7 @@ class Psr4DirectoryLoaderTest extends TestCase
             new LoaderResolver([
                 new Psr4DirectoryLoader($locator),
                 new class() extends AnnotationClassLoader {
-                    protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                    protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                     {
                         $route->setDefault('_controller', $class->getName().'::'.$method->getName());
                     }

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -607,7 +607,7 @@ class XmlFileLoaderTest extends TestCase
             $loader = new XmlFileLoader($locator),
             new Psr4DirectoryLoader($locator),
             new class() extends AnnotationClassLoader {
-                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
                 }
@@ -632,7 +632,7 @@ class XmlFileLoaderTest extends TestCase
         new LoaderResolver([
             $loader = new XmlFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
             new class() extends AnnotationClassLoader {
-                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
                 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -473,7 +473,7 @@ class YamlFileLoaderTest extends TestCase
             $loader = new YamlFileLoader($locator),
             new Psr4DirectoryLoader($locator),
             new class() extends AnnotationClassLoader {
-                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
                 }
@@ -498,7 +498,7 @@ class YamlFileLoaderTest extends TestCase
         new LoaderResolver([
             $loader = new YamlFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
             new class() extends AnnotationClassLoader {
-                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
                 }

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
@@ -50,6 +50,8 @@ class InMemoryUserProvider implements UserProviderInterface
     /**
      * Adds a new User to the provider.
      *
+     * @return void
+     *
      * @throws \LogicException
      */
     public function createUser(UserInterface $user)

--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -108,6 +108,9 @@ class Firewall implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return [

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -139,12 +139,17 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     /**
      * @param array $context
+     *
+     * @return bool
      */
     public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */)
     {
         return \is_object($data) && !$data instanceof \Traversable;
     }
 
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
     public function normalize(mixed $object, string $format = null, array $context = [])
     {
         if (!isset($context['cache_key'])) {
@@ -226,6 +231,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         return $data;
     }
 
+    /**
+     * @return object
+     */
     protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
     {
         if ($this->classDiscriminatorResolver && $mapping = $this->classDiscriminatorResolver->getMappingForClass($class)) {
@@ -299,12 +307,17 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     /**
      * @param array $context
+     *
+     * @return bool
      */
     public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */)
     {
         return class_exists($type) || (interface_exists($type, false) && null !== $this->classDiscriminatorResolver?->getMappingForClass($type));
     }
 
+    /**
+     * @return mixed
+     */
     public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
     {
         if (!isset($context['cache_key'])) {
@@ -408,7 +421,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     }
 
     /**
-     * Sets attribute value.
+     * @return void
      */
     abstract protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = []);
 

--- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
@@ -183,6 +183,8 @@ abstract class AbstractOperation implements OperationInterface
      * stores the results.
      *
      * @param string $domain The domain which the operation will be performed for
+     *
+     * @return void
      */
     abstract protected function processDomain(string $domain);
 }

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -154,7 +154,7 @@ EOF
         return ['file' => $file, 'valid' => 0 === \count($errors), 'messages' => $errors];
     }
 
-    private function display(SymfonyStyle $io, array $files)
+    private function display(SymfonyStyle $io, array $files): int
     {
         return match ($this->format) {
             'txt' => $this->displayTxt($io, $files),
@@ -196,7 +196,7 @@ EOF
         return min($erroredFiles, 1);
     }
 
-    private function displayJson(SymfonyStyle $io, array $filesInfo)
+    private function displayJson(SymfonyStyle $io, array $filesInfo): int
     {
         $errors = 0;
 
@@ -212,6 +212,9 @@ EOF
         return min($errors, 1);
     }
 
+    /**
+     * @return iterable<\SplFileInfo>
+     */
     private function getFiles(string $fileOrDirectory): iterable
     {
         if (is_file($fileOrDirectory)) {
@@ -229,7 +232,10 @@ EOF
         }
     }
 
-    private function getDirectoryIterator(string $directory)
+    /**
+     * @return iterable<\SplFileInfo>
+     */
+    private function getDirectoryIterator(string $directory): iterable
     {
         $default = fn ($directory) => new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),
@@ -243,7 +249,7 @@ EOF
         return $default($directory);
     }
 
-    private function isReadable(string $fileOrDirectory)
+    private function isReadable(string $fileOrDirectory): bool
     {
         $default = fn ($fileOrDirectory) => is_readable($fileOrDirectory);
 

--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -168,7 +168,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
     /**
      * Seeks to a non-whitespace token.
      */
-    private function seekToNextRelevantToken(\Iterator $tokenIterator)
+    private function seekToNextRelevantToken(\Iterator $tokenIterator): void
     {
         for (; $tokenIterator->valid(); $tokenIterator->next()) {
             $t = $tokenIterator->current();
@@ -178,7 +178,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
         }
     }
 
-    private function skipMethodArgument(\Iterator $tokenIterator)
+    private function skipMethodArgument(\Iterator $tokenIterator): void
     {
         $openBraces = 0;
 
@@ -261,6 +261,8 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
 
     /**
      * Extracts trans message from PHP tokens.
+     *
+     * @return void
      */
     protected function parseTokens(array $tokens, MessageCatalogue $catalog, string $filename)
     {

--- a/src/Symfony/Component/Translation/Util/ArrayConverter.php
+++ b/src/Symfony/Component/Translation/Util/ArrayConverter.php
@@ -46,7 +46,7 @@ class ArrayConverter
         return $tree;
     }
 
-    private static function &getElementByPath(array &$tree, array $parts)
+    private static function &getElementByPath(array &$tree, array $parts): mixed
     {
         $elem = &$tree;
         $parentOfElem = null;

--- a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
@@ -175,6 +175,9 @@ class IsbnValidator extends ConstraintValidator
         return 0 === $checkSum % 10 ? true : Isbn::CHECKSUM_FAILED_ERROR;
     }
 
+    /**
+     * @return string
+     */
     protected function getMessage(Isbn $constraint, string $type = null)
     {
         if (null !== $constraint->message) {

--- a/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
+++ b/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
@@ -28,6 +28,9 @@ class ValidationFailedException extends RuntimeException
         parent::__construct($violations);
     }
 
+    /**
+     * @return mixed
+     */
     public function getValue()
     {
         return $this->value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Ref #47551
| License       | MIT
| Doc PR        | -

Last one, for the components. Only some bundle methods are missing now.