### PR TITLE
[Mime] Remote email feature

### DIFF
--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+ * Change the visibility of Email::ensureBodyValid() to "protected" to override its behavior in child classes.  
+ * Add RemoteEmail to support remote emails with template defined on the cloud (empty body)
+
 6.3
 ---
 

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -410,7 +410,7 @@ class Email extends Message
         parent::ensureValidity();
     }
 
-    private function ensureBodyValid(): void
+    protected function ensureBodyValid(): void
     {
         if (null === $this->text && null === $this->html && !$this->attachments) {
             throw new LogicException('A message must have a text or an HTML part or attachments.');

--- a/src/Symfony/Component/Mime/RemoteEmail.php
+++ b/src/Symfony/Component/Mime/RemoteEmail.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime;
+
+use Symfony\Component\Mime\Exception\LogicException;
+use Symfony\Component\Mime\Part\AbstractPart;
+use Symfony\Component\Mime\Part\TextPart;
+
+/**
+ * @author Mounir Mouih <mounir.mouih@gmail.com>
+ */
+final class RemoteEmail extends Email
+{
+    /**
+     * The name of the header that contains the remote email template.
+     */
+    private string $headerName = '';
+
+    /**
+     * The templateId hosted on the cloud.
+     */
+    private string $templateId = '';
+
+    protected function ensureBodyValid(): void
+    {
+        if (null === $this->getHeaders()->get($this->headerName)) {
+            throw new LogicException('Cannot send remote email without template.');
+        }
+    }
+
+    /**
+     * Set the remote template to the header.
+     */
+    public function setRemoteTemplate(string $headerName, string $templateId): static
+    {
+        if ('' !== $this->headerName && $this->getHeaders()->has($this->headerName)) {
+            $this->getHeaders()->remove($this->headerName);
+        }
+
+        $this->headerName = $headerName;
+        $this->templateId = $templateId;
+        $this->getHeaders()->addTextHeader($headerName, $templateId);
+
+        return $this;
+    }
+
+    public function getBody(): AbstractPart
+    {
+        return new TextPart('');
+    }
+
+    public function getTemplateHeaderName(): string
+    {
+        return $this->headerName;
+    }
+
+    public function getTemplateId(): string
+    {
+        return $this->templateId;
+    }
+}

--- a/src/Symfony/Component/Mime/Tests/RemoteEmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/RemoteEmailTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Exception\LogicException;
+use Symfony\Component\Mime\RemoteEmail;
+
+/**
+ * @author Mounir Mouih <mounir.mouih@gmail.com>
+ */
+class RemoteEmailTest extends TestCase
+{
+    public function testBody()
+    {
+        $email = new RemoteEmail();
+        $this->assertEquals('', $email->getBody()->bodyToString());
+    }
+
+    public function testInvalidEmail()
+    {
+        $email = new RemoteEmail();
+        $email->subject('Remote Email Subject !')
+            ->to(new Address('mounir.mouih@gmail.com', 'Mounir Mouih'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->addCc('foo@bar.fr')
+            ->addBcc('foo@bar.fr')
+            ->addReplyTo('foo@bar.fr');
+
+        $this->expectException(LogicException::class);
+        $email->ensureValidity();
+    }
+
+    public function testvalidEmail()
+    {
+        $email = new RemoteEmail();
+        $email->subject('Remote Email Subject !')
+            ->to(new Address('mounir.mouih@gmail.com', 'Mounir Mouih'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->addCc('foo@bar.fr')
+            ->addBcc('foo@bar.fr')
+            ->addReplyTo('foo@bar.fr');
+
+        $email->setRemoteTemplate('templateId', '1');
+        $email->ensureValidity();
+        $this->assertTrue(true);
+    }
+
+    public function testSetTemplate()
+    {
+        $email = new RemoteEmail();
+        $email->subject('Remote Email Subject !')
+            ->to(new Address('mounir.mouih@gmail.com', 'Mounir Mouih'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->addCc('foo@bar.fr')
+            ->addBcc('foo@bar.fr')
+            ->addReplyTo('foo@bar.fr');
+
+        $email->setRemoteTemplate('templateId', '1');
+        $email->ensureValidity();
+
+        $this->assertSame('templateId', $email->getTemplateHeaderName());
+        $this->assertSame('1', $email->getTemplateId());
+    }
+
+    public function testConsecutiveSetTemplateCalls()
+    {
+        $email = new RemoteEmail();
+        $email->subject('Remote Email Subject !')
+            ->to(new Address('mounir.mouih@gmail.com', 'Mounir Mouih'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->addCc('foo@bar.fr')
+            ->addBcc('foo@bar.fr')
+            ->addReplyTo('foo@bar.fr');
+
+        $email->setRemoteTemplate('templateId', '1');
+        $email->ensureValidity();
+        $this->assertSame('templateId', $email->getTemplateHeaderName());
+        $this->assertSame('1', $email->getTemplateId());
+
+        // Change template name
+        $email->setRemoteTemplate('templateId', '2');
+        $this->assertSame('templateId', $email->getTemplateHeaderName());
+        $this->assertSame('2', $email->getTemplateId());
+
+        // Change template header name
+        $email->setRemoteTemplate('template_name', 'my_template');
+        $this->assertSame('template_name', $email->getTemplateHeaderName());
+        $this->assertSame('my_template', $email->getTemplateId());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | NO
| New feature?  | YES
| Deprecations? | NO
| Tickets       | -
| License       | MIT
| Doc PR        | TODO
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
Hello,

To send emails via sendingblue, I used Mime Email class with sendingBlue bridge,
I noticed an Exception while trying to send the email to a remote template hosted on sending blue; 
Sendingblue/brevo expects to receive a `templateId` header to select the template to be used for this email, that is supposed to be enough; 
I encountered a LogicException because an Email *should always have body or an attachment*,
The source of this exception comes from `Email::ensureBodyValid()` private method.

A simple solution for this issue, is to define an arbitrary body (I usually send the templateId as body text), so no big deal.
I do not consider this to be a bug, not a serious one at least.

That gave me the idea to make a pull request, to define a *special type* for *Remote email*, with I called `RemoteEmail` in the Mime component for emails hosted on the cloud, which allows the email to have an empty body, instead it will define two things, a **templateId**,  the **header name** to be sent the email api, 

I had to change the visibility of the class `Email::ensureBodyValid()` to protected instead of private, to be able to customize it's behaviour.

I included tests for `RemoteEmail` class in the Mime component, and Tests to integrate it with **SendingBlueBridge**, but I did not integration bridge tests to avoid unit tests issues in the Mailer component since the RemoteEmail class would not be recognised,

Sending Blue Test file in another branch: 
https://github.com/mmouih/symfony/blob/be08c7ca6bdf44ac148f09761cdd0b9e8c755190/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportRemoteEmailTest.php

Example of a failure test: 
https://github.com/symfony/symfony/blob/75157ca610da69186b80c6dfafb61541121c53c4/src/Symfony/Component/Mime/Tests/RemoteEmailTest.php#L30-L42

A success example below:
https://github.com/symfony/symfony/blob/75157ca610da69186b80c6dfafb61541121c53c4/src/Symfony/Component/Mime/Tests/RemoteEmailTest.php#L44-L57

This RemoteEmail class is a subtitute to Email on most usages, however the body is always Empty.
