### PR TITLE
[HttpKernel] Forward `_stateless` attribute to inline rendered fragments

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -130,6 +130,9 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         if ($request->getDefaultLocale() !== $request->getLocale()) {
             $subRequest->setLocale($request->getLocale());
         }
+        if ($request->attributes->has('_stateless')) {
+            $subRequest->attributes->set('_stateless', $request->attributes->get('_stateless'));
+        }
 
         return $subRequest;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -258,6 +258,36 @@ class InlineFragmentRendererTest extends TestCase
         Request::setTrustedProxies([], -1);
     }
 
+    public function testStatelessAttributeIsForwardedByDefault()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('_stateless', true);
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel
+            ->expects($this->once())
+            ->method('handle')
+            ->with($this->callback(static fn (Request $subRequest) => $subRequest->attributes->get('_stateless')))
+        ;
+        $strategy = new InlineFragmentRenderer($kernel);
+        $strategy->render('/', $request);
+    }
+
+    public function testStatelessAttributeCanBeDisabled()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('_stateless', true);
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel
+            ->expects($this->once())
+            ->method('handle')
+            ->with($this->callback(static fn (Request $subRequest) => !$subRequest->attributes->get('_stateless')))
+        ;
+        $strategy = new InlineFragmentRenderer($kernel);
+        $strategy->render(new ControllerReference('main_controller', ['_stateless' => false]), $request);
+    }
+
     /**
      * Creates a Kernel expecting a request equals to $request.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Prerequisite for #50037
| License       | MIT
| Doc PR        | N/A

For now inline rendered fragments have no mean of checking if [the `_stateless` attribute](https://symfony.com/blog/new-in-symfony-5-1-routing-improvements#added-stateless-route-attribute) has been set so they cannot adapt accordingly. This PR would allow them not to use the session if `$request->attributes->getBoolean('_stateless')` is true.

This could be used in `ProfilerController`’s `searchBarAction` eg.



