### PR TITLE
[HttpFoundation] Fix file streaming after connection aborted

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -349,7 +349,7 @@ class BinaryFileResponse extends Response
                 while ('' !== $data) {
                     $read = fwrite($out, $data);
                     if (false === $read || connection_aborted()) {
-                        break;
+                        break 2;
                     }
                     if (0 < $length) {
                         $length -= $read;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

After connection aborted HttpFoundation/BinaryFileResponse.php will stream file until it's end.

This fix add connection aborted checks.
