### PR TITLE
[Mailer] Adds `assertEmailSubjectContains` and `assertEmailSubjectNotContains` methods

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
@@ -90,6 +90,16 @@ trait MailerAssertionsTrait
         self::assertThat($email, new MimeConstraint\EmailAddressContains($headerName, $expectedValue), $message);
     }
 
+    public static function assertEmailSubjectContains(RawMessage $email, string $expectedValue, string $message = ''): void
+    {
+        self::assertThat($email, new MimeConstraint\EmailSubjectContains($expectedValue), $message);
+    }
+
+    public static function assertEmailSubjectNotContains(RawMessage $email, string $expectedValue, string $message = ''): void
+    {
+        self::assertThat($email, new LogicalNot(new MimeConstraint\EmailSubjectContains($expectedValue)), $message);
+    }
+
     /**
      * @return MessageEvent[]
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
@@ -104,6 +104,8 @@ class MailerTest extends AbstractWebTestCase
         $this->assertEmailAttachmentCount($email, 1);
 
         $email = $this->getMailerMessage($second);
+        $this->assertEmailSubjectContains($email, 'Foo');
+        $this->assertEmailSubjectNotContains($email, 'Bar');
         $this->assertEmailAddressContains($email, 'To', 'fabien@symfony.com');
         $this->assertEmailAddressContains($email, 'To', 'thomas@symfony.com');
         $this->assertEmailAddressContains($email, 'Reply-To', 'me@symfony.com');

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailSubjectContains.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailSubjectContains.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\Mime\Email;
+
+final class EmailSubjectContains extends Constraint
+{
+    public function __construct(
+        private readonly string $expectedSubjectValue,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return sprintf('contains subject with value "%s"', $this->expectedSubjectValue);
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Email) {
+            throw new \LogicException('Can only test a message subject on a Email instance.');
+        }
+
+        return str_contains((string) $other->getSubject(), $this->expectedSubjectValue);
+    }
+
+    protected function failureDescription($other): string
+    {
+        $message = 'The email subject '.$this->toString();
+        if ($other instanceof Email) {
+            $message .= sprintf('. The subject was: "%s"', $other->getSubject() ?? '<empty>');
+        }
+
+        return $message;
+    }
+}


### PR DESCRIPTION
> Adds assertEmailSubjectContains and assertEmailSubjectNotContains

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | No
| New feature?  | yes
| Deprecations? | No
| Tickets       | Fix #49939
| License       | MIT
| Doc PR        | symfony/symfony-docs#18269
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
