### PR TITLE
[Messenger] Add `IS_REPEATABLE` flag to `AsMessageHandler` attribute

### DIFF
--- a/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Messenger\Attribute;
  *
  * @author Alireza Mirsepassi <alirezamirsepassi@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class AsMessageHandler
 {
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50267
| License       | MIT
| Doc PR        | N/A

Allows repeating the `AsMessageHandler` attribute to support the preexisting behavior of the now-deprecated `MessageSubscriberInterface`.
