### PR TITLE
[AssetMapper] Fixing improper use of hasOption() in command

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
@@ -81,18 +81,22 @@ EOT
 
         $packageList = $input->getArgument('packages');
         $path = null;
-        if ($input->hasOption('path')) {
+        if ($input->getOption('path')) {
             if (\count($packageList) > 1) {
                 $io->error('The "--path" option can only be used when you require a single package.');
 
                 return Command::FAILURE;
             }
 
-            $path = $this->projectDir.'/'.$input->getOption('path');
+            $path = $input->getOption('path');
             if (!is_file($path)) {
-                $io->error(sprintf('The path "%s" does not exist.', $input->getOption('path')));
+                $path = $this->projectDir.'/'.$path;
 
-                return Command::FAILURE;
+                if (!is_file($path)) {
+                    $io->error(sprintf('The path "%s" does not exist.', $input->getOption('path')));
+
+                    return Command::FAILURE;
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | n/a

My fault - I wasn't also testing the "normal" situation when I added the path option - made a silly mistake. `hasOption()` checks whether or not the option exists on the command... which it always does. That causes an error because we try to find a `''` path when no `--path` was passed.

Also, I'm allowing absolute paths as `--path`. We ultimately send whatever this path is through to `AssetMapper::getAssetFromSourcePath()` for it to figure out the final "logical path".

Thanks!