### PR TITLE
[Messenger] Use immutable dates in the storage when using Doctrine

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -148,8 +148,8 @@ class Connection implements ResetInterface
             null,
             null,
             null,
-            Types::DATETIME_MUTABLE,
-            Types::DATETIME_MUTABLE,
+            Types::DATETIME_IMMUTABLE,
+            Types::DATETIME_IMMUTABLE,
         ]);
 
         return $this->driverConnection->lastInsertId();
@@ -226,7 +226,7 @@ class Connection implements ResetInterface
                 $now,
                 $doctrineEnvelope['id'],
             ], [
-                Types::DATETIME_MUTABLE,
+                Types::DATETIME_IMMUTABLE,
             ]);
 
             $this->driverConnection->commit();
@@ -354,8 +354,8 @@ class Connection implements ResetInterface
                 $now,
                 $this->configuration['queue_name'],
             ], [
-                Types::DATETIME_MUTABLE,
-                Types::DATETIME_MUTABLE,
+                Types::DATETIME_IMMUTABLE,
+                Types::DATETIME_IMMUTABLE,
             ]);
     }
 
@@ -449,11 +449,11 @@ class Connection implements ResetInterface
         $table->addColumn('queue_name', Types::STRING)
             ->setLength(190) // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
             ->setNotnull(true);
-        $table->addColumn('created_at', Types::DATETIME_MUTABLE)
+        $table->addColumn('created_at', Types::DATETIME_IMMUTABLE)
             ->setNotnull(true);
-        $table->addColumn('available_at', Types::DATETIME_MUTABLE)
+        $table->addColumn('available_at', Types::DATETIME_IMMUTABLE)
             ->setNotnull(true);
-        $table->addColumn('delivered_at', Types::DATETIME_MUTABLE)
+        $table->addColumn('delivered_at', Types::DATETIME_IMMUTABLE)
             ->setNotnull(false);
         $table->setPrimaryKey(['id']);
         $table->addIndex(['queue_name']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #47580
| License       | MIT
| Doc PR        | -

We already started using `DateTimeImmutable` in that class but we missed these updates.