### PR TITLE
[TwigBridge] Add `AppVariable::getEnabledLocales()` 

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -31,6 +31,7 @@ class AppVariable
     private string $environment;
     private bool $debug;
     private LocaleSwitcher $localeSwitcher;
+    private array $enabledLocales;
 
     /**
      * @return void
@@ -67,6 +68,11 @@ class AppVariable
     public function setLocaleSwitcher(LocaleSwitcher $localeSwitcher): void
     {
         $this->localeSwitcher = $localeSwitcher;
+    }
+
+    public function setEnabledLocales(array $enabledLocales): void
+    {
+        $this->enabledLocales = $enabledLocales;
     }
 
     /**
@@ -153,6 +159,15 @@ class AppVariable
         }
 
         return $this->localeSwitcher->getLocale();
+    }
+
+    public function getEnabled_locales(): array
+    {
+        if (!isset($this->enabledLocales)) {
+            throw new \RuntimeException('The "app.enabled_locales" variable is not available.');
+        }
+
+        return $this->enabledLocales;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Allow an array to be passed as the first argument to the `importmap()` Twig function
  * Add `TemplatedEmail::locale()` to set the locale for the email rendering
+ * Add `AppVariable::getEnabledLocales()` to retrieve the enabled locales
 
 6.3
 ---

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -112,6 +112,13 @@ class AppVariableTest extends TestCase
         self::assertEquals('fr', $this->appVariable->getLocale());
     }
 
+    public function testGetEnabledLocales()
+    {
+        $this->appVariable->setEnabledLocales(['en', 'fr']);
+
+        self::assertSame(['en', 'fr'], $this->appVariable->getEnabled_locales());
+    }
+
     public function testGetTokenWithNoToken()
     {
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
@@ -169,6 +176,13 @@ class AppVariableTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The "app.locale" variable is not available.');
         $this->appVariable->getLocale();
+    }
+
+    public function testGetEnabledLocalesWithEnabledLocalesNotSet()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The "app.enabled_locales" variable is not available.');
+        $this->appVariable->getEnabled_locales();
     }
 
     public function testGetFlashesWithNoRequest()

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -77,6 +77,7 @@ return static function (ContainerConfigurator $container) {
             ->call('setTokenStorage', [service('security.token_storage')->ignoreOnInvalid()])
             ->call('setRequestStack', [service('request_stack')->ignoreOnInvalid()])
             ->call('setLocaleSwitcher', [service('translation.locale_switcher')->ignoreOnInvalid()])
+            ->call('setEnabledLocales', [param('kernel.enabled_locales')])
 
         ->set('twig.template_iterator', TemplateIterator::class)
             ->args([service('kernel'), abstract_arg('Twig paths'), param('twig.default_path'), abstract_arg('File name pattern')])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

This PR aims to provide a new `app.enabled_locales` getter for templates to retrieve the enabled locales configured using the `framework.enabled_locales` configuration, to make e.g. a locale switcher in the templates without to have to pass the enabled locales using e.g. a Twig global.

The docs PR will me made if the PR is accepted.

Targeting the 6.3 branch for now, will switch to 6.4 when it will be available (as feature freeze is active since late March).