### PR TITLE
[Security] Validate `aud` and `iss` claims on OidcTokenHandler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -335,10 +335,20 @@
     </xsd:complexType>
 
     <xsd:complexType name="oidc">
+        <xsd:choice maxOccurs="unbounded">
+            <xsd:element name="issuers" type="oidc_issuers" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="issuer" type="password_hasher" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:choice>
         <xsd:attribute name="claim" type="xsd:string" />
-        <xsd:attribute name="audience" type="xsd:string" />
+        <xsd:attribute name="audience" type="xsd:string" use="required" />
         <xsd:attribute name="algorithm" type="xsd:string" use="required" />
         <xsd:attribute name="key" type="xsd:string" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="oidc_issuers">
+        <xsd:sequence>
+            <xsd:element name="issuer" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+        </xsd:sequence>
     </xsd:complexType>
 
     <xsd:complexType name="login_throttling">

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -69,10 +69,11 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('signature algorithm'),
                 abstract_arg('signature key'),
+                abstract_arg('audience'),
+                abstract_arg('issuers'),
+                'sub',
                 service('logger')->nullOnInvalid(),
                 service('clock'),
-                'sub',
-                null,
             ])
 
         ->set('security.access_token_handler.oidc.jwk', JWK::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
@@ -343,7 +343,7 @@ class AccessTokenTest extends AbstractWebTestCase
             'iat' => $time,
             'nbf' => $time,
             'exp' => $time + 3600,
-            'iss' => 'https://www.example.com/',
+            'iss' => 'https://www.example.com',
             'aud' => 'Symfony OIDC',
             'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
             'username' => 'dunglas',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
@@ -23,6 +23,7 @@ security:
                     oidc:
                         claim: 'username'
                         audience: 'Symfony OIDC'
+                        issuers: [ 'https://www.example.com' ]
                         algorithm: 'ES256'
                         # tip: use https://mkjwk.org/ to generate a JWK
                         key: '{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}'

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -41,10 +41,11 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
     public function __construct(
         private Algorithm $signatureAlgorithm,
         private JWK $jwk,
-        private ?LoggerInterface $logger = null,
-        private ClockInterface $clock = new Clock(),
+        private string $audience,
+        private array $issuers,
         private string $claim = 'sub',
-        private ?string $audience = null
+        private ?LoggerInterface $logger = null,
+        private ClockInterface $clock = new Clock()
     ) {
     }
 
@@ -80,10 +81,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
                 new Checker\IssuedAtChecker(0, false, $this->clock),
                 new Checker\NotBeforeChecker(0, false, $this->clock),
                 new Checker\ExpirationTimeChecker(0, false, $this->clock),
+                new Checker\AudienceChecker($this->audience),
+                new Checker\IssuerChecker($this->issuers),
             ];
-            if ($this->audience) {
-                $checkers[] = new Checker\AudienceChecker($this->audience);
-            }
             $claimCheckerManager = new ClaimCheckerManager($checkers);
             // if this check fails, an InvalidClaimException is thrown
             $claimCheckerManager->check($claims);

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -18,7 +18,6 @@ use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Clock\Clock;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OidcUser;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenHandler;
@@ -41,7 +40,7 @@ class OidcTokenHandlerTest extends TestCase
             'iat' => $time,
             'nbf' => $time,
             'exp' => $time + 3600,
-            'iss' => 'https://www.example.com/',
+            'iss' => 'https://www.example.com',
             'aud' => self::AUDIENCE,
             'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
             'email' => 'foo@example.com',
@@ -55,10 +54,10 @@ class OidcTokenHandlerTest extends TestCase
         $userBadge = (new OidcTokenHandler(
             new ES256(),
             $this->getJWK(),
-            $loggerMock,
-            new Clock(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
             $claim,
-            self::AUDIENCE
+            $loggerMock,
         ))->getUserBadgeFrom($token);
         $actualUser = $userBadge->getUserLoader()();
 
@@ -89,10 +88,10 @@ class OidcTokenHandlerTest extends TestCase
         (new OidcTokenHandler(
             new ES256(),
             $this->getJWK(),
-            $loggerMock,
-            new Clock(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
             'sub',
-            self::AUDIENCE
+            $loggerMock,
         ))->getUserBadgeFrom($token);
     }
 
@@ -106,7 +105,7 @@ class OidcTokenHandlerTest extends TestCase
                 'iat' => time() - 3600,
                 'nbf' => time() - 3600,
                 'exp' => time() - 3590,
-                'iss' => 'https://www.example.com/',
+                'iss' => 'https://www.example.com',
                 'aud' => self::AUDIENCE,
                 'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
                 'email' => 'foo@example.com',
@@ -118,7 +117,7 @@ class OidcTokenHandlerTest extends TestCase
                 'iat' => time(),
                 'nbf' => time(),
                 'exp' => time() + 3590,
-                'iss' => 'https://www.example.com/',
+                'iss' => 'https://www.example.com',
                 'aud' => 'invalid',
                 'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
                 'email' => 'foo@example.com',
@@ -139,7 +138,7 @@ class OidcTokenHandlerTest extends TestCase
             'iat' => $time,
             'nbf' => $time,
             'exp' => $time + 3600,
-            'iss' => 'https://www.example.com/',
+            'iss' => 'https://www.example.com',
             'aud' => self::AUDIENCE,
             'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
         ];
@@ -148,10 +147,10 @@ class OidcTokenHandlerTest extends TestCase
         (new OidcTokenHandler(
             new ES256(),
             self::getJWK(),
-            $loggerMock,
-            new Clock(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
             'email',
-            self::AUDIENCE
+            $loggerMock,
         ))->getUserBadgeFrom($token);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

According to the [OIDC Specification](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation), the `aud` and `iss` claims MUST be validated by the server.