### PR TITLE
[HttpFoundation] UrlHelper is now aware of RequestContext changes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -110,7 +110,7 @@ return static function (ContainerConfigurator $container) {
         ->set('url_helper', UrlHelper::class)
             ->args([
                 service('request_stack'),
-                service('router.request_context')->ignoreOnInvalid(),
+                service('router')->ignoreOnInvalid(),
             ])
         ->alias(UrlHelper::class, 'url_helper')
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -24,7 +24,7 @@
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/event-dispatcher": "^5.1|^6.0",
         "symfony/error-handler": "^4.4.1|^5.0.1|^6.0",
-        "symfony/http-foundation": "^5.3|^6.0",
+        "symfony/http-foundation": "^5.4.24|^6.2.11",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php80": "^1.16",

--- a/src/Symfony/Component/HttpFoundation/Tests/UrlHelperTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UrlHelperTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\UrlHelper;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RequestContextAwareInterface;
 
 class UrlHelperTest extends TestCase
 {
@@ -65,6 +66,40 @@ class UrlHelperTest extends TestCase
 
         $requestContext = new RequestContext($baseUrl, 'GET', $host, $scheme, $httpPort, $httpsPort, $path);
         $helper = new UrlHelper(new RequestStack(), $requestContext);
+
+        $this->assertEquals($expected, $helper->getAbsoluteUrl($path));
+    }
+
+    /**
+     * @dataProvider getGenerateAbsoluteUrlRequestContextData
+     */
+    public function testGenerateAbsoluteUrlWithRequestContextAwareInterface($path, $baseUrl, $host, $scheme, $httpPort, $httpsPort, $expected)
+    {
+        if (!class_exists(RequestContext::class)) {
+            $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
+        }
+
+        $requestContext = new RequestContext($baseUrl, 'GET', $host, $scheme, $httpPort, $httpsPort, $path);
+        $contextAware = new class($requestContext) implements RequestContextAwareInterface {
+            private $requestContext;
+
+            public function __construct($requestContext)
+            {
+                $this->requestContext = $requestContext;
+            }
+
+            public function setContext(RequestContext $context)
+            {
+                $this->requestContext = $context;
+            }
+
+            public function getContext()
+            {
+                return $this->requestContext;
+            }
+        };
+
+        $helper = new UrlHelper(new RequestStack(), $contextAware);
 
         $this->assertEquals($expected, $helper->getAbsoluteUrl($path));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        |

`RequestContext` in routing can change at runtime after the `UrlHelper` has been created, so using a `RequestContextAwareInterface` instance (i.e. the router) will workaround URL generation issues.

In my application I have a CLI command that dynamically create the RequestContext, based on database queries and other user-driven configuration. With this information at hand, I retrieve the router and set the new context that should then be used on any other URL generation.

This works for the Router, but then I render some twig templates (to send formatted email) and found that the `UrlHelper` is using the old context, and not helping at all :) Also, the helper is final and without interface, so I have no way of decorating or replacing it.

Long story short: in my opinion, the `RequestContext` should be treated just like the `Request`, and so we should use `RequestContextAwareInterface` just like we use the `RequestStack`.

....or maybe the context should be carried out with the `RequestStack`? Any other ideas?

~~no longer relevant: this PR introduce a BC on the constructor of `UrlHelper`, but since it's final maybe is not required to keep backward compatility. If not, I may update the class to support both `RequestContextAwareInterface` and `RequestContext` as the second parameter.~~