### PR TITLE
Remove unnecessary usages of DateTime

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -231,7 +231,7 @@ index 38618fc15e..eb599eb0b4 100644
      {
          $this->clearEntityManagers();
 diff --git a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
-index 9d61be61bd..e89985de26 100644
+index 3af51ffd60..2743b97f31 100644
 --- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
 +++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
 @@ -70,5 +70,5 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
@@ -6182,7 +6182,7 @@ index 32c58447cd..ec35f6ee41 100644
      {
          $compound = static fn (Options $options) => 'single_text' !== $options['widget'];
 diff --git a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
-index 3b68dc241a..474139a6ee 100644
+index 80023affcb..d6051f52d1 100644
 --- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
 +++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
 @@ -47,5 +47,5 @@ class DateType extends AbstractType
@@ -7352,7 +7352,7 @@ index a87171d2ca..cec8a6f027 100644
      {
          if ($this->client instanceof ResetInterface) {
 diff --git a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
-index cd716e590e..68a0479ef4 100644
+index 71e806fc15..d60290b3ed 100644
 --- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
 +++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
 @@ -362,5 +362,5 @@ class BinaryFileResponse extends Response
@@ -7399,7 +7399,7 @@ index b74a02e2e1..51b4f7f1c3 100644
      {
          foreach ($files as $key => $file) {
 diff --git a/src/Symfony/Component/HttpFoundation/HeaderBag.php b/src/Symfony/Component/HttpFoundation/HeaderBag.php
-index c49a239726..440f3297de 100644
+index 3128a1d833..6721bbe974 100644
 --- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
 +++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
 @@ -90,5 +90,5 @@ class HeaderBag implements \IteratorAggregate, \Countable
@@ -7430,21 +7430,28 @@ index c49a239726..440f3297de 100644
 +    public function remove(string $key): void
      {
          $key = strtr($key, self::UPPER, self::LOWER);
-@@ -214,5 +214,5 @@ class HeaderBag implements \IteratorAggregate, \Countable
+@@ -198,5 +198,5 @@ class HeaderBag implements \IteratorAggregate, \Countable
+      * @throws \RuntimeException When the HTTP header is not parseable
+      */
+-    public function getDate(string $key, \DateTimeInterface $default = null): ?\DateTimeInterface
++    public function getDate(string $key, \DateTimeInterface $default = null): ?\DateTimeImmutable
+     {
+         if (null === $value = $this->get($key)) {
+@@ -216,5 +216,5 @@ class HeaderBag implements \IteratorAggregate, \Countable
       * @return void
       */
 -    public function addCacheControlDirective(string $key, bool|string $value = true)
 +    public function addCacheControlDirective(string $key, bool|string $value = true): void
      {
          $this->cacheControl[$key] = $value;
-@@ -242,5 +242,5 @@ class HeaderBag implements \IteratorAggregate, \Countable
+@@ -244,5 +244,5 @@ class HeaderBag implements \IteratorAggregate, \Countable
       * @return void
       */
 -    public function removeCacheControlDirective(string $key)
 +    public function removeCacheControlDirective(string $key): void
      {
          unset($this->cacheControl[$key]);
-@@ -270,5 +270,5 @@ class HeaderBag implements \IteratorAggregate, \Countable
+@@ -272,5 +272,5 @@ class HeaderBag implements \IteratorAggregate, \Countable
       * @return string
       */
 -    protected function getCacheControlHeader()
@@ -12907,7 +12914,7 @@ index d53bbb196f..4eecf85f8e 100644
      {
          return self::PROPERTY_CONSTRAINT;
 diff --git a/src/Symfony/Component/Validator/ConstraintValidator.php b/src/Symfony/Component/Validator/ConstraintValidator.php
-index 8fa522314f..a4c0c5ec64 100644
+index 3c4167be33..59e5b3c09e 100644
 --- a/src/Symfony/Component/Validator/ConstraintValidator.php
 +++ b/src/Symfony/Component/Validator/ConstraintValidator.php
 @@ -40,5 +40,5 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
@@ -12998,7 +13005,7 @@ index 1fdbf0bc3f..aad702453b 100644
 +    public function remove(int $offset): void;
  }
 diff --git a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
-index 29fd4daa8a..c358e6cc6f 100644
+index a81d589f2b..87155e513c 100644
 --- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
 +++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
 @@ -38,5 +38,5 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
@@ -13170,7 +13177,7 @@ index a50ea62ab6..5f5b5b4e5a 100644
      {
          if (!$constraint instanceof Currency) {
 diff --git a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
-index f02ba54daf..e89c616ec8 100644
+index c88732d4d8..4c0e11eacf 100644
 --- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
 +++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
 @@ -25,5 +25,5 @@ class DateTimeValidator extends DateValidator
@@ -13455,7 +13462,7 @@ index 3f8f951280..503e779244 100644
      {
          if (!$constraint instanceof NotNull) {
 diff --git a/src/Symfony/Component/Validator/Constraints/RangeValidator.php b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
-index 18c399cd08..c98312a9aa 100644
+index 73273d6788..f8d0945f23 100644
 --- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
 +++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
 @@ -35,5 +35,5 @@ class RangeValidator extends ConstraintValidator

--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 6.3 to 6.4
+=======================
+
+HttpFoundation
+--------------
+
+ * Make `HeaderBag::getDate()`, `Response::getDate()`, `getExpires()` and `getLastModified()` return a `DateTimeImmutable`

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -89,12 +89,12 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
         $sql = 'UPDATE rememberme_token SET value=:value, lastUsed=:lastUsed WHERE series=:series';
         $paramValues = [
             'value' => $tokenValue,
-            'lastUsed' => $lastUsed,
+            'lastUsed' => \DateTimeImmutable::createFromInterface($lastUsed),
             'series' => $series,
         ];
         $paramTypes = [
             'value' => ParameterType::STRING,
-            'lastUsed' => Types::DATETIME_MUTABLE,
+            'lastUsed' => Types::DATETIME_IMMUTABLE,
             'series' => ParameterType::STRING,
         ];
         if (method_exists($this->conn, 'executeStatement')) {
@@ -118,14 +118,14 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
             'username' => $token->getUserIdentifier(),
             'series' => $token->getSeries(),
             'value' => $token->getTokenValue(),
-            'lastUsed' => $token->getLastUsed(),
+            'lastUsed' => \DateTimeImmutable::createFromInterface($token->getLastUsed()),
         ];
         $paramTypes = [
             'class' => ParameterType::STRING,
             'username' => ParameterType::STRING,
             'series' => ParameterType::STRING,
             'value' => ParameterType::STRING,
-            'lastUsed' => Types::DATETIME_MUTABLE,
+            'lastUsed' => Types::DATETIME_IMMUTABLE,
         ];
         if (method_exists($this->conn, 'executeStatement')) {
             $this->conn->executeStatement($sql, $paramValues, $paramTypes);
@@ -186,6 +186,7 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
         $this->conn->beginTransaction();
         try {
             $this->deleteTokenBySeries($tmpSeries);
+            $lastUsed = \DateTime::createFromInterface($lastUsed);
             $this->createNewToken(new PersistentToken($token->getClass(), $token->getUserIdentifier(), $tmpSeries, $token->getTokenValue(), $lastUsed));
 
             $this->conn->commit();
@@ -220,7 +221,7 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
         $table = $schema->createTable('rememberme_token');
         $table->addColumn('series', Types::STRING, ['length' => 88]);
         $table->addColumn('value', Types::STRING, ['length' => 88]);
-        $table->addColumn('lastUsed', Types::DATETIME_MUTABLE);
+        $table->addColumn('lastUsed', Types::DATETIME_IMMUTABLE);
         $table->addColumn('class', Types::STRING, ['length' => 100]);
         $table->addColumn('username', Types::STRING, ['length' => 200]);
         $table->setPrimaryKey(['series']);

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorWithDebugStackTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorWithDebugStackTest.php
@@ -115,6 +115,7 @@ class DoctrineDataCollectorWithDebugStackTest extends TestCase
             [true, [], true, true],
             [null, [], null, true],
             [new \DateTime('2011-09-11'), ['date'], '2011-09-11', true],
+            [new \DateTimeImmutable('2011-09-11'), ['date_immutable'], '2011-09-11', true],
             [fopen(__FILE__, 'r'), [], '/* Resource(stream) */', false, false],
             [
                 new \stdClass(),

--- a/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
@@ -126,7 +126,7 @@ EOT;
         $stmt->bindValue(3, 5, ParameterType::INTEGER);
         $stmt->bindValue(4, $res = $this->getResourceFromString('mydata'), ParameterType::BINARY);
         $stmt->bindValue(5, ['foo', 'bar'], Types::SIMPLE_ARRAY);
-        $stmt->bindValue(6, new \DateTime('2022-06-12 11:00:00'), Types::DATETIME_MUTABLE);
+        $stmt->bindValue(6, new \DateTimeImmutable('2022-06-12 11:00:00'), Types::DATETIME_IMMUTABLE);
 
         $executeMethod($stmt);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
@@ -77,7 +77,7 @@ class DoctrineTokenProviderTest extends TestCase
         $provider->createNewToken($token);
 
         // new request comes in requiring remember-me auth, which updates the token
-        $provider->updateExistingToken($token, $newValue, new \DateTime('-5 seconds'));
+        $provider->updateExistingToken($token, $newValue, new \DateTimeImmutable('-5 seconds'));
         $provider->updateToken($series, $newValue, new \DateTime('-5 seconds'));
 
         // parallel request comes in with the old remember-me cookie and session, which also requires reauth
@@ -102,7 +102,7 @@ class DoctrineTokenProviderTest extends TestCase
         $provider->createNewToken($token);
 
         // new request comes in requiring remember-me auth, which updates the token
-        $provider->updateExistingToken($token, $newValue, new \DateTime('-61 seconds'));
+        $provider->updateExistingToken($token, $newValue, new \DateTimeImmutable('-61 seconds'));
         $provider->updateToken($series, $newValue, new \DateTime('-5 seconds'));
 
         // parallel request comes in with the old remember-me cookie and session, which also requires reauth

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -80,7 +80,7 @@ EOT
             ['Version', \PHP_VERSION],
             ['Architecture', (\PHP_INT_SIZE * 8).' bits'],
             ['Intl locale', class_exists(\Locale::class, false) && \Locale::getDefault() ? \Locale::getDefault() : 'n/a'],
-            ['Timezone', date_default_timezone_get().' (<comment>'.(new \DateTime())->format(\DateTime::W3C).'</>)'],
+            ['Timezone', date_default_timezone_get().' (<comment>'.(new \DateTimeImmutable())->format(\DateTimeInterface::W3C).'</>)'],
             ['OPcache', \extension_loaded('Zend OPcache') && filter_var(\ini_get('opcache.enable'), \FILTER_VALIDATE_BOOL) ? 'true' : 'false'],
             ['APCu', \extension_loaded('apcu') && filter_var(\ini_get('apc.enabled'), \FILTER_VALIDATE_BOOL) ? 'true' : 'false'],
             ['Xdebug', \extension_loaded('xdebug') ? 'true' : 'false'],

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -375,7 +375,7 @@
                     %}
                     <tr class="log-status-{{ css_class }}" data-type="{{ log.type }}" data-priority="{{ log.priority }}" data-channel="{{ log.channel }}" style="{{ 'event' == log.channel or 'DEBUG' == log.priorityName ? 'display: none' }}">
                         <td class="log-timestamp">
-                            <time class="newline" title="{{ log.timestamp|date('r') }}" datetime="{{ log.timestamp|date(constant('\DateTime::RFC3339_EXTENDED')) }}" data-convert-to-user-timezone data-render-as-time data-render-with-millisecond-precision>
+                            <time class="newline" title="{{ log.timestamp|date('r') }}" datetime="{{ log.timestamp|date(constant('DateTimeInterface::RFC3339_EXTENDED')) }}" data-convert-to-user-timezone data-render-as-time data-render-with-millisecond-precision>
                                 {{ log.timestamp|date('H:i:s.v') }}
                             </time>
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -67,10 +67,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         }
 
         if ($this->inputTimezone !== $this->outputTimezone) {
-            if (!$dateTime instanceof \DateTimeImmutable) {
-                $dateTime = clone $dateTime;
-            }
-
+            $dateTime = \DateTimeImmutable::createFromInterface($dateTime);
             $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
@@ -53,10 +53,7 @@ class DateTimeToHtml5LocalDateTimeTransformer extends BaseDateTimeTransformer
         }
 
         if ($this->inputTimezone !== $this->outputTimezone) {
-            if (!$dateTime instanceof \DateTimeImmutable) {
-                $dateTime = clone $dateTime;
-            }
-
+            $dateTime = \DateTimeImmutable::createFromInterface($dateTime);
             $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
@@ -38,10 +38,7 @@ class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
         }
 
         if ($this->inputTimezone !== $this->outputTimezone) {
-            if (!$dateTime instanceof \DateTimeImmutable) {
-                $dateTime = clone $dateTime;
-            }
-
+            $dateTime = \DateTimeImmutable::createFromInterface($dateTime);
             $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -85,10 +85,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
             throw new TransformationFailedException('Expected a \DateTimeInterface.');
         }
 
-        if (!$dateTime instanceof \DateTimeImmutable) {
-            $dateTime = clone $dateTime;
-        }
-
+        $dateTime = \DateTimeImmutable::createFromInterface($dateTime);
         $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
 
         return $dateTime->format($this->generateFormat);

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -362,7 +362,7 @@ class DateType extends AbstractType
         $result = [];
 
         foreach ($years as $year) {
-            $result[\PHP_INT_SIZE === 4 ? \DateTime::createFromFormat('Y e', $year.' UTC')->format('U') : gmmktime(0, 0, 0, 6, 15, $year)] = $year;
+            $result[\PHP_INT_SIZE === 4 ? \DateTimeImmutable::createFromFormat('Y e', $year.' UTC')->format('U') : gmmktime(0, 0, 0, 6, 15, $year)] = $year;
         }
 
         return $result;

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -115,6 +115,12 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                     case '\DateTime':
                         return new TypeGuess(DateType::class, [], Guess::MEDIUM_CONFIDENCE);
 
+                    case \DateTimeImmutable::class:
+                    case '\DateTimeImmutable':
+                    case \DateTimeInterface::class:
+                    case '\DateTimeInterface':
+                        return new TypeGuess(DateType::class, ['input' => 'datetime_immutable'], Guess::MEDIUM_CONFIDENCE);
+
                     case 'string':
                         return new TypeGuess(TextType::class, [], Guess::LOW_CONFIDENCE);
                 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/Traits/DateTimeEqualsTrait.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/Traits/DateTimeEqualsTrait.php
@@ -18,7 +18,7 @@ trait DateTimeEqualsTrait
 {
     public static function assertDateTimeEquals($expected, $actual)
     {
-        if ($expected instanceof \DateTime && $actual instanceof \DateTime) {
+        if ($expected instanceof \DateTimeInterface && $actual instanceof \DateTimeInterface) {
             $expected = $expected->format('c');
             $actual = $actual->format('c');
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -93,6 +93,7 @@ class ValidatorTypeGuesserTest extends TestCase
             [new Type('long'), new TypeGuess(IntegerType::class, [], Guess::MEDIUM_CONFIDENCE)],
             [new Type('string'), new TypeGuess(TextType::class, [], Guess::LOW_CONFIDENCE)],
             [new Type(\DateTime::class), new TypeGuess(DateType::class, [], Guess::MEDIUM_CONFIDENCE)],
+            [new Type(\DateTimeImmutable::class), new TypeGuess(DateType::class, ['input' => 'datetime_immutable'], Guess::MEDIUM_CONFIDENCE)],
             [new Type('\DateTime'), new TypeGuess(DateType::class, [], Guess::MEDIUM_CONFIDENCE)],
         ];
     }

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -125,7 +125,7 @@ class BinaryFileResponse extends Response
      */
     public function setAutoLastModified(): static
     {
-        $this->setLastModified(\DateTime::createFromFormat('U', $this->file->getMTime()));
+        $this->setLastModified(\DateTimeImmutable::createFromFormat('U', $this->file->getMTime()));
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Make `HeaderBag::getDate()`, `Response::getDate()`, `getExpires()` and `getLastModified()` return a `DateTimeImmutable`
+
 6.3
 ---
 

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -193,15 +193,17 @@ class HeaderBag implements \IteratorAggregate, \Countable
     /**
      * Returns the HTTP header value converted to a date.
      *
+     * @return \DateTimeImmutable|null
+     *
      * @throws \RuntimeException When the HTTP header is not parseable
      */
-    public function getDate(string $key, \DateTime $default = null): ?\DateTimeInterface
+    public function getDate(string $key, \DateTimeInterface $default = null): ?\DateTimeInterface
     {
         if (null === $value = $this->get($key)) {
-            return $default;
+            return null !== $default ? \DateTimeImmutable::createFromInterface($default) : null;
         }
 
-        if (false === $date = \DateTime::createFromFormat(\DATE_RFC2822, $value)) {
+        if (false === $date = \DateTimeImmutable::createFromFormat(\DATE_RFC2822, $value)) {
             throw new \RuntimeException(sprintf('The "%s" HTTP header is not parseable (%s).', $key, $value));
         }
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -687,7 +687,7 @@ class Response
      *
      * @final
      */
-    public function getDate(): ?\DateTimeInterface
+    public function getDate(): ?\DateTimeImmutable
     {
         return $this->headers->getDate('Date');
     }
@@ -701,10 +701,7 @@ class Response
      */
     public function setDate(\DateTimeInterface $date): static
     {
-        if ($date instanceof \DateTime) {
-            $date = \DateTimeImmutable::createFromMutable($date);
-        }
-
+        $date = \DateTimeImmutable::createFromInterface($date);
         $date = $date->setTimezone(new \DateTimeZone('UTC'));
         $this->headers->set('Date', $date->format('D, d M Y H:i:s').' GMT');
 
@@ -745,13 +742,13 @@ class Response
      *
      * @final
      */
-    public function getExpires(): ?\DateTimeInterface
+    public function getExpires(): ?\DateTimeImmutable
     {
         try {
             return $this->headers->getDate('Expires');
         } catch (\RuntimeException) {
             // according to RFC 2616 invalid date formats (e.g. "0" and "-1") must be treated as in the past
-            return \DateTime::createFromFormat('U', time() - 172800);
+            return \DateTimeImmutable::createFromFormat('U', time() - 172800);
         }
     }
 
@@ -775,10 +772,7 @@ class Response
             return $this;
         }
 
-        if ($date instanceof \DateTime) {
-            $date = \DateTimeImmutable::createFromMutable($date);
-        }
-
+        $date = \DateTimeImmutable::createFromInterface($date);
         $date = $date->setTimezone(new \DateTimeZone('UTC'));
         $this->headers->set('Expires', $date->format('D, d M Y H:i:s').' GMT');
 
@@ -934,7 +928,7 @@ class Response
      *
      * @final
      */
-    public function getLastModified(): ?\DateTimeInterface
+    public function getLastModified(): ?\DateTimeImmutable
     {
         return $this->headers->getDate('Last-Modified');
     }
@@ -959,10 +953,7 @@ class Response
             return $this;
         }
 
-        if ($date instanceof \DateTime) {
-            $date = \DateTimeImmutable::createFromMutable($date);
-        }
-
+        $date = \DateTimeImmutable::createFromInterface($date);
         $date = $date->setTimezone(new \DateTimeZone('UTC'));
         $this->headers->set('Last-Modified', $date->format('D, d M Y H:i:s').' GMT');
 

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -45,7 +45,7 @@ class HeaderBagTest extends TestCase
     {
         $bag = new HeaderBag(['foo' => 'Tue, 4 Sep 2012 20:00:00 +0200']);
         $headerDate = $bag->getDate('foo');
-        $this->assertInstanceOf(\DateTime::class, $headerDate);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $headerDate);
     }
 
     public function testGetDateNull()

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
@@ -77,7 +77,7 @@ class ResponseCacheStrategyTest extends TestCase
         $cacheStrategy = new ResponseCacheStrategy();
 
         $embeddedResponse = new Response();
-        $embeddedResponse->setLastModified(new \DateTime());
+        $embeddedResponse->setLastModified(new \DateTimeImmutable());
         $cacheStrategy->add($embeddedResponse);
 
         $mainResponse = new Response();
@@ -95,7 +95,7 @@ class ResponseCacheStrategyTest extends TestCase
 
         // This main response uses the "validation" model
         $mainResponse = new Response();
-        $mainResponse->setLastModified(new \DateTime());
+        $mainResponse->setLastModified(new \DateTimeImmutable());
         $mainResponse->setEtag('foo');
 
         // Embedded response uses "expiry" model
@@ -117,7 +117,7 @@ class ResponseCacheStrategyTest extends TestCase
         $cacheStrategy = new ResponseCacheStrategy();
 
         $mainResponse = new Response();
-        $mainResponse->setLastModified(new \DateTime());
+        $mainResponse->setLastModified(new \DateTimeImmutable());
         $cacheStrategy->update($mainResponse);
 
         $this->assertTrue($mainResponse->isValidateable());
@@ -138,11 +138,11 @@ class ResponseCacheStrategyTest extends TestCase
     {
         $cacheStrategy = new ResponseCacheStrategy();
 
-        $embeddedDate = new \DateTime('-1 hour');
+        $embeddedDate = new \DateTimeImmutable('-1 hour');
 
         // This master response uses the "validation" model
         $masterResponse = new Response();
-        $masterResponse->setLastModified(new \DateTime('-2 hour'));
+        $masterResponse->setLastModified(new \DateTimeImmutable('-2 hour'));
         $masterResponse->setEtag('foo');
 
         // Embedded response uses "expiry" model
@@ -244,7 +244,7 @@ class ResponseCacheStrategyTest extends TestCase
         $mainResponse = new Response();
         $mainResponse->setSharedMaxAge(3600);
         $mainResponse->setEtag('foo');
-        $mainResponse->setLastModified(new \DateTime());
+        $mainResponse->setLastModified(new \DateTimeImmutable());
 
         $embeddedResponse = new Response();
         $embeddedResponse->setSharedMaxAge(60);

--- a/src/Symfony/Component/Mailer/README.md
+++ b/src/Symfony/Component/Mailer/README.md
@@ -57,7 +57,7 @@ $email = (new TemplatedEmail())
     // ...
     ->htmlTemplate('emails/signup.html.twig')
     ->context([
-        'expiration_date' => new \DateTime('+7 days'),
+        'expiration_date' => new \DateTimeImmutable('+7 days'),
         'username' => 'foo',
     ])
 ;

--- a/src/Symfony/Component/Mime/Header/DateHeader.php
+++ b/src/Symfony/Component/Mime/Header/DateHeader.php
@@ -52,15 +52,11 @@ final class DateHeader extends AbstractHeader
      */
     public function setDateTime(\DateTimeInterface $dateTime): void
     {
-        if ($dateTime instanceof \DateTime) {
-            $immutable = new \DateTimeImmutable('@'.$dateTime->getTimestamp());
-            $dateTime = $immutable->setTimezone($dateTime->getTimezone());
-        }
-        $this->dateTime = $dateTime;
+        $this->dateTime = \DateTimeImmutable::createFromInterface($dateTime);
     }
 
     public function getBodyAsString(): string
     {
-        return $this->dateTime->format(\DateTime::RFC2822);
+        return $this->dateTime->format(\DateTimeInterface::RFC2822);
     }
 }

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -43,7 +43,7 @@ class EmailTest extends TestCase
     {
         $e = new Email();
         $e->date($d = new \DateTimeImmutable());
-        $this->assertSame($d, $e->getDate());
+        $this->assertEquals($d, $e->getDate());
     }
 
     public function testReturnPath()

--- a/src/Symfony/Component/Mime/Tests/Header/DateHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/DateHeaderTest.php
@@ -23,14 +23,14 @@ class DateHeaderTest extends TestCase
     public function testGetDateTime()
     {
         $header = new DateHeader('Date', $dateTime = new \DateTimeImmutable());
-        $this->assertSame($dateTime, $header->getDateTime());
+        $this->assertEquals($dateTime, $header->getDateTime());
     }
 
     public function testDateTimeCanBeSetBySetter()
     {
         $header = new DateHeader('Date', new \DateTimeImmutable());
         $header->setDateTime($dateTime = new \DateTimeImmutable());
-        $this->assertSame($dateTime, $header->getDateTime());
+        $this->assertEquals($dateTime, $header->getDateTime());
     }
 
     public function testDateTimeIsConvertedToImmutable()

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -84,7 +84,7 @@ class HeadersTest extends TestCase
         $this->assertSame('bar', $headers->get('foo')->getBody());
 
         $this->assertInstanceOf(DateHeader::class, $headers->get('date'));
-        $this->assertSame($now, $headers->get('date')->getBody());
+        $this->assertEquals($now, $headers->get('date')->getBody());
 
         $this->assertInstanceOf(IdentificationHeader::class, $headers->get('message-id'));
         $this->assertSame(['id@id'], $headers->get('message-id')->getBody());

--- a/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
@@ -75,7 +75,7 @@ final class CronExpressionTrigger implements TriggerInterface
 
     public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable
     {
-        return \DateTimeImmutable::createFromMutable($this->expression->getNextRunDate($run));
+        return \DateTimeImmutable::createFromInterface($this->expression->getNextRunDate($run));
     }
 
     private static function parseHashed(string $expression, string $context): string

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -121,7 +121,7 @@ class LoginLinkHandlerTest extends TestCase
         ];
 
         yield [
-            new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash', new \DateTime('2020-06-01 00:00:00', new \DateTimeZone('+0000'))),
+            new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash', new \DateTimeImmutable('2020-06-01 00:00:00', new \DateTimeZone('+0000'))),
             ['lastAuthenticatedAt' => '2020-06-01T00:00:00+00:00'],
         ];
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -29,7 +29,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
     public const TIMEZONE_KEY = 'datetime_timezone';
 
     private array $defaultContext = [
-        self::FORMAT_KEY => \DateTime::RFC3339,
+        self::FORMAT_KEY => \DateTimeInterface::RFC3339,
         self::TIMEZONE_KEY => null,
     ];
 
@@ -108,14 +108,16 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         }
 
         try {
-            if (null !== $dateTimeFormat) {
-                $object = \DateTime::class === $type ? \DateTime::createFromFormat($dateTimeFormat, $data, $timezone) : \DateTimeImmutable::createFromFormat($dateTimeFormat, $data, $timezone);
+            if (\DateTimeInterface::class === $type) {
+                $type = \DateTimeImmutable::class;
+            }
 
-                if (false !== $object) {
+            if (null !== $dateTimeFormat) {
+                if (false !== $object = $type::createFromFormat($dateTimeFormat, $data, $timezone)) {
                     return $object;
                 }
 
-                $dateTimeErrors = \DateTime::class === $type ? \DateTime::getLastErrors() : \DateTimeImmutable::getLastErrors();
+                $dateTimeErrors = $type::getLastErrors();
 
                 throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Parsing datetime string "%s" using format "%s" resulted in %d errors: ', $data, $dateTimeFormat, $dateTimeErrors['error_count'])."\n".implode("\n", $this->formatDateTimeErrors($dateTimeErrors['errors'])), $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
             }
@@ -123,14 +125,12 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
             $defaultDateTimeFormat = $this->defaultContext[self::FORMAT_KEY] ?? null;
 
             if (null !== $defaultDateTimeFormat) {
-                $object = \DateTime::class === $type ? \DateTime::createFromFormat($defaultDateTimeFormat, $data, $timezone) : \DateTimeImmutable::createFromFormat($defaultDateTimeFormat, $data, $timezone);
-
-                if (false !== $object) {
+                if (false !== $object = $type::createFromFormat($defaultDateTimeFormat, $data, $timezone)) {
                     return $object;
                 }
             }
 
-            return \DateTime::class === $type ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
+            return new $type($data, $timezone);
         } catch (NotNormalizableValueException $e) {
             throw $e;
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -826,7 +826,7 @@ XML;
     {
         $xmlEncoder = $this->createXmlEncoderWithDateTimeNormalizer();
 
-        $actualXml = $xmlEncoder->encode(['dateTime' => new \DateTime($this->exampleDateTimeString)], 'xml');
+        $actualXml = $xmlEncoder->encode(['dateTime' => new \DateTimeImmutable($this->exampleDateTimeString)], 'xml');
 
         $this->assertEquals($this->createXmlWithDateTime(), $actualXml);
     }
@@ -835,7 +835,7 @@ XML;
     {
         $xmlEncoder = $this->createXmlEncoderWithDateTimeNormalizer();
 
-        $actualXml = $xmlEncoder->encode(['foo' => ['@dateTime' => new \DateTime($this->exampleDateTimeString)]], 'xml');
+        $actualXml = $xmlEncoder->encode(['foo' => ['@dateTime' => new \DateTimeImmutable($this->exampleDateTimeString)]], 'xml');
 
         $this->assertEquals($this->createXmlWithDateTimeField(), $actualXml);
     }
@@ -939,18 +939,18 @@ XML;
         $mock
             ->expects($this->once())
             ->method('normalize')
-            ->with(new \DateTime($this->exampleDateTimeString), 'xml', [])
+            ->with(new \DateTimeImmutable($this->exampleDateTimeString), 'xml', [])
             ->willReturn($this->exampleDateTimeString);
 
         $mock
             ->expects($this->once())
             ->method('getSupportedTypes')
-            ->willReturn([\DateTime::class => true]);
+            ->willReturn([\DateTimeImmutable::class => true]);
 
         $mock
             ->expects($this->once())
             ->method('supportsNormalization')
-            ->with(new \DateTime($this->exampleDateTimeString), 'xml')
+            ->with(new \DateTimeImmutable($this->exampleDateTimeString), 'xml')
             ->willReturn(true);
 
         return $mock;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -46,21 +46,21 @@ class DateTimeNormalizerTest extends TestCase
 
     public function testNormalizeUsingFormatPassedInContext()
     {
-        $this->assertEquals('2016', $this->normalizer->normalize(new \DateTime('2016/01/01'), null, [DateTimeNormalizer::FORMAT_KEY => 'Y']));
+        $this->assertEquals('2016', $this->normalizer->normalize(new \DateTimeImmutable('2016/01/01'), null, [DateTimeNormalizer::FORMAT_KEY => 'Y']));
     }
 
     public function testNormalizeUsingFormatPassedInConstructor()
     {
         $normalizer = new DateTimeNormalizer([DateTimeNormalizer::FORMAT_KEY => 'y']);
-        $this->assertEquals('16', $normalizer->normalize(new \DateTime('2016/01/01', new \DateTimeZone('UTC'))));
+        $this->assertEquals('16', $normalizer->normalize(new \DateTimeImmutable('2016/01/01', new \DateTimeZone('UTC'))));
     }
 
     public function testNormalizeUsingTimeZonePassedInConstructor()
     {
         $normalizer = new DateTimeNormalizer([DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('Japan')]);
 
-        $this->assertSame('2016-12-01T00:00:00+09:00', $normalizer->normalize(new \DateTime('2016/12/01', new \DateTimeZone('Japan'))));
-        $this->assertSame('2016-12-01T09:00:00+09:00', $normalizer->normalize(new \DateTime('2016/12/01', new \DateTimeZone('UTC'))));
+        $this->assertSame('2016-12-01T00:00:00+09:00', $normalizer->normalize(new \DateTimeImmutable('2016/12/01', new \DateTimeZone('Japan'))));
+        $this->assertSame('2016-12-01T09:00:00+09:00', $normalizer->normalize(new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC'))));
     }
 
     /**
@@ -75,10 +75,10 @@ class DateTimeNormalizerTest extends TestCase
 
     public static function normalizeUsingTimeZonePassedInContextProvider()
     {
-        yield ['2016-12-01T00:00:00+00:00', new \DateTime('2016/12/01', new \DateTimeZone('UTC')), null];
-        yield ['2016-12-01T00:00:00+09:00', new \DateTime('2016/12/01', new \DateTimeZone('Japan')), new \DateTimeZone('Japan')];
-        yield ['2016-12-01T09:00:00+09:00', new \DateTime('2016/12/01', new \DateTimeZone('UTC')), new \DateTimeZone('Japan')];
+        yield ['2016-12-01T00:00:00+00:00', new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC')), null];
+        yield ['2016-12-01T00:00:00+09:00', new \DateTimeImmutable('2016/12/01', new \DateTimeZone('Japan')), new \DateTimeZone('Japan')];
         yield ['2016-12-01T09:00:00+09:00', new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC')), new \DateTimeZone('Japan')];
+        yield ['2016-12-01T09:00:00+09:00', new \DateTime('2016/12/01', new \DateTimeZone('UTC')), new \DateTimeZone('Japan')];
     }
 
     /**
@@ -185,10 +185,10 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeUsingTimezonePassedInConstructor()
     {
         $timezone = new \DateTimeZone('Japan');
-        $expected = new \DateTime('2016/12/01 17:35:00', $timezone);
+        $expected = new \DateTimeImmutable('2016/12/01 17:35:00', $timezone);
         $normalizer = new DateTimeNormalizer([DateTimeNormalizer::TIMEZONE_KEY => $timezone]);
 
-        $this->assertEquals($expected, $normalizer->denormalize('2016.12.01 17:35:00', \DateTime::class, null, [
+        $this->assertEquals($expected, $normalizer->denormalize('2016.12.01 17:35:00', \DateTimeImmutable::class, null, [
             DateTimeNormalizer::FORMAT_KEY => 'Y.m.d H:i:s',
         ]));
     }
@@ -235,7 +235,7 @@ class DateTimeNormalizerTest extends TestCase
             '2016-12-01T17:35:00Z',
             new \DateTimeImmutable('2016/12/01 17:35:00', new \DateTimeZone('UTC')),
             'Europe/Paris',
-            \DateTime::RFC3339,
+            \DateTimeInterface::RFC3339,
         ];
     }
 
@@ -294,7 +294,7 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeDateTimeStringWithDefaultContextAllowsErrorFormat()
     {
         $format = 'd/m/Y'; // the default format
-        $string = '2020-01-01'; // the value which is in the wrong format, but is accepted because of `new \DateTime` in DateTimeNormalizer::denormalize
+        $string = '2020-01-01'; // the value which is in the wrong format, but is accepted because of `new \DateTimeImmutable` in DateTimeNormalizer::denormalize
 
         $normalizer = new DateTimeNormalizer([DateTimeNormalizer::FORMAT_KEY => $format]);
         $denormalizedDate = $normalizer->denormalize($string, \DateTimeInterface::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
@@ -156,12 +156,12 @@ trait CallbacksTestTrait
             'Format a date' => [
                 [
                     'bar' => function ($bar) {
-                        $this->assertInstanceOf(\DateTime::class, $bar);
+                        $this->assertInstanceOf(\DateTimeImmutable::class, $bar);
 
                         return $bar->format('d-m-Y H:i:s');
                     },
                 ],
-                new \DateTime('2011-09-10 06:30:00'),
+                new \DateTimeImmutable('2011-09-10 06:30:00'),
                 ['bar' => '10-09-2011 06:30:00', 'foo' => null],
             ],
             'Collect a property' => [
@@ -220,11 +220,11 @@ trait CallbacksTestTrait
                     'bar' => function ($bar) {
                         $this->assertIsString($bar);
 
-                        return \DateTime::createFromFormat('d-m-Y H:i:s', $bar);
+                        return \DateTimeImmutable::createFromFormat('d-m-Y H:i:s', $bar);
                     },
                 ],
                 '10-09-2011 06:30:00',
-                new CallbacksObject(new \DateTime('2011-09-10 06:30:00')),
+                new CallbacksObject(new \DateTimeImmutable('2011-09-10 06:30:00')),
             ],
             'Collect a property' => [
                 [

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
@@ -39,7 +39,7 @@ trait ContextMetadataTestTrait
         new Serializer([new DateTimeNormalizer(), $normalizer]);
 
         $dummy = new $contextMetadataDummyClass();
-        $dummy->date = new \DateTime('2011-07-28T08:44:00.123+00:00');
+        $dummy->date = new \DateTimeImmutable('2011-07-28T08:44:00.123+00:00');
 
         self::assertEquals(['date' => '2011-07-28T08:44:00+00:00'], $normalizer->normalize($dummy));
 
@@ -63,13 +63,13 @@ trait ContextMetadataTestTrait
 
         /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '2011-07-28T08:44:00+00:00'], $contextMetadataDummyClass);
-        self::assertEquals(new \DateTime('2011-07-28T08:44:00+00:00'), $dummy->date);
+        self::assertEquals(new \DateTimeImmutable('2011-07-28T08:44:00+00:00'), $dummy->date);
 
         /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '2011-07-28T08:44:00+00:00'], ContextMetadataDummy::class, null, [
             ObjectNormalizer::GROUPS => 'extended',
         ]);
-        self::assertEquals(new \DateTime('2011-07-28T08:44:00+00:00'), $dummy->date, 'base denormalization context is unchanged for this group');
+        self::assertEquals(new \DateTimeImmutable('2011-07-28T08:44:00+00:00'), $dummy->date, 'base denormalization context is unchanged for this group');
 
         /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '28/07/2011'], $contextMetadataDummyClass, null, [
@@ -105,9 +105,9 @@ class ContextMetadataDummy
      *
      * @Groups({ "extended", "simple" })
      *
-     * @Context({ DateTimeNormalizer::FORMAT_KEY = \DateTime::RFC3339 })
+     * @Context({ DateTimeNormalizer::FORMAT_KEY = \DateTimeInterface::RFC3339 })
      * @Context(
-     *     normalizationContext = { DateTimeNormalizer::FORMAT_KEY = \DateTime::RFC3339_EXTENDED },
+     *     normalizationContext = { DateTimeNormalizer::FORMAT_KEY = \DateTimeInterface::RFC3339_EXTENDED },
      *     groups = {"extended"}
      * )
      * @Context(
@@ -125,9 +125,9 @@ class ContextChildMetadataDummy
      *
      * @Groups({ "extended", "simple" })
      *
-     * @DummyContextChild({ DateTimeNormalizer::FORMAT_KEY = \DateTime::RFC3339 })
+     * @DummyContextChild({ DateTimeNormalizer::FORMAT_KEY = \DateTimeInterface::RFC3339 })
      * @DummyContextChild(
-     *     normalizationContext = { DateTimeNormalizer::FORMAT_KEY = \DateTime::RFC3339_EXTENDED },
+     *     normalizationContext = { DateTimeNormalizer::FORMAT_KEY = \DateTimeInterface::RFC3339_EXTENDED },
      *     groups = {"extended"}
      * )
      * @DummyContextChild(

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -722,20 +722,20 @@ class SerializerTest extends TestCase
         );
 
         $actual = $serializer->deserialize('{ "changed": null }', DummyUnionType::class, 'json', [
-            DateTimeNormalizer::FORMAT_KEY => \DateTime::ISO8601,
+            DateTimeNormalizer::FORMAT_KEY => \DateTimeinterface::ATOM,
         ]);
 
         $this->assertEquals((new DummyUnionType())->setChanged(null), $actual, 'Union type denormalization first case failed.');
 
         $actual = $serializer->deserialize('{ "changed": "2022-03-22T16:15:05+0000" }', DummyUnionType::class, 'json', [
-            DateTimeNormalizer::FORMAT_KEY => \DateTime::ISO8601,
+            DateTimeNormalizer::FORMAT_KEY => \DateTimeinterface::ATOM,
         ]);
 
-        $expectedDateTime = \DateTime::createFromFormat(\DateTime::ISO8601, '2022-03-22T16:15:05+0000');
+        $expectedDateTime = \DateTimeImmutable::createFromFormat(\DateTimeinterface::ATOM, '2022-03-22T16:15:05+0000');
         $this->assertEquals((new DummyUnionType())->setChanged($expectedDateTime), $actual, 'Union type denormalization second case failed.');
 
         $actual = $serializer->deserialize('{ "changed": false }', DummyUnionType::class, 'json', [
-            DateTimeNormalizer::FORMAT_KEY => \DateTime::ISO8601,
+            DateTimeNormalizer::FORMAT_KEY => \DateTimeinterface::ATOM,
         ]);
 
         $this->assertEquals(new DummyUnionType(), $actual, 'Union type denormalization third case failed.');

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -82,7 +82,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
             if (class_exists(\IntlDateFormatter::class)) {
                 $formatter = new \IntlDateFormatter(\Locale::getDefault(), \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT, 'UTC');
 
-                return $formatter->format(new \DateTime(
+                return $formatter->format(new \DateTimeImmutable(
                     $value->format('Y-m-d H:i:s.u'),
                     new \DateTimeZone('UTC')
                 ));

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -61,18 +61,14 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
             $comparedValue = $constraint->value;
         }
 
-        // Convert strings to DateTimes if comparing another DateTime
-        // This allows to compare with any date/time value supported by
-        // the DateTime constructor:
+        // Convert strings to date-time objects if comparing to another date-time object
+        // This allows to compare with any date/time value supported by date-time constructors:
         // https://php.net/datetime.formats
         if (\is_string($comparedValue) && $value instanceof \DateTimeInterface) {
-            // If $value is immutable, convert the compared value to a DateTimeImmutable too, otherwise use DateTime
-            $dateTimeClass = $value instanceof \DateTimeImmutable ? \DateTimeImmutable::class : \DateTime::class;
-
             try {
-                $comparedValue = new $dateTimeClass($comparedValue);
+                $comparedValue = new $value($comparedValue);
             } catch (\Exception) {
-                throw new ConstraintDefinitionException(sprintf('The compared value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $comparedValue, $dateTimeClass, get_debug_type($constraint)));
+                throw new ConstraintDefinitionException(sprintf('The compared value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $comparedValue, get_debug_type($value), get_debug_type($constraint)));
             }
         }
 

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -40,9 +40,9 @@ class DateTimeValidator extends DateValidator
 
         $value = (string) $value;
 
-        \DateTime::createFromFormat($constraint->format, $value);
+        \DateTimeImmutable::createFromFormat($constraint->format, $value);
 
-        $errors = \DateTime::getLastErrors() ?: ['error_count' => 0, 'warnings' => []];
+        $errors = \DateTimeImmutable::getLastErrors() ?: ['error_count' => 0, 'warnings' => []];
 
         if (0 < $errors['error_count']) {
             $this->context->buildViolation($constraint->message)

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -68,25 +68,19 @@ class RangeValidator extends ConstraintValidator
         // the DateTime constructor:
         // https://php.net/datetime.formats
         if ($value instanceof \DateTimeInterface) {
-            $dateTimeClass = null;
-
             if (\is_string($min)) {
-                $dateTimeClass = $value instanceof \DateTimeImmutable ? \DateTimeImmutable::class : \DateTime::class;
-
                 try {
-                    $min = new $dateTimeClass($min);
+                    $min = new $value($min);
                 } catch (\Exception) {
-                    throw new ConstraintDefinitionException(sprintf('The min value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $min, $dateTimeClass, get_debug_type($constraint)));
+                    throw new ConstraintDefinitionException(sprintf('The min value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $min, get_debug_type($value), get_debug_type($constraint)));
                 }
             }
 
             if (\is_string($max)) {
-                $dateTimeClass = $dateTimeClass ?: ($value instanceof \DateTimeImmutable ? \DateTimeImmutable::class : \DateTime::class);
-
                 try {
-                    $max = new $dateTimeClass($max);
+                    $max = new $value($max);
                 } catch (\Exception) {
-                    throw new ConstraintDefinitionException(sprintf('The max value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $max, $dateTimeClass, get_debug_type($constraint)));
+                    throw new ConstraintDefinitionException(sprintf('The max value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $max, get_debug_type($value), get_debug_type($constraint)));
                 }
             }
         }
@@ -187,7 +181,7 @@ class RangeValidator extends ConstraintValidator
         }
 
         try {
-            new \DateTime($boundary);
+            new \DateTimeImmutable($boundary);
         } catch (\Exception) {
             return false;
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -175,7 +175,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
     {
         // Conversion of dates to string differs between ICU versions
         // Make sure we have the correct version loaded
-        if ($dirtyValue instanceof \DateTime || $dirtyValue instanceof \DateTimeInterface) {
+        if ($dirtyValue instanceof \DateTimeInterface) {
             IntlTestHelper::requireIntl($this, '57.1');
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
@@ -69,7 +69,7 @@ class IsNullValidatorTest extends ConstraintValidatorTestCase
             [true, 'true'],
             ['', '""'],
             ['foo bar', '"foo bar"'],
-            [new \DateTime(), 'object'],
+            [new \DateTimeImmutable(), 'object'],
             [new \stdClass(), 'object'],
             [[], 'array'],
         ];

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -288,11 +288,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             [new \DateTime('March 10, 2014')],
             [new \DateTime('March 15, 2014')],
             [new \DateTime('March 20, 2014')],
+            [new \DateTimeImmutable('March 10, 2014')],
+            [new \DateTimeImmutable('March 15, 2014')],
+            [new \DateTimeImmutable('March 20, 2014')],
         ];
-
-        $tests[] = [new \DateTimeImmutable('March 10, 2014')];
-        $tests[] = [new \DateTimeImmutable('March 15, 2014')];
-        $tests[] = [new \DateTimeImmutable('March 20, 2014')];
 
         date_default_timezone_set($timezone);
 
@@ -309,10 +308,9 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $tests = [
             [new \DateTime('March 20, 2013'), 'Mar 20, 2013, 12:00 AM'],
             [new \DateTime('March 9, 2014'), 'Mar 9, 2014, 12:00 AM'],
+            [new \DateTimeImmutable('March 20, 2013'), 'Mar 20, 2013, 12:00 AM'],
+            [new \DateTimeImmutable('March 9, 2014'), 'Mar 9, 2014, 12:00 AM'],
         ];
-
-        $tests[] = [new \DateTimeImmutable('March 20, 2013'), 'Mar 20, 2013, 12:00 AM'];
-        $tests[] = [new \DateTimeImmutable('March 9, 2014'), 'Mar 9, 2014, 12:00 AM'];
 
         date_default_timezone_set($timezone);
 
@@ -329,10 +327,9 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $tests = [
             [new \DateTime('March 21, 2014'), 'Mar 21, 2014, 12:00 AM'],
             [new \DateTime('March 9, 2015'), 'Mar 9, 2015, 12:00 AM'],
+            [new \DateTimeImmutable('March 21, 2014'), 'Mar 21, 2014, 12:00 AM'],
+            [new \DateTimeImmutable('March 9, 2015'), 'Mar 9, 2015, 12:00 AM'],
         ];
-
-        $tests[] = [new \DateTimeImmutable('March 21, 2014'), 'Mar 21, 2014, 12:00 AM'];
-        $tests[] = [new \DateTimeImmutable('March 9, 2015'), 'Mar 9, 2015, 12:00 AM'];
 
         date_default_timezone_set($timezone);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeTest.php
@@ -27,7 +27,7 @@ class TypeTest extends TestCase
         self::assertSame('integer', $aConstraint->type);
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();
-        self::assertSame(\DateTime::class, $bConstraint->type);
+        self::assertSame(\DateTimeImmutable::class, $bConstraint->type);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'TypeDummy'], $bConstraint->groups);
 
@@ -43,7 +43,7 @@ class TypeDummy
     #[Type('integer')]
     private $a;
 
-    #[Type(type: \DateTime::class, message: 'myMessage')]
+    #[Type(type: \DateTimeImmutable::class, message: 'myMessage')]
     private $b;
 
     #[Type(type: ['string', 'array'], groups: ['my_group'], payload: 'some attached data')]

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/datetime-legacy.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/datetime-legacy.php
@@ -7,7 +7,7 @@ return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
         clone ($p['DateTimeZone'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('DateTimeZone')),
         clone ($p['DateInterval'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('DateInterval')),
     ], [
-        4 => 'O:10:"DatePeriod":6:{s:5:"start";O:8:"DateTime":3:{s:4:"date";s:26:"2009-10-11 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:12:"Europe/Paris";}s:7:"current";N;s:3:"end";N;s:8:"interval";O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:7;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:7;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}s:11:"recurrences";i:5;s:18:"include_start_date";b:1;}',
+        4 => 'O:10:"DatePeriod":6:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2009-10-11 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:12:"Europe/Paris";}s:7:"current";N;s:3:"end";N;s:8:"interval";O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:7;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:7;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}s:11:"recurrences";i:5;s:18:"include_start_date";b:1;}',
     ]),
     null,
     [

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/datetime.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/datetime.php
@@ -7,7 +7,7 @@ return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
         clone ($p['DateTimeZone'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('DateTimeZone')),
         clone ($p['DateInterval'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('DateInterval')),
         clone ($p['DatePeriod'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('DatePeriod')),
-        clone $p['DateTime'],
+        clone $p['DateTimeImmutable'],
         clone $p['DateInterval'],
     ],
     null,

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -127,7 +127,7 @@ class VarExporterTest extends TestCase
             \DateTime::createFromFormat('U', 0),
             \DateTimeImmutable::createFromFormat('U', 0),
             $tz = new \DateTimeZone('Europe/Paris'),
-            $interval = ($start = new \DateTime('2009-10-11', $tz))->diff(new \DateTime('2009-10-18', $tz)),
+            $interval = ($start = new \DateTimeImmutable('2009-10-11', $tz))->diff(new \DateTimeImmutable('2009-10-18', $tz)),
             new \DatePeriod($start, $interval, 4),
         ]];
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -574,7 +574,7 @@ class InlineTest extends TestCase
      */
     public function testParseTimestampAsDateTimeObject(string $yaml, int $year, int $month, int $day, int $hour, int $minute, int $second, int $microsecond, string $timezone)
     {
-        $expected = (new \DateTime($yaml))
+        $expected = (new \DateTimeImmutable($yaml))
             ->setTimeZone(new \DateTimeZone('UTC'))
             ->setDate($year, $month, $day)
             ->setTime($hour, $minute, $second, $microsecond);
@@ -599,7 +599,7 @@ class InlineTest extends TestCase
      */
     public function testParseNestedTimestampListAsDateTimeObject(string $yaml, int $year, int $month, int $day, int $hour, int $minute, int $second, int $microsecond)
     {
-        $expected = (new \DateTime($yaml))
+        $expected = (new \DateTimeImmutable($yaml))
             ->setTimeZone(new \DateTimeZone('UTC'))
             ->setDate($year, $month, $day)
             ->setTime($hour, $minute, $second, $microsecond);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #47580
| License       | MIT
| Doc PR        | -

Together with #50290, this PR removes `DateTime` everywhere possible.

What remains is:
- test cases that test both DateTime and DateTimeImmutable - legit to keep
- date/time form-types and transformers in the Form component - we'd need a separate effort for them, related to #50295
- `PersistentTokenInterface::getLastUsed(): \DateTime` - separate effort also
