### PR TITLE
[Serializer] Fix `SerializedPath` not working with constructor arguments

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/SerializedPathInConstructorDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/SerializedPathInConstructorDummy.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\SerializedPath;
+
+class SerializedPathInConstructorDummy
+{
+    public function __construct(
+        /**
+         * @SerializedPath("[one][two]")
+         */
+        public $three,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPathInConstructorDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPathInConstructorDummy.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\SerializedPath;
+
+class SerializedPathInConstructorDummy
+{
+    public function __construct(
+        #[SerializedPath('[one][two]')] public $three,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -30,6 +30,10 @@
         <attribute name="seven" serialized-path="[three][four]" />
     </class>
 
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy">
+        <attribute name="three" serialized-path="[one][two]" />
+    </class>
+
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy">
         <discriminator-map type-property="type">
             <mapping type="first" class="Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild" />

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -22,6 +22,10 @@
       serialized_path: '[one][two]'
     seven:
       serialized_path: '[three][four]'
+'Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy':
+  attributes:
+    three:
+      serialized_path: '[one][two]'
 'Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy':
   discriminator_map:
     type_property: type

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 
 final class ClassMetadataFactoryCompilerTest extends TestCase
@@ -46,18 +47,20 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $maxDepthDummyMetadata = $classMetatadataFactory->getMetadataFor(MaxDepthDummy::class);
         $serializedNameDummyMetadata = $classMetatadataFactory->getMetadataFor(SerializedNameDummy::class);
         $serializedPathDummyMetadata = $classMetatadataFactory->getMetadataFor(SerializedPathDummy::class);
+        $serializedPathInConstructorDummyMetadata = $classMetatadataFactory->getMetadataFor(SerializedPathInConstructorDummy::class);
 
         $code = (new ClassMetadataFactoryCompiler())->compile([
             $dummyMetadata,
             $maxDepthDummyMetadata,
             $serializedNameDummyMetadata,
             $serializedPathDummyMetadata,
+            $serializedPathInConstructorDummyMetadata,
         ]);
 
         file_put_contents($this->dumpPath, $code);
         $compiledMetadata = require $this->dumpPath;
 
-        $this->assertCount(4, $compiledMetadata);
+        $this->assertCount(5, $compiledMetadata);
 
         $this->assertArrayHasKey(Dummy::class, $compiledMetadata);
         $this->assertEquals([
@@ -99,5 +102,13 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
             ],
             null,
         ], $compiledMetadata[SerializedPathDummy::class]);
+
+        $this->assertArrayHasKey(SerializedPathInConstructorDummy::class, $compiledMetadata);
+        $this->assertEquals([
+            [
+                'three' => [[], null, null, '[one][two]'],
+            ],
+            null,
+        ], $compiledMetadata[SerializedPathInConstructorDummy::class]);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
@@ -103,6 +103,15 @@ abstract class AnnotationLoaderTestCase extends TestCase
         $this->assertEquals(new PropertyPath('[three][four]'), $attributesMetadata['seven']->getSerializedPath());
     }
 
+    public function testLoadSerializedPathInConstructor()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace().'\SerializedPathInConstructorDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(new PropertyPath('[one][two]'), $attributesMetadata['three']->getSerializedPath());
+    }
+
     public function testLoadClassMetadataAndMerge()
     {
         $classMetadata = new ClassMetadata($this->getNamespace().'\GroupDummy');

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -94,6 +94,15 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals('[three][four]', $attributesMetadata['seven']->getSerializedPath());
     }
 
+    public function testSerializedPathInConstructor()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals('[one][two]', $attributesMetadata['three']->getSerializedPath());
+    }
+
     public function testLoadDiscriminatorMap()
     {
         $classMetadata = new ClassMetadata(AbstractDummy::class);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -108,6 +108,15 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(new PropertyPath('[three][four]'), $attributesMetadata['seven']->getSerializedPath());
     }
 
+    public function testSerializedPathInConstructor()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(new PropertyPath('[one][two]'), $attributesMetadata['three']->getSerializedPath());
+    }
+
     public function testLoadDiscriminatorMap()
     {
         $classMetadata = new ClassMetadata(AbstractDummy::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Annotation\Context;
+use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Serializer\Annotation\SerializedPath;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
@@ -171,6 +172,53 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizer->denormalize($data, DuplicateKeyNestedDummy::class, 'any');
     }
 
+    public function testDenormalizeWithNestedAttributesInConstructor()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+        $data = [
+            'one' => [
+                'two' => [
+                    'three' => 'foo',
+                ],
+                'four' => 'quux',
+            ],
+            'foo' => 'notfoo',
+            'baz' => 'baz',
+        ];
+        $test = $normalizer->denormalize($data, NestedDummyWithConstructor::class, 'any');
+        $this->assertSame('foo', $test->foo);
+        $this->assertSame('quux', $test->quux);
+        $this->assertSame('notfoo', $test->notfoo);
+        $this->assertSame('baz', $test->baz);
+    }
+
+    public function testDenormalizeWithNestedAttributesInConstructorAndDiscriminatorMap()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+        $data = [
+            'one' => [
+                'two' => [
+                    'three' => 'foo',
+                ],
+                'four' => 'quux',
+            ],
+            'foo' => 'notfoo',
+            'baz' => 'baz',
+        ];
+
+        $test1 = $normalizer->denormalize($data + ['type' => 'first'], AbstractNestedDummyWithConstructorAndDiscriminator::class, 'any');
+        $this->assertInstanceOf(FirstNestedDummyWithConstructorAndDiscriminator::class, $test1);
+        $this->assertSame('foo', $test1->foo);
+        $this->assertSame('notfoo', $test1->notfoo);
+        $this->assertSame('baz', $test1->baz);
+
+        $test2 = $normalizer->denormalize($data + ['type' => 'second'], AbstractNestedDummyWithConstructorAndDiscriminator::class, 'any');
+        $this->assertInstanceOf(SecondNestedDummyWithConstructorAndDiscriminator::class, $test2);
+        $this->assertSame('quux', $test2->quux);
+        $this->assertSame('notfoo', $test2->notfoo);
+        $this->assertSame('baz', $test2->baz);
+    }
+
     public function testNormalizeWithNestedAttributesMixingArrayTypes()
     {
         $this->expectException(LogicException::class);
@@ -234,6 +282,52 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizer = new ObjectNormalizer();
         $test = $normalizer->normalize($foobar, 'any');
         $this->assertSame($data, $test);
+    }
+
+    public function testNormalizeWithNestedAttributesInConstructor()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+
+        $test = $normalizer->normalize(new NestedDummyWithConstructor('foo', 'quux', 'notfoo', 'baz'), 'any');
+        $this->assertSame([
+            'one' => [
+                'two' => [
+                    'three' => 'foo',
+                ],
+                'four' => 'quux',
+            ],
+            'foo' => 'notfoo',
+            'baz' => 'baz',
+        ], $test);
+    }
+
+    public function testNormalizeWithNestedAttributesInConstructorAndDiscriminatorMap()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+
+        $test1 = $normalizer->normalize(new FirstNestedDummyWithConstructorAndDiscriminator('foo', 'notfoo', 'baz'), 'any');
+        $this->assertSame([
+            'type' => 'first',
+            'one' => [
+                'two' => [
+                    'three' => 'foo',
+                ],
+            ],
+            'foo' => 'notfoo',
+            'baz' => 'baz',
+        ], $test1);
+
+        $test2 = $normalizer->normalize(new SecondNestedDummyWithConstructorAndDiscriminator('quux', 'notfoo', 'baz'), 'any');
+        $this->assertSame([
+            'type' => 'second',
+            'one' => [
+                'four' => 'quux',
+            ],
+            'foo' => 'notfoo',
+            'baz' => 'baz',
+        ], $test2);
     }
 
     public function testDenormalizeCollectionDecodedFromXmlWithOneChild()
@@ -661,6 +755,78 @@ class NestedDummy
     public $baz;
 }
 
+class NestedDummyWithConstructor
+{
+    public function __construct(
+        /**
+         * @SerializedPath("[one][two][three]")
+         */
+        public $foo,
+
+        /**
+         * @SerializedPath("[one][four]")
+         */
+        public $quux,
+
+        /**
+         * @SerializedPath("[foo]")
+         */
+        public $notfoo,
+
+        public $baz,
+    ) {
+    }
+}
+
+/**
+ * @DiscriminatorMap(typeProperty="type", mapping={
+ *     "first" = FirstNestedDummyWithConstructorAndDiscriminator::class,
+ *     "second" = SecondNestedDummyWithConstructorAndDiscriminator::class,
+ * })
+ */
+abstract class AbstractNestedDummyWithConstructorAndDiscriminator
+{
+    public function __construct(
+        /**
+         * @SerializedPath("[foo]")
+         */
+        public $notfoo,
+
+        public $baz,
+    ) {
+    }
+}
+
+class FirstNestedDummyWithConstructorAndDiscriminator extends AbstractNestedDummyWithConstructorAndDiscriminator
+{
+    public function __construct(
+        /**
+         * @SerializedPath("[one][two][three]")
+         */
+        public $foo,
+
+        $notfoo,
+        $baz,
+    ) {
+        parent::__construct($notfoo, $baz);
+    }
+}
+
+class SecondNestedDummyWithConstructorAndDiscriminator extends AbstractNestedDummyWithConstructorAndDiscriminator
+{
+    public function __construct(
+        /**
+         * @SerializedPath("[one][four]")
+         */
+        public $quux,
+
+        $notfoo,
+        $baz,
+    ) {
+        parent::__construct($notfoo, $baz);
+    }
+}
+
 class DuplicateKeyNestedDummy
 {
     /**
@@ -711,7 +877,9 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
 
     protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = [])
     {
-        $object->$attribute = $value;
+        if (property_exists($object, $attribute)) {
+            $object->$attribute = $value;
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the `#[SerializedPath]` attribute doesn't work with constructor arguments:

```php
class Test
{
    public function __construct(
        #[SerializedPath('[foo][bar]')] public string $bar,
    ) {
    }
}

$serializer->denormalize(['foo' => ['bar' => 'something']], Test::class);
```
```
In AbstractNormalizer.php line 384:
                                                                                                                                    
  Cannot create an instance of "Test" from serialized data because its constructor requires parameter "bar" to be present.  
```