### PR TITLE
[HttpKernel] Make `QueryParameterValueResolver` provide a value if possible when a parameter is not found

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
@@ -31,8 +31,12 @@ final class QueryParameterValueResolver implements ValueResolverInterface
 
         $name = $attribute->name ?? $argument->getName();
         if (!$request->query->has($name)) {
-            if ($argument->isNullable() || $argument->hasDefaultValue()) {
-                return [];
+            if ($argument->hasDefaultValue()) {
+                return [$argument->getDefaultValue()];
+            }
+
+            if ($argument->isNullable()) {
+                return [null];
             }
 
             throw new NotFoundHttpException(sprintf('Missing query parameter "%s".', $name));

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/QueryParameterValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/QueryParameterValueResolverTest.php
@@ -179,14 +179,14 @@ class QueryParameterValueResolverTest extends TestCase
         yield 'parameter not found but nullable' => [
             Request::create('/', 'GET'),
             new ArgumentMetadata('firstName', 'string', false, false, false, true, [new MapQueryParameter()]),
-            [],
+            [null],
             null,
         ];
 
         yield 'parameter not found but optional' => [
             Request::create('/', 'GET'),
             new ArgumentMetadata('firstName', 'string', false, true, false, attributes: [new MapQueryParameter()]),
-            [],
+            [false],
             null,
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50339
| License | MIT
| Doc PR        | N/A

As `QueryParameterValueResolver` is “targeted” it must provide a value itself if possible.

When a parameter is not found in the query string, we want to return the argument’s default value if it has one, or `null` if it is nullable. Else the behavior do not change: we throw a `NotFoundHttpException`.