### PR TITLE
[Process] Stop the process correctly even if underlying input stream is not closed

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -428,7 +428,7 @@ class Process implements \IteratorAggregate
 
         do {
             $this->checkTimeout();
-            $running = '\\' === \DIRECTORY_SEPARATOR ? $this->isRunning() : $this->processPipes->areOpen();
+            $running = $this->isRunning() && ('\\' === \DIRECTORY_SEPARATOR || $this->processPipes->areOpen());
             $this->readPipes($running, '\\' !== \DIRECTORY_SEPARATOR || !$running);
         } while ($running);
 

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1538,6 +1538,16 @@ class ProcessTest extends TestCase
         }
     }
 
+    public function testNotTerminableInputPipe()
+    {
+        $process = $this->getProcess('echo foo');
+        $process->setInput(\STDIN);
+        $process->start();
+        $process->setTimeout(2);
+        $process->wait();
+        $this->assertFalse($process->isRunning());
+    }
+
     /**
      * @param string|array $commandline
      * @param mixed        $input


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |  /
| License       | MIT
| Doc PR        | /

While checking a process to end, on posix system, process component only checks if pipes are still open, this fix ensure that if the process is terminated it correctly return, even if the underlying pipe is not closed.

It can be useful when using \STDIN as a input stream as it will always be open

