### PR TITLE
[HttpFoundation] Fix problem with empty generator in StreamedJsonResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedJsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedJsonResponse.php
@@ -130,6 +130,10 @@ class StreamedJsonResponse extends StreamedResponse
                 echo json_encode($item, $jsonEncodingOptions);
             }
 
+            if ($isFirstItem) { // indicates that the generator was empty
+                echo '[';
+            }
+
             echo '[' === $startTag ? ']' : '}';
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedJsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedJsonResponseTest.php
@@ -30,6 +30,19 @@ class StreamedJsonResponseTest extends TestCase
         $this->assertSame('{"_embedded":{"articles":["Article 1","Article 2","Article 3"],"news":["News 1","News 2","News 3"]}}', $content);
     }
 
+    public function testResponseEmptyList()
+    {
+        $content = $this->createSendResponse(
+            [
+                '_embedded' => [
+                    'articles' => $this->generatorSimple('Article', 0),
+                ],
+            ],
+        );
+
+        $this->assertSame('{"_embedded":{"articles":[]}}', $content);
+    }
+
     public function testResponseObjectsList()
     {
         $content = $this->createSendResponse(
@@ -222,20 +235,20 @@ class StreamedJsonResponseTest extends TestCase
     /**
      * @return \Generator<int, string>
      */
-    private function generatorSimple(string $test): \Generator
+    private function generatorSimple(string $test, int $length = 3): \Generator
     {
-        yield $test.' 1';
-        yield $test.' 2';
-        yield $test.' 3';
+        for ($i = 1; $i <= $length; ++$i) {
+            yield $test.' '.$i;
+        }
     }
 
     /**
      * @return \Generator<int, array{title: string}>
      */
-    private function generatorArray(string $test): \Generator
+    private function generatorArray(string $test, int $length = 3): \Generator
     {
-        yield ['title' => $test.' 1'];
-        yield ['title' => $test.' 2'];
-        yield ['title' => $test.' 3'];
+        for ($i = 1; $i <= $length; ++$i) {
+            yield ['title' => $test.' '.$i];
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 (Feature `StreamedJsonResponse`: https://github.com/symfony/symfony/pull/47709)
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix - was reported to me on Slack by @norkunas
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Currently when the Generator is empty the return is invalid JSON which should not happen. So adding a testcase and a fix to the problem with the empty generator.
