### PR TITLE
[AssetMapper] Fixing wrong values being output in command

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\AssetMapper\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapManager;
 use Symfony\Component\AssetMapper\ImportMap\PackageRequireOptions;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -95,7 +96,8 @@ final class ImportMapRequireCommand extends Command
 
             $message .= '.';
         } else {
-            $message = sprintf('%d new packages (%s) added to the importmap.php!', \count($newPackages), implode(', ', array_keys($newPackages)));
+            $names = array_map(fn (ImportMapEntry $package) => $package->importName, $newPackages);
+            $message = sprintf('%d new packages (%s) added to the importmap.php!', \count($newPackages), implode(', ', $names));
         }
 
         $messages = [$message];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | none
| Tickets       | None
| License       | MIT
| Doc PR        | Not needed

A leftover from working on the component. `$newPackages` is an indexed array of `ImportMapEntry`. So, before this, the message would output "new packages (0, 1)". Now:

<img width="966" alt="Screenshot 2023-05-02 at 12 59 12 PM" src="https://user-images.githubusercontent.com/121003/235734153-93050033-9fc2-4ebe-9258-60d92400a081.png">

Cheers!