### PR TITLE
[HttpKernel] Add optional `$className` param to `ControllerEvent::getAttributes()`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add optional `$className` parameter to `ControllerEvent::getAttributes()`
+
 6.3
 ---
 

--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
@@ -94,10 +94,16 @@ final class ControllerArgumentsEvent extends KernelEvent
     }
 
     /**
-     * @return array<class-string, list<object>>
+     * @template T of class-string|null
+     *
+     * @param T $className
+     *
+     * @return array<class-string, list<object>>|list<object>
+     *
+     * @psalm-return (T is null ? array<class-string, list<object>> : list<object>)
      */
-    public function getAttributes(): array
+    public function getAttributes(string $className = null): array
     {
-        return $this->controllerEvent->getAttributes();
+        return $this->controllerEvent->getAttributes($className);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
@@ -79,12 +79,18 @@ final class ControllerEvent extends KernelEvent
     }
 
     /**
-     * @return array<class-string, list<object>>
+     * @template T of class-string|null
+     *
+     * @param T $className
+     *
+     * @return array<class-string, list<object>>|list<object>
+     *
+     * @psalm-return (T is null ? array<class-string, list<object>> : list<object>)
      */
-    public function getAttributes(): array
+    public function getAttributes(string $className = null): array
     {
         if (isset($this->attributes)) {
-            return $this->attributes;
+            return null === $className ? $this->attributes : $this->attributes[$className] ?? [];
         }
 
         if (\is_array($this->controller) && method_exists(...$this->controller)) {
@@ -102,6 +108,6 @@ final class ControllerEvent extends KernelEvent
             }
         }
 
-        return $this->attributes;
+        return null === $className ? $this->attributes : $this->attributes[$className] ?? [];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ControllerArgumentsEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ControllerArgumentsEventTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Bar;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Baz;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\AttributeController;
 use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
 
@@ -51,6 +52,9 @@ class ControllerArgumentsEventTest extends TestCase
                 new Bar('class'),
                 new Bar('method'),
             ],
+            Baz::class => [
+                new Baz(),
+            ],
         ];
 
         $this->assertEquals($expected, $event->getAttributes());
@@ -60,5 +64,28 @@ class ControllerArgumentsEventTest extends TestCase
 
         $this->assertEquals($expected, $event->getAttributes());
         $this->assertSame($controllerEvent->getAttributes(), $event->getAttributes());
+    }
+
+    public function testGetAttributesByClassName()
+    {
+        $controller = new AttributeController();
+        $request = new Request();
+
+        $controllerEvent = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $event = new ControllerArgumentsEvent(new TestHttpKernel(), $controllerEvent, ['test'], new Request(), HttpKernelInterface::MAIN_REQUEST);
+
+        $expected = [
+            new Bar('class'),
+            new Bar('method'),
+        ];
+
+        $this->assertEquals($expected, $event->getAttributes(Bar::class));
+
+        $expected[] = new Bar('foo');
+        $event->setController($controller, [Bar::class => $expected]);
+
+        $this->assertEquals($expected, $event->getAttributes(Bar::class));
+        $this->assertSame($controllerEvent->getAttributes(Bar::class), $event->getAttributes(Bar::class));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ControllerEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ControllerEventTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Bar;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Baz;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\AttributeController;
 use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
 
@@ -33,9 +34,37 @@ class ControllerEventTest extends TestCase
                 new Bar('class'),
                 new Bar('method'),
             ],
+            Baz::class => [
+                new Baz(),
+            ],
         ];
 
         $this->assertEquals($expected, $event->getAttributes());
+    }
+
+    /**
+     * @dataProvider provideGetAttributes
+     */
+    public function testGetAttributesByClassName(callable $controller)
+    {
+        $event = new ControllerEvent(new TestHttpKernel(), $controller, new Request(), HttpKernelInterface::MAIN_REQUEST);
+
+        $expected = [
+            new Bar('class'),
+            new Bar('method'),
+        ];
+
+        $this->assertEquals($expected, $event->getAttributes(Bar::class));
+    }
+
+    /**
+     * @dataProvider provideGetAttributes
+     */
+    public function testGetAttributesByInvalidClassName(callable $controller)
+    {
+        $event = new ControllerEvent(new TestHttpKernel(), $controller, new Request(), HttpKernelInterface::MAIN_REQUEST);
+
+        $this->assertEquals([], $event->getAttributes(\stdClass::class));
     }
 
     public static function provideGetAttributes()
@@ -43,6 +72,6 @@ class ControllerEventTest extends TestCase
         yield [[new AttributeController(), '__invoke']];
         yield [new AttributeController()];
         yield [(new AttributeController())->__invoke(...)];
-        yield [#[Bar('class'), Bar('method')] static function () {}];
+        yield [#[Bar('class'), Bar('method'), Baz] static function () {}];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Baz.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Baz.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
+class Baz
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
@@ -12,12 +12,13 @@
 namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
 
 use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Bar;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Baz;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Foo;
 
 #[Bar('class'), Undefined('class')]
 class AttributeController
 {
-    #[Bar('method'), Undefined('method')]
+    #[Bar('method'), Baz, Undefined('method')]
     public function __invoke()
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

A minor DX improvement since most of the time only one type of attribute is needed, eg:

```php
public function onKernelControllerArguments(ControllerArgumentsEvent $event)
{
    $attributes = $event->getAttributes(SomeAttribute::class);

    // ...
}
```