### PR TITLE
[Filesystem] Follow symlinks when dumping files

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -669,6 +669,12 @@ class Filesystem
 
         $dir = \dirname($filename);
 
+        if (is_link($filename) && $linkTarget = $this->readlink($filename)) {
+            $this->dumpFile(Path::makeAbsolute($linkTarget, $dir), $content);
+
+            return;
+        }
+
         if (!is_dir($dir)) {
             $this->mkdir($dir);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently, if `Filesystem::dumpFile()` is called on a symlink, the link gets replaced with a new file.

This is unexpected I think because both `Filesystem::appendToFile()` as well as `file_put_contents()` follow the symlink instead.

This PR changes `dumpFile()` to behave the same way.