### PR TITLE
[Scheduler] add `JitterTrigger`

### DIFF
--- a/src/Symfony/Component/Scheduler/RecurringMessage.php
+++ b/src/Symfony/Component/Scheduler/RecurringMessage.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Scheduler;
 use Symfony\Component\Scheduler\Exception\InvalidArgumentException;
 use Symfony\Component\Scheduler\Trigger\CronExpressionTrigger;
 use Symfony\Component\Scheduler\Trigger\DateIntervalTrigger;
+use Symfony\Component\Scheduler\Trigger\JitterTrigger;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
 /**
@@ -57,6 +58,11 @@ final class RecurringMessage
     public static function trigger(TriggerInterface $trigger, object $message): self
     {
         return new self($trigger, $message);
+    }
+
+    public function withJitter(int $maxSeconds = 60): self
+    {
+        return new self(new JitterTrigger($this->trigger, $maxSeconds), $this->message);
     }
 
     public function getMessage(): object

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/JitterTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/JitterTriggerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Tests\Trigger;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Scheduler\Trigger\JitterTrigger;
+use Symfony\Component\Scheduler\Trigger\TriggerInterface;
+
+class JitterTriggerTest extends TestCase
+{
+    public function testCanAddJitter()
+    {
+        $time = new \DateTimeImmutable();
+        $inner = $this->createMock(TriggerInterface::class);
+        $inner->method('getNextRunDate')->willReturn($time);
+
+        $trigger = new JitterTrigger($inner);
+
+        $values = array_map(
+            fn () => (int) $trigger->getNextRunDate($time)?->getTimestamp(),
+            array_fill(0, 100, null)
+        );
+
+        foreach ($values as $value) {
+            $this->assertGreaterThanOrEqual($time->getTimestamp(), $value);
+            $this->assertLessThanOrEqual($time->getTimestamp() + 60, $value);
+        }
+
+        $values = array_unique($values);
+
+        $this->assertGreaterThan(1, \count($values));
+    }
+}

--- a/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Trigger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class JitterTrigger implements TriggerInterface
+{
+    /**
+     * @param positive-int $maxSeconds
+     */
+    public function __construct(private readonly TriggerInterface $trigger, private readonly int $maxSeconds = 60)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s with 0-%d second jitter', $this->trigger, $this->maxSeconds);
+    }
+
+    public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable
+    {
+        if (!$nextRun = $this->trigger->getNextRunDate($run)) {
+            return null;
+        }
+
+        return $nextRun->add(new \DateInterval(sprintf('PT%sS', random_int(0, $this->maxSeconds))));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #49806
| License       | MIT
| Doc PR        | n/a

I think this is what @vtsykun was trying to accomplish with #49806. FreeBSD has a `-jitter` option that does the same thing so I think there's precedent. From the (https://man.freebsd.org/cgi/man.cgi?cron):

> -j	jitter
>	     Enable time jitter.  Prior	to executing commands, cron will sleep
	     a random number of	seconds	in the range from 0 to jitter.	~This
	     will not affect superuser jobs (see -J).~  A value for jitter must
	     be	between	0 and 60 inclusive.  Default is	0, which effectively
	     disables time jitter.
>	     This option can help to smooth down system	load spikes during mo-
	     ments when	a lot of jobs are likely to start at once, e.g., at
	     the beginning of the first	minute of each hour.

Usage:

```php
// defaults to 0-60 seconds
$schedule->add(RecurringMessage::cron('@daily', $message1)->withJitter());

// customize the max seconds (0-30)
$schedule->add(RecurringMessage::cron('@daily', $message1)->withJitter(30));
```

