### PR TITLE
[Validator] Allow single integer for the `versions` option of the `Uuid` constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Allow single integer for the `versions` option of the `Uuid` constraint
+
 6.3
 ---
 

--- a/src/Symfony/Component/Validator/Constraints/Uuid.php
+++ b/src/Symfony/Component/Validator/Constraints/Uuid.php
@@ -100,12 +100,12 @@ class Uuid extends Constraint
     public $normalizer;
 
     /**
-     * @param int[]|null $versions
+     * @param int[]|int|null $versions
      */
     public function __construct(
         array $options = null,
         string $message = null,
-        array $versions = null,
+        array|int $versions = null,
         bool $strict = null,
         callable $normalizer = null,
         array $groups = null,
@@ -114,7 +114,7 @@ class Uuid extends Constraint
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;
-        $this->versions = $versions ?? $this->versions;
+        $this->versions = (array) ($versions ?? $this->versions);
         $this->strict = $strict ?? $this->strict;
         $this->normalizer = $normalizer ?? $this->normalizer;
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -296,4 +296,13 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
         yield Uuid::V7_MONOTONIC => ['0184c292-b133-7e10-a3b4-d49c1ab49b2a', true];
         yield Uuid::V8_CUSTOM => ['00112233-4455-8677-8899-aabbccddeeff', false];
     }
+
+    public function testAcceptsSingleIntegerAsVersion()
+    {
+        $constraint = new Uuid(versions: 7);
+
+        $this->validator->validate('0184c292-b133-7e10-a3b4-d49c1ab49b2a', $constraint);
+
+        $this->assertNoViolation();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

Improve DX by allowing to pass a single integer for the `versions` option of the `Uuid` constraint