### PR TITLE
[Console] Remove ``exec`` and replace it by ``shell_exec``

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -500,13 +500,11 @@ class QuestionHelper extends Helper
             return self::$stdinIsInteractive = @posix_isatty(fopen('php://stdin', 'r'));
         }
 
-        if (!\function_exists('exec')) {
+        if (!\function_exists('shell_exec')) {
             return self::$stdinIsInteractive = true;
         }
 
-        exec('stty 2> /dev/null', $output, $status);
-
-        return self::$stdinIsInteractive = 1 !== $status;
+        return self::$stdinIsInteractive = (bool) shell_exec('stty 2> '.('\\' === \DIRECTORY_SEPARATOR ? 'NUL' : '/dev/null'));
     }
 
     /**

--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -64,14 +64,12 @@ class Terminal
             return self::$stty;
         }
 
-        // skip check if exec function is disabled
-        if (!\function_exists('exec')) {
+        // skip check if shell_exec function is disabled
+        if (!\function_exists('shell_exec')) {
             return false;
         }
 
-        exec('stty 2>&1', $output, $exitcode);
-
-        return self::$stty = 0 === $exitcode;
+        return self::$stty = (bool) shell_exec('stty 2> '.('\\' === \DIRECTORY_SEPARATOR ? 'NUL' : '/dev/null'));
     }
 
     private static function initDimensions()

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -430,7 +430,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         $this->assertEquals('8AM', $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream("8AM\n")), $this->createOutputInterface(), $question));
     }
 
-    public function testAskHiddenResponseTrimmed()
+    public function testAskHiddenResponseNotTrimmed()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('This test is not supported on Windows');
@@ -442,7 +442,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         $question->setHidden(true);
         $question->setTrimmable(false);
 
-        $this->assertEquals(' 8AM', $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream(' 8AM')), $this->createOutputInterface(), $question));
+        $this->assertEquals(' 8AM'.\PHP_EOL, $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream(' 8AM'.\PHP_EOL)), $this->createOutputInterface(), $question));
     }
 
     public function testAskMultilineResponseWithEOF()

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -77,8 +77,8 @@ class TerminalTest extends TestCase
             $this->markTestSkipped('Must be on windows');
         }
 
-        $sttyString = exec('(stty -a | grep columns) 2>&1', $output, $exitcode);
-        if (0 !== $exitcode) {
+        $sttyString = shell_exec('(stty -a | grep columns) 2> NUL');
+        if (!$sttyString) {
             $this->markTestSkipped('Must have stty support');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49646
| License       | MIT
| Doc PR        | n/a

It could happen an error like `Error: Call to undefined function Symfony\Component\Console\shell_exec() in /{path_to_project}/vendor/symfony/console/Application.php:989 ` when `exec` is available but `shell_exec` not. There is very often used the check `Terminal::hasSttyAvailable()` in the symfony codebase and then `shell_exec` used.

More Details see in the issue #49646.
