### PR TITLE
[AssetMapper] Fix import map package parsing with an @ namespace

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -111,8 +111,8 @@ class ImportMapManager
      */
     public static function parsePackageName(string $packageName): ?array
     {
-        // https://regex101.com/r/58bl9L/1
-        $regex = '/(?:(?P<registry>[^:\n]+):)?(?P<package>[^@\n]+)(?:@(?P<version>[^\s\n]+))?/';
+        // https://regex101.com/r/d99BEc/1
+        $regex = '/(?:(?P<registry>[^:\n]+):)?((?P<package>@?[^@\n]+))(?:@(?P<version>[^\s\n]+))?/';
 
         return preg_match($regex, $packageName, $matches) ? $matches : null;
     }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -422,6 +422,40 @@ class ImportMapManagerTest extends TestCase
                 'version' => '^1.2.3',
             ],
         ];
+
+        yield 'namespaced_package_simple' => [
+            '@hotwired/stimulus',
+            [
+                'package' => '@hotwired/stimulus',
+                'registry' => '',
+            ],
+        ];
+
+        yield 'namespaced_package_with_version_constraint' => [
+            '@hotwired/stimulus@^1.2.3',
+            [
+                'package' => '@hotwired/stimulus',
+                'registry' => '',
+                'version' => '^1.2.3',
+            ],
+        ];
+
+        yield 'namespaced_package_with_registry' => [
+            'npm:@hotwired/stimulus',
+            [
+                'package' => '@hotwired/stimulus',
+                'registry' => 'npm',
+            ],
+        ];
+
+        yield 'namespaced_package_with_registry_and_version' => [
+            'npm:@hotwired/stimulus@^1.2.3',
+            [
+                'package' => '@hotwired/stimulus',
+                'registry' => 'npm',
+                'version' => '^1.2.3',
+            ],
+        ];
     }
 
     private function createImportMapManager(array $dirs, string $rootDir, string $publicPrefix = '/assets/', string $publicDirName = 'public'): ImportMapManager


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Not needed

This method is used with the `importmap:require` command - e.g.

```
./bin/console importmap:require @hotwired/stimulus
```

It parses the string into the package name and potential version (and something called a "registry" which is specific to jspm). The original regex didn't account for namespaced packages.

Cheers!