### PR TITLE
[FrameworkBundle] Generate caches consistently on successive run of `cache:clear` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -129,14 +129,7 @@ EOF
                 if ($output->isVerbose()) {
                     $io->comment('Warming up optional cache...');
                 }
-                $warmer = $kernel->getContainer()->get('cache_warmer');
-                // non optional warmers already ran during container compilation
-                $warmer->enableOnlyOptionalWarmers();
-                $preload = (array) $warmer->warmUp($realCacheDir, $io);
-
-                if ($preload && file_exists($preloadFile = $realCacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
-                    Preloader::append($preloadFile, $preload);
-                }
+                $this->warmupOptionals($io, $realCacheDir);
             }
         } else {
             $fs->mkdir($warmupDir);
@@ -145,7 +138,14 @@ EOF
                 if ($output->isVerbose()) {
                     $io->comment('Warming up cache...');
                 }
-                $this->warmup($io, $warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
+                $this->warmup($warmupDir, $realBuildDir);
+
+                if (!$input->getOption('no-optional-warmers')) {
+                    if ($output->isVerbose()) {
+                        $io->comment('Warming up optional cache...');
+                    }
+                    $this->warmupOptionals($io, $realCacheDir);
+                }
             }
 
             if (!$fs->exists($warmupDir.'/'.$containerDir)) {
@@ -219,7 +219,7 @@ EOF
         return false;
     }
 
-    private function warmup(SymfonyStyle $io, string $warmupDir, string $realBuildDir, bool $enableOptionalWarmers = true): void
+    private function warmup(string $warmupDir, string $realBuildDir): void
     {
         // create a temporary kernel
         $kernel = $this->getApplication()->getKernel();
@@ -227,18 +227,6 @@ EOF
             throw new \LogicException('Calling "cache:clear" with a kernel that does not implement "Symfony\Component\HttpKernel\RebootableInterface" is not supported.');
         }
         $kernel->reboot($warmupDir);
-
-        // warmup temporary dir
-        if ($enableOptionalWarmers) {
-            $warmer = $kernel->getContainer()->get('cache_warmer');
-            // non optional warmers already ran during container compilation
-            $warmer->enableOnlyOptionalWarmers();
-            $preload = (array) $warmer->warmUp($warmupDir, $io);
-
-            if ($preload && file_exists($preloadFile = $warmupDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
-                Preloader::append($preloadFile, $preload);
-            }
-        }
 
         // fix references to cached files with the real cache directory name
         $search = [$warmupDir, str_replace('\\', '\\\\', $warmupDir)];
@@ -248,6 +236,19 @@ EOF
             if ($count) {
                 file_put_contents($file, $content);
             }
+        }
+    }
+
+    private function warmupOptionals(SymfonyStyle $io, string $realCacheDir): void
+    {
+        $kernel = $this->getApplication()->getKernel();
+        $warmer = $kernel->getContainer()->get('cache_warmer');
+        // non optional warmers already ran during container compilation
+        $warmer->enableOnlyOptionalWarmers();
+        $preload = (array) $warmer->warmUp($realCacheDir, $io);
+
+        if ($preload && file_exists($preloadFile = $realCacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
+            Preloader::append($preloadFile, $preload);
         }
     }
 }


### PR DESCRIPTION
Provides forward-port of #50253 onto branch 6.3