### PR TITLE
Add disposition form-data to HeaderUtils

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderUtils.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderUtils.php
@@ -20,6 +20,7 @@ class HeaderUtils
 {
     public const DISPOSITION_ATTACHMENT = 'attachment';
     public const DISPOSITION_INLINE = 'inline';
+    public const DISPOSITION_FORM_DATA = 'form-data';
 
     /**
      * This class should not be instantiated.
@@ -148,7 +149,7 @@ class HeaderUtils
     /**
      * Generates an HTTP Content-Disposition field-value.
      *
-     * @param string $disposition      One of "inline" or "attachment"
+     * @param string $disposition      One of "inline", "attachment" or "form-data"
      * @param string $filename         A unicode string
      * @param string $filenameFallback A string containing only ASCII characters that
      *                                 is semantically equivalent to $filename. If the filename is already ASCII,
@@ -160,8 +161,8 @@ class HeaderUtils
      */
     public static function makeDisposition(string $disposition, string $filename, string $filenameFallback = ''): string
     {
-        if (!\in_array($disposition, [self::DISPOSITION_ATTACHMENT, self::DISPOSITION_INLINE])) {
-            throw new \InvalidArgumentException(sprintf('The disposition must be either "%s" or "%s".', self::DISPOSITION_ATTACHMENT, self::DISPOSITION_INLINE));
+        if (!\in_array($disposition, [self::DISPOSITION_ATTACHMENT, self::DISPOSITION_INLINE, self::DISPOSITION_FORM_DATA])) {
+            throw new \InvalidArgumentException(sprintf('The disposition must be either "%s", "%s", "%s".', self::DISPOSITION_ATTACHMENT, self::DISPOSITION_INLINE, self::DISPOSITION_FORM_DATA));
         }
 
         if ('' === $filenameFallback) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... will do later

I want to use the symfony request as PSR request. The PSR bridge is already helpful but it lacks to fill the server request body due to php://input being empty on multipart form data requests. So now I want to re-create the content of the request and build my own multipart message. I know the HeaderUtils being super useful for content disposition headers and I need disposition headers in the multipart message. So I tried it to make use of the HeaderUtils but they do not allow form-data as input ([although allowed looking at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#as_a_header_for_a_multipart_body)). Therefore I changed the constraint to also allow form-data as disposition type.

Now as I wanted to write a test I also saw that you only make use of these utils in a file download, not in a file upload. So I am not even sure if you like having this support in this component. So shall I work further on this? Any specific test you expect as the context extends from only file download to also contain file upload?

I will add docs and changelog changes depending on the reaction of my suggestion.

TODO:
- Always add tests and ensure they pass.
- For new features, provide some code snippets to help understand usage.
- Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
