### PR TITLE
[Translation] Improve handling of non-string messages in `MessageCatalogue`

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -32,6 +32,15 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
     public function __construct(string $locale, array $messages = [])
     {
         $this->locale = $locale;
+        foreach ($messages as $domain => $domainMessages) {
+            foreach ($domainMessages as $key => $message) {
+                if (null === $message) {
+                    unset($messages[$domain][$key]);
+                } else {
+                    $messages[$domain][$key] = (string) $message;
+                }
+            }
+        }
         $this->messages = $messages;
     }
 
@@ -157,8 +166,12 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
     {
         $altDomain = str_ends_with($domain, self::INTL_DOMAIN_SUFFIX) ? substr($domain, 0, -\strlen(self::INTL_DOMAIN_SUFFIX)) : $domain.self::INTL_DOMAIN_SUFFIX;
         foreach ($messages as $id => $message) {
-            unset($this->messages[$altDomain][$id]);
-            $this->messages[$domain][$id] = $message;
+            if (null === $message) {
+                unset($this->messages[$domain][$id]);
+            } else {
+                unset($this->messages[$altDomain][$id]);
+                $this->messages[$domain][$id] = (string) $message;
+            }
         }
 
         if ([] === ($this->messages[$altDomain] ?? null)) {

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -118,6 +118,20 @@ class MessageCatalogueTest extends TestCase
         $this->assertEquals('bar', $catalogue->get('foo', 'domain88'));
     }
 
+    public function testAddWithNonStringMessages()
+    {
+        $catalogue = new MessageCatalogue('en', [
+            'domain1' => ['foo' => 'foo', 'bar' => new StringableObject('bar'), 'baz' => null],
+        ]);
+        $this->assertSame(['foo' => 'foo', 'bar' => 'bar'], $catalogue->all('domain1'));
+
+        $catalogue->add(['foo1' => 'foo1', 'bar1' => new StringableObject('bar1'), 'baz1' => null], 'domain1');
+        $this->assertSame(['foo' => 'foo', 'bar' => 'bar', 'foo1' => 'foo1', 'bar1' => 'bar1'], $catalogue->all('domain1'));
+
+        $catalogue->add(['bar' => null, 'bar1' => null], 'domain1');
+        $this->assertSame(['foo' => 'foo', 'foo1' => 'foo1'], $catalogue->all('domain1'));
+    }
+
     public function testAddIntlIcu()
     {
         $catalogue = new MessageCatalogue('en', ['domain1+intl-icu' => ['foo' => 'foo']]);
@@ -269,5 +283,20 @@ class MessageCatalogueTest extends TestCase
 
         $cat1->addCatalogue($cat2);
         $this->assertEquals(['messages' => ['a' => 'b'], 'domain' => ['b' => 'c']], $cat1->getMetadata('', ''), 'Cat1 contains merged metadata.');
+    }
+}
+
+class StringableObject
+{
+    public $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49894
| License       | MIT
| Doc PR        | -

