### PR TITLE
[FrameworkBundle] Generate caches consistently on successive run of `cache:clear` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -137,14 +137,7 @@ EOF
                 if ($output->isVerbose()) {
                     $io->comment('Warming up optional cache...');
                 }
-                $warmer = $kernel->getContainer()->get('cache_warmer');
-                // non optional warmers already ran during container compilation
-                $warmer->enableOnlyOptionalWarmers();
-                $preload = (array) $warmer->warmUp($realCacheDir);
-
-                if ($preload && file_exists($preloadFile = $realCacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
-                    Preloader::append($preloadFile, $preload);
-                }
+                $this->warmupOptionals($realCacheDir);
             }
         } else {
             $fs->mkdir($warmupDir);
@@ -153,7 +146,14 @@ EOF
                 if ($output->isVerbose()) {
                     $io->comment('Warming up cache...');
                 }
-                $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
+                $this->warmup($warmupDir, $realBuildDir);
+
+                if (!$input->getOption('no-optional-warmers')) {
+                    if ($output->isVerbose()) {
+                        $io->comment('Warming up optional cache...');
+                    }
+                    $this->warmupOptionals($realCacheDir);
+                }
             }
 
             if (!$fs->exists($warmupDir.'/'.$containerDir)) {
@@ -227,7 +227,7 @@ EOF
         return false;
     }
 
-    private function warmup(string $warmupDir, string $realBuildDir, bool $enableOptionalWarmers = true)
+    private function warmup(string $warmupDir, string $realBuildDir): void
     {
         // create a temporary kernel
         $kernel = $this->getApplication()->getKernel();
@@ -235,18 +235,6 @@ EOF
             throw new \LogicException('Calling "cache:clear" with a kernel that does not implement "Symfony\Component\HttpKernel\RebootableInterface" is not supported.');
         }
         $kernel->reboot($warmupDir);
-
-        // warmup temporary dir
-        if ($enableOptionalWarmers) {
-            $warmer = $kernel->getContainer()->get('cache_warmer');
-            // non optional warmers already ran during container compilation
-            $warmer->enableOnlyOptionalWarmers();
-            $preload = (array) $warmer->warmUp($warmupDir);
-
-            if ($preload && file_exists($preloadFile = $warmupDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
-                Preloader::append($preloadFile, $preload);
-            }
-        }
 
         // fix references to cached files with the real cache directory name
         $search = [$warmupDir, str_replace('\\', '\\\\', $warmupDir)];
@@ -256,6 +244,19 @@ EOF
             if ($count) {
                 file_put_contents($file, $content);
             }
+        }
+    }
+
+    private function warmupOptionals(string $realCacheDir): void
+    {
+        $kernel = $this->getApplication()->getKernel();
+        $warmer = $kernel->getContainer()->get('cache_warmer');
+        // non optional warmers already ran during container compilation
+        $warmer->enableOnlyOptionalWarmers();
+        $preload = (array) $warmer->warmUp($realCacheDir);
+
+        if ($preload && file_exists($preloadFile = $realCacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
+            Preloader::append($preloadFile, $preload);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46324 
| License       | MIT
| Doc PR        | N/A

When the Kernel is configured to use different directories for `build_dir` and `cache_dir`, successive runs of the `cache:clear` produce different outputs. See #46324 for the reproduction steps and the differences observed.

This is due to the fact that if the cached kernel needs to be regenerated when invoking `cache:clear` command, the cache warmers are run in the same directory where the kernel was regenerated (`$warmupDir`, which will become the `build_dir`). When the cache is fresh, only cache warmers are run, and in `cache_dir` this time.
