### PR TITLE
[AssetMapper] Normalizing logicalPath to a getter like all other properties

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapper.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapper.php
@@ -131,7 +131,7 @@ class AssetMapper implements AssetMapperInterface
     private function getDigest(MappedAsset $asset): array
     {
         // check for a pre-digested file
-        if (1 === preg_match(self::PREDIGESTED_REGEX, $asset->logicalPath, $matches)) {
+        if (1 === preg_match(self::PREDIGESTED_REGEX, $asset->getLogicalPath(), $matches)) {
             return [$matches[1], true];
         }
 
@@ -143,14 +143,14 @@ class AssetMapper implements AssetMapperInterface
 
     private function calculateContent(MappedAsset $asset): string
     {
-        if (isset($this->fileContentsCache[$asset->logicalPath])) {
-            return $this->fileContentsCache[$asset->logicalPath];
+        if (isset($this->fileContentsCache[$asset->getLogicalPath()])) {
+            return $this->fileContentsCache[$asset->getLogicalPath()];
         }
 
         $content = file_get_contents($asset->getSourcePath());
         $content = $this->compiler->compile($content, $asset, $this);
 
-        $this->fileContentsCache[$asset->logicalPath] = $content;
+        $this->fileContentsCache[$asset->getLogicalPath()] = $content;
 
         return $content;
     }

--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -129,7 +129,7 @@ EOT
             }
 
             $this->filesystem->dumpFile($targetPath, $asset->getContent());
-            $manifest[$asset->logicalPath] = $asset->getPublicPath();
+            $manifest[$asset->getLogicalPath()] = $asset->getPublicPath();
         }
         ksort($manifest);
 

--- a/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
@@ -70,7 +70,7 @@ EOT
 
         $rows = [];
         foreach ($allAssets as $asset) {
-            $logicalPath = $asset->logicalPath;
+            $logicalPath = $asset->getLogicalPath();
             $sourcePath = $this->relativizePath($asset->getSourcePath());
 
             if (!$input->getOption('full')) {

--- a/src/Symfony/Component/AssetMapper/Compiler/CssAssetUrlCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/CssAssetUrlCompiler.php
@@ -35,7 +35,7 @@ final class CssAssetUrlCompiler implements AssetCompilerInterface
     public function compile(string $content, MappedAsset $asset, AssetMapperInterface $assetMapper): string
     {
         return preg_replace_callback(self::ASSET_URL_PATTERN, function ($matches) use ($asset, $assetMapper) {
-            $resolvedPath = $this->resolvePath(\dirname($asset->logicalPath), $matches[1]);
+            $resolvedPath = $this->resolvePath(\dirname($asset->getLogicalPath()), $matches[1]);
             $dependentAsset = $assetMapper->getAsset($resolvedPath);
 
             if (null === $dependentAsset) {

--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -35,7 +35,7 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
     public function compile(string $content, MappedAsset $asset, AssetMapperInterface $assetMapper): string
     {
         return preg_replace_callback(self::IMPORT_PATTERN, function ($matches) use ($asset, $assetMapper) {
-            $resolvedPath = $this->resolvePath(\dirname($asset->logicalPath), $matches[1]);
+            $resolvedPath = $this->resolvePath(\dirname($asset->getLogicalPath()), $matches[1]);
 
             $dependentAsset = $assetMapper->getAsset($resolvedPath);
 

--- a/src/Symfony/Component/AssetMapper/Compiler/SourceMappingUrlsCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/SourceMappingUrlsCompiler.php
@@ -35,7 +35,7 @@ final class SourceMappingUrlsCompiler implements AssetCompilerInterface
     public function compile(string $content, MappedAsset $asset, AssetMapperInterface $assetMapper): string
     {
         return preg_replace_callback(self::SOURCE_MAPPING_PATTERN, function ($matches) use ($asset, $assetMapper) {
-            $resolvedPath = $this->resolvePath(\dirname($asset->logicalPath), $matches[2]);
+            $resolvedPath = $this->resolvePath(\dirname($asset->getLogicalPath()), $matches[2]);
 
             $dependentAsset = $assetMapper->getAsset($resolvedPath);
             if (!$dependentAsset) {

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -281,7 +281,7 @@ class ImportMapManager
 
                     throw new \LogicException(sprintf('The package was downloaded to "%s", but this path does not appear to be in any of your asset paths.', $vendorPath));
                 }
-                $path = $mappedAsset->logicalPath;
+                $path = $mappedAsset->getLogicalPath();
             }
 
             $newEntry = new ImportMapEntry($importName, $path, $url, $download, $preload);
@@ -395,7 +395,7 @@ class ImportMapManager
             $dependencyImportMapEntries = array_map(function (AssetDependency $dependency) {
                 return new ImportMapEntry(
                     $dependency->asset->getPublicPathWithoutDigest(),
-                    $dependency->asset->logicalPath,
+                    $dependency->asset->getLogicalPath(),
                     preload: !$dependency->isLazy,
                 );
             }, $dependencies);

--- a/src/Symfony/Component/AssetMapper/MappedAsset.php
+++ b/src/Symfony/Component/AssetMapper/MappedAsset.php
@@ -32,8 +32,13 @@ final class MappedAsset
     /** @var AssetDependency[] */
     private array $dependencies = [];
 
-    public function __construct(public readonly string $logicalPath)
+    public function __construct(private readonly string $logicalPath)
     {
+    }
+
+    public function getLogicalPath(): string
+    {
+        return $this->logicalPath;
     }
 
     public function getPublicPath(): string

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
@@ -30,7 +30,7 @@ class AssetMapperTest extends TestCase
         $this->assertNull($assetMapper->getAsset('non-existent.js'));
 
         $asset = $assetMapper->getAsset('file2.js');
-        $this->assertSame('file2.js', $asset->logicalPath);
+        $this->assertSame('file2.js', $asset->getLogicalPath());
         $this->assertMatchesRegularExpression('/^\/final-assets\/file2-[a-zA-Z0-9]{7,128}\.js$/', $asset->getPublicPath());
         $this->assertSame('/final-assets/file2.js', $asset->getPublicPathWithoutDigest());
     }
@@ -39,7 +39,7 @@ class AssetMapperTest extends TestCase
     {
         $assetMapper = $this->createAssetMapper();
         $asset = $assetMapper->getAsset('already-abcdefVWXYZ0123456789.digested.css');
-        $this->assertSame('already-abcdefVWXYZ0123456789.digested.css', $asset->logicalPath);
+        $this->assertSame('already-abcdefVWXYZ0123456789.digested.css', $asset->getLogicalPath());
         $this->assertSame('/final-assets/already-abcdefVWXYZ0123456789.digested.css', $asset->getPublicPath());
         // for pre-digested files, the digest *is* part of the public path
         $this->assertSame('/final-assets/already-abcdefVWXYZ0123456789.digested.css', $asset->getPublicPathWithoutDigest());
@@ -73,7 +73,7 @@ class AssetMapperTest extends TestCase
     {
         $assetMapper = $this->createAssetMapper();
         $asset = $assetMapper->getAssetFromSourcePath(__DIR__.'/fixtures/dir1/file1.css');
-        $this->assertSame('file1.css', $asset->logicalPath);
+        $this->assertSame('file1.css', $asset->getLogicalPath());
     }
 
     public function testGetAssetWithContentBasic()
@@ -124,7 +124,7 @@ class AssetMapperTest extends TestCase
 
             public function compile(string $content, MappedAsset $asset, AssetMapperInterface $assetMapper): string
             {
-                if ('subdir/file6.js' === $asset->logicalPath) {
+                if ('subdir/file6.js' === $asset->getLogicalPath()) {
                     return $content.'/* compiled */';
                 }
 

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/CssAssetUrlCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/CssAssetUrlCompilerTest.php
@@ -28,7 +28,7 @@ class CssAssetUrlCompilerTest extends TestCase
         $asset = new MappedAsset($sourceLogicalName);
         $asset->setPublicPathWithoutDigest('/assets/'.$sourceLogicalName);
         $this->assertSame($expectedOutput, $compiler->compile($input, $asset, $this->createAssetMapper()));
-        $assetDependencyLogicalPaths = array_map(fn (AssetDependency $dependency) => $dependency->asset->logicalPath, $asset->getDependencies());
+        $assetDependencyLogicalPaths = array_map(fn (AssetDependency $dependency) => $dependency->asset->getLogicalPath(), $asset->getDependencies());
         $this->assertSame($expectedDependencies, $assetDependencyLogicalPaths);
     }
 

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -31,7 +31,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
         $this->assertSame($input, $compiler->compile($input, $asset, $this->createAssetMapper()));
         $actualDependencies = [];
         foreach ($asset->getDependencies() as $dependency) {
-            $actualDependencies[$dependency->asset->logicalPath] = $dependency->isLazy;
+            $actualDependencies[$dependency->asset->getLogicalPath()] = $dependency->isLazy;
         }
         $this->assertEquals($expectedDependencies, $actualDependencies);
     }

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/SourceMappingUrlsCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/SourceMappingUrlsCompilerTest.php
@@ -56,7 +56,7 @@ class SourceMappingUrlsCompilerTest extends TestCase
         $asset = new MappedAsset($sourceLogicalName);
         $asset->setPublicPathWithoutDigest('/assets/'.$sourceLogicalName);
         $this->assertSame($expectedOutput, $compiler->compile($input, $asset, $assetMapper));
-        $assetDependencyLogicalPaths = array_map(fn (AssetDependency $dependency) => $dependency->asset->logicalPath, $asset->getDependencies());
+        $assetDependencyLogicalPaths = array_map(fn (AssetDependency $dependency) => $dependency->asset->getLogicalPath(), $asset->getDependencies());
         $this->assertSame($expectedDependencies, $assetDependencyLogicalPaths);
     }
 

--- a/src/Symfony/Component/AssetMapper/Tests/MappedAssetTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/MappedAssetTest.php
@@ -20,7 +20,7 @@ class MappedAssetTest extends TestCase
     {
         $asset = new MappedAsset('foo.css');
 
-        $this->assertSame('foo.css', $asset->logicalPath);
+        $this->assertSame('foo.css', $asset->getLogicalPath());
     }
 
     public function testGetPublicPath()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | I'd say yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Still TODO

Hi!

In the original AssetMapper PR, I had one gone back and forth in `MappedAsset` using public properties vs getter methods. I eventually settled on getter methods, but I missed `$logicalPath`. This makes that consistent with the rest of the class, instead of being an odd exception.