### PR TITLE
[HttpClient] Fix getting through proxies via CONNECT

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -47,7 +47,6 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
 
     private $multi;
     private $options;
-    private $canceller;
     private $onProgress;
 
     private static $delay;
@@ -73,7 +72,7 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
 
         $info = &$this->info;
         $headers = &$this->headers;
-        $canceller = $this->canceller = new CancellationTokenSource();
+        $canceller = new CancellationTokenSource();
         $handle = &$this->handle;
 
         $info['url'] = (string) $request->getUri();

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -76,17 +76,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
         }
 
         curl_setopt($ch, \CURLOPT_HEADERFUNCTION, static function ($ch, string $data) use (&$info, &$headers, $options, $multi, $id, &$location, $resolveRedirect, $logger): int {
-            if (0 !== substr_compare($data, "\r\n", -2)) {
-                return 0;
-            }
-
-            $len = 0;
-
-            foreach (explode("\r\n", substr($data, 0, -2)) as $data) {
-                $len += 2 + self::parseHeaderLine($ch, $data, $info, $headers, $options, $multi, $id, $location, $resolveRedirect, $logger);
-            }
-
-            return $len;
+            return self::parseHeaderLine($ch, $data, $info, $headers, $options, $multi, $id, $location, $resolveRedirect, $logger);
         });
 
         if (null === $options) {
@@ -381,19 +371,29 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
      */
     private static function parseHeaderLine($ch, string $data, array &$info, array &$headers, ?array $options, CurlClientState $multi, int $id, ?string &$location, ?callable $resolveRedirect, ?LoggerInterface $logger): int
     {
+        if (!str_ends_with($data, "\r\n")) {
+            return 0;
+        }
+
         $waitFor = @curl_getinfo($ch, \CURLINFO_PRIVATE) ?: '_0';
 
         if ('H' !== $waitFor[0]) {
             return \strlen($data); // Ignore HTTP trailers
         }
 
-        if ('' !== $data) {
+        $statusCode = curl_getinfo($ch, \CURLINFO_RESPONSE_CODE);
+
+        if ($statusCode !== $info['http_code'] && !preg_match("#^HTTP/\d+(?:\.\d+)? {$statusCode}(?: |\r\n$)#", $data)) {
+            return \strlen($data); // Ignore headers from responses to CONNECT requests
+        }
+
+        if ("\r\n" !== $data) {
             // Regular header line: add it to the list
-            self::addResponseHeaders([$data], $info, $headers);
+            self::addResponseHeaders([substr($data, 0, -2)], $info, $headers);
 
             if (!str_starts_with($data, 'HTTP/')) {
                 if (0 === stripos($data, 'Location:')) {
-                    $location = trim(substr($data, 9));
+                    $location = trim(substr($data, 9, -2));
                 }
 
                 return \strlen($data);
@@ -416,7 +416,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
 
         // End of headers: handle informational responses, redirects, etc.
 
-        if (200 > $statusCode = curl_getinfo($ch, \CURLINFO_RESPONSE_CODE)) {
+        if (200 > $statusCode) {
             $multi->handlesActivity[$id][] = new InformationalChunk($statusCode, $headers);
             $location = null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted while trying to hit google via `symfony proxy:start`:

```sh
https_proxy=http://127.0.0.1:7080 php test.php
```

where test.php contains:

```php
$client = new CurlHttpClient();

$r = $client->request('GET', 'https://google.com/');

dump($r->getStatusCode());
dump($r->getHeaders());
dump($r->getInfo('debug'));
```