### PR TITLE
[FrameworkBundle][HttpKernel] Introduce `$buildDir` argument to `WarmableInterface::warmup` to warm read-only artefacts in `build_dir`

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -8109,11 +8109,11 @@ diff --git a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerInterface.p
 diff --git a/src/Symfony/Component/HttpKernel/CacheWarmer/WarmableInterface.php b/src/Symfony/Component/HttpKernel/CacheWarmer/WarmableInterface.php
 --- a/src/Symfony/Component/HttpKernel/CacheWarmer/WarmableInterface.php
 +++ b/src/Symfony/Component/HttpKernel/CacheWarmer/WarmableInterface.php
-@@ -24,4 +24,4 @@ interface WarmableInterface
+@@ -27,4 +27,4 @@ interface WarmableInterface
       * @return string[] A list of classes or files to preload on PHP 7.4+
       */
--    public function warmUp(string $cacheDir);
-+    public function warmUp(string $cacheDir): array;
+-    public function warmUp(string $cacheDir /* , string $buildDir = null */);
++    public function warmUp(string $cacheDir /* , string $buildDir = null */): array;
  }
 diff --git a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
 --- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php

--- a/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
@@ -38,9 +38,9 @@ class ProxyCacheWarmer implements CacheWarmerInterface
     }
 
     /**
-     * @return string[] A list of files to preload on PHP 7.4+
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
         $files = [];
         foreach ($this->registry->getManagers() as $em) {

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -32,6 +32,7 @@ CHANGELOG
  * Add `--exclude` option to the `cache:pool:clear` command
  * Add parameters deprecations to the output of `debug:container` command
  * Change `framework.asset_mapper.importmap_polyfill` from a URL to the name of an item in the importmap
+ * Provide `$buildDir` when running `CacheWarmer` to build read-only resources
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -35,15 +35,16 @@ abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
     }
 
     /**
-     * @return string[] A list of classes to preload on PHP 7.4+
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
+        $buildDir = 1 < \func_num_args() ? func_get_arg(1) : null;
         $arrayAdapter = new ArrayAdapter();
 
         spl_autoload_register([ClassExistenceResource::class, 'throwOnRequiredClass']);
         try {
-            if (!$this->doWarmUp($cacheDir, $arrayAdapter)) {
+            if (!$this->doWarmUp($cacheDir, $arrayAdapter, $buildDir)) {
                 return [];
             }
         } finally {
@@ -78,7 +79,9 @@ abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
     }
 
     /**
+     * @param string|null $buildDir
+     *
      * @return bool false if there is nothing to warm-up
      */
-    abstract protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter): bool;
+    abstract protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter /* , string $buildDir = null */): bool;
 }

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -44,7 +44,10 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         parent::__construct($phpArrayFile);
     }
 
-    protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter): bool
+    /**
+     * @param string|null $buildDir
+     */
+    protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter /* , string $buildDir = null */): bool
     {
         $annotatedClassPatterns = $cacheDir.'/annotations.map';
 

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/CachePoolClearerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/CachePoolClearerCacheWarmer.php
@@ -37,10 +37,7 @@ final class CachePoolClearerCacheWarmer implements CacheWarmerInterface
         $this->pools = $pools;
     }
 
-    /**
-     * @return string[]
-     */
-    public function warmUp(string $cacheDirectory): array
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         foreach ($this->pools as $pool) {
             if ($this->poolClearer->hasPool($pool)) {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -38,11 +38,17 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
     }
 
     /**
-     * @return string[]
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
-        $generator = new ConfigBuilderGenerator($this->kernel->getBuildDir());
+        $buildDir = 1 < \func_num_args() ? func_get_arg(1) : null;
+
+        if (!$buildDir) {
+            return [];
+        }
+
+        $generator = new ConfigBuilderGenerator($buildDir);
 
         foreach ($this->kernel->getBundles() as $bundle) {
             $extension = $bundle->getContainerExtension();

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
@@ -34,12 +34,12 @@ class RouterCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInterf
         $this->container = $container;
     }
 
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         $router = $this->container->get('router');
 
         if ($router instanceof WarmableInterface) {
-            return (array) $router->warmUp($cacheDir);
+            return (array) $router->warmUp($cacheDir, $buildDir);
         }
 
         throw new \LogicException(sprintf('The router "%s" cannot be warmed up because it does not implement "%s".', get_debug_type($router), WarmableInterface::class));

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -39,7 +39,10 @@ class SerializerCacheWarmer extends AbstractPhpFileCacheWarmer
         $this->loaders = $loaders;
     }
 
-    protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter): bool
+    /**
+     * @param string|null $buildDir
+     */
+    protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter /* , string $buildDir = null */): bool
     {
         if (!$this->loaders) {
             return true;

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TranslationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TranslationsCacheWarmer.php
@@ -34,14 +34,16 @@ class TranslationsCacheWarmer implements CacheWarmerInterface, ServiceSubscriber
     }
 
     /**
-     * @return string[]
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
         $this->translator ??= $this->container->get('translator');
 
         if ($this->translator instanceof WarmableInterface) {
-            return (array) $this->translator->warmUp($cacheDir);
+            $buildDir = 1 < \func_num_args() ? func_get_arg(1) : null;
+
+            return (array) $this->translator->warmUp($cacheDir, $buildDir);
         }
 
         return [];

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
@@ -39,7 +39,10 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
         $this->validatorBuilder = $validatorBuilder;
     }
 
-    protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter): bool
+    /**
+     * @param string|null $buildDir
+     */
+    protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter /* , string $buildDir = null */): bool
     {
         $loaders = $this->validatorBuilder->getLoaders();
         $metadataFactory = new LazyLoadingMetadataFactory(new LoaderChain($loaders), $arrayAdapter);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -245,7 +245,7 @@ EOF
         $warmer = $kernel->getContainer()->get('cache_warmer');
         // non optional warmers already ran during container compilation
         $warmer->enableOnlyOptionalWarmers();
-        $preload = (array) $warmer->warmUp($cacheDir, $io);
+        $preload = (array) $warmer->warmUp($cacheDir, $warmupDir, $io);
 
         if ($preload && file_exists($preloadFile = $warmupDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
             Preloader::append($preloadFile, $preload);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -74,7 +74,8 @@ EOF
 
         $preload = $this->cacheWarmer->warmUp($cacheDir);
 
-        if ($preload && file_exists($preloadFile = $cacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
+        $buildDir = $kernel->getContainer()->getParameter('kernel.build_dir');
+        if ($preload && $cacheDir === $buildDir && file_exists($preloadFile = $buildDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
             Preloader::append($preloadFile, $preload);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -81,9 +81,9 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
     }
 
     /**
-     * @return string[] A list of classes to preload on PHP 7.4+
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
         $currentDir = $this->getOption('cache_dir');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
@@ -52,7 +52,7 @@ class DummyFileCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         file_put_contents($cacheDir.'/dummy.txt', 'Hello');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -95,9 +95,9 @@ class Translator extends BaseTranslator implements WarmableInterface
     }
 
     /**
-     * @return string[]
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
         // skip warmUp when translator doesn't use cache
         if (null === $this->options['cache_dir']) {

--- a/src/Symfony/Bundle/SecurityBundle/CacheWarmer/ExpressionCacheWarmer.php
+++ b/src/Symfony/Bundle/SecurityBundle/CacheWarmer/ExpressionCacheWarmer.php
@@ -35,9 +35,9 @@ class ExpressionCacheWarmer implements CacheWarmerInterface
     }
 
     /**
-     * @return string[]
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
         foreach ($this->expressions as $expression) {
             $this->expressionLanguage->parse($expression, ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']);

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
@@ -36,9 +36,9 @@ class TemplateCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInte
     }
 
     /**
-     * @return string[] A list of template files to preload on PHP 7.4+
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
         $this->twig ??= $this->container->get('twig');
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Support the `!` character at the beginning of a string as a negation operator in the url filter of the profiler
  * Deprecate `UriSigner`, use `UriSigner` from the HttpFoundation component instead
  * Deprecate `FileLinkFormatter`, use `FileLinkFormatter` from the ErrorHandler component instead
+ * Add argument `$buildDir` to `WarmableInterface`
 
 6.3
 ---

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -48,8 +48,17 @@ class CacheWarmerAggregate implements CacheWarmerInterface
         $this->onlyOptionalsEnabled = $this->optionalsEnabled = true;
     }
 
-    public function warmUp(string $cacheDir, SymfonyStyle $io = null): array
+    /**
+     * @param string|null $buildDir
+     */
+    public function warmUp(string $cacheDir, string|SymfonyStyle $buildDir = null, SymfonyStyle $io = null): array
     {
+        if ($buildDir instanceof SymfonyStyle) {
+            trigger_deprecation('symfony/http-kernel', '6.4', 'Passing a "%s" as second argument of "%s()" is deprecated, pass it as third argument instead, after the build directory.', SymfonyStyle::class, __METHOD__);
+            $io = $buildDir;
+            $buildDir = null;
+        }
+
         if ($collectDeprecations = $this->debug && !\defined('PHPUNIT_COMPOSER_INSTALL')) {
             $collectedLogs = [];
             $previousHandler = set_error_handler(function ($type, $message, $file, $line) use (&$collectedLogs, &$previousHandler) {
@@ -96,8 +105,8 @@ class CacheWarmerAggregate implements CacheWarmerInterface
                 }
 
                 $start = microtime(true);
-                foreach ((array) $warmer->warmUp($cacheDir) as $item) {
-                    if (is_dir($item) || (str_starts_with($item, \dirname($cacheDir)) && !is_file($item))) {
+                foreach ((array) $warmer->warmUp($cacheDir, $buildDir) as $item) {
+                    if (is_dir($item) || (str_starts_with($item, \dirname($cacheDir)) && !is_file($item)) || ($buildDir && str_starts_with($item, \dirname($buildDir)) && !is_file($item))) {
                         throw new \LogicException(sprintf('"%s::warmUp()" should return a list of files or classes but "%s" is none of them.', $warmer::class, $item));
                     }
                     $preload[] = $item;

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/WarmableInterface.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/WarmableInterface.php
@@ -21,7 +21,10 @@ interface WarmableInterface
     /**
      * Warms up the cache.
      *
+     * @param string      $cacheDir Where warm-up artifacts should be stored
+     * @param string|null $buildDir Where read-only artifacts should go; null when called after compile-time
+     *
      * @return string[] A list of classes or files to preload on PHP 7.4+
      */
-    public function warmUp(string $cacheDir);
+    public function warmUp(string $cacheDir /* , string $buildDir = null */);
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -539,10 +539,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             touch($oldContainerDir.'.legacy');
         }
 
-        $preload = $this instanceof WarmableInterface ? (array) $this->warmUp($this->container->getParameter('kernel.cache_dir')) : [];
+        $preload = $this instanceof WarmableInterface ? (array) $this->warmUp($this->container->getParameter('kernel.cache_dir'), $buildDir) : [];
 
         if ($this->container->has('cache_warmer')) {
-            $preload = array_merge($preload, (array) $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir')));
+            $preload = array_merge($preload, (array) $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'), $buildDir));
         }
 
         if ($preload && file_exists($preloadFile = $buildDir.'/'.$class.'.preload.php')) {

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
@@ -93,6 +93,40 @@ class CacheWarmerAggregateTest extends TestCase
         $aggregate->warmUp(__DIR__);
     }
 
+    public function testWarmupPassBuildDir()
+    {
+        $warmer = $this->createMock(CacheWarmerInterface::class);
+        $warmer
+            ->expects($this->once())
+            ->method('isOptional')
+            ->willReturn(false);
+        $warmer
+            ->expects($this->once())
+            ->method('warmUp')
+            ->with('cache_dir', 'build_dir');
+
+        $aggregate = new CacheWarmerAggregate([$warmer]);
+        $aggregate->enableOptionalWarmers();
+        $aggregate->warmUp('cache_dir', 'build_dir');
+    }
+
+    public function testWarmupOnOptionalWarmerDoNotPassBuildDir()
+    {
+        $warmer = $this->createMock(CacheWarmerInterface::class);
+        $warmer
+            ->expects($this->once())
+            ->method('isOptional')
+            ->willReturn(true);
+        $warmer
+            ->expects($this->once())
+            ->method('warmUp')
+            ->with('cache_dir', null);
+
+        $aggregate = new CacheWarmerAggregate([$warmer]);
+        $aggregate->enableOptionalWarmers();
+        $aggregate->warmUp('cache_dir', 'build_dir');
+    }
+
     public function testWarmupWhenDebugDisplaysWarmupDuration()
     {
         $warmer = $this->createMock(CacheWarmerInterface::class);
@@ -115,7 +149,7 @@ class CacheWarmerAggregateTest extends TestCase
             ->method('warmUp');
 
         $aggregate = new CacheWarmerAggregate([$warmer]);
-        $aggregate->warmUp(__DIR__, $io);
+        $aggregate->warmUp(__DIR__, null, $io);
     }
 
     public function testWarmupWhenNotDebugDoesntDisplayWarmupDuration()
@@ -140,6 +174,6 @@ class CacheWarmerAggregateTest extends TestCase
             ->method('warmUp');
 
         $aggregate = new CacheWarmerAggregate([$warmer]);
-        $aggregate->warmUp(__DIR__, $io);
+        $aggregate->warmUp(__DIR__, null, $io);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
@@ -54,7 +54,7 @@ class TestCacheWarmer extends CacheWarmer
         $this->file = $file;
     }
 
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         $this->writeCacheFile($this->file, 'content');
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -562,6 +562,7 @@ EOF
         $kernel->boot();
 
         $this->assertTrue($kernel->warmedUp);
+        $this->assertSame($kernel->getBuildDir(), $kernel->warmedUpBuildDir);
     }
 
     public function testServicesResetter()
@@ -756,6 +757,8 @@ class CustomProjectDirKernel extends Kernel implements WarmableInterface
 {
     public bool $warmedUp = false;
 
+    public ?string $warmedUpBuildDir = null;
+
     public function __construct(
         private readonly ?\Closure $buildContainer = null,
         private readonly ?HttpKernelInterface $httpKernel = null,
@@ -778,9 +781,10 @@ class CustomProjectDirKernel extends Kernel implements WarmableInterface
         return __DIR__.'/Fixtures';
     }
 
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         $this->warmedUp = true;
+        $this->warmedUpBuildDir = $buildDir;
 
         return [];
     }

--- a/src/Symfony/Component/Serializer/CacheWarmer/CompiledClassMetadataCacheWarmer.php
+++ b/src/Symfony/Component/Serializer/CacheWarmer/CompiledClassMetadataCacheWarmer.php
@@ -29,7 +29,7 @@ final class CompiledClassMetadataCacheWarmer implements CacheWarmerInterface
     ) {
     }
 
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         $metadatas = [];
 

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -72,12 +72,14 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     }
 
     /**
-     * @return string[]
+     * @param string|null $buildDir
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
     {
+        $buildDir = 1 < \func_num_args() ? func_get_arg(1) : null;
+
         if ($this->translator instanceof WarmableInterface) {
-            return (array) $this->translator->warmUp($cacheDir);
+            return (array) $this->translator->warmUp($cacheDir, $buildDir);
         }
 
         return [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50357 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

See #50357 for the details and the reproduction steps. In this PR, I also moved `ConfigBuilderCacheWarmer` to use the `buildDir` argument.
