### PR TITLE
Consistently use var $container to reference the container builder+configurator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 trait BuildDebugContainerTrait
 {
-    protected $containerBuilder;
+    protected ContainerBuilder $container;
 
     /**
      * Loads the ContainerBuilder from the cache.
@@ -35,8 +35,8 @@ trait BuildDebugContainerTrait
      */
     protected function getContainerBuilder(KernelInterface $kernel): ContainerBuilder
     {
-        if ($this->containerBuilder) {
-            return $this->containerBuilder;
+        if (isset($this->container)) {
+            return $this->container;
         }
 
         if (!$kernel->isDebug() || !$kernel->getContainer()->getParameter('debug.container.dump') || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
@@ -59,6 +59,6 @@ trait BuildDebugContainerTrait
             $container->getCompilerPassConfig()->setBeforeRemovingPasses([]);
         }
 
-        return $this->containerBuilder = $container;
+        return $this->container = $container;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -261,15 +261,15 @@ EOF
         }
     }
 
-    private function findProperServiceName(InputInterface $input, SymfonyStyle $io, ContainerBuilder $builder, string $name, bool $showHidden): string
+    private function findProperServiceName(InputInterface $input, SymfonyStyle $io, ContainerBuilder $container, string $name, bool $showHidden): string
     {
         $name = ltrim($name, '\\');
 
-        if ($builder->has($name) || !$input->isInteractive()) {
+        if ($container->has($name) || !$input->isInteractive()) {
             return $name;
         }
 
-        $matchingServices = $this->findServiceIdsContaining($builder, $name, $showHidden);
+        $matchingServices = $this->findServiceIdsContaining($container, $name, $showHidden);
         if (!$matchingServices) {
             throw new InvalidArgumentException(sprintf('No services found that match "%s".', $name));
         }
@@ -281,13 +281,13 @@ EOF
         return $io->choice('Select one of the following services to display its information', $matchingServices);
     }
 
-    private function findProperTagName(InputInterface $input, SymfonyStyle $io, ContainerBuilder $builder, string $tagName): string
+    private function findProperTagName(InputInterface $input, SymfonyStyle $io, ContainerBuilder $container, string $tagName): string
     {
-        if (\in_array($tagName, $builder->findTags(), true) || !$input->isInteractive()) {
+        if (\in_array($tagName, $container->findTags(), true) || !$input->isInteractive()) {
             return $tagName;
         }
 
-        $matchingTags = $this->findTagsContaining($builder, $tagName);
+        $matchingTags = $this->findTagsContaining($container, $tagName);
         if (!$matchingTags) {
             throw new InvalidArgumentException(sprintf('No tags found that match "%s".', $tagName));
         }
@@ -299,15 +299,15 @@ EOF
         return $io->choice('Select one of the following tags to display its information', $matchingTags);
     }
 
-    private function findServiceIdsContaining(ContainerBuilder $builder, string $name, bool $showHidden): array
+    private function findServiceIdsContaining(ContainerBuilder $container, string $name, bool $showHidden): array
     {
-        $serviceIds = $builder->getServiceIds();
+        $serviceIds = $container->getServiceIds();
         $foundServiceIds = $foundServiceIdsIgnoringBackslashes = [];
         foreach ($serviceIds as $serviceId) {
             if (!$showHidden && str_starts_with($serviceId, '.')) {
                 continue;
             }
-            if (!$showHidden && $builder->hasDefinition($serviceId) && $builder->getDefinition($serviceId)->hasTag('container.excluded')) {
+            if (!$showHidden && $container->hasDefinition($serviceId) && $container->getDefinition($serviceId)->hasTag('container.excluded')) {
                 continue;
             }
             if (false !== stripos(str_replace('\\', '', $serviceId), $name)) {
@@ -321,9 +321,9 @@ EOF
         return $foundServiceIds ?: $foundServiceIdsIgnoringBackslashes;
     }
 
-    private function findTagsContaining(ContainerBuilder $builder, string $tagName): array
+    private function findTagsContaining(ContainerBuilder $container, string $tagName): array
     {
-        $tags = $builder->findTags();
+        $tags = $container->findTags();
         $foundTags = [];
         foreach ($tags as $tag) {
             if (str_contains($tag, $tagName)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpKernel\Kernel;
 #[AsCommand(name: 'lint:container', description: 'Ensure that arguments injected into services match type declarations')]
 final class ContainerLintCommand extends Command
 {
-    private ContainerBuilder $containerBuilder;
+    private ContainerBuilder $container;
 
     protected function configure(): void
     {
@@ -70,8 +70,8 @@ final class ContainerLintCommand extends Command
 
     private function getContainerBuilder(): ContainerBuilder
     {
-        if (isset($this->containerBuilder)) {
-            return $this->containerBuilder;
+        if (isset($this->container)) {
+            return $this->container;
         }
 
         $kernel = $this->getApplication()->getKernel();
@@ -108,6 +108,6 @@ final class ContainerLintCommand extends Command
 
         $container->addCompilerPass(new CheckTypeDeclarationsPass(true), PassConfig::TYPE_AFTER_REMOVING, -100);
 
-        return $this->containerBuilder = $container;
+        return $this->container = $container;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -70,8 +70,8 @@ EOF
         $io = new SymfonyStyle($input, $output);
         $errorIo = $io->getErrorStyle();
 
-        $builder = $this->getContainerBuilder($this->getApplication()->getKernel());
-        $serviceIds = $builder->getServiceIds();
+        $container = $this->getContainerBuilder($this->getApplication()->getKernel());
+        $serviceIds = $container->getServiceIds();
         $serviceIds = array_filter($serviceIds, $this->filterToServiceTypes(...));
 
         if ($search = $input->getArgument('search')) {
@@ -98,7 +98,7 @@ EOF
         $previousId = '-';
         $serviceIdsNb = 0;
         foreach ($serviceIds as $serviceId) {
-            if ($builder->hasDefinition($serviceId) && $builder->getDefinition($serviceId)->hasTag('container.excluded')) {
+            if ($container->hasDefinition($serviceId) && $container->getDefinition($serviceId)->hasTag('container.excluded')) {
                 continue;
             }
             $text = [];
@@ -119,11 +119,11 @@ EOF
                 $serviceLine = sprintf('<fg=yellow;href=%s>%s</>', $fileLink, $serviceId);
             }
 
-            if ($builder->hasAlias($serviceId)) {
+            if ($container->hasAlias($serviceId)) {
                 $hasAlias[$serviceId] = true;
-                $serviceAlias = $builder->getAlias($serviceId);
+                $serviceAlias = $container->getAlias($serviceId);
 
-                if ($builder->hasDefinition($serviceAlias) && $decorated = $builder->getDefinition($serviceAlias)->getTag('container.decorator')) {
+                if ($container->hasDefinition($serviceAlias) && $decorated = $container->getDefinition($serviceAlias)->getTag('container.decorator')) {
                     $serviceLine .= ' <fg=cyan>('.$decorated[0]['id'].')</>';
                 } else {
                     $serviceLine .= ' <fg=cyan>('.$serviceAlias.')</>';
@@ -135,7 +135,7 @@ EOF
             } elseif (!$all) {
                 ++$serviceIdsNb;
                 continue;
-            } elseif ($builder->getDefinition($serviceId)->isDeprecated()) {
+            } elseif ($container->getDefinition($serviceId)->isDeprecated()) {
                 $serviceLine .= ' - <fg=magenta>deprecated</>';
             }
             $text[] = $serviceLine;
@@ -169,9 +169,9 @@ EOF
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
         if ($input->mustSuggestArgumentValuesFor('search')) {
-            $builder = $this->getContainerBuilder($this->getApplication()->getKernel());
+            $container = $this->getContainerBuilder($this->getApplication()->getKernel());
 
-            $suggestions->suggestValues(array_filter($builder->getServiceIds(), $this->filterToServiceTypes(...)));
+            $suggestions->suggestValues(array_filter($container->getServiceIds(), $this->filterToServiceTypes(...)));
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -84,7 +84,7 @@ abstract class Descriptor implements DescriptorInterface
 
     abstract protected function describeContainerParameters(ParameterBag $parameters, array $options = []): void;
 
-    abstract protected function describeContainerTags(ContainerBuilder $builder, array $options = []): void;
+    abstract protected function describeContainerTags(ContainerBuilder $container, array $options = []): void;
 
     /**
      * Describes a container service by its name.
@@ -94,7 +94,7 @@ abstract class Descriptor implements DescriptorInterface
      *
      * @param Definition|Alias|object $service
      */
-    abstract protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null): void;
+    abstract protected function describeContainerService(object $service, array $options = [], ContainerBuilder $container = null): void;
 
     /**
      * Describes container services.
@@ -102,13 +102,13 @@ abstract class Descriptor implements DescriptorInterface
      * Common options are:
      * * tag: filters described services by given tag
      */
-    abstract protected function describeContainerServices(ContainerBuilder $builder, array $options = []): void;
+    abstract protected function describeContainerServices(ContainerBuilder $container, array $options = []): void;
 
-    abstract protected function describeContainerDeprecations(ContainerBuilder $builder, array $options = []): void;
+    abstract protected function describeContainerDeprecations(ContainerBuilder $container, array $options = []): void;
 
-    abstract protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null): void;
+    abstract protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $container = null): void;
 
-    abstract protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null): void;
+    abstract protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $container = null): void;
 
     abstract protected function describeContainerParameter(mixed $parameter, array $options = []): void;
 
@@ -170,15 +170,15 @@ abstract class Descriptor implements DescriptorInterface
         return (string) $value;
     }
 
-    protected function resolveServiceDefinition(ContainerBuilder $builder, string $serviceId): mixed
+    protected function resolveServiceDefinition(ContainerBuilder $container, string $serviceId): mixed
     {
-        if ($builder->hasDefinition($serviceId)) {
-            return $builder->getDefinition($serviceId);
+        if ($container->hasDefinition($serviceId)) {
+            return $container->getDefinition($serviceId);
         }
 
         // Some service IDs don't have a Definition, they're aliases
-        if ($builder->hasAlias($serviceId)) {
-            return $builder->getAlias($serviceId);
+        if ($container->hasAlias($serviceId)) {
+            return $container->getAlias($serviceId);
         }
 
         if ('service_container' === $serviceId) {
@@ -186,18 +186,18 @@ abstract class Descriptor implements DescriptorInterface
         }
 
         // the service has been injected in some special way, just return the service
-        return $builder->get($serviceId);
+        return $container->get($serviceId);
     }
 
-    protected function findDefinitionsByTag(ContainerBuilder $builder, bool $showHidden): array
+    protected function findDefinitionsByTag(ContainerBuilder $container, bool $showHidden): array
     {
         $definitions = [];
-        $tags = $builder->findTags();
+        $tags = $container->findTags();
         asort($tags);
 
         foreach ($tags as $tag) {
-            foreach ($builder->findTaggedServiceIds($tag) as $serviceId => $attributes) {
-                $definition = $this->resolveServiceDefinition($builder, $serviceId);
+            foreach ($container->findTaggedServiceIds($tag) as $serviceId => $attributes) {
+                $definition = $this->resolveServiceDefinition($container, $serviceId);
 
                 if ($showHidden xor '.' === ($serviceId[0] ?? null)) {
                     continue;
@@ -334,12 +334,12 @@ abstract class Descriptor implements DescriptorInterface
         return array_values($envs);
     }
 
-    protected function getServiceEdges(ContainerBuilder $builder, string $serviceId): array
+    protected function getServiceEdges(ContainerBuilder $container, string $serviceId): array
     {
         try {
             return array_values(array_unique(array_map(
                 fn (ServiceReferenceGraphEdge $edge) => $edge->getSourceNode()->getId(),
-                $builder->getCompiler()->getServiceReferenceGraph()->getNode($serviceId)->getInEdges()
+                $container->getCompiler()->getServiceReferenceGraph()->getNode($serviceId)->getInEdges()
             )));
         } catch (InvalidArgumentException $exception) {
             return [];

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -52,41 +52,41 @@ class JsonDescriptor extends Descriptor
         $this->writeData($this->sortParameters($parameters), $options);
     }
 
-    protected function describeContainerTags(ContainerBuilder $builder, array $options = []): void
+    protected function describeContainerTags(ContainerBuilder $container, array $options = []): void
     {
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $data = [];
 
-        foreach ($this->findDefinitionsByTag($builder, $showHidden) as $tag => $definitions) {
+        foreach ($this->findDefinitionsByTag($container, $showHidden) as $tag => $definitions) {
             $data[$tag] = [];
             foreach ($definitions as $definition) {
-                $data[$tag][] = $this->getContainerDefinitionData($definition, true, false, $builder, $options['id'] ?? null);
+                $data[$tag][] = $this->getContainerDefinitionData($definition, true, false, $container, $options['id'] ?? null);
             }
         }
 
         $this->writeData($data, $options);
     }
 
-    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null): void
+    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $container = null): void
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
         }
 
         if ($service instanceof Alias) {
-            $this->describeContainerAlias($service, $options, $builder);
+            $this->describeContainerAlias($service, $options, $container);
         } elseif ($service instanceof Definition) {
-            $this->writeData($this->getContainerDefinitionData($service, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $builder, $options['id']), $options);
+            $this->writeData($this->getContainerDefinitionData($service, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, $options['id']), $options);
         } else {
             $this->writeData($service::class, $options);
         }
     }
 
-    protected function describeContainerServices(ContainerBuilder $builder, array $options = []): void
+    protected function describeContainerServices(ContainerBuilder $container, array $options = []): void
     {
         $serviceIds = isset($options['tag']) && $options['tag']
-            ? $this->sortTaggedServicesByPriority($builder->findTaggedServiceIds($options['tag']))
-            : $this->sortServiceIds($builder->getServiceIds());
+            ? $this->sortTaggedServicesByPriority($container->findTaggedServiceIds($options['tag']))
+            : $this->sortServiceIds($container->getServiceIds());
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $omitTags = isset($options['omit_tags']) && $options['omit_tags'];
         $showArguments = isset($options['show_arguments']) && $options['show_arguments'];
@@ -97,7 +97,7 @@ class JsonDescriptor extends Descriptor
         }
 
         foreach ($serviceIds as $serviceId) {
-            $service = $this->resolveServiceDefinition($builder, $serviceId);
+            $service = $this->resolveServiceDefinition($container, $serviceId);
 
             if ($showHidden xor '.' === ($serviceId[0] ?? null)) {
                 continue;
@@ -106,7 +106,7 @@ class JsonDescriptor extends Descriptor
             if ($service instanceof Alias) {
                 $data['aliases'][$serviceId] = $this->getContainerAliasData($service);
             } elseif ($service instanceof Definition) {
-                $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments, $builder, $serviceId);
+                $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments, $container, $serviceId);
             } else {
                 $data['services'][$serviceId] = $service::class;
             }
@@ -115,21 +115,21 @@ class JsonDescriptor extends Descriptor
         $this->writeData($data, $options);
     }
 
-    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null): void
+    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $container = null): void
     {
-        $this->writeData($this->getContainerDefinitionData($definition, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $builder, $options['id'] ?? null), $options);
+        $this->writeData($this->getContainerDefinitionData($definition, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, $options['id'] ?? null), $options);
     }
 
-    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null): void
+    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $container = null): void
     {
-        if (!$builder) {
+        if (!$container) {
             $this->writeData($this->getContainerAliasData($alias), $options);
 
             return;
         }
 
         $this->writeData(
-            [$this->getContainerAliasData($alias), $this->getContainerDefinitionData($builder->getDefinition((string) $alias), isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $builder, (string) $alias)],
+            [$this->getContainerAliasData($alias), $this->getContainerDefinitionData($container->getDefinition((string) $alias), isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, (string) $alias)],
             array_merge($options, ['id' => (string) $alias])
         );
     }
@@ -156,9 +156,9 @@ class JsonDescriptor extends Descriptor
         throw new LogicException('Using the JSON format to debug environment variables is not supported.');
     }
 
-    protected function describeContainerDeprecations(ContainerBuilder $builder, array $options = []): void
+    protected function describeContainerDeprecations(ContainerBuilder $container, array $options = []): void
     {
-        $containerDeprecationFilePath = sprintf('%s/%sDeprecations.log', $builder->getParameter('kernel.build_dir'), $builder->getParameter('kernel.container_class'));
+        $containerDeprecationFilePath = sprintf('%s/%sDeprecations.log', $container->getParameter('kernel.build_dir'), $container->getParameter('kernel.container_class'));
         if (!file_exists($containerDeprecationFilePath)) {
             throw new RuntimeException('The deprecation file does not exist, please try warming the cache first.');
         }
@@ -217,7 +217,7 @@ class JsonDescriptor extends Descriptor
         return $data;
     }
 
-    private function getContainerDefinitionData(Definition $definition, bool $omitTags = false, bool $showArguments = false, ContainerBuilder $builder = null, string $id = null): array
+    private function getContainerDefinitionData(Definition $definition, bool $omitTags = false, bool $showArguments = false, ContainerBuilder $container = null, string $id = null): array
     {
         $data = [
             'class' => (string) $definition->getClass(),
@@ -242,7 +242,7 @@ class JsonDescriptor extends Descriptor
         }
 
         if ($showArguments) {
-            $data['arguments'] = $this->describeValue($definition->getArguments(), $omitTags, $showArguments, $builder, $id);
+            $data['arguments'] = $this->describeValue($definition->getArguments(), $omitTags, $showArguments, $container, $id);
         }
 
         $data['file'] = $definition->getFile();
@@ -279,7 +279,7 @@ class JsonDescriptor extends Descriptor
             }
         }
 
-        $data['usages'] = null !== $builder && null !== $id ? $this->getServiceEdges($builder, $id) : [];
+        $data['usages'] = null !== $container && null !== $id ? $this->getServiceEdges($container, $id) : [];
 
         return $data;
     }
@@ -390,12 +390,12 @@ class JsonDescriptor extends Descriptor
         throw new \InvalidArgumentException('Callable is not describable.');
     }
 
-    private function describeValue($value, bool $omitTags, bool $showArguments, ContainerBuilder $builder = null, string $id = null): mixed
+    private function describeValue($value, bool $omitTags, bool $showArguments, ContainerBuilder $container = null, string $id = null): mixed
     {
         if (\is_array($value)) {
             $data = [];
             foreach ($value as $k => $v) {
-                $data[$k] = $this->describeValue($v, $omitTags, $showArguments, $builder, $id);
+                $data[$k] = $this->describeValue($v, $omitTags, $showArguments, $container, $id);
             }
 
             return $data;
@@ -417,11 +417,11 @@ class JsonDescriptor extends Descriptor
         }
 
         if ($value instanceof ArgumentInterface) {
-            return $this->describeValue($value->getValues(), $omitTags, $showArguments, $builder, $id);
+            return $this->describeValue($value->getValues(), $omitTags, $showArguments, $container, $id);
         }
 
         if ($value instanceof Definition) {
-            return $this->getContainerDefinitionData($value, $omitTags, $showArguments, $builder, $id);
+            return $this->getContainerDefinitionData($value, $omitTags, $showArguments, $container, $id);
         }
 
         return $value;

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -48,7 +48,7 @@ class WebProfilerBundleKernel extends Kernel
         $routes->add('_', '/')->controller('kernel::homepageController');
     }
 
-    protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $config = [
             'http_method_override' => false,
@@ -58,9 +58,9 @@ class WebProfilerBundleKernel extends Kernel
             'router' => ['utf8' => true],
         ];
 
-        $containerBuilder->loadFromExtension('framework', $config);
+        $container->loadFromExtension('framework', $config);
 
-        $containerBuilder->loadFromExtension('web_profiler', [
+        $container->loadFromExtension('web_profiler', [
             'toolbar' => true,
             'intercept_redirects' => false,
         ]);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -77,55 +77,55 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
         $this->expectException(ParameterNotFoundException::class);
         $this->expectExceptionMessage('The service "baz_service_id" has a dependency on a non-existent parameter "non_existent_param".');
 
-        $containerBuilder = new ContainerBuilder();
-        $definition = $containerBuilder->register('baz_service_id');
+        $container = new ContainerBuilder();
+        $definition = $container->register('baz_service_id');
         $definition->setArgument(0, '%non_existent_param%');
 
         $pass = new ResolveParameterPlaceHoldersPass();
-        $pass->process($containerBuilder);
+        $pass->process($container);
     }
 
     public function testParameterNotFoundExceptionsIsNotThrown()
     {
-        $containerBuilder = new ContainerBuilder();
-        $definition = $containerBuilder->register('baz_service_id');
+        $container = new ContainerBuilder();
+        $definition = $container->register('baz_service_id');
         $definition->setArgument(0, '%non_existent_param%');
 
         $pass = new ResolveParameterPlaceHoldersPass(true, false);
-        $pass->process($containerBuilder);
+        $pass->process($container);
 
         $this->assertCount(1, $definition->getErrors());
     }
 
     public function testOnlyProxyTagIsResolved()
     {
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->setParameter('a_param', 'here_you_go');
-        $definition = $containerBuilder->register('def');
+        $container = new ContainerBuilder();
+        $container->setParameter('a_param', 'here_you_go');
+        $definition = $container->register('def');
         $definition->addTag('foo', ['bar' => '%a_param%']);
         $definition->addTag('proxy', ['interface' => '%a_param%']);
 
         $pass = new ResolveParameterPlaceHoldersPass(true, false);
-        $pass->process($containerBuilder);
+        $pass->process($container);
 
         $this->assertSame(['foo' => [['bar' => '%a_param%']], 'proxy' => [['interface' => 'here_you_go']]], $definition->getTags());
     }
 
     private function createContainerBuilder(): ContainerBuilder
     {
-        $containerBuilder = new ContainerBuilder();
+        $container = new ContainerBuilder();
 
-        $containerBuilder->setParameter('foo.class', 'Foo');
-        $containerBuilder->setParameter('foo.factory.class', 'FooFactory');
-        $containerBuilder->setParameter('foo.arg1', 'bar');
-        $containerBuilder->setParameter('foo.arg2', ['%foo.arg1%' => 'baz']);
-        $containerBuilder->setParameter('foo.method', 'foobar');
-        $containerBuilder->setParameter('foo.property.name', 'bar');
-        $containerBuilder->setParameter('foo.property.value', 'baz');
-        $containerBuilder->setParameter('foo.file', 'foo.php');
-        $containerBuilder->setParameter('alias.id', 'bar');
+        $container->setParameter('foo.class', 'Foo');
+        $container->setParameter('foo.factory.class', 'FooFactory');
+        $container->setParameter('foo.arg1', 'bar');
+        $container->setParameter('foo.arg2', ['%foo.arg1%' => 'baz']);
+        $container->setParameter('foo.method', 'foobar');
+        $container->setParameter('foo.property.name', 'bar');
+        $container->setParameter('foo.property.value', 'baz');
+        $container->setParameter('foo.file', 'foo.php');
+        $container->setParameter('alias.id', 'bar');
 
-        $fooDefinition = $containerBuilder->register('foo', '%foo.class%');
+        $fooDefinition = $container->register('foo', '%foo.class%');
         $fooDefinition->setFactory(['%foo.factory.class%', 'getFoo']);
         $fooDefinition->setArguments(['%foo.arg1%', ['%foo.arg1%' => 'baz']]);
         $fooDefinition->addMethodCall('%foo.method%', ['%foo.arg1%', '%foo.arg2%']);
@@ -133,8 +133,8 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
         $fooDefinition->setFile('%foo.file%');
         $fooDefinition->setBindings(['$baz' => '%env(BAZ)%']);
 
-        $containerBuilder->setAlias('%alias.id%', 'foo');
+        $container->setAlias('%alias.id%', 'foo');
 
-        return $containerBuilder;
+        return $container;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_enumeration.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_enumeration.php
@@ -6,12 +6,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 
-return function (ContainerConfigurator $containerConfigurator) {
-    $containerConfigurator->parameters()
+return function (ContainerConfigurator $container) {
+    $container->parameters()
         ->set('unit_enum', FooUnitEnum::BAR)
         ->set('enum_array', [FooUnitEnum::BAR, FooUnitEnum::FOO]);
 
-    $services = $containerConfigurator->services();
+    $services = $container->services();
 
     $services->defaults()->public();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -112,11 +112,11 @@ class XmlFileLoaderTest extends TestCase
 
     public function testLoadWithExternalEntitiesDisabled()
     {
-        $containerBuilder = new ContainerBuilder();
-        $loader = new XmlFileLoader($containerBuilder, new FileLocator(self::$fixturesPath.'/xml'));
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('services2.xml');
 
-        $this->assertGreaterThan(0, $containerBuilder->getParameterBag()->all(), 'Parameters can be read from the config file.');
+        $this->assertGreaterThan(0, $container->getParameterBag()->all(), 'Parameters can be read from the config file.');
     }
 
     public function testLoadParameters()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Related to https://github.com/symfony/symfony-docs/pull/18299

The vast majority of the code base uses `$container` to reference either the `ContainerBuilder` or the `ContainerConfigurator`, depending on the context.

There are just a few inconsistencies, fixed in this PR.