### PR TITLE
[WebProfilerBundle] Fix cursor on link that has no href

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -154,7 +154,7 @@
                     {% else %}
                         {{ caller.name }}
                     {% endif %}
-                    line <a class="text-small sf-toggle" data-toggle-selector="#sf-trace-{{ discr }}-{{ loop.index0 }}">{{ caller.line }}</a>
+                    line <a class="text-small sf-toggle" data-toggle-selector="#sf-trace-{{ discr }}-{{ loop.index0 }}" style="cursor: pointer">{{ caller.line }}</a>
 
                     <div class="hidden" id="sf-trace-{{ discr }}-{{ loop.index0 }}">
                         <div class="trace">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
@@ -83,7 +83,7 @@
                 {% else %}
                     {{ caller.name }}
                 {% endif %}
-                line <a class="text-small sf-toggle" data-toggle-selector="#sf-trace-{{ loop.index0 }}">{{ caller.line }}</a> (<a class="text-small sf-toggle" data-toggle-selector="#sf-context-{{ loop.index0 }}">context</a>):
+                line <a class="text-small sf-toggle" data-toggle-selector="#sf-trace-{{ loop.index0 }}" style="cursor: pointer">{{ caller.line }}</a> (<a class="text-small sf-toggle" data-toggle-selector="#sf-context-{{ loop.index0 }}" style="cursor: pointer">context</a>):
             </span>
 
             <div class="sf-validator-compact hidden" id="sf-trace-{{ loop.index0 }}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

A `a` link tag with no `href` has the wrong cursor icon by default when hovering it. Eg: https://codepen.io/philetaylor/pen/mdzQoxR

# Before

https://github.com/symfony/symfony/assets/400092/e8a60b94-2898-436e-8371-c5c897c97653


https://github.com/symfony/symfony/assets/400092/ce457d97-aa2e-41e7-b404-d9beac605388



# After


https://github.com/symfony/symfony/assets/400092/e1bba094-3771-40c5-96c7-20bbc527326c


