### PR TITLE
[AssetMapper] Better public without digest

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapper.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapper.php
@@ -138,6 +138,7 @@ class AssetMapper implements AssetMapperInterface
             $asset->setSourcePath($filePath);
 
             $asset->setMimeType($this->getMimeType($logicalPath));
+            $asset->setPublicPathWithoutDigest($this->getPublicPathWithoutDigest($logicalPath));
             $publicPath = $this->getPublicPath($logicalPath);
             $asset->setPublicPath($publicPath);
             [$digest, $isPredigested] = $this->getDigest($asset);
@@ -202,6 +203,11 @@ class AssetMapper implements AssetMapperInterface
         }, $logicalPath);
     }
 
+    private function getPublicPathWithoutDigest(string $logicalPath): string
+    {
+        return $this->publicPrefix.$logicalPath;
+    }
+
     public static function isPathPredigested(string $path): bool
     {
         return 1 === preg_match(self::PREDIGESTED_REGEX, $path);
@@ -239,11 +245,7 @@ class AssetMapper implements AssetMapperInterface
 
         $extension = pathinfo($logicalPath, \PATHINFO_EXTENSION);
 
-        if (!isset($this->extensionsMap[$extension])) {
-            throw new \LogicException(sprintf('The file extension "%s" from "%s" does not correspond to any known types in the asset mapper. To support this extension, configure framework.asset_mapper.extensions.', $extension, $logicalPath));
-        }
-
-        return $this->extensionsMap[$extension];
+        return $this->extensionsMap[$extension] ?? null;
     }
 
     private function calculateContent(MappedAsset $asset): string

--- a/src/Symfony/Component/AssetMapper/MappedAsset.php
+++ b/src/Symfony/Component/AssetMapper/MappedAsset.php
@@ -20,7 +20,8 @@ namespace Symfony\Component\AssetMapper;
  */
 final class MappedAsset
 {
-    public string $publicPath;
+    private string $publicPath;
+    private string $publicPathWithoutDigest;
     /**
      * @var string the filesystem path to the source file
      */
@@ -88,6 +89,15 @@ final class MappedAsset
         $this->publicPath = $publicPath;
     }
 
+    public function setPublicPathWithoutDigest(string $publicPathWithoutDigest): void
+    {
+        if (isset($this->publicPathWithoutDigest)) {
+            throw new \LogicException('Cannot set public path without digest: it was already set on the asset.');
+        }
+
+        $this->publicPathWithoutDigest = $publicPathWithoutDigest;
+    }
+
     public function setSourcePath(string $sourcePath): void
     {
         if (isset($this->sourcePath)) {
@@ -132,16 +142,6 @@ final class MappedAsset
 
     public function getPublicPathWithoutDigest(): string
     {
-        if ($this->isPredigested()) {
-            return $this->getPublicPath();
-        }
-
-        // remove last part of publicPath and replace with last part of logicalPath
-        $publicPathParts = explode('/', $this->getPublicPath());
-        $logicalPathParts = explode('/', $this->logicalPath);
-        array_pop($publicPathParts);
-        $publicPathParts[] = array_pop($logicalPathParts);
-
-        return implode('/', $publicPathParts);
+        return $this->publicPathWithoutDigest;
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
@@ -65,6 +65,7 @@ class AssetMapperTest extends TestCase
         $asset = $assetMapper->getAsset('file2.js');
         $this->assertSame('file2.js', $asset->logicalPath);
         $this->assertMatchesRegularExpression('/^\/final-assets\/file2-[a-zA-Z0-9]{7,128}\.js$/', $asset->getPublicPath());
+        $this->assertSame('/final-assets/file2.js', $asset->getPublicPathWithoutDigest());
     }
 
     public function testGetAssetRespectsPreDigestedPaths()
@@ -73,6 +74,8 @@ class AssetMapperTest extends TestCase
         $asset = $assetMapper->getAsset('already-abcdefVWXYZ0123456789.digested.css');
         $this->assertSame('already-abcdefVWXYZ0123456789.digested.css', $asset->logicalPath);
         $this->assertSame('/final-assets/already-abcdefVWXYZ0123456789.digested.css', $asset->getPublicPath());
+        // for pre-digested files, the digest *is* part of the public path
+        $this->assertSame('/final-assets/already-abcdefVWXYZ0123456789.digested.css', $asset->getPublicPathWithoutDigest());
     }
 
     public function testGetAssetUsesManifestIfAvailable()

--- a/src/Symfony/Component/AssetMapper/Tests/MappedAssetTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/MappedAssetTest.php
@@ -31,6 +31,14 @@ class MappedAssetTest extends TestCase
         $this->assertSame('/assets/foo.1234567.css', $asset->getPublicPath());
     }
 
+    public function testGetPublicPathWithoutDigest()
+    {
+        $asset = new MappedAsset('anything');
+        $asset->setPublicPathWithoutDigest('/assets/foo.css');
+
+        $this->assertSame('/assets/foo.css', $asset->getPublicPathWithoutDigest());
+    }
+
     /**
      * @dataProvider getExtensionTests
      */
@@ -48,21 +56,21 @@ class MappedAssetTest extends TestCase
         yield 'with_directory' => ['foo/bar.css', 'css'];
     }
 
-    public function testGetSourcePath(): void
+    public function testGetSourcePath()
     {
         $asset = new MappedAsset('foo.css');
         $asset->setSourcePath('/path/to/source.css');
         $this->assertSame('/path/to/source.css', $asset->getSourcePath());
     }
 
-    public function testGetMimeType(): void
+    public function testGetMimeType()
     {
         $asset = new MappedAsset('foo.css');
         $asset->setMimeType('text/css');
         $this->assertSame('text/css', $asset->getMimeType());
     }
 
-    public function testGetDigest(): void
+    public function testGetDigest()
     {
         $asset = new MappedAsset('foo.css');
         $asset->setDigest('1234567', false);
@@ -70,7 +78,7 @@ class MappedAssetTest extends TestCase
         $this->assertFalse($asset->isPredigested());
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $asset = new MappedAsset('foo.css');
         $asset->setContent('body { color: red; }');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Not needed

We have a `MappedAsset::getPublicPathWithoutDigest()` method, which would return something like `/assets/file2.js`. This, sort of odd method, is super useful, for example, when generating the importmap, where we want to communicate to the browser that when it searches for `/assets/file2.js` (e.g. because inside `assets/file1.js` there is an `import './file1.js'`), here it should use the digested path - e.g.

```
'/assets/file2.js' => '/assets/file2.1234abcd.js',
```

Anyway, the way that I calculated this originally was a little sketchy. In truth, we have this info very easily in `AssetMapper`, so now we pass it in. This also allows an "asset compiler" to figure out which "directory" the final asset will be in, which isn't possible with "public path" as it's still being generated. That little nice detail will be needed in StimulusBundle :).

Cheers!