### PR TITLE
[HttpKernel] Fix restoring surrogate content from cache

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -133,4 +133,15 @@ abstract class AbstractSurrogate implements SurrogateInterface
             $response->headers->set('Surrogate-Control', preg_replace(sprintf('#content="%s/1.0",\s*#', $upperName), '', $value));
         }
     }
+
+    protected static function generateBodyEvalBoundary(): string
+    {
+        static $cookie;
+        $cookie = hash('md5', $cookie ?? $cookie = random_bytes(16), true);
+        $boundary = base64_encode($cookie);
+
+        \assert(HttpCache::BODY_EVAL_BOUNDARY_LENGTH === \strlen($boundary));
+
+        return $boundary;
+    }
 }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -80,9 +80,7 @@ class Esi extends AbstractSurrogate
         $content = preg_replace('#<esi\:remove>.*?</esi\:remove>#s', '', $content);
         $content = preg_replace('#<esi\:comment[^>]+>#s', '', $content);
 
-        static $cookie;
-        $cookie = hash('md5', $cookie ?? $cookie = random_bytes(16), true);
-        $boundary = base64_encode($cookie);
+        $boundary = self::generateBodyEvalBoundary();
         $chunks = preg_split('#<esi\:include\s+(.*?)\s*(?:/|</esi\:include)>#', $content, -1, \PREG_SPLIT_DELIM_CAPTURE);
 
         $i = 1;

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -29,6 +29,8 @@ use Symfony\Component\HttpKernel\TerminableInterface;
  */
 class HttpCache implements HttpKernelInterface, TerminableInterface
 {
+    public const BODY_EVAL_BOUNDARY_LENGTH = 24;
+
     private $kernel;
     private $store;
     private $request;
@@ -631,26 +633,22 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     private function restoreResponseBody(Request $request, Response $response)
     {
         if ($response->headers->has('X-Body-Eval')) {
+            \assert(self::BODY_EVAL_BOUNDARY_LENGTH === 24);
+
             ob_start();
 
-            if ($response->headers->has('X-Body-File')) {
-                include $response->headers->get('X-Body-File');
-            } else {
-                $content = $response->getContent();
+            $content = $response->getContent();
+            $boundary = substr($content, 0, 24);
+            $j = strpos($content, $boundary, 24);
+            echo substr($content, 24, $j - 24);
+            $i = $j + 24;
 
-                if (substr($content, -24) === $boundary = substr($content, 0, 24)) {
-                    $j = strpos($content, $boundary, 24);
-                    echo substr($content, 24, $j - 24);
-                    $i = $j + 24;
+            while (false !== $j = strpos($content, $boundary, $i)) {
+                [$uri, $alt, $ignoreErrors, $part] = explode("\n", substr($content, $i, $j - $i), 4);
+                $i = $j + 24;
 
-                    while (false !== $j = strpos($content, $boundary, $i)) {
-                        [$uri, $alt, $ignoreErrors, $part] = explode("\n", substr($content, $i, $j - $i), 4);
-                        $i = $j + 24;
-
-                        echo $this->surrogate->handle($this, $uri, $alt, $ignoreErrors);
-                        echo $part;
-                    }
-                }
+                echo $this->surrogate->handle($this, $uri, $alt, $ignoreErrors);
+                echo $part;
             }
 
             $response->setContent(ob_get_clean());

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -64,10 +64,7 @@ class Ssi extends AbstractSurrogate
 
         // we don't use a proper XML parser here as we can have SSI tags in a plain text response
         $content = $response->getContent();
-
-        static $cookie;
-        $cookie = hash('md5', $cookie ?? $cookie = random_bytes(16), true);
-        $boundary = base64_encode($cookie);
+        $boundary = self::generateBodyEvalBoundary();
         $chunks = preg_split('#<!--\#include\s+(.*?)\s*-->#', $content, -1, \PREG_SPLIT_DELIM_CAPTURE);
 
         $i = 1;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpCache\Store;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class HttpCacheTestCase extends TestCase
+abstract class HttpCacheTestCase extends TestCase
 {
     protected $kernel;
     protected $cache;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As spotted by @stof in https://github.com/symfony/symfony/pull/50238/files#r1186005579

Best reviewed [ignoring white spaces](https://github.com/symfony/symfony/pull/50244/files?w=1).