### PR TITLE
[HttpClient] Use hrtime() to compute timeouts

### DIFF
--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -85,14 +85,14 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
                     return;
                 }
             } catch (TransportExceptionInterface) {
-                $state->lastError = $lastError ?? microtime(true);
+                $state->lastError = $lastError ?? hrtime(true) / 1E9;
 
-                if (null === $state->buffer || ($isTimeout && microtime(true) - $state->lastError < $state->reconnectionTime)) {
+                if (null === $state->buffer || ($isTimeout && hrtime(true) / 1E9 - $state->lastError < $state->reconnectionTime)) {
                     yield $chunk;
                 } else {
                     $options['headers']['Last-Event-ID'] = $state->lastEventId;
                     $state->buffer = '';
-                    $state->lastError = microtime(true);
+                    $state->lastError = hrtime(true) / 1E9;
                     $context->getResponse()->cancel();
                     $context->replaceRequest($method, $url, $options);
                     if ($isTimeout) {

--- a/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
+++ b/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
@@ -57,7 +57,7 @@ final class HttplugWaitLoop
         if (0.0 === $remainingDuration = $maxDuration) {
             $idleTimeout = 0.0;
         } elseif (null !== $maxDuration) {
-            $startTime = microtime(true);
+            $startTime = hrtime(true) / 1E9;
             $idleTimeout = max(0.0, min($maxDuration / 5, $idleTimeout ?? $maxDuration));
         }
 
@@ -100,7 +100,7 @@ final class HttplugWaitLoop
                 }
 
                 check_duration:
-                if (null !== $maxDuration && $idleTimeout && $idleTimeout > $remainingDuration = max(0.0, $maxDuration - microtime(true) + $startTime)) {
+                if (null !== $maxDuration && $idleTimeout && $idleTimeout > $remainingDuration = max(0.0, $maxDuration - hrtime(true) / 1E9 + $startTime)) {
                     $idleTimeout = $remainingDuration / 5;
                     break;
                 }

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -201,9 +201,9 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
      */
     private static function select(ClientState $multi, float $timeout): int
     {
-        $timeout += microtime(true);
+        $timeout += hrtime(true) / 1E9;
         self::$delay = Loop::defer(static function () use ($timeout) {
-            if (0 < $timeout -= microtime(true)) {
+            if (0 < $timeout -= hrtime(true) / 1E9) {
                 self::$delay = Loop::delay(ceil(1000 * $timeout), Loop::stop(...));
             } else {
                 Loop::stop();

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -103,7 +103,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
                 }
 
                 $lastExpiry = end($multi->pauseExpiries);
-                $multi->pauseExpiries[(int) $ch] = $duration += microtime(true);
+                $multi->pauseExpiries[(int) $ch] = $duration += hrtime(true) / 1E9;
                 if (false !== $lastExpiry && $lastExpiry > $duration) {
                     asort($multi->pauseExpiries);
                 }
@@ -326,7 +326,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
     private static function select(ClientState $multi, float $timeout): int
     {
         if ($multi->pauseExpiries) {
-            $now = microtime(true);
+            $now = hrtime(true) / 1E9;
 
             foreach ($multi->pauseExpiries as $id => $pauseExpiry) {
                 if ($now < $pauseExpiry) {
@@ -344,7 +344,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
             return $selected;
         }
 
-        if ($multi->pauseExpiries && 0 < $timeout -= microtime(true) - $now) {
+        if ($multi->pauseExpiries && 0 < $timeout -= hrtime(true) / 1E9 - $now) {
             usleep((int) (1E6 * $timeout));
         }
 

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -75,7 +75,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
 
         $pauseExpiry = &$this->pauseExpiry;
         $info['pause_handler'] = static function (float $duration) use (&$pauseExpiry) {
-            $pauseExpiry = 0 < $duration ? microtime(true) + $duration : 0;
+            $pauseExpiry = 0 < $duration ? hrtime(true) / 1E9 + $duration : 0;
         };
 
         $this->canary = new Canary(static function () use ($multi, $id) {
@@ -232,7 +232,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
     {
         foreach ($multi->openHandles as $i => [$pauseExpiry, $h, $buffer, $onProgress]) {
             if ($pauseExpiry) {
-                if (microtime(true) < $pauseExpiry) {
+                if (hrtime(true) / 1E9 < $pauseExpiry) {
                     continue;
                 }
 
@@ -321,7 +321,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
                 continue;
             }
 
-            if ($response->pauseExpiry && microtime(true) < $response->pauseExpiry) {
+            if ($response->pauseExpiry && hrtime(true) / 1E9 < $response->pauseExpiry) {
                 // Create empty open handles to tell we still have pending requests
                 $multi->openHandles[$i] = [\INF, null, null, null];
             } elseif ($maxHosts && $maxHosts > ($multi->hosts[parse_url($response->url, \PHP_URL_HOST)] ?? 0)) {
@@ -351,7 +351,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
                 continue;
             }
 
-            if ($pauseExpiry && ($now ??= microtime(true)) < $pauseExpiry) {
+            if ($pauseExpiry && ($now ??= hrtime(true) / 1E9) < $pauseExpiry) {
                 $timeout = min($timeout, $pauseExpiry - $now);
                 continue;
             }

--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -147,7 +147,7 @@ trait TransportResponseTrait
             self::schedule($response, $runningResponses);
         }
 
-        $lastActivity = microtime(true);
+        $lastActivity = hrtime(true) / 1E9;
         $elapsedTimeout = 0;
 
         if ($fromLastTimeout = 0.0 === $timeout && '-0' === (string) $timeout) {
@@ -172,7 +172,7 @@ trait TransportResponseTrait
                     $chunk = false;
 
                     if ($fromLastTimeout && null !== $multi->lastTimeout) {
-                        $elapsedTimeout = microtime(true) - $multi->lastTimeout;
+                        $elapsedTimeout = hrtime(true) / 1E9 - $multi->lastTimeout;
                     }
 
                     if (isset($multi->handlesActivity[$j])) {
@@ -291,7 +291,7 @@ trait TransportResponseTrait
             }
 
             if ($hasActivity) {
-                $lastActivity = microtime(true);
+                $lastActivity = hrtime(true) / 1E9;
                 continue;
             }
 
@@ -299,7 +299,7 @@ trait TransportResponseTrait
                 usleep(min(500, 1E6 * $timeoutMin));
             }
 
-            $elapsedTimeout = microtime(true) - $lastActivity;
+            $elapsedTimeout = hrtime(true) / 1E9 - $lastActivity;
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Makes the computation of timeouts resistant to clock drifts.