### PR TITLE
[AssetMapper] Improving XSD to use attributes whenever possible

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -191,16 +191,17 @@
         <xsd:sequence>
             <xsd:element name="path" type="asset_mapper_path" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="excluded-pattern" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
-            <xsd:element name="server" type="xsd:boolean" minOccurs="0" />
-            <xsd:element name="public_prefix" type="xsd:string" minOccurs="0" />
-            <xsd:element name="strict-mode" type="xsd:boolean" minOccurs="0" />
             <xsd:element name="extension" type="asset_mapper_extension" minOccurs="0" maxOccurs="unbounded" />
-            <xsd:element name="importmap-path" type="xsd:string" minOccurs="0" />
-            <xsd:element name="importmap-polyfill" type="xsd:string" minOccurs="0" nillable="true" />
             <xsd:element name="importmap-script-attribute" type="asset_mapper_attribute" minOccurs="0" maxOccurs="unbounded" />
-            <xsd:element name="vendor_dir" type="xsd:string" minOccurs="0" />
-            <xsd:element name="provider" type="xsd:string" minOccurs="0" />
         </xsd:sequence>
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="server" type="xsd:boolean" />
+        <xsd:attribute name="public-prefix" type="xsd:string" />
+        <xsd:attribute name="strict-mode" type="xsd:boolean" />
+        <xsd:attribute name="importmap-path" type="xsd:string" />
+        <xsd:attribute name="importmap-polyfill" type="xsd:string" />
+        <xsd:attribute name="vendor-dir" type="xsd:string" />
+        <xsd:attribute name="provider" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="asset_mapper_path" mixed="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/asset_mapper.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/asset_mapper.xml
@@ -7,19 +7,21 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
-        <framework:asset-mapper>
+        <framework:asset-mapper
+            enabled="true"
+            server="true"
+            public-prefix="/assets_path/"
+            strict-mode="true"
+            importmap-path="%kernel.project_dir%/importmap.php"
+            importmap-polyfill="https://cdn.example.com/polyfill.js"
+            vendor-dir="%kernel.project_dir%/assets/vendor"
+            provider="jspm"
+        >
             <framework:path>assets/</framework:path>
             <framework:path namespace="my_namespace">assets2/</framework:path>
-            <framework:excluded-pattern>*/*.scss</framework:excluded-pattern>
-            <framework:server>true</framework:server>
-            <framework:public_prefix>/assets_path/</framework:public_prefix>
-            <framework:strict-mode>true</framework:strict-mode>
+            <framework:excluded-pattern>*/assets/build/*</framework:excluded-pattern>
             <framework:extension extension="zip">application/zip</framework:extension>
-            <framework:importmap-path>%kernel.project_dir%/importmap.php</framework:importmap-path>
-            <framework:importmap-polyfill>https://cdn.example.com/polyfill.js</framework:importmap-polyfill>
             <framework:importmap-script-attribute key="data-turbo-track">reload</framework:importmap-script-attribute>
-            <framework:vendor_dir>%kernel.project_dir%/assets/vendor</framework:vendor_dir>
-            <framework:provider>jspm</framework:provider>
         </framework:asset-mapper>
     </framework:config>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | TODO

Some notes from @stof - I was using `<elements>` for scalar config that works much better as attributes.

Cheers!