### PR TITLE
[AssetMapper] Fix bug where dependencies were preloaded even if the parent was not

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -417,11 +417,11 @@ class ImportMapManager
                 $this->modulesToPreload[] = $path;
             }
 
-            $dependencyImportMapEntries = array_map(function (AssetDependency $dependency) {
+            $dependencyImportMapEntries = array_map(function (AssetDependency $dependency) use ($entryOptions) {
                 return new ImportMapEntry(
                     $dependency->asset->getPublicPathWithoutDigest(),
                     $dependency->asset->getLogicalPath(),
-                    preload: !$dependency->isLazy,
+                    preload: $entryOptions->preload && !$dependency->isLazy,
                 );
             }, $dependencies);
             $imports = array_merge($imports, $this->convertEntriesToImports($dependencyImportMapEntries));

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -77,7 +77,8 @@ class ImportMapManagerTest extends TestCase
             '/assets/pizza/index.js' => '/assets/pizza/index-b3fb5ee31adaf5e1b32d28edf1ab8e7a.js',
             '/assets/popcorn.js' => '/assets/popcorn-c0778b84ef9893592385aebc95a2896e.js',
             '/assets/imported_async.js' => '/assets/imported_async-8f0cd418bfeb0cf63826e09a4474a81c.js',
-            'other_app' => '/assets/namespaced_assets2/app2-344d0d513d424647e7d8a394ffe5e4b5.js',
+            'other_app' => '/assets/namespaced_assets2/app2-d5bf10c20bf9a0b77e67d78fcac301c5.js',
+            '/assets/namespaced_assets2/imported.js' => '/assets/namespaced_assets2/imported-9ab37dabcfe317fba77123a4e573d53b.js',
         ]], json_decode($manager->getImportMapJson(), true));
     }
 

--- a/src/Symfony/Component/AssetMapper/Tests/fixtures/importmaps/assets2/app2.js
+++ b/src/Symfony/Component/AssetMapper/Tests/fixtures/importmaps/assets2/app2.js
@@ -1,1 +1,3 @@
+import './imported.js';
+
 console.log('app2');

--- a/src/Symfony/Component/AssetMapper/Tests/fixtures/importmaps/assets2/imported.js
+++ b/src/Symfony/Component/AssetMapper/Tests/fixtures/importmaps/assets2/imported.js
@@ -1,0 +1,1 @@
+console.log('imported.js');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Still TODO

In `importmap.php`, if you have `preload => false` for an assets... but that asset imports another assets, we would always list that imported asset as "preload => true". Basically, when looking at a dependency to determine if it should be preloaded, we need to first look at the parent to see if IT was preloaded.

Cheers!
