### PR TITLE
[Validator] Allow single constraint to be passed to the `constraints` option of the `When` constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow single integer for the `versions` option of the `Uuid` constraint
+ * Allow single constraint to be passed to the `constraints` option of the `When` constraint
 
 6.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/When.php
+++ b/src/Symfony/Component/Validator/Constraints/When.php
@@ -13,10 +13,12 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
 /**
  * @Annotation
+ *
  * @Target({"CLASS", "PROPERTY", "METHOD", "ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
@@ -26,7 +28,7 @@ class When extends Composite
     public $constraints = [];
     public $values = [];
 
-    public function __construct(string|Expression|array $expression, array $constraints = null, array $values = null, array $groups = null, $payload = null, array $options = [])
+    public function __construct(string|Expression|array $expression, array|Constraint $constraints = null, array $values = null, array $groups = null, $payload = null, array $options = [])
     {
         if (!class_exists(ExpressionLanguage::class)) {
             throw new LogicException(sprintf('The "symfony/expression-language" component is required to use the "%s" constraint. Try running "composer require symfony/expression-language".', __CLASS__));
@@ -37,6 +39,10 @@ class When extends Composite
         } else {
             $options['expression'] = $expression;
             $options['constraints'] = $constraints;
+        }
+
+        if (isset($options['constraints']) && !\is_array($options['constraints'])) {
+            $options['constraints'] = [$options['constraints']];
         }
 
         if (null !== $groups) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/WhenTestWithAttributes.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/WhenTestWithAttributes.php
@@ -33,6 +33,9 @@ class WhenTestWithAttributes
     ], groups: ['foo'])]
     private $bar;
 
+    #[When(expression: 'true', constraints: new NotNull(), groups: ['foo'])]
+    private $qux;
+
     #[When(expression: 'true', constraints: [
         new NotNull(),
         new NotBlank(),

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -88,6 +88,17 @@ final class WhenTest extends TestCase
         ], $barConstraint->constraints);
         self::assertSame(['foo'], $barConstraint->groups);
 
+        [$quxConstraint] = $metadata->properties['qux']->getConstraints();
+
+        self::assertInstanceOf(When::class, $quxConstraint);
+        self::assertSame('true', $quxConstraint->expression);
+        self::assertEquals([
+            new NotNull([
+                'groups' => ['foo'],
+            ]),
+        ], $quxConstraint->constraints);
+        self::assertSame(['foo'], $quxConstraint->groups);
+
         [$bazConstraint] = $metadata->getters['baz']->getConstraints();
 
         self::assertInstanceOf(When::class, $bazConstraint);
@@ -152,6 +163,17 @@ final class WhenTest extends TestCase
         ], $barConstraint->constraints);
         self::assertSame(['foo'], $barConstraint->groups);
 
+        [$quxConstraint] = $metadata->properties['qux']->getConstraints();
+
+        self::assertInstanceOf(When::class, $quxConstraint);
+        self::assertSame('true', $quxConstraint->expression);
+        self::assertEquals([
+            new NotNull([
+                'groups' => ['foo'],
+            ]),
+        ], $quxConstraint->constraints);
+        self::assertSame(['foo'], $quxConstraint->groups);
+
         [$bazConstraint] = $metadata->getters['baz']->getConstraints();
 
         self::assertInstanceOf(When::class, $bazConstraint);
@@ -182,6 +204,11 @@ class WhenTestWithAnnotations
      * @When(expression="false", constraints={@NotNull, @NotBlank}, groups={"foo"})
      */
     private $bar;
+
+    /**
+     * @When(expression="true", constraints=@NotNull, groups={"foo"})
+     */
+    private $qux;
 
     /**
      * @When(expression="true", constraints={@NotNull, @NotBlank})

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
@@ -39,6 +39,17 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
         ]));
     }
 
+    public function testConstraintIsExecuted()
+    {
+        $constraint = new NotNull();
+        $this->expectValidateValue(0, 'Foo', [$constraint]);
+
+        $this->validator->validate('Foo', new When([
+            'expression' => 'true',
+            'constraints' => $constraint,
+        ]));
+    }
+
     public function testConstraintsAreExecutedWithNull()
     {
         $constraints = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

It would be nice for the DX to allow passing a single constraint to `When`, allowing to write the following:

```php
final class MyClass
{
    public string $type;

    #[Assert\When(
        expression: 'this.type === ...',
        constraints: new Assert\NotNull()
    )]
    public ?int $thickness = null;
}
```