### PR TITLE
[Security] Skip clearing CSRF Token on stateless logout

### DIFF
--- a/src/Symfony/Component/Security/Http/EventListener/CsrfTokenClearingLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CsrfTokenClearingLogoutListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
+use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 
 /**
@@ -31,6 +32,10 @@ class CsrfTokenClearingLogoutListener implements EventSubscriberInterface
 
     public function onLogout(LogoutEvent $event): void
     {
+        if ($this->csrfTokenStorage instanceof SessionTokenStorage && !$event->getRequest()->hasPreviousSession()) {
+            return;
+        }
+
         $this->csrfTokenStorage->clear();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50310 
| License       | MIT
| Doc PR        | -

Not targeting 5.4 LTS as the bug is only breaking on 6.3 although it does exist on prior versions.