### PR TITLE
[HttpKernel] Prevent initialising lazy services during services reset

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\DependencyInjection;
 
+use ProxyManager\Proxy\LazyLoadingInterface;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -39,6 +41,14 @@ class ServicesResetter implements ResetInterface
     public function reset()
     {
         foreach ($this->resettableServices as $id => $service) {
+            if ($service instanceof LazyObjectInterface && !$service->isLazyObjectInitialized(true)) {
+                continue;
+            }
+
+            if ($service instanceof LazyLoadingInterface && !$service->isProxyInitialized()) {
+                continue;
+            }
+
             foreach ((array) $this->resetMethods[$id] as $resetMethod) {
                 if ('?' === $resetMethod[0] && !method_exists($service, $resetMethod = substr($resetMethod, 1))) {
                     continue;

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/LazyResettableService.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/LazyResettableService.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+class LazyResettableService
+{
+    public static $counter = 0;
+
+    public function foo(): bool
+    {
+        return true;
+    }
+
+    public function reset(): void
+    {
+        ++self::$counter;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -40,6 +40,7 @@
         "symfony/translation": "^5.4|^6.0",
         "symfony/translation-contracts": "^1.1|^2|^3",
         "symfony/uid": "^5.4|^6.0",
+        "symfony/var-exporter": "^6.2",
         "psr/cache": "^1.0|^2.0|^3.0",
         "twig/twig": "^2.13|^3.0.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes-ish
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT
| Doc PR        | 

If one happens to have a service that is configured to be lazy AND also implements `ResetInterface`, when Symfony resets resettableService, it will call `reset` on the service which will trigger the initialization even though the service has not been actually used by the code, which defeats the purpose of having the service lazy.
To fix this I propose to skip resetting a service that is marked as `LazyObjectInterface` and has not been initialized (ie not used yet)
