### PR TITLE
[HttpClient] Add `max_retries` option to `RetryableHttpClient`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add `max_retries` option to `RetryableHttpClient` to adjust the retry logic on a per request level
+
 6.3
 ---
 

--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -60,6 +60,9 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
         }
 
         $clone = clone $this;
+        $clone->maxRetries = (int) ($options['max_retries'] ?? $this->maxRetries);
+        unset($options['max_retries']);
+
         $clone->client = $this->client->withOptions($options);
 
         return $clone;
@@ -71,11 +74,14 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
         $baseUris = \is_array($baseUris) ? $baseUris : [];
         $options = self::shiftBaseUri($options, $baseUris);
 
-        if ($this->maxRetries <= 0) {
+        $maxRetries = (int) ($options['max_retries'] ?? $this->maxRetries);
+        unset($options['max_retries']);
+
+        if ($maxRetries <= 0) {
             return new AsyncResponse($this->client, $method, $url, $options);
         }
 
-        return new AsyncResponse($this->client, $method, $url, $options, function (ChunkInterface $chunk, AsyncContext $context) use ($method, $url, $options, &$baseUris) {
+        return new AsyncResponse($this->client, $method, $url, $options, function (ChunkInterface $chunk, AsyncContext $context) use ($method, $url, $options, $maxRetries, &$baseUris) {
             static $retryCount = 0;
             static $content = '';
             static $firstChunk;
@@ -152,7 +158,7 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
             $context->replaceRequest($method, $url, self::shiftBaseUri($options, $baseUris));
             $context->pause($delay / 1000);
 
-            if ($retryCount >= $this->maxRetries) {
+            if ($retryCount >= $maxRetries) {
                 $context->passthru();
             }
         });

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -344,4 +344,45 @@ class RetryableHttpClientTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('http://example.com/d/foo-bar', $response->getInfo('url'));
     }
+
+    public function testMaxRetriesOption()
+    {
+        $client = new RetryableHttpClient(
+            new MockHttpClient([
+                new MockResponse('', ['http_code' => 500]),
+                new MockResponse('', ['http_code' => 502]),
+                new MockResponse('', ['http_code' => 200]),
+            ]),
+            new GenericRetryStrategy([500, 502], 0),
+            3
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar', [
+            'max_retries' => 1,
+        ]);
+
+        self::assertSame(502, $response->getStatusCode());
+    }
+
+    public function testMaxRetriesWithOptions()
+    {
+        $client = new RetryableHttpClient(
+            new MockHttpClient([
+                new MockResponse('', ['http_code' => 500]),
+                new MockResponse('', ['http_code' => 502]),
+                new MockResponse('', ['http_code' => 504]),
+                new MockResponse('', ['http_code' => 200]),
+            ]),
+            new GenericRetryStrategy([500, 502, 504], 0),
+            3
+        );
+
+        $client = $client->withOptions([
+            'max_retries' => 2,
+        ]);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+
+        self::assertSame(504, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | N/A
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18288

Added a `max_retries` option to RetryableHttpClient that allows the user to configure the RetryableHttpClient on a per request level, which is especially useful when `retry_failed` was configured for the global `http_client` service.

```php
<?php

use Symfony\Component\HttpClient\HttpClient;
use Symfony\Component\HttpClient\RetryableHttpClient;

$client = HttpClient::create();
$client = new RetryableHttpClient($client, null, 3);

$client->request('GET', '/foo-bar', [
    'max_retries' => 1 // 0 disables retrying
]);

// $client = $client->withOptions(['max_retries' => 1]);
```