### PR TITLE
[Serializer] backed enum throw notNormalizableValueException outside construct method

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -342,6 +342,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
         $constructor = $this->getConstructor($data, $class, $context, $reflectionClass, $allowedAttributes);
         if ($constructor) {
+            $context['has_constructor'] = true;
             if (true !== $constructor->isPublic()) {
                 return $reflectionClass->newInstanceWithoutConstructor();
             }
@@ -430,6 +431,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                 return $constructor->invokeArgs(null, $params);
             }
         }
+
+        unset($context['has_constructor']);
 
         return new $class();
     }

--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -64,7 +64,11 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
         try {
             return $type::from($data);
         } catch (\ValueError $e) {
-            throw new InvalidArgumentException('The data must belong to a backed enumeration of type '.$type);
+            if (isset($context['has_constructor'])) {
+                throw new InvalidArgumentException('The data must belong to a backed enumeration of type '.$type);
+            }
+
+            throw NotNormalizableValueException::createForUnexpectedDataType('The data must belong to a backed enumeration of type '.$type, $data, [$type], $context['deserialization_path'] ?? null, true, 0, $e);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyObjectWithEnumProperty.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyObjectWithEnumProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy;
+
+class DummyObjectWithEnumProperty
+{
+    public StringBackedEnumDummy $get;
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -115,7 +115,7 @@ class BackedEnumNormalizerTest extends TestCase
      */
     public function testDenormalizeBadBackingValueThrowsException()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(NotNormalizableValueException::class);
         $this->expectExceptionMessage('The data must belong to a backed enumeration of type '.StringBackedEnumDummy::class);
 
         $this->normalizer->denormalize('POST', StringBackedEnumDummy::class);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -60,6 +60,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumConstructor;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumProperty;
 use Symfony\Component\Serializer\Tests\Fixtures\FalseBuiltInDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Full;
@@ -1230,7 +1231,51 @@ class SerializerTest extends TestCase
     /**
      * @requires PHP 8.1
      */
-    public function testNoCollectDenormalizationErrorsWithWrongEnum()
+    public function testCollectDenormalizationErrorsWithWrongPropertyWithoutConstruct()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
+        $reflectionExtractor = new ReflectionExtractor();
+        $propertyInfoExtractor = new PropertyInfoExtractor([], [$reflectionExtractor], [], [], []);
+
+        $serializer = new Serializer(
+            [
+                new BackedEnumNormalizer(),
+                new ObjectNormalizer($classMetadataFactory, null, null, $propertyInfoExtractor),
+            ],
+            ['json' => new JsonEncoder()]
+        );
+
+        try {
+            $serializer->deserialize('{"get": "POST"}', DummyObjectWithEnumProperty::class, 'json', [
+                 DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+             ]);
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(PartialDenormalizationException::class, $e);
+        }
+
+        $exceptionsAsArray = array_map(function (NotNormalizableValueException $e): array {
+            return [
+                'currentType' => $e->getCurrentType(),
+                'useMessageForUser' => $e->canUseMessageForUser(),
+                'message' => $e->getMessage(),
+            ];
+        }, $e->getErrors());
+
+        $expected = [
+            [
+                'currentType' => 'string',
+                'useMessageForUser' => true,
+                'message' => 'The data must belong to a backed enumeration of type Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy',
+            ],
+        ];
+
+        $this->assertSame($expected, $exceptionsAsArray);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testNoCollectDenormalizationErrorsWithWrongEnumOnConstructor()
     {
         $serializer = new Serializer(
             [
@@ -1241,7 +1286,7 @@ class SerializerTest extends TestCase
         );
 
         try {
-            $serializer->deserialize('{"get": "invalid"}', DummyObjectWithEnumConstructor::class, 'json', [
+            $serializer->deserialize('{"get": "POST"}', DummyObjectWithEnumConstructor::class, 'json', [
                 DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
             ]);
         } catch (\Throwable $th) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/47128#issuecomment-1527776830
| License       | MIT
| Doc PR        | 


PR https://github.com/symfony/symfony/pull/47128#issuecomment-1527776830 was aiming  to throw  an InvalidArgumentException if a constructor's argument is not a valid backedEnum( knowing an error will be thrown in all case e.g when it will be instantiated).

This PR aims to throw a NotNormalizableValueException  (like it was the case before) if an error occurs on an BackedEnum outside the case of the first PR

So we have two different types of exceptions depending on whether it's an error at the constructor level or not.