### PR TITLE
[PropertyAccess] Auto-cast from/to DateTime/Immutable when appropriate

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TypeHinted.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TypeHinted.php
@@ -28,6 +28,11 @@ class TypeHinted
         $this->date = $date;
     }
 
+    public function setDateMutable(\DateTime $date)
+    {
+        $this->date = $date;
+    }
+
     public function getDate()
     {
         return $this->date;

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -940,4 +940,22 @@ class PropertyAccessorTest extends TestCase
         $this->expectExceptionMessage('Expected argument of type "float", "string" given at property path "publicProperty"');
         $this->propertyAccessor->setValue($object, 'publicProperty', 'string');
     }
+
+    public function testCastDateTime()
+    {
+        $object = new TypeHinted();
+
+        $this->propertyAccessor->setValue($object, 'date', new \DateTime());
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $object->getDate());
+    }
+
+    public function testCastDateTimeImmutable()
+    {
+        $object = new TypeHinted();
+
+        $this->propertyAccessor->setValue($object, 'date_mutable', new \DateTimeImmutable());
+
+        $this->assertInstanceOf(\DateTime::class, $object->getDate());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Best reviewed [ignoring whitespaces](https://github.com/symfony/symfony/pull/50295/files?w=1).

My starting point is a form with a date defined as such:

```php
class MyFormType extends AbstractType {
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add('some_date', DateTimeType::class)
        ;
    }
// ...
}

class MyEntity
{
    private ?\DateTimeImmutable $someDate = null;
//...
}
```

Then doing something like:
```php
$myEntity = new MyEntity();
$form = $this->createForm(MyFormType::class, $myEntity);
```

If I submit this form, I get:
```
Expected argument of type "DateTimeImmutable", "DateTime" given at property path "some_date".
```

The current solution is to set option `input` to `datetime_immutable` in `buildForm()`.

But this is boring. Too much boilerplate.

I've tried looking at the Form component to define the `input` option based on the entity provided when building the form, but this entity is not passed to sub-forms, so that we have no way to do this.

The only way I found is the one attached: if we cannot set a `DateTime`, we try setting a `DateTimeImmutable`.

I thought about changing the default value of option `input` to `datetime_immutable`, but this would need a nasty deprecation that'd force everybody to write even more boilerplate before v7, while what we want is less.

So here we are.
