### PR TITLE
[Serializer] Improve denormalization of backed enums

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -21,6 +21,8 @@ CHANGELOG
    * `JsonSerializableNormalizer`
    * `ObjectNormalizer`
    * `PropertyNormalizer`
+ * Make `BackedEnumNormalizer` throw `NotNormalizableValueException` when the backed type doesn't match
+ * Make `BackedEnumNormalizer` throw `NotNormalizableValueException` when the value does not belong to a backed enumeration
 
 6.2
 ---

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -86,9 +86,16 @@ class BackedEnumNormalizerTest extends TestCase
         $this->normalizer->denormalize(new \stdClass(), StringBackedEnumDummy::class);
     }
 
+    public function testDenormalizeBadBackingTypeThrowsException()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Data expected to be "string", "int" given. You should pass a value that can be parsed as an enumeration case of type '.StringBackedEnumDummy::class.'.');
+        $this->normalizer->denormalize(1, StringBackedEnumDummy::class);
+    }
+
     public function testDenormalizeBadBackingValueThrowsException()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(NotNormalizableValueException::class);
         $this->expectExceptionMessage('The data must belong to a backed enumeration of type '.StringBackedEnumDummy::class);
 
         $this->normalizer->denormalize('POST', StringBackedEnumDummy::class);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -59,6 +59,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\FalseBuiltInDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Full;
 use Symfony\Component\Serializer\Tests\Fixtures\Php80WithPromotedTypedConstructor;
+use Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\TraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\TrueBuiltInDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\UpcomingDenormalizerInterface as DenormalizerInterface;
@@ -1208,7 +1209,7 @@ class SerializerTest extends TestCase
         $this->assertSame($expected, $exceptionsAsArray);
     }
 
-    public function testNoCollectDenormalizationErrorsWithWrongEnum()
+    public function testCollectDenormalizationErrorsWithWrongEnum()
     {
         $serializer = new Serializer(
             [
@@ -1223,8 +1224,9 @@ class SerializerTest extends TestCase
                 DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
             ]);
         } catch (\Throwable $th) {
-            $this->assertNotInstanceOf(PartialDenormalizationException::class, $th);
-            $this->assertInstanceOf(InvalidArgumentException::class, $th);
+            $this->assertInstanceOf(PartialDenormalizationException::class, $th);
+            $this->assertArrayHasKey(0, $th->getErrors());
+            $this->assertSame("The data must belong to a backed enumeration of type ".StringBackedEnumDummy::class, $th->getErrors()[0]->getMessage());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | --
| License       | MIT
| Doc PR        | --

The goal is to improve error handling when denormalizing an enum.

Currently, if a string value is given when an integer is expected for the BackedEnum then such an error is thrown:
`TypeError: TestEnum::from(): Argument #1 ($value) must be of type int, string given`

This PR adds validation for such cases.

Also in case of an invalid enum case, the NotNormalizableValueException is thrown.