### PR TITLE
[HttpClient] Ensure HttplugClient ignores invalid HTTP headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,6 +165,7 @@
     },
     "config": {
         "allow-plugins": {
+            "php-http/discovery": false,
             "symfony/runtime": true
         }
     },

--- a/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
+++ b/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
@@ -120,7 +120,11 @@ final class HttplugWaitLoop
 
         foreach ($response->getHeaders(false) as $name => $values) {
             foreach ($values as $value) {
-                $psrResponse = $psrResponse->withAddedHeader($name, $value);
+                try {
+                    $psrResponse = $psrResponse->withAddedHeader($name, $value);
+                } catch (\InvalidArgumentException $e) {
+                    // ignore invalid header
+                }
             }
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
@@ -267,4 +267,22 @@ class HttplugClientTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('OK', (string) $response->getBody());
     }
+
+    public function testInvalidHeaderResponse()
+    {
+        $responseHeaders = [
+            // space in header name not allowed in RFC 7230
+            ' X-XSS-Protection' => '0',
+            'Cache-Control' => 'no-cache',
+        ];
+        $response = new MockResponse('body', ['response_headers' => $responseHeaders]);
+        $this->assertArrayHasKey(' x-xss-protection', $response->getHeaders());
+
+        $client = new HttplugClient(new MockHttpClient($response));
+        $request = $client->createRequest('POST', 'http://localhost:8057/post')
+            ->withBody($client->createStream('foo=0123456789'));
+
+        $resultResponse = $client->sendRequest($request);
+        $this->assertCount(1, $resultResponse->getHeaders());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Something we forgot in #47415