### PR TITLE
[7.0] Remove hacks that made the CI green

### DIFF
--- a/.github/build-packages.php
+++ b/.github/build-packages.php
@@ -11,10 +11,6 @@ array_shift($dirs);
 $mergeBase = trim(shell_exec(sprintf('git merge-base "%s" HEAD', array_shift($dirs))));
 $version = array_shift($dirs);
 
-if ('7.0' === $version) {
-    $version = '6.4'; // to be removed once deps allow ^7.0
-}
-
 $packages = [];
 $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 $preferredInstall = json_decode(file_get_contents(__DIR__.'/composer-config.json'), true)['config']['preferred-install'];

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -155,8 +155,7 @@ jobs:
         run: |
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
-          #export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
-          export COMPOSER_ROOT_VERSION=6.4.x-dev # to be removed once deps allow ^7.0
+          export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
           echo COMPOSER_ROOT_VERSION=$COMPOSER_ROOT_VERSION >> $GITHUB_ENV
 
           echo "::group::composer update"

--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -63,8 +63,7 @@ jobs:
         run: |
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
-          #export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
-          export COMPOSER_ROOT_VERSION=6.4.x-dev # to be removed once deps allow ^7.0
+          export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
           echo COMPOSER_ROOT_VERSION=$COMPOSER_ROOT_VERSION >> $GITHUB_ENV
 
           echo "::group::composer update"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -41,8 +41,7 @@ jobs:
         run: |
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
-          #export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
-          export COMPOSER_ROOT_VERSION=6.4.x-dev # to be removed once deps allow ^7.0
+          export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
           composer remove --dev --no-update --no-interaction symfony/phpunit-bridge
           composer require --no-progress --ansi --no-plugins psalm/phar phpunit/phpunit:^9.6 php-http/discovery psr/event-dispatcher mongodb/mongodb jetbrains/phpstorm-stubs
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -122,8 +122,7 @@ jobs:
           [[ "${{ matrix.mode }}" = high-deps && $SYMFONY_VERSION = *.4 ]] && echo LEGACY=,legacy >> $GITHUB_ENV || true
 
           echo SYMFONY_VERSION=$SYMFONY_VERSION >> $GITHUB_ENV
-          #echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
-          echo COMPOSER_ROOT_VERSION=6.4.x-dev >> $GITHUB_ENV # to be removed once all deps allow ^7.0
+          echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
           echo SYMFONY_REQUIRE=">=$([ '${{ matrix.mode }}' = low-deps ] && echo 5.4 || echo $SYMFONY_VERSION)" >> $GITHUB_ENV
           [[ "${{ matrix.mode }}" = *-deps ]] && mv composer.json.phpunit composer.json || true
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follows #50404

The Windows build is blocked by ext-redis and ext-apcu not being available as DLL for PHP 8.2. /cc @weltling :pray: 

It's time to allow Symfony 7 again :)

- [x] https://github.com/composer/composer/pull/11474
- [x] https://github.com/async-aws/aws/pull/1409
- [x] https://github.com/doctrine/orm/pull/10724
- [x] [FriendsOfPHP/proxy-manager-lts](https://github.com/FriendsOfPHP/proxy-manager-lts/commit/d93bd79aadae70923f47603aaa81db45ba0da10f)
- [x] https://github.com/symfony/security-acl/pull/111
- [x] https://github.com/tijsverkoyen/CssToInlineStyles/pull/243

We also need a sigchild-enabled PHP, which @derrabus knows how to build :)