### PR TITLE
[WebProfilerBundle] Remove legacy filters remnants

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -155,22 +155,20 @@
             </div>
         </div>
 
-        <script>Sfjs.createFilters();</script>
-
         {% endblock messages %}
     {% endif %}
 
 {% endblock %}
 
 {% macro render_table(messages, is_fallback) %}
-    <table data-filters>
+    <table>
         <thead>
             <tr>
-                <th data-filter="locale">Locale</th>
+                <th>Locale</th>
                 {% if is_fallback %}
                     <th>Fallback locale</th>
                 {% endif %}
-                <th data-filter="domain">Domain</th>
+                <th>Domain</th>
                 <th>Times used</th>
                 <th>Message ID</th>
                 <th>Message Preview</th>
@@ -178,7 +176,7 @@
         </thead>
         <tbody>
         {% for message in messages %}
-            <tr data-filter-locale="{{ message.locale }}" data-filter-domain="{{ message.domain }}">
+            <tr>
                 <td class="font-normal text-small nowrap">{{ message.locale }}</td>
                 {% if is_fallback %}
                     <td class="font-normal text-small nowrap">{{ message.fallbackLocale|default('-') }}</td>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -963,42 +963,6 @@ tr.status-warning td {
     display: block;
 }
 
-{# Filters
-   ========================================================================= #}
-[data-filters] { position: relative; }
-[data-filtered] { cursor: pointer; }
-[data-filtered]:after { content: '\00a0\25BE'; }
-[data-filtered]:hover .filter-list li { display: inline-flex; }
-[class*="filter-hidden-"] { display: none; }
-.filter-list { position: absolute; border: var(--border); box-shadow: var(--shadow); margin: 0; padding: 0; display: flex; flex-direction: column; }
-.filter-list :after { content: ''; }
-.filter-list li {
-    background: var(--tab-disabled-background);
-    border-bottom: var(--border);
-    color: var(--tab-disabled-color);
-    display: none;
-    list-style: none;
-    margin: 0;
-    padding: 5px 10px;
-    text-align: left;
-    font-weight: normal;
-}
-.filter-list li.active {
-    background: var(--tab-background);
-    color: var(--tab-color);
-}
-.filter-list li.last-active {
-    background: var(--tab-active-background);
-    color: var(--tab-active-color);
-}
-
-.filter-list-level li { cursor: s-resize; }
-.filter-list-level li.active { cursor: n-resize; }
-.filter-list-level li.last-active { cursor: default; }
-.filter-list-level li.last-active:before { content: '\2714\00a0'; }
-.filter-list-choice li:before { content: '\2714\00a0'; color: transparent; }
-.filter-list-choice li.active:before { color: unset; }
-
 {# Twig panel
    ========================================================================= #}
 #twig-dump pre {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

#42195 introduced new filters for the WebProfilerBundle but it still contains some remnants, for example in the translation panel:

> Uncaught TypeError: Sfjs.createFilters is not a function

This PR removes them all.