### PR TITLE
[DependencyInjection] Allow `AutowireCallable` without method

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireCallable.php
@@ -32,8 +32,8 @@ class AutowireCallable extends Autowire
         if (!(null !== $callable xor null !== $service)) {
             throw new LogicException('#[AutowireCallable] attribute must declare exactly one of $callable or $service.');
         }
-        if (!(null !== $callable xor null !== $method)) {
-            throw new LogicException('#[AutowireCallable] attribute must declare one of $callable or $method.');
+        if (null === $service && null !== $method) {
+            throw new LogicException('#[AutowireCallable] attribute cannot have a $method without a $service.');
         }
 
         parent::__construct($callable ?? [new Reference($service), $method ?? '__invoke'], lazy: $lazy);

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireCallableTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireCallableTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AutowireCallableTest extends TestCase
+{
+    public function testNoArguments()
+    {
+        $this->expectException(LogicException::class);
+
+        new AutowireCallable();
+    }
+
+    public function testCallableAndService()
+    {
+        $this->expectException(LogicException::class);
+
+        new AutowireCallable(callable: 'my_callable', service: 'my_service', method: 'my_method');
+    }
+
+    public function testMethodOnly()
+    {
+        $this->expectException(LogicException::class);
+
+        new AutowireCallable(method: 'my_method');
+    }
+
+    public function testCallableAndMethod()
+    {
+        $this->expectException(LogicException::class);
+
+        new AutowireCallable(callable: 'my_callable', method: 'my_method');
+    }
+
+    public function testStringCallable()
+    {
+        $attribute = new AutowireCallable(callable: 'my_callable');
+
+        self::assertSame('my_callable', $attribute->value);
+        self::assertFalse($attribute->lazy);
+    }
+
+    public function testArrayCallable()
+    {
+        $attribute = new AutowireCallable(callable: ['My\StaticClass', 'my_callable']);
+
+        self::assertSame(['My\StaticClass', 'my_callable'], $attribute->value);
+        self::assertFalse($attribute->lazy);
+    }
+
+    public function testArrayCallableWithReferenceAndMethod()
+    {
+        $attribute = new AutowireCallable(callable: [new Reference('my_service'), 'my_callable']);
+
+        self::assertEquals([new Reference('my_service'), 'my_callable'], $attribute->value);
+        self::assertFalse($attribute->lazy);
+    }
+
+    public function testArrayCallableWithReferenceOnly()
+    {
+        $attribute = new AutowireCallable(callable: [new Reference('my_service')]);
+
+        self::assertEquals([new Reference('my_service')], $attribute->value);
+        self::assertFalse($attribute->lazy);
+    }
+
+    public function testArrayCallableWithServiceAndMethod()
+    {
+        $attribute = new AutowireCallable(service: 'my_service', method: 'my_callable');
+
+        self::assertEquals([new Reference('my_service'), 'my_callable'], $attribute->value);
+        self::assertFalse($attribute->lazy);
+    }
+
+    public function testArrayCallableWithServiceOnly()
+    {
+        $attribute = new AutowireCallable(service: 'my_service');
+
+        self::assertEquals([new Reference('my_service'), '__invoke'], $attribute->value);
+        self::assertFalse($attribute->lazy);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\DependencyInjection\Tests\Compiler\AInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
 use Symfony\Component\DependencyInjection\Tests\Compiler\FooAnnotation;
 use Symfony\Component\DependencyInjection\Tests\Compiler\IInterface;
+use Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable;
 use Symfony\Component\DependencyInjection\Tests\Compiler\SingleMethodInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Wither;
 use Symfony\Component\DependencyInjection\Tests\Compiler\WitherAnnotation;
@@ -1720,6 +1721,8 @@ PHP
         $container = new ContainerBuilder();
         $container->register('foo', Foo::class)
             ->setPublic('true');
+        $container->register('my_callable', MyCallable::class)
+            ->setPublic('true');
         $container->register('baz', \Closure::class)
             ->setFactory(['Closure', 'fromCallable'])
             ->setArguments(['var_dump'])
@@ -1873,6 +1876,8 @@ class LazyClosureConsumer
         public \Closure $baz,
         #[AutowireCallable(service: 'foo', method: 'cloneFoo')]
         public \Closure $buz,
+        #[AutowireCallable(service: 'my_callable')]
+        public \Closure $bar,
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -558,3 +558,10 @@ interface SingleMethodInterface
 {
     public function theMethod();
 }
+
+class MyCallable
+{
+    public function __invoke(): void
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/autowire_closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/autowire_closure.php
@@ -25,6 +25,7 @@ class Symfony_DI_PhpDumper_Test_Autowire_Closure extends Container
             'bar' => 'getBarService',
             'baz' => 'getBazService',
             'foo' => 'getFooService',
+            'my_callable' => 'getMyCallableService',
         ];
 
         $this->aliases = [];
@@ -53,7 +54,7 @@ class Symfony_DI_PhpDumper_Test_Autowire_Closure extends Container
             $container = $containerRef->get();
 
             return ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo());
-        }, ($container->services['baz'] ?? self::getBazService($container)), ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo())->cloneFoo(...));
+        }, ($container->services['baz'] ?? self::getBazService($container)), ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo())->cloneFoo(...), ($container->services['my_callable'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable())->__invoke(...));
     }
 
     /**
@@ -74,5 +75,15 @@ class Symfony_DI_PhpDumper_Test_Autowire_Closure extends Container
     protected static function getFooService($container)
     {
         return $container->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo();
+    }
+
+    /**
+     * Gets the public 'my_callable' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable
+     */
+    protected static function getMyCallableService($container)
+    {
+        return $container->services['my_callable'] = new \Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | kinda
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR enables the syntax `#[AutowireCallable(service: 'my_service')]` as a shorthand for `#[AutowireCallable(service: 'my_service', method: '__invoke')]`.