### PR TITLE
[VarDumper] Fix `dd()` showing line with `null`

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -49,7 +49,7 @@ if (!function_exists('dd')) {
             header('HTTP/1.1 500 Internal Server Error');
         }
 
-        if (isset($vars[0]) && 1 === count($vars)) {
+        if (array_key_exists(0, $vars) && 1 === count($vars)) {
             VarDumper::dump($vars[0]);
         } else {
             foreach ($vars as $k => $v) {

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_multiple_args.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_multiple_args.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test dd() with multiple args shows line number
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dd(null, 1, 'foo');
+
+--EXPECT--
+1 null
+2 1
+3 "foo"

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_null.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_null.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test dd() with null doesn't show line number
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dd(null);
+
+--EXPECT--
+null

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_single_arg.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_single_arg.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test dd() with one arg doesn't show line number
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dd('foo');
+
+--EXPECT--
+"foo"

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_multiple_args.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_multiple_args.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test dump() with multiple args shows line number
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dump(null, 1, 'foo');
+
+--EXPECT--
+1 null
+2 1
+3 "foo"

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_null.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_null.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test dump() with null doesn't show line number
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dump(null);
+
+--EXPECT--
+null

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_single_arg.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_single_arg.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test dump() with one arg doesn't show line number
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dump('foo');
+
+--EXPECT--
+"foo"

--- a/src/Symfony/Component/VarDumper/phpunit.xml.dist
+++ b/src/Symfony/Component/VarDumper/phpunit.xml.dist
@@ -17,6 +17,7 @@
     <testsuites>
         <testsuite name="Symfony VarDumper Component Test Suite">
             <directory>./Tests/</directory>
+            <directory suffix=".phpt">./Tests/Dumper/functions/</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Similar to https://github.com/symfony/symfony/pull/50347#discussion_r1196158247 but for the `dd()` function:

```php
dd(null);
```

![image](https://github.com/symfony/symfony/assets/2445045/5615db1d-d48d-4720-85ce-239d3921f624)