### PR TITLE
[Mime] Keep context after rendering emails

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -76,7 +76,6 @@ class TemplatedEmail extends Email
     {
         $this->textTemplate = null;
         $this->htmlTemplate = null;
-        $this->context = [];
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
@@ -133,6 +133,24 @@ HTML;
         $this->assertEquals('Text', $email->getTextBody());
     }
 
+    public function testRendererKeepsContext()
+    {
+        $twig = new Environment(new ArrayLoader([
+            'text' => 'Text',
+        ]));
+        $renderer = new BodyRenderer($twig);
+        $email = (new TemplatedEmail())
+            ->to('fabien@symfony.com')
+            ->from('helene@symfony.com')
+        ;
+        $email->textTemplate('text');
+        $email->context(['test' => 'kept']);
+
+        $renderer->render($email);
+
+        $this->assertSame('kept', $email->getContext()['test']);
+    }
+
     private function prepareEmail(?string $text, ?string $html, array $context = [], HtmlToTextConverterInterface $converter = null): TemplatedEmail
     {
         $twig = new Environment(new ArrayLoader([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This PR keeps the context after rendering emails. This behavior was present up to 6.1 and was changed with cc3b87189dbd99afd82a77f4986eeacabbacc276.

The context is useful when testing generated values passed to the template. I.e. we generate a salutation for emails depending on user gender and pass it to the template through the context. A test would then look like that:

```php
final class EmailTest extends KernelTestCase
{
    public function testContext(): void
    {
        $this->createUser(); // trigger welcome email

        $this->assertQueuedEmailCount(1);

        $message = $this->getMailerMessage();
        $salutation = $message->getContext()['salutation'];

        $this->assertEmailHtmlBodyContains($message, $salutation);
    }
}
```

This way we can change the salutation generator implementation without having to adapt the functional tests for email delivery and content.
