### PR TITLE
[Security] Make `PersistentToken` immutable and tell `TokenProviderInterface::updateToken()` implementations should accept `DateTimeInterface`

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -60,3 +60,5 @@ Security
 --------
 
  * `UserValueResolver` no longer implements `ArgumentValueResolverInterface`
+ * Make `PersistentToken` immutable
+ * Deprecate accepting only `DateTime` for `TokenProviderInterface::updateToken()`, use `DateTimeInterface` instead

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -40,6 +40,8 @@ use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
  *         `class`    varchar(100) NOT NULL,
  *         `username` varchar(200) NOT NULL
  *     );
+ *
+ * @final since Symfony 6.4
  */
 class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInterface
 {
@@ -60,7 +62,7 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
         $row = $stmt instanceof Result || $stmt instanceof DriverResult ? $stmt->fetchAssociative() : $stmt->fetch(\PDO::FETCH_ASSOC);
 
         if ($row) {
-            return new PersistentToken($row['class'], $row['username'], $series, $row['value'], new \DateTime($row['last_used']));
+            return new PersistentToken($row['class'], $row['username'], $series, $row['value'], new \DateTimeImmutable($row['last_used']));
         }
 
         throw new TokenNotFoundException('No token found.');
@@ -82,6 +84,8 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
     }
 
     /**
+     * @param \DateTimeInterface $lastUsed Accepting only DateTime is deprecated since Symfony 6.4
+     *
      * @return void
      */
     public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed)

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
@@ -29,7 +29,7 @@ class DoctrineTokenProviderTest extends TestCase
     {
         $provider = $this->bootstrapProvider();
 
-        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTime('2013-01-26T18:23:51'));
+        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
         $provider->createNewToken($token);
 
         $this->assertEquals($provider->loadTokenBySeries('someSeries'), $token);
@@ -47,7 +47,7 @@ class DoctrineTokenProviderTest extends TestCase
     {
         $provider = $this->bootstrapProvider();
 
-        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTime('2013-01-26T18:23:51'));
+        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
         $provider->createNewToken($token);
         $provider->updateToken('someSeries', 'newValue', $lastUsed = new \DateTime('2014-06-26T22:03:46'));
         $token = $provider->loadTokenBySeries('someSeries');
@@ -59,7 +59,7 @@ class DoctrineTokenProviderTest extends TestCase
     public function testDeleteToken()
     {
         $provider = $this->bootstrapProvider();
-        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTime('2013-01-26T18:23:51'));
+        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
         $provider->createNewToken($token);
         $provider->deleteTokenBySeries('someSeries');
 
@@ -76,7 +76,7 @@ class DoctrineTokenProviderTest extends TestCase
         $newValue = 'newValue';
 
         // setup existing token
-        $token = new PersistentToken('someClass', 'someUser', $series, $oldValue, new \DateTime('2013-01-26T18:23:51'));
+        $token = new PersistentToken('someClass', 'someUser', $series, $oldValue, new \DateTimeImmutable('2013-01-26T18:23:51'));
         $provider->createNewToken($token);
 
         // new request comes in requiring remember-me auth, which updates the token
@@ -101,7 +101,7 @@ class DoctrineTokenProviderTest extends TestCase
         $newValue = 'newValue';
 
         // setup existing token
-        $token = new PersistentToken('someClass', 'someUser', $series, $oldValue, new \DateTime('2013-01-26T18:23:51'));
+        $token = new PersistentToken('someClass', 'someUser', $series, $oldValue, new \DateTimeImmutable('2013-01-26T18:23:51'));
         $provider->createNewToken($token);
 
         // new request comes in requiring remember-me auth, which updates the token

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -37,7 +37,7 @@
         "symfony/property-access": "^5.4|^6.0|^7.0",
         "symfony/property-info": "^5.4|^6.0|^7.0",
         "symfony/proxy-manager-bridge": "^5.4|^6.0|^7.0",
-        "symfony/security-core": "^6.0|^7.0",
+        "symfony/security-core": "^6.4|^7.0",
         "symfony/stopwatch": "^5.4|^6.0|^7.0",
         "symfony/translation": "^5.4|^6.0|^7.0",
         "symfony/uid": "^5.4|^6.0|^7.0",
@@ -64,7 +64,7 @@
         "symfony/messenger": "<5.4",
         "symfony/property-info": "<5.4",
         "symfony/security-bundle": "<5.4",
-        "symfony/security-core": "<6.0",
+        "symfony/security-core": "<6.4",
         "symfony/validator": "<5.4.25|>=6,<6.2.12|>=6.3,<6.3.1"
     },
     "autoload": {

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
  * This class is used for testing purposes, and is not really suited for production.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @final since Symfony 6.4
  */
 class InMemoryTokenProvider implements TokenProviderInterface
 {
@@ -32,6 +34,8 @@ class InMemoryTokenProvider implements TokenProviderInterface
     }
 
     /**
+     * @param \DateTimeInterface $lastUsed Accepting only DateTime is deprecated since Symfony 6.4
+     *
      * @return void
      */
     public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed)

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
@@ -22,9 +22,9 @@ final class PersistentToken implements PersistentTokenInterface
     private string $userIdentifier;
     private string $series;
     private string $tokenValue;
-    private \DateTime $lastUsed;
+    private \DateTimeImmutable $lastUsed;
 
-    public function __construct(string $class, string $userIdentifier, string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed)
+    public function __construct(string $class, string $userIdentifier, string $series, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed)
     {
         if (empty($class)) {
             throw new \InvalidArgumentException('$class must not be empty.');
@@ -43,7 +43,7 @@ final class PersistentToken implements PersistentTokenInterface
         $this->userIdentifier = $userIdentifier;
         $this->series = $series;
         $this->tokenValue = $tokenValue;
-        $this->lastUsed = $lastUsed;
+        $this->lastUsed = \DateTimeImmutable::createFromInterface($lastUsed);
     }
 
     public function getClass(): string
@@ -68,6 +68,6 @@ final class PersistentToken implements PersistentTokenInterface
 
     public function getLastUsed(): \DateTime
     {
-        return $this->lastUsed;
+        return \DateTime::createFromImmutable($this->lastUsed);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
@@ -36,6 +36,8 @@ interface PersistentTokenInterface
 
     /**
      * Returns the time the token was last used.
+     *
+     * Each call SHOULD return a new distinct DateTime instance.
      */
     public function getLastUsed(): \DateTime;
 

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
@@ -39,6 +39,8 @@ interface TokenProviderInterface
     /**
      * Updates the token according to this data.
      *
+     * @param \DateTimeInterface $lastUsed Accepting only DateTime is deprecated since Symfony 6.4
+     *
      * @return void
      *
      * @throws TokenNotFoundException if the token is not found

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Make `PersistentToken` immutable
+ * Deprecate accepting only `DateTime` for `TokenProviderInterface::updateToken()`, use `DateTimeInterface` instead
+
 6.3
 ---
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/CacheTokenVerifierTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/CacheTokenVerifierTest.php
@@ -21,23 +21,23 @@ class CacheTokenVerifierTest extends TestCase
     public function testVerifyCurrentToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
+        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
         $this->assertTrue($verifier->verifyToken($token, 'value'));
     }
 
     public function testVerifyFailsInvalidToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
+        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
         $this->assertFalse($verifier->verifyToken($token, 'wrong-value'));
     }
 
     public function testVerifyOutdatedToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $outdatedToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
-        $newToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'newvalue', new \DateTime());
-        $verifier->updateExistingToken($outdatedToken, 'newvalue', new \DateTime());
+        $outdatedToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
+        $newToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'newvalue', new \DateTimeImmutable());
+        $verifier->updateExistingToken($outdatedToken, 'newvalue', new \DateTimeImmutable());
         $this->assertTrue($verifier->verifyToken($newToken, 'value'));
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/InMemoryTokenProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/InMemoryTokenProviderTest.php
@@ -22,7 +22,7 @@ class InMemoryTokenProviderTest extends TestCase
     {
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTime());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
         $provider->createNewToken($token);
 
         $this->assertSame($provider->loadTokenBySeries('foo'), $token);
@@ -39,13 +39,13 @@ class InMemoryTokenProviderTest extends TestCase
     {
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTime());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
         $provider->createNewToken($token);
         $provider->updateToken('foo', 'newFoo', $lastUsed = new \DateTime());
         $token = $provider->loadTokenBySeries('foo');
 
         $this->assertEquals('newFoo', $token->getTokenValue());
-        $this->assertSame($token->getLastUsed(), $lastUsed);
+        $this->assertEquals($token->getLastUsed(), $lastUsed);
     }
 
     public function testDeleteToken()
@@ -53,7 +53,7 @@ class InMemoryTokenProviderTest extends TestCase
         $this->expectException(TokenNotFoundException::class);
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTime());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
         $provider->createNewToken($token);
         $provider->deleteTokenBySeries('foo');
         $provider->loadTokenBySeries('foo');

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/PersistentTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/PersistentTokenTest.php
@@ -18,13 +18,21 @@ class PersistentTokenTest extends TestCase
 {
     public function testConstructor()
     {
-        $lastUsed = new \DateTime();
+        $lastUsed = new \DateTimeImmutable();
         $token = new PersistentToken('fooclass', 'fooname', 'fooseries', 'footokenvalue', $lastUsed);
 
         $this->assertEquals('fooclass', $token->getClass());
         $this->assertEquals('fooname', $token->getUserIdentifier());
         $this->assertEquals('fooseries', $token->getSeries());
         $this->assertEquals('footokenvalue', $token->getTokenValue());
-        $this->assertSame($lastUsed, $token->getLastUsed());
+        $this->assertEquals($lastUsed, $token->getLastUsed());
+    }
+
+    public function testDateTime()
+    {
+        $lastUsed = new \DateTime();
+        $token = new PersistentToken('fooclass', 'fooname', 'fooseries', 'footokenvalue', $lastUsed);
+
+        $this->assertEquals($lastUsed, $token->getLastUsed());
     }
 }

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -88,7 +88,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         $series = random_bytes(66);
         $tokenValue = strtr(base64_encode(substr($series, 33)), '+/=', '-_~');
         $series = strtr(base64_encode(substr($series, 0, 33)), '+/=', '-_~');
-        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $tokenValue, new \DateTime());
+        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable());
 
         $this->tokenProvider->createNewToken($token);
         $this->createCookie(RememberMeDetails::fromPersistentToken($token, time() + $this->options['lifetime']));
@@ -122,7 +122,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
     public function processRememberMe(RememberMeDetails $rememberMeDetails, UserInterface $user): void
     {
         [$lastUsed, $series, $tokenValue, $class] = explode(':', $rememberMeDetails->getValue(), 4);
-        $persistentToken = new PersistentToken($class, $rememberMeDetails->getUserIdentifier(), $series, $tokenValue, new \DateTime('@'.$lastUsed));
+        $persistentToken = new PersistentToken($class, $rememberMeDetails->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable('@'.$lastUsed));
 
         // if a token was regenerated less than a minute ago, there is no need to regenerate it
         // if multiple concurrent requests reauthenticate a user we do not want to update the token several times

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -78,7 +78,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
             ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('-10 min')))
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')))
         ;
 
         $this->tokenProvider->expects($this->once())->method('updateToken')->with('series1');
@@ -106,7 +106,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $verifier = $this->createMock(TokenVerifierInterface::class);
         $handler = new PersistentRememberMeHandler($this->tokenProvider, $this->userProvider, $this->requestStack, [], null, $verifier);
 
-        $persistentToken = new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('30 seconds'));
+        $persistentToken = new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('30 seconds'));
 
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
@@ -133,7 +133,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
             ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue1', new \DateTime('-10 min')));
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue1', new \DateTimeImmutable('-10 min')));
 
         $this->tokenProvider->expects($this->never())->method('updateToken')->with('series1');
 
@@ -148,7 +148,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
             ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('@'.(time() - (31536000 + 1)))));
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('@'.(time() - (31536000 + 1)))));
 
         $this->tokenProvider->expects($this->never())->method('updateToken')->with('series1');
 
@@ -160,7 +160,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
             ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('-10 min')))
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')))
         ;
 
         $this->tokenProvider->expects($this->once())->method('updateToken')->with('series1');

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/security-core": "^6.3|^7.0",
+        "symfony/security-core": "^6.4|^7.0",
         "symfony/http-foundation": "^6.2|^7.0",
         "symfony/http-kernel": "^6.3|^7.0",
         "symfony/polyfill-mbstring": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #47580
| License       | MIT
| Doc PR        | -