### PR TITLE
[AssetMapper] Adding "path" option to importmap:require

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -149,6 +149,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('asset_mapper.importmap.manager'),
                 service('asset_mapper'),
+                param('kernel.project_dir'),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRemoveCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRemoveCommand.php
@@ -35,7 +35,18 @@ final class ImportMapRemoveCommand extends Command
 
     protected function configure(): void
     {
-        $this->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The packages to remove');
+        $this
+            ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The packages to remove')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command removes packages from the <comment>importmap.php</comment>.
+If a package was downloaded into your app, the downloaded file will also be removed.
+
+For example:
+
+    <info>php %command.full_name% lodash</info>
+EOT
+            )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
@@ -35,15 +35,44 @@ final class ImportMapRequireCommand extends Command
     public function __construct(
         private readonly ImportMapManager $importMapManager,
         private readonly AssetMapperInterface $assetMapper,
+        private readonly string $projectDir,
     ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
-        $this->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The packages to add');
-        $this->addOption('download', 'd', InputOption::VALUE_NONE, 'Download packages locally');
-        $this->addOption('preload', 'p', InputOption::VALUE_NONE, 'Preload packages');
+        $this
+            ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The packages to add')
+            ->addOption('download', 'd', InputOption::VALUE_NONE, 'Download packages locally')
+            ->addOption('preload', 'p', InputOption::VALUE_NONE, 'Preload packages')
+            ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The local path where the package lives relative to the project root')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command adds packages to <comment>importmap.php</comment> usually
+by finding a CDN URL for the given package and version.
+
+For example:
+
+    <info>php %command.full_name% lodash --preload</info>
+    <info>php %command.full_name% "lodash@^4.15"</info>
+
+The <info>preload</info> option will set the <info>preload</info> option in the importmap,
+which will tell the browser to preload the package. This should be used for all
+critical packages that are needed on page load.
+
+The <info>download</info> option will download the package locally and point the
+importmap to it. Use this if you want to avoid using a CDN or if you want to
+ensure that the package is available even if the CDN is down.
+
+Sometimes, a package may require other packages and multiple new items may be added
+to the import map.
+
+You can also require multiple packages at once:
+
+    <info>php %command.full_name% "lodash@^4.15" "@hotwired/stimulus"</info>
+
+EOT
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -51,10 +80,20 @@ final class ImportMapRequireCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         $packageList = $input->getArgument('packages');
-        if ($input->hasOption('path') && \count($packageList) > 1) {
-            $io->error('The "--path" option can only be used when you require a single package.');
+        $path = null;
+        if ($input->hasOption('path')) {
+            if (\count($packageList) > 1) {
+                $io->error('The "--path" option can only be used when you require a single package.');
 
-            return Command::FAILURE;
+                return Command::FAILURE;
+            }
+
+            $path = $this->projectDir.'/'.$input->getOption('path');
+            if (!is_file($path)) {
+                $io->error(sprintf('The path "%s" does not exist.', $input->getOption('path')));
+
+                return Command::FAILURE;
+            }
         }
 
         $packages = [];
@@ -73,6 +112,7 @@ final class ImportMapRequireCommand extends Command
                 $input->getOption('preload'),
                 null,
                 isset($parts['registry']) && $parts['registry'] ? $parts['registry'] : null,
+                $path,
             );
         }
 

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapUpdateCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapUpdateCommand.php
@@ -32,6 +32,18 @@ final class ImportMapUpdateCommand extends Command
         parent::__construct();
     }
 
+    protected function configure(): void
+    {
+        $this
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command will update all from the 3rd part packages
+in <comment>importmap.php</comment> to their latest version, including downloaded packages.
+
+   <info>php %command.full_name%</info>
+EOT
+            );
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Component/AssetMapper/ImportMap/PackageRequireOptions.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/PackageRequireOptions.php
@@ -27,6 +27,7 @@ final class PackageRequireOptions
         public readonly bool $preload = false,
         public readonly ?string $importName = null,
         public readonly ?string $registryName = null,
+        public readonly ?string $path = null,
     ) {
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -38,6 +38,10 @@ class ImportMapManagerTest extends TestCase
         if (!file_exists(__DIR__.'/../fixtures/importmaps_for_writing')) {
             $this->filesystem->mkdir(__DIR__.'/../fixtures/importmaps_for_writing');
         }
+        if (!file_exists(__DIR__.'/../fixtures/importmaps_for_writing/assets')) {
+            $this->filesystem->mkdir(__DIR__.'/../fixtures/importmaps_for_writing/assets');
+        }
+        file_put_contents(__DIR__.'/../fixtures/importmaps_for_writing/assets/some_file.js', '// some_file.js contents');
     }
 
     protected function tearDown(): void
@@ -257,6 +261,18 @@ class ImportMapManagerTest extends TestCase
             'expectedImportMap' => [
                 'lodash' => [
                     'url' => 'https://ga.jspm.io/npm:lodash@1.2.3/lodash.js',
+                ],
+            ],
+            'expectedDownloadedFiles' => [],
+        ];
+
+        yield 'single_package_with_a_path' => [
+            'packages' => [new PackageRequireOptions('some/module', path: __DIR__.'/../fixtures/importmaps_for_writing/assets/some_file.js')],
+            'expectedInstallRequest' => [],
+            'responseMap' => [],
+            'expectedImportMap' => [
+                'some/module' => [
+                    'path' => 'some_file.js',
                 ],
             ],
             'expectedDownloadedFiles' => [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Still TODO

The `path` option was added by @dunglas - it was always intended to be there. I forgot about it and (mostly) failed to add it. Now I've found a use-case for it when installing UX bundles (i.e. call the command to update the user's importmap with a pointer to an asset inside of the bundle).

Thanks!
