### PR TITLE
[WebProfilerBundle] Tweak the HTML code of the Twig entry view

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -53,7 +53,7 @@
             <b>Entry View</b>
             <span>
                  {% if link %}
-                     <a href="{{ link }}" title="{{ file }}" class="stretched-link">
+                     <a href="{{ link }}" title="{{ file }}">
                          {{ template }}
                      </a>
                  {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Stretched links are used to make entire sections, like a card, clickable. See https://getbootstrap.com/docs/5.3/helpers/stretched-link/

Maybe @PhilETaylor can answer us about this (he made the original PR to add this in #49887) but I think it wasn't intended to make entire Twig panel clickable to open the template. So, in this PR I propose to remove this behavior.

Here you can see how in the Security panel, the link is not stretched but in the Twig panel it is:

![profiler-panel](https://github.com/symfony/symfony/assets/73419/155170f3-115d-4043-98cd-8844c1a3a4bf)
