### PR TITLE
[TwigBundle] fixed wrong `symfony/twig-bridge` dependency version

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -20,7 +20,7 @@
         "composer-runtime-api": ">=2.1",
         "symfony/config": "^6.1",
         "symfony/dependency-injection": "^6.1",
-        "symfony/twig-bridge": "^6.2",
+        "symfony/twig-bridge": "^6.3",
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/http-kernel": "^6.2",
         "twig/twig": "^2.13|^3.0.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #50245
| License       | MIT
| Doc PR        | -

`TwigBundle` had wrong dependency version  after #49913. This PR fixes this issue.
