### PR TITLE
[FrameworkBundle] Fix Workflow without a marking store definition uses marking store definition of previously defined workflow

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -920,6 +920,7 @@ class FrameworkExtension extends Extension
             $workflows[$workflowId] = $definitionDefinition;
 
             // Create MarkingStore
+            $markingStoreDefinition = null;
             if (isset($workflow['marking_store']['type'])) {
                 $markingStoreDefinition = new ChildDefinition('workflow.marking_store.method');
                 $markingStoreDefinition->setArguments([
@@ -933,7 +934,7 @@ class FrameworkExtension extends Extension
             // Create Workflow
             $workflowDefinition = new ChildDefinition(sprintf('%s.abstract', $type));
             $workflowDefinition->replaceArgument(0, new Reference(sprintf('%s.definition', $workflowId)));
-            $workflowDefinition->replaceArgument(1, $markingStoreDefinition ?? null);
+            $workflowDefinition->replaceArgument(1, $markingStoreDefinition);
             $workflowDefinition->replaceArgument(3, $name);
             $workflowDefinition->replaceArgument(4, $workflow['events_to_dispatch']);
             $workflowDefinition->addTag('container.private', [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -85,6 +85,62 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
         });
     }
 
+    public function testWorkflowDefaultMarkingStoreDefinition()
+    {
+        $container = $this->createContainerFromClosure(function ($container) {
+            $container->loadFromExtension('framework', [
+                'workflows' => [
+                    'workflow_a' => [
+                        'type' => 'state_machine',
+                        'marking_store' => [
+                            'type' => 'method',
+                            'property' => 'status',
+                        ],
+                        'supports' => [
+                            __CLASS__,
+                        ],
+                        'places' => [
+                            'a',
+                            'b',
+                        ],
+                        'transitions' => [
+                            'a_to_b' => [
+                                'from' => ['a'],
+                                'to' => ['b'],
+                            ],
+                        ],
+                    ],
+                    'workflow_b' => [
+                        'type' => 'state_machine',
+                        'supports' => [
+                            __CLASS__,
+                        ],
+                        'places' => [
+                            'a',
+                            'b',
+                        ],
+                        'transitions' => [
+                            'a_to_b' => [
+                                'from' => ['a'],
+                                'to' => ['b'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        });
+
+        $workflowA = $container->getDefinition('state_machine.workflow_a');
+        $argumentsA = $workflowA->getArguments();
+        $this->assertArrayHasKey('index_1', $argumentsA, 'workflow_a has a marking_store argument');
+        $this->assertNotNull($argumentsA['index_1'], 'workflow_a marking_store argument is not null');
+
+        $workflowB = $container->getDefinition('state_machine.workflow_b');
+        $argumentsB = $workflowB->getArguments();
+        $this->assertArrayHasKey('index_1', $argumentsB, 'workflow_b has a marking_store argument');
+        $this->assertNull($argumentsB['index_1'], 'workflow_b marking_store argument is null');
+    }
+
     public function testRateLimiterWithLockFactory()
     {
         try {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48099
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixed a bug in the `Framework Bundle` with the `registerWorkflowConfiguration()` method not initializing `$workflowMarkingStore` to null when processing each workflow. This results in subsequent workflows reusing the previously set `$workflowMarkingStore` value if one has not been explicitly configured.

In the example below, `workflow_b` has no marking_store configured, so it will utilize the marking_store configuration for `workflow_a` instead of the default `MethodMarkingStore` due to this bug.

```yaml
framework:
    workflows:
        workflow_a:
            type: 'state_machine'
            marking_store:
                type: 'method'
                property: 'status'
        workflow_b:
            type: 'state_machine'
```