### PR TITLE
[AssetMapper] Fixing 2 bugs related to the compile command and importmaps

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapper.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapper.php
@@ -267,7 +267,7 @@ class AssetMapper implements AssetMapperInterface
         if (null === $this->manifestData) {
             $path = $this->getPublicAssetsFilesystemPath().'/'.self::MANIFEST_FILE_NAME;
 
-            if (!file_exists($path)) {
+            if (!is_file($path)) {
                 $this->manifestData = [];
             } else {
                 $this->manifestData = json_decode(file_get_contents($path), true);

--- a/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
@@ -54,7 +54,7 @@ class AssetMapperRepository
             }
 
             $file = rtrim($path, '/').'/'.$localLogicalPath;
-            if (file_exists($file)) {
+            if (is_file($file)) {
                 return realpath($file);
             }
         }

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -49,6 +49,7 @@ class ImportMapManager
      */
     private const PACKAGE_PATTERN = '/^(?:https?:\/\/[\w\.-]+\/)?(?:(?<registry>\w+):)?(?<package>(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*)(?:@(?<version>[\w\._-]+))?(?:(?<subpath>\/.*))?$/';
     public const IMPORT_MAP_FILE_NAME = 'importmap.json';
+    public const IMPORT_MAP_PRELOAD_FILE_NAME = 'importmap.preload.json';
 
     private array $importMapEntries;
     private array $modulesToPreload;
@@ -125,9 +126,11 @@ class ImportMapManager
             return;
         }
 
-        $dumpedPath = $this->assetMapper->getPublicAssetsFilesystemPath().'/'.self::IMPORT_MAP_FILE_NAME;
-        if (file_exists($dumpedPath)) {
-            $this->json = file_get_contents($dumpedPath);
+        $dumpedImportMapPath = $this->assetMapper->getPublicAssetsFilesystemPath().'/'.self::IMPORT_MAP_FILE_NAME;
+        $dumpedModulePreloadPath = $this->assetMapper->getPublicAssetsFilesystemPath().'/'.self::IMPORT_MAP_PRELOAD_FILE_NAME;
+        if (is_file($dumpedImportMapPath) && is_file($dumpedModulePreloadPath)) {
+            $this->json = file_get_contents($dumpedImportMapPath);
+            $this->modulesToPreload = json_decode(file_get_contents($dumpedModulePreloadPath), true, 512, \JSON_THROW_ON_ERROR);
 
             return;
         }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -84,6 +84,9 @@ class ImportMapManagerTest extends TestCase
             '@hotwired/stimulus' => 'https://unpkg.com/@hotwired/stimulus@3.2.1/dist/stimulus.js',
             'app' => '/assets/app-ea9ebe6156adc038aba53164e2be0867.js',
         ]], json_decode($manager->getImportMapJson(), true));
+        $this->assertEquals([
+            '/assets/app-ea9ebe6156adc038aba53164e2be0867.js',
+        ], $manager->getModulesToPreload());
     }
 
     /**

--- a/src/Symfony/Component/AssetMapper/Tests/fixtures/importmap.php
+++ b/src/Symfony/Component/AssetMapper/Tests/fixtures/importmap.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    '@hotwired/stimulus' => [
+        'url' => 'https://unpkg.com/@hotwired/stimulus@3.2.1/dist/stimulus.js',
+        'preload' => true,
+    ],
+    'lodash' => [
+        'url' => 'https://ga.jspm.io/npm:lodash@4.17.21/lodash.js',
+        'preload' => false,
+    ],
+    'file6' => [
+        'path' => 'subdir/file6.js',
+        'preload' => true,
+    ],
+];

--- a/src/Symfony/Component/AssetMapper/Tests/fixtures/test_public/final-assets/importmap.preload.json
+++ b/src/Symfony/Component/AssetMapper/Tests/fixtures/test_public/final-assets/importmap.preload.json
@@ -1,0 +1,3 @@
+[
+    "/assets/app-ea9ebe6156adc038aba53164e2be0867.js"
+]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | none
| Tickets       | none
| License       | MIT
| Doc PR        | not needed

Fixes 2 bugs:

A) Running `assetmap:compile` gives you a `public/assets/importmap.json` for fast importmap dumping on production. But, running `assetmap:compile` again later would re-use the `importmap.json` info to create the new `importmap.json`... meaning it would never update after the first compile.

B) The importmap process generates 2 pieces of information: (A) the importmap and (B) which files from the importmap should be preloaded. When we use `assetmap:compile`, we need to dump both pieces of info. So, we now also dump an `importmap.preload.json` file. These are TWO files (and not just one) because we avoid parsing `importmap.json` at runtime: we read the file and dump it straight out. We DO need to parse the "preload" file. So, I've kept them separate.

Blocked by #50219, which has some changes that will fix the tests here.

Cheers!