### PR TITLE
[Notifier] Document Notifier options in README files

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/README.md
@@ -15,6 +15,35 @@ where:
  - `APIKEY` is your AllMySms API key
  - `FROM` is your sender (optional, default: 36180)
 
+Adding Options to a Message
+---------------------------
+
+With a AllMySms Message, you can use the `AllMySmsOptions` class to add
+[message options](https://doc.allmysms.com/api/allmysms_api_https_v9.0_EN.pdf).
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new AllMySmsOptions())
+    ->alerting(1)
+    ->campaignName('API')
+    ->cliMsgId('test_cli_msg_id')
+    ->date('2023-05-23 23:47:25')
+    ->simulate(1)
+    ->uniqueIdentifier('unique_identifier')
+    ->verbose(1)
+    // ...
+    ;
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneOptions.php
@@ -33,7 +33,7 @@ final class ContactEveryoneOptions implements MessageOptionsInterface
     /**
      * @return $this
      */
-    public function diffusionName(int $diffusionName): static
+    public function diffusionName(string $diffusionName): static
     {
         $this->options['diffusion_name'] = $diffusionName;
 

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/README.md
@@ -19,6 +19,30 @@ This bridge uses the light version of Contact Everyone API.
 
 See your account info at https://contact-everyone.orange-business.com/#/login
 
+Adding Options to a Message
+---------------------------
+
+With a Contact everyone Message, you can use the `ContactEveryoneOptions` class to add
+message options.
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\ContactEveryone\ContactEveryoneOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new ContactEveryoneOptions())
+    ->diffusionName('My label')
+    ->category('my-category')
+    // ...
+    ;
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneOptionsTest.php
@@ -20,11 +20,11 @@ class ContactEveryoneOptionsTest extends TestCase
     {
         $contactEveryoneOptions = (new ContactEveryoneOptions())
             ->category('test_category')
-            ->diffusionName(123);
+            ->diffusionName('test_diffusion_name');
 
         self::assertSame([
             'category' => 'test_category',
-            'diffusion_name' => 123,
+            'diffusion_name' => 'test_diffusion_name',
         ], $contactEveryoneOptions->toArray());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/README.md
@@ -18,6 +18,28 @@ where:
 
 See Esendex documentation at https://developers.esendex.com/api-reference#smsapis
 
+Adding Options to a Message
+---------------------------
+
+With an Esendex Message, you can use the `EsendexOptions` class to add message options.
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\Esendex\EsendexOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new EsendexOptions())
+    ->accountReference('account_reference')
+    // ...
+    ;
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiOptions.php
@@ -33,7 +33,7 @@ final class GatewayApiOptions implements MessageOptionsInterface
     /**
      * @return $this
      */
-    public function class(int $class): static
+    public function class(string $class): static
     {
         $this->options['class'] = $class;
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/README.md
@@ -16,6 +16,31 @@ where:
 
 See your account info at https://gatewayapi.com
 
+Adding Options to a Message
+---------------------------
+
+With a GatewayApi Message, you can use the `GatewayApiOptions` class to add
+[message options](https://gatewayapi.com/docs/apis/rest/).
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\GatewayApi\GatewayApiOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new GatewayApiOptions())
+    ->class('standard')
+    ->callbackUrl('https://my-callback-url')
+    ->userRef('user_ref')
+    // ...
+    ;
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiOptionsTest.php
@@ -19,12 +19,12 @@ class GatewayApiOptionsTest extends TestCase
     public function testGatewayApiOptions()
     {
         $gatewayApiOptions = (new GatewayApiOptions())
-            ->class(123)
+            ->class('test_class')
             ->callbackUrl('test_callback_url')
             ->userRef('test_user_ref');
 
         self::assertSame([
-            'class' => 123,
+            'class' => 'test_class',
             'callback_url' => 'test_callback_url',
             'userref' => 'test_user_ref',
         ], $gatewayApiOptions->toArray());

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/README.md
@@ -14,6 +14,40 @@ where:
  - `TOKEN` is your MessageBird token
  - `FROM` is your sender
 
+Adding Options to a Message
+---------------------------
+
+With a MessageBird Message, you can use the `MessageBirdOptions` class to add
+[message options](https://developers.messagebird.com/api/sms-messaging/#send-outbound-sms).
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\MessageBird\MessageBirdOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new MessageBirdOptions())
+    ->type('test_type')
+    ->scheduledDatetime('test_scheduled_datetime')
+    ->createdDatetime('test_created_datetime')
+    ->dataCoding('test_data_coding')
+    ->gateway(999)
+    ->groupIds(['test_group_ids'])
+    ->mClass(888)
+    ->reference('test_reference')
+    ->reportUrl('test_report_url')
+    ->shortenUrls(true)
+    ->typeDetails('test_type_details')
+    ->validity(777)
+    // ...
+    ;
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/README.md
@@ -16,6 +16,36 @@ where:
  - `FROM` is your registered sender ID (optional). Accepted values: 3-15 letters, could be alpha tag, shortcode or international phone number.
 When phone number starts with a `+` sign, it needs to be url encoded in the DSN
 
+Adding Options to a Message
+---------------------------
+
+With a MessageMedia Message, you can use the `MessageMediaOptions` class to add
+[message options](https://messagemedia.github.io/documentation/#tag/Messages/operation/SendMessages).
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\MessageMedia\MessageMediaOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new MessageMediaOptions())
+    ->media(['media'])
+    ->callbackUrl('callback_url')
+    ->format('format')
+    ->deliveryReport(true)
+    ->expiry(999)
+    ->metadata(['metadata'])
+    ->scheduled('scheduled')
+    ->subject('subject');
+    // ...
+    ;
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/Termii/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Termii/README.md
@@ -16,6 +16,31 @@ where:
  - `FROM` is your sender
  - `CHANNEL` is your channel (generic, dnd, whatsapp)
 
+Adding Options to a Message
+---------------------------
+
+With a Termii Message, you can use the `TermiiOptions` class to add
+[message options](https://developer.termii.com/messaging#send-message).
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\Termii\TermiiOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new TermiiOptions())
+    ->type('test_type')
+    ->channel('test_channel')
+    ->media('test_media_url', 'test_media_caption')
+    // ...
+    ;
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/README.md
@@ -15,6 +15,28 @@ where:
  - `TOKEN` is your Twilio token
  - `FROM` is your sender
 
+Adding Options to a Message
+---------------------------
+
+With a Twilio Message, you can use the `TwilioOptions` class to add message options.
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\Twilio\TwilioOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new TwilioOptions())
+    ->webhookUrl('test_webhook_url')
+    // ...
+    ;
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR add missing `*Options` documentations in notifier bridges readme

Documented bridges are:
- AllMySMS https://github.com/symfony/symfony-docs/issues/18315
- ContactEveryone https://github.com/symfony/symfony-docs/issues/18310
- Essendex https://github.com/symfony/symfony-docs/issues/18308
- GatewayApi https://github.com/symfony/symfony-docs/issues/18313
- MessageBird https://github.com/symfony/symfony-docs/issues/18311
- MessageMedia https://github.com/symfony/symfony-docs/issues/18312
- Twilio
- Termii

Waiting your feedback :smile: 

I will create another PR for AmazonSnsOptions, BandwidthOptions, ClickSendOptions, MobytOptions, PlivoOptions, RingCentralOptions, SmsmodeOptions, TwilioOptions after this one
