### PR TITLE
[PropertyAccess] Fix nullsafe operator on array index

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -301,7 +301,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 if (($zval[self::VALUE] instanceof \ArrayAccess && !$zval[self::VALUE]->offsetExists($property)) ||
                     (\is_array($zval[self::VALUE]) && !isset($zval[self::VALUE][$property]) && !\array_key_exists($property, $zval[self::VALUE]))
                 ) {
-                    if (!$ignoreInvalidIndices) {
+                    if (!$ignoreInvalidIndices && !$isNullSafe) {
                         if (!\is_array($zval[self::VALUE])) {
                             if (!$zval[self::VALUE] instanceof \Traversable) {
                                 throw new NoSuchIndexException(sprintf('Cannot read index "%s" while trying to traverse path "%s".', $property, (string) $propertyPath));

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -573,10 +573,26 @@ class PropertyAccessorTest extends TestCase
         yield [(object) ['foo' => null], 'foo?.bar.baz', null];
         yield [(object) ['foo' => (object) ['bar' => null]], 'foo?.bar?.baz', null];
         yield [(object) ['foo' => (object) ['bar' => null]], 'foo.bar?.baz', null];
+
+        yield from self::getNullSafeIndexPaths();
+    }
+
+    public static function getNullSafeIndexPaths(): iterable
+    {
         yield [(object) ['foo' => ['bar' => null]], 'foo[bar?].baz', null];
         yield [[], '[foo?]', null];
         yield [['foo' => ['firstName' => 'Bernhard']], '[foo][bar?]', null];
         yield [['foo' => ['firstName' => 'Bernhard']], '[foo][bar?][baz?]', null];
+    }
+
+    /**
+     * @dataProvider getNullSafeIndexPaths
+     */
+    public function testNullSafeIndexWithThrowOnInvalidIndex($objectOrArray, $path, $value)
+    {
+        $this->propertyAccessor = new PropertyAccessor(PropertyAccessor::DISALLOW_MAGIC_METHODS, PropertyAccessor::THROW_ON_INVALID_INDEX | PropertyAccessor::THROW_ON_INVALID_PROPERTY_PATH);
+
+        $this->assertSame($value, $this->propertyAccessor->getValue($objectOrArray, $path));
     }
 
     public function testTicket5755()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the nullsafe operator doesn't work with array index paths. However, this is not obvious at first since `THROW_ON_INVALID_PROPERTY_PATH` is not enabled by default:

```php
use Symfony\Component\PropertyAccess\PropertyAccessor;

var_dump((new PropertyAccessor())->getValue([], '[foo]')); // NULL
var_dump((new PropertyAccessor())->getValue([], '[foo?]')); // NULL

var_dump((new PropertyAccessor(throw: PropertyAccessor::THROW_ON_INVALID_INDEX))->getValue([], '[foo]'));
// Cannot read index "foo" while trying to traverse path "[foo]".

var_dump((new PropertyAccessor(throw: PropertyAccessor::THROW_ON_INVALID_INDEX))->getValue([], '[foo?]'));
// Cannot read index "foo" while trying to traverse path "[foo]". (THIS IS WRONG, SHOULD BE NULL)
```