### PR TITLE
Supported "Marking" enum php

### DIFF
--- a/src/Symfony/Component/Workflow/Marking.php
+++ b/src/Symfony/Component/Workflow/Marking.php
@@ -22,6 +22,9 @@ class Marking
      * @var array<string, int>
      */
     private array $places = [];
+    /**
+     * @var array<string, \UnitEnum>
+     */
     private array $enumPlaces = [];
     private ?array $context = null;
 
@@ -37,7 +40,7 @@ class Marking
 
     public function mark(string|\UnitEnum $place): void
     {
-        $key = $this->placeToKey($place);
+        $key = $this->enumOrStringToKey($place);
         $this->places[$key] = 1;
         if ($place instanceof \UnitEnum) {
             $this->enumPlaces[$key] = $place;
@@ -46,7 +49,7 @@ class Marking
 
     public function unmark(string|\UnitEnum $place): void
     {
-        $key = $this->placeToKey($place);
+        $key = $this->enumOrStringToKey($place);
         unset(
             $this->places[$key],
             $this->enumPlaces[$key]
@@ -55,7 +58,7 @@ class Marking
 
     public function has(string|\UnitEnum $place): bool
     {
-        return isset($this->places[$this->placeToKey($place)]);
+        return isset($this->places[$this->enumOrStringToKey($place)]);
     }
 
     /**
@@ -67,7 +70,7 @@ class Marking
     }
 
     /**
-     * @return array<string, string|\UnitEnum>
+     * @return array<string, \UnitEnum>
      */
     public function getEnumPlaces(): array
     {
@@ -90,7 +93,7 @@ class Marking
         return $this->context;
     }
 
-    private function placeToKey(string|\UnitEnum $place): string
+    private function enumOrStringToKey(string|\UnitEnum $place): string
     {
         if (is_string($place)) {
             return $place;

--- a/src/Symfony/Component/Workflow/Marking.php
+++ b/src/Symfony/Component/Workflow/Marking.php
@@ -18,11 +18,15 @@ namespace Symfony\Component\Workflow;
  */
 class Marking
 {
+    /**
+     * @var array<string, int>
+     */
     private array $places = [];
+    private array $enumPlaces = [];
     private ?array $context = null;
 
     /**
-     * @param int[] $representation Keys are the place name and values should be 1
+     * @param array<string, int> $representation Keys are the place name and values should be 1
      */
     public function __construct(array $representation = [])
     {
@@ -31,36 +35,43 @@ class Marking
         }
     }
 
-    /**
-     * @return void
-     */
-    public function mark(string $place)
+    public function mark(string|\UnitEnum $place): void
     {
-        $this->places[$place] = 1;
+        $key = $this->placeToKey($place);
+        $this->places[$key] = 1;
+        if ($place instanceof \UnitEnum) {
+            $this->enumPlaces[$key] = $place;
+        }
+    }
+
+    public function unmark(string|\UnitEnum $place): void
+    {
+        $key = $this->placeToKey($place);
+        unset(
+            $this->places[$key],
+            $this->enumPlaces[$key]
+        );
+    }
+
+    public function has(string|\UnitEnum $place): bool
+    {
+        return isset($this->places[$this->placeToKey($place)]);
     }
 
     /**
-     * @return void
+     * @return array<string, int>
      */
-    public function unmark(string $place)
-    {
-        unset($this->places[$place]);
-    }
-
-    /**
-     * @return bool
-     */
-    public function has(string $place)
-    {
-        return isset($this->places[$place]);
-    }
-
-    /**
-     * @return array
-     */
-    public function getPlaces()
+    public function getPlaces(): array
     {
         return $this->places;
+    }
+
+    /**
+     * @return array<string, string|\UnitEnum>
+     */
+    public function getEnumPlaces(): array
+    {
+        return $this->enumPlaces;
     }
 
     /**
@@ -77,5 +88,18 @@ class Marking
     public function getContext(): ?array
     {
         return $this->context;
+    }
+
+    private function placeToKey(string|\UnitEnum $place): string
+    {
+        if (is_string($place)) {
+            return $place;
+        }
+
+        if ($place instanceof \BackedEnum) {
+            return (string)$place->value;
+        }
+
+        return $place->name;
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/MarkingEnum.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Tests;
+
+enum MarkingEnum: int
+{
+    case FIRST_PLACE = 1;
+}

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Workflow\Tests\MarkingStore;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
+use Symfony\Component\Workflow\Tests\MarkingEnum;
 use Symfony\Component\Workflow\Tests\Subject;
 
 class MethodMarkingStoreTest extends TestCase
@@ -109,6 +110,28 @@ class MethodMarkingStoreTest extends TestCase
         $this->expectExceptionMessage('Typed property Symfony\Component\Workflow\Tests\MarkingStore\SubjectWithType::$marking must not be accessed before initialization');
 
         $markingStore->getMarking($subject);
+    }
+
+    public function testGetSetMarkingWithSingleEnumState()
+    {
+        $subject = new Subject();
+
+        $markingStore = new MethodMarkingStore(true);
+
+        $marking = $markingStore->getMarking($subject);
+
+        $this->assertInstanceOf(Marking::class, $marking);
+        $this->assertCount(0, $marking->getPlaces());
+
+        $marking->mark(MarkingEnum::FIRST_PLACE);
+
+        $markingStore->setMarking($subject, $marking);
+
+        $this->assertSame(MarkingEnum::FIRST_PLACE, $subject->getMarking());
+
+        $marking2 = $markingStore->getMarking($subject);
+
+        $this->assertEquals($marking, $marking2);
     }
 
     private function createValueObject(string $markingValue): object

--- a/src/Symfony/Component/Workflow/Tests/Subject.php
+++ b/src/Symfony/Component/Workflow/Tests/Subject.php
@@ -22,7 +22,7 @@ final class Subject
         $this->context = [];
     }
 
-    public function getMarking(): string|array|null
+    public function getMarking(): string|array|null|MarkingEnum
     {
         return $this->marking;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I would like to be able to use the getters and setters of my entity with the enum type without custom implements `MarkingStoreInterface`.

Because php does not support enum in associative arrays, and `\WeakMap` is not suitable for this case, it was decided to make a method `getEnumPlaces`