### PR TITLE
[AssetMapper] Using a separate logger channel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -122,6 +122,7 @@ return static function (ContainerConfigurator $container) {
                 service('logger'),
             ])
             ->tag('asset_mapper.compiler')
+            ->tag('monolog.logger', ['channel' => 'asset_mapper'])
 
         ->set('asset_mapper.compiler.source_mapping_urls_compiler', SourceMappingUrlsCompiler::class)
             ->tag('asset_mapper.compiler')
@@ -132,6 +133,7 @@ return static function (ContainerConfigurator $container) {
                 service('logger'),
             ])
             ->tag('asset_mapper.compiler')
+            ->tag('monolog.logger', ['channel' => 'asset_mapper'])
 
         ->set('asset_mapper.importmap.manager', ImportMapManager::class)
             ->args([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes-ish
| New feature?  | yes-ish
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Still TODO

Super minor - putting these in their own logging channel might be useful. For example, we could (later, or in a 3rd party bundle) grab all of these warnings and write them out as JavaScript console warnings to make it easier for the user to see (in dev only).

Cheers!