### PR TITLE
[AssetMapper] Sometimes asset contents are built from non-asset files

### DIFF
--- a/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
@@ -59,7 +59,8 @@ class CachedMappedAssetFactory implements MappedAssetFactoryInterface
      */
     private function collectResourcesFromAsset(MappedAsset $mappedAsset): array
     {
-        $resources = [new FileResource($mappedAsset->getSourcePath())];
+        $resources = array_map(fn (string $path) => new FileResource($path), $mappedAsset->getFileDependencies());
+        $resources[] = new FileResource($mappedAsset->getSourcePath());
 
         foreach ($mappedAsset->getDependencies() as $dependency) {
             if (!$dependency->isContentDependency) {

--- a/src/Symfony/Component/AssetMapper/MappedAsset.php
+++ b/src/Symfony/Component/AssetMapper/MappedAsset.php
@@ -31,6 +31,8 @@ final class MappedAsset
     private bool $isPredigested;
     /** @var AssetDependency[] */
     private array $dependencies = [];
+    /** @var string[] */
+    private array $fileDependencies = [];
 
     public function __construct(private readonly string $logicalPath)
     {
@@ -77,6 +79,14 @@ final class MappedAsset
     public function getDependencies(): array
     {
         return $this->dependencies;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFileDependencies(): array
+    {
+        return $this->fileDependencies;
     }
 
     public function setPublicPath(string $publicPath): void
@@ -128,6 +138,16 @@ final class MappedAsset
     public function addDependency(AssetDependency $assetDependency): void
     {
         $this->dependencies[] = $assetDependency;
+    }
+
+    /**
+     * Any filesystem files whose contents are used to create this asset.
+     *
+     * This is used to invalidate the cache when any of these files change.
+     */
+    public function addFileDependency(string $sourcePath): void
+    {
+        $this->fileDependencies[] = $sourcePath;
     }
 
     public function getPublicPathWithoutDigest(): string

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
@@ -106,6 +106,9 @@ class CachedMappedAssetFactoryTest extends TestCase
         $notDependentOnContentAsset->setSourcePath(__DIR__.'/../fixtures/dir2/already-abcdefVWXYZ0123456789.digested.css');
         $mappedAsset->addDependency(new AssetDependency($notDependentOnContentAsset, isContentDependency: false));
 
+        // just adding any file as an example
+        $mappedAsset->addFileDependency(__DIR__.'/../fixtures/importmap.php');
+
         $factory = $this->createMock(MappedAssetFactoryInterface::class);
         $factory->expects($this->once())
             ->method('createMappedAsset')
@@ -119,12 +122,13 @@ class CachedMappedAssetFactoryTest extends TestCase
         $cachedFactory->createMappedAsset('file1.css', $sourcePath);
 
         $configCacheMetadata = $this->loadConfigCacheMetadataFor($mappedAsset);
-        $this->assertCount(3, $configCacheMetadata);
+        $this->assertCount(4, $configCacheMetadata);
         $this->assertInstanceOf(FileResource::class, $configCacheMetadata[0]);
         $this->assertInstanceOf(FileResource::class, $configCacheMetadata[1]);
-        $this->assertSame($mappedAsset->getSourcePath(), $configCacheMetadata[0]->getResource());
-        $this->assertSame($dependentOnContentAsset->getSourcePath(), $configCacheMetadata[1]->getResource());
-        $this->assertSame($deeplyNestedAsset->getSourcePath(), $configCacheMetadata[2]->getResource());
+        $this->assertSame(realpath(__DIR__.'/../fixtures/importmap.php'), $configCacheMetadata[0]->getResource());
+        $this->assertSame($mappedAsset->getSourcePath(), $configCacheMetadata[1]->getResource());
+        $this->assertSame($dependentOnContentAsset->getSourcePath(), $configCacheMetadata[2]->getResource());
+        $this->assertSame($deeplyNestedAsset->getSourcePath(), $configCacheMetadata[3]->getResource());
     }
 
     private function loadConfigCacheMetadataFor(MappedAsset $mappedAsset): array

--- a/src/Symfony/Component/AssetMapper/Tests/MappedAssetTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/MappedAssetTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\AssetMapper\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\AssetDependency;
 use Symfony\Component\AssetMapper\MappedAsset;
 
 class MappedAssetTest extends TestCase
@@ -77,5 +78,18 @@ class MappedAssetTest extends TestCase
         $asset = new MappedAsset('foo.css');
         $asset->setContent('body { color: red; }');
         $this->assertSame('body { color: red; }', $asset->getContent());
+    }
+
+    public function testAddDependencies()
+    {
+        $mainAsset = new MappedAsset('file.js');
+
+        $assetFoo = new MappedAsset('foo.js');
+        $dependency = new AssetDependency($assetFoo, false, false);
+        $mainAsset->addDependency($dependency);
+        $mainAsset->addFileDependency('/path/to/foo.js');
+
+        $this->assertSame([$dependency], $mainAsset->getDependencies());
+        $this->assertSame(['/path/to/foo.js'], $mainAsset->getFileDependencies());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes-ish
| New feature?  | yes-ish
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Still TODO

Apologies again for the late thing - I'm *really* trying to push the component to find critical bugs or missing items.

In StimulusBundle, we dynamically build the contents of a `controllers.js` mapped asset from the `assets/controllers.json` file. This PR allows us to "bust" that asset's cache when `assets/controllers.json` is modified. Right now, it would be a bug in StimulusBundle that we can't really work around.

Other use-cases: someone decides to write an asset compiler that runs Tailwind automatically on a CSS file, and they want that dynamic asset to "vary" on the `tailwind.config.js` file.

Thanks!