### PR TITLE
[Notifier][TurboSMS] Fix get sender name

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
@@ -71,7 +71,16 @@ final class TurboSmsTransportTest extends TransportTestCase
             ]))
         ;
 
-        $client = new MockHttpClient(static function () use ($response): ResponseInterface {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use ($response): ResponseInterface {
+            $body = json_decode($options['body'], true);
+            self::assertSame([
+                'sms' => [
+                    'sender' => 'sender',
+                    'recipients' => ['380931234567'],
+                    'text' => 'Тест/Test',
+                ]
+            ], $body);
+
             return $response;
         });
 

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
@@ -66,7 +66,8 @@ final class TurboSmsTransport extends AbstractTransport
         $this->assertValidSubject($message->getSubject());
 
         $fromMessage = $message->getFrom();
-        if (null !== $fromMessage) {
+
+        if ($fromMessage) {
             $this->assertValidFrom($fromMessage);
             $from = $fromMessage;
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| License       | MIT

Fix get sender name in Turbo Sms Transport.
