### PR TITLE
[AssetMapper] Not allowing installation alongside FwBundle less than 6.3

### DIFF
--- a/src/Symfony/Component/AssetMapper/composer.json
+++ b/src/Symfony/Component/AssetMapper/composer.json
@@ -29,6 +29,9 @@
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0"
     },
+    "conflict": {
+        "symfony/framework-bundle": "<6.3"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\AssetMapper\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Not needed

Hi!

AssetMapper shouldn't be installed alongside FrameworkBundle 6.2 or lower. I believe adding this conflict is pretty standard.

Thanks!