### PR TITLE
[Console] block input stream if needed

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -128,7 +128,18 @@ class QuestionHelper extends Helper
             }
 
             if (false === $ret) {
+                $isBlocked = stream_get_meta_data($inputStream)['blocked'] ?? true;
+
+                if (!$isBlocked) {
+                    stream_set_blocking($inputStream, true);
+                }
+
                 $ret = $this->readInput($inputStream, $question);
+
+                if (!$isBlocked) {
+                    stream_set_blocking($inputStream, false);
+                }
+
                 if (false === $ret) {
                     throw new MissingInputException('Aborted.');
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | n
| Tickets       | /
| License       | MIT
| Doc PR        | /

When the input stream used in the question helper is not blocking, the default value is always used as the stream return false instead of waiting. In order to fix that, we force the stream to be in blocking state and go back to the old state after so other logic is not impacted by this change.

I don't think making a test for that is possible without writing a lot of codes, as we need to have a stream that is not ready for this test, and make it ready later, given there is no async possible. it could be done with a fork or another process writing to a file **after** the question was asked so we do not block following tests when there is no failure, however i'm not sure if this is wanted ?.
If you have a clean way to make a reproducible test for this bug i'm open to write it.


