### PR TITLE
[AssetMapper] Adding debug:assetmap command + normalize paths

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -17,6 +17,7 @@ use Symfony\Component\AssetMapper\AssetMapperDevServerSubscriber;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\AssetMapperRepository;
 use Symfony\Component\AssetMapper\Command\AssetMapperCompileCommand;
+use Symfony\Component\AssetMapper\Command\DebugAssetMapperCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapExportCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapRemoveCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapRequireCommand;
@@ -69,6 +70,14 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.debug'),
             ])
             ->tag('console.command')
+
+            ->set('asset_mapper.command.debug', DebugAssetMapperCommand::class)
+                ->args([
+                    service('asset_mapper'),
+                    service('asset_mapper.repository'),
+                    param('kernel.project_dir'),
+                ])
+                ->tag('console.command')
 
         ->set('asset_mapper_compiler', AssetMapperCompiler::class)
             ->args([

--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -31,7 +31,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-#[AsCommand(name: 'assetmap:compile', description: 'Compiles all mapped assets and writes them to the final public output directory.')]
+#[AsCommand(name: 'asset-map:compile', description: 'Compiles all mapped assets and writes them to the final public output directory.')]
 final class AssetMapperCompileCommand extends Command
 {
     public function __construct(
@@ -105,6 +105,6 @@ EOT
             ));
         }
 
-        return self::SUCCESS;
+        return 0;
     }
 }

--- a/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Command;
+
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\AssetMapperRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Outputs all the assets in the asset mapper.
+ *
+ * @experimental
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+#[AsCommand(name: 'debug:asset-map', description: 'Outputs all mapped assets.')]
+final class DebugAssetMapperCommand extends Command
+{
+    private bool $didShortenPaths = false;
+
+    public function __construct(
+        private readonly AssetMapperInterface $assetMapper,
+        private readonly AssetMapperRepository $assetMapperRepository,
+        private readonly string $projectDir,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('full', null, null, 'Whether to show the full paths')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command outputs all of the assets in
+asset mapper for debugging purposes.
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $allAssets = $this->assetMapper->allAssets();
+
+        $pathRows = [];
+        foreach ($this->assetMapperRepository->allDirectories() as $path => $namespace) {
+            $path = $this->relativizePath($path);
+            if (!$input->getOption('full')) {
+                $path = $this->shortenPath($path);
+            }
+
+            $pathRows[] = [$path, $namespace];
+        }
+        $io->section('Asset Mapper Paths');
+        $io->table(['Path', 'Namespace prefix'], $pathRows);
+
+        $rows = [];
+        foreach ($allAssets as $asset) {
+            $logicalPath = $asset->logicalPath;
+            $sourcePath = $this->relativizePath($asset->getSourcePath());
+
+            if (!$input->getOption('full')) {
+                $logicalPath = $this->shortenPath($logicalPath);
+                $sourcePath = $this->shortenPath($sourcePath);
+            }
+
+            $rows[] = [
+                $logicalPath,
+                $sourcePath,
+            ];
+        }
+        $io->section('Mapped Assets');
+        $io->table(['Logical Path', 'Filesystem Path'], $rows);
+
+        if ($this->didShortenPaths) {
+            $io->note('To see the full paths, re-run with the --full option.');
+        }
+
+        return 0;
+    }
+
+    private function relativizePath(string $path): string
+    {
+        return str_replace($this->projectDir.'/', '', $path);
+    }
+
+    private function shortenPath($path): string
+    {
+        $limit = 50;
+
+        if (\strlen($path) <= $limit) {
+            return $path;
+        }
+
+        $this->didShortenPaths = true;
+        $limit = floor(($limit - 3) / 2);
+
+        return substr($path, 0, $limit).'...'.substr($path, -$limit);
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetsMapperCompileCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetsMapperCompileCommandTest.php
@@ -40,7 +40,7 @@ class AssetsMapperCompileCommandTest extends TestCase
     {
         $application = new Application($this->kernel);
 
-        $command = $application->find('assetmap:compile');
+        $command = $application->find('asset-map:compile');
         $tester = new CommandTester($command);
         $res = $tester->execute([]);
         $this->assertSame(0, $res);
@@ -59,6 +59,21 @@ class AssetsMapperCompileCommandTest extends TestCase
         $finder->in($targetBuildDir)->files();
         $this->assertCount(9, $finder);
         $this->assertFileExists($targetBuildDir.'/manifest.json');
+
+        $expected = [
+            'file1.css',
+            'file2.js',
+            'file3.css',
+            'subdir/file6.js',
+            'subdir/file5.js',
+            'file4.js',
+            'already-abcdefVWXYZ0123456789.digested.css',
+        ];
+        $actual = array_keys(json_decode(file_get_contents($targetBuildDir.'/manifest.json'), true));
+        sort($expected);
+        sort($actual);
+
+        $this->assertSame($expected, $actual);
         $this->assertFileExists($targetBuildDir.'/importmap.json');
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/Command/DebugAssetsMapperCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/DebugAssetsMapperCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\AssetMapper\Tests\fixtures\AssetMapperTestAppKernel;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DebugAssetsMapperCommandTest extends TestCase
+{
+    public function testCommandDumpsInformation()
+    {
+        $application = new Application(new AssetMapperTestAppKernel('test', true));
+
+        $command = $application->find('debug:asset-map');
+        $tester = new CommandTester($command);
+        $res = $tester->execute([]);
+        $this->assertSame(0, $res);
+
+        $this->assertStringContainsString('dir1', $tester->getDisplay());
+        $this->assertStringContainsString('subdir/file6.js', $tester->getDisplay());
+        $this->assertStringContainsString('dir2'.\DIRECTORY_SEPARATOR.'subdir'.\DIRECTORY_SEPARATOR.'file6.js', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Docs are TODO already for the component

For UX, those packages will add their own namespaced paths to the "asset mapper" to make their Stimulus controllers available. So, between your own paths and automatically-added paths, having a way to visualize everything seems helpful.

<img width="1178" alt="Screenshot 2023-05-02 at 4 15 49 PM" src="https://user-images.githubusercontent.com/121003/235776433-d35a0ba6-dc90-47da-891f-81a6a8e74c67.png">

**ALSO**

This PR normalizes the paths in asset mapper in 2 ways:

A) Use `/` always for logical path - e.g. you would use `asset('images/foo.png')` everywhere... you wouldn't say `asset('images\\foo.png')` on Windows
B) All absolute paths are converted with `realpath` internally. We do some "directory comparisons" (e.g. is `/var/foo` inside of `/var/foo/bar`) so having real paths consistently everywhere keeps this working.

Tests added for all of these changes

Cheers!