### PR TITLE
[DependencyInjection] Allow using enums in container configurator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -101,6 +101,7 @@ abstract class AbstractConfigurator
         switch (true) {
             case null === $value:
             case \is_scalar($value):
+            case $value instanceof \UnitEnum:
                 return $value;
 
             case $value instanceof ArgumentInterface:

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_enumeration.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_enumeration.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
+
+return function (ContainerConfigurator $container) {
+    $container->parameters()
+        ->set('unit_enum', FooUnitEnum::BAR)
+        ->set('enum_array', [FooUnitEnum::BAR, FooUnitEnum::FOO]);
+
+    $services = $container->services();
+
+    $services->defaults()->public();
+
+    $services->set('service_container', ContainerInterface::class)
+        ->synthetic();
+
+    $services->set(FooClassWithEnumAttribute::class)
+        ->args([FooUnitEnum::BAR]);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 
 class PhpFileLoaderTest extends TestCase
 {
@@ -163,6 +165,22 @@ class PhpFileLoaderTest extends TestCase
         $loader->load('env_configurator.php');
 
         $this->assertSame('%env(int:CCC)%', $container->getDefinition('foo')->getArgument(0));
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnumeration()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator($fixtures.'/config'));
+        $loader->load('services_with_enumeration.php');
+
+        $container->compile();
+
+        $definition = $container->getDefinition(FooClassWithEnumAttribute::class);
+        $this->assertSame([FooUnitEnum::BAR], $definition->getArguments());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50275
| License       | MIT
| Doc PR        | 

[DependencyInjection] Allow using enums in container configurator

```php
return static function (ContainerConfigurator $configurator): void {
    $configurator->services()->set(MyService::class)
        ->arg('$myEnum', MyEnum::First)
    ;
};
```
