### PR TITLE
cast integer to string in case date time format is „U“

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -96,6 +96,8 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         $dateTimeFormat = $context[self::FORMAT_KEY] ?? null;
         $timezone = $this->getTimezone($context);
 
+        if ( "U" === $dateTimeFormat &&  "integer" === gettype($data)) $data = (string) $data;
+
         if (null === $data || !\is_string($data) || '' === trim($data)) {
             throw NotNormalizableValueException::createForUnexpectedDataType('The data is either not an string, an empty string, or null; you should pass a string that can be parsed with the passed format or a valid DateTime string.', $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
         }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -80,9 +80,6 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         return $object->format($dateTimeFormat);
     }
 
-    /**
-     * @param array $context
-     */
     public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */): bool
     {
         return $data instanceof \DateTimeInterface;
@@ -96,7 +93,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         $dateTimeFormat = $context[self::FORMAT_KEY] ?? null;
         $timezone = $this->getTimezone($context);
 
-        if (null === $data || (!\is_string($data) && !(\is_int($data) && "U" === $dateTimeFormat) ) || '' === trim($data)) {
+        if (null === $data || (!\is_string($data) && !(\is_int($data) && 'U' === $dateTimeFormat)) || '' === trim($data)) {
             throw NotNormalizableValueException::createForUnexpectedDataType('The data is either not an string, an empty string, or null; you should pass a string that can be parsed with the passed format or a valid DateTime string.', $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
         }
 
@@ -131,9 +128,6 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         }
     }
 
-    /**
-     * @param array $context
-     */
     public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */): bool
     {
         return isset(self::SUPPORTED_TYPES[$type]);

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -96,9 +96,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         $dateTimeFormat = $context[self::FORMAT_KEY] ?? null;
         $timezone = $this->getTimezone($context);
 
-        if ( "U" === $dateTimeFormat &&  "integer" === gettype($data)) $data = (string) $data;
-
-        if (null === $data || !\is_string($data) || '' === trim($data)) {
+        if (null === $data || (!\is_string($data) && !(\is_int($data) && "U" === $dateTimeFormat) ) || '' === trim($data)) {
             throw NotNormalizableValueException::createForUnexpectedDataType('The data is either not an string, an empty string, or null; you should pass a string that can be parsed with the passed format or a valid DateTime string.', $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
+use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
@@ -304,5 +306,12 @@ class DateTimeNormalizerTest extends TestCase
     {
         $this->expectException(UnexpectedValueException::class);
         $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTimeInterface::class, null, [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d|']);
+    }
+
+    public function testDenormalizeDateTimeIntegerWithTimestampFormat()
+    {
+        $timestamp = time();
+        $denormalizedDate = $this->normalizer->denormalize($timestamp, \DateTimeImmutable::class, null, [DateTimeNormalizer::FORMAT_KEY => "U"]);
+        $this->assertSame($timestamp, $denormalizedDate->getTimestamp());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use DateTime;
-use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
@@ -311,7 +309,7 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeDateTimeIntegerWithTimestampFormat()
     {
         $timestamp = time();
-        $denormalizedDate = $this->normalizer->denormalize($timestamp, \DateTimeImmutable::class, null, [DateTimeNormalizer::FORMAT_KEY => "U"]);
+        $denormalizedDate = $this->normalizer->denormalize($timestamp, \DateTimeImmutable::class, null, [DateTimeNormalizer::FORMAT_KEY => 'U']);
         $this->assertSame($timestamp, $denormalizedDate->getTimestamp());
     }
 }


### PR DESCRIPTION
In case the date time format is „U“, the data comes as a integer (timestamp in seconds). To keep the „data is string“-condition, the integer is casted to a string.

| Q             | A
| ------------- | ---
| Branch?       | 6.3<!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #50236 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Fixes DateTimeNormalizer::denormalize throwing a NotNormalizableValueException when DateTimeFormat is "U" and data is passed as an integer.
The Exception should not be thrown, as data being an integer is valid for a timestamp.
My solution is to check if $dateTImeFormat is "U" and $data is an integer. In that case the integer is casted to a string. 
This way, the condition that $data is a string does not need to be changed.
