### PR TITLE
[DebugBundle][VarDumper] Fix dump labels compatibility

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DebugBundle.php
+++ b/src/Symfony/Bundle/DebugBundle/DebugBundle.php
@@ -35,14 +35,19 @@ class DebugBundle extends Bundle
             // The dump data collector is used by default, so dump output is sent to
             // the WDT. In a CLI context, if dump is used too soon, the data collector
             // will buffer it, and release it at the end of the script.
-            VarDumper::setHandler(function ($var) use ($container) {
+            VarDumper::setHandler(function ($var, string $label = null) use ($container) {
                 $dumper = $container->get('data_collector.dump');
                 $cloner = $container->get('var_dumper.cloner');
-                $handler = function ($var) use ($dumper, $cloner) {
-                    $dumper->dump($cloner->cloneVar($var));
+                $handler = function ($var, string $label = null) use ($dumper, $cloner) {
+                    $var = $cloner->cloneVar($var);
+                    if (null !== $label) {
+                        $var = $var->withContext(['label' => $label]);
+                    }
+
+                    $dumper->dump($var);
                 };
                 VarDumper::setHandler($handler);
-                $handler($var);
+                $handler($var, $label);
             });
         }
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -45,8 +45,11 @@ class DumpListener implements EventSubscriberInterface
         $dumper = $this->dumper;
         $connection = $this->connection;
 
-        VarDumper::setHandler(static function ($var) use ($cloner, $dumper, $connection) {
+        VarDumper::setHandler(static function ($var, string $label = null) use ($cloner, $dumper, $connection) {
             $data = $cloner->cloneVar($var);
+            if (null !== $label) {
+                $data = $data->withContext(['label' => $label]);
+            }
 
             if (!$connection || !$connection->write($data)) {
                 $dumper->dump($data);

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -269,17 +269,10 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
     {
         $refs = [0];
         $cursor = new Cursor();
-        $label = $this->context['label'] ?? '';
-
-        if ($cursor->attr = $this->context[SourceContextProvider::class] ?? []) {
-            $cursor->attr['if_links'] = true;
-            $cursor->hashType = -1;
-            $dumper->dumpScalar($cursor, 'default', $label.'^');
-            $cursor->attr = ['if_links' => true];
-            $dumper->dumpScalar($cursor, 'default', ' ');
-            $cursor->hashType = 0;
-        }
-
+        $cursor->hashType = -1;
+        $cursor->attr = $this->context[SourceContextProvider::class] ?? [];
+        $dumper->dumpScalar($cursor, 'label', $this->context['label'] ?? '');
+        $cursor->hashType = 0;
         $this->dumpItem($dumper, $cursor, $refs, $this->data[$this->position][$this->key]);
     }
 

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -139,9 +139,8 @@ class CliDumper extends AbstractDumper
         $attr = $cursor->attr;
 
         switch ($type) {
-            case 'default':
-                $style = 'default';
-                break;
+            case 'label': $style = 'label'; break;
+            case 'default': $style = 'default'; break;
 
             case 'integer':
                 $style = 'num';
@@ -468,7 +467,7 @@ class CliDumper extends AbstractDumper
 
         $map = static::$controlCharsMap;
         $startCchr = $this->colors ? "\033[m\033[{$this->styles['default']}m" : '';
-        $endCchr = $this->colors ? "\033[m\033[{$this->styles[$style]}m" : '';
+        $endCchr = $this->colors ? "\033[m\033[{$this->styles['label' === $style ? 'default' : $style]}m" : '';
         $value = preg_replace_callback(static::$controlCharsRx, function ($c) use ($map, $startCchr, $endCchr) {
             $s = $startCchr;
             $c = $c[$i = 0];
@@ -487,11 +486,11 @@ class CliDumper extends AbstractDumper
             }, $value);
         }
 
-        if ($this->colors) {
+        if ($this->colors && '' !== $value) {
             if ($cchrCount && "\033" === $value[0]) {
                 $value = substr($value, \strlen($startCchr));
             } else {
-                $value = "\033[{$this->styles[$style]}m".$value;
+                $value = "\033[{$this->styles['label' === $style ? 'default' : $style]}m".$value;
             }
             if ($cchrCount && str_ends_with($value, $endCchr)) {
                 $value = substr($value, 0, -\strlen($endCchr));
@@ -510,10 +509,15 @@ class CliDumper extends AbstractDumper
                 }
             }
             if (isset($attr['href'])) {
+                if ('label' === $style) {
+                    $value .= '^';
+                }
                 $value = "\033]8;;{$attr['href']}\033\\{$value}\033]8;;\033\\";
             }
-        } elseif ($attr['if_links'] ?? false) {
-            return '';
+        }
+
+        if ('label' === $style && '' !== $value) {
+            $value .= ' ';
         }
 
         return $value;

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -849,7 +849,7 @@ EOHTML
 
     protected function style(string $style, string $value, array $attr = []): string
     {
-        if ('' === $value) {
+        if ('' === $value && ('label' !== $style || !isset($attr['file']) && !isset($attr['href']))) {
             return '';
         }
 
@@ -903,7 +903,7 @@ EOHTML
         }
 
         $map = static::$controlCharsMap;
-        $v = "<span class=sf-dump-{$style}>".preg_replace_callback(static::$controlCharsRx, function ($c) use ($map) {
+        $v = '<span class=sf-dump-'.('label' === $style ? 'default' : $style).'>'.preg_replace_callback(static::$controlCharsRx, function ($c) use ($map) {
             $s = $b = '<span class="sf-dump-default';
             $c = $c[$i = 0];
             if ($ns = "\r" === $c[$i] || "\n" === $c[$i]) {
@@ -927,7 +927,7 @@ EOHTML
 
         if (!($attr['binary'] ?? false)) {
             $v = preg_replace_callback(static::$unicodeCharsRx, function ($c) {
-                return '<span class="sf-dump-default">\u{'.strtoupper(dechex(mb_ord($c[0]))).'}</span>';
+                return '<span class=sf-dump-default>\u{'.strtoupper(dechex(mb_ord($c[0]))).'}</span>';
             }, $v);
         }
 
@@ -935,6 +935,9 @@ EOHTML
             $attr['href'] = $href;
         }
         if (isset($attr['href'])) {
+            if ('label' === $style) {
+                $v .= '^';
+            }
             $target = isset($attr['file']) ? '' : ' target="_blank"';
             $v = sprintf('<a href="%s"%s rel="noopener noreferrer">%s</a>', esc($this->utf8Encode($attr['href'])), $target, $v);
         }

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -25,7 +25,7 @@ if (!function_exists('dump')) {
             return null;
         }
 
-        if (isset($vars[0]) && 1 === count($vars)) {
+        if (array_key_exists(0, $vars) && 1 === count($vars)) {
             VarDumper::dump($vars[0]);
             $k = 0;
         } else {

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -69,7 +69,7 @@ class HtmlDumperTest extends TestCase
     <span class=sf-dump-str title="11 binary or non-UTF-8 characters">&#233;<span class="sf-dump-default">\\x01</span>test<span class="sf-dump-default">\\t</span><span class="sf-dump-default sf-dump-ns">\\n</span></span>
     <span class=sf-dump-str title="11 binary or non-UTF-8 characters">ing</span>
     """
-  "<span class=sf-dump-key>bo<span class="sf-dump-default">\\u{FEFF}</span>m</span>" => "<span class=sf-dump-str title="5 characters">te<span class="sf-dump-default">\\u{FEFF}</span>st</span>"
+  "<span class=sf-dump-key>bo<span class=sf-dump-default>\\u{FEFF}</span>m</span>" => "<span class=sf-dump-str title="5 characters">te<span class=sf-dump-default>\\u{FEFF}</span>st</span>"
   "<span class=sf-dump-key>[]</span>" => []
   "<span class=sf-dump-key>res</span>" => <span class=sf-dump-note>stream resource</span> <a class=sf-dump-ref>@{$res}</a><samp data-depth=2 class=sf-dump-compact>
 %A  <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str title="9 characters">plainfile</span>"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR fixes the handling of dumps labels when the DebugBundle is enabled and stays BC with older versions.

@javiereguiluz Unfortunately, the CSS of the web profiler toolbar is not perfect for labels and invisible characters:
![Screenshot from 2023-05-16 18-31-01](https://github.com/symfony/symfony/assets/3658119/8dbaab35-b9a1-42be-b10c-88c4009215ee)
Could you take care of this part plz? :pray: 