### PR TITLE
[HttpKernel] conflict with VarDumper < 6.3

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -67,6 +67,7 @@
         "symfony/translation-contracts": "<2.5",
         "symfony/twig-bridge": "<5.4",
         "symfony/validator": "<5.4",
+        "symfony/var-dumper": "<6.3",
         "twig/twig": "<2.13"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Required to let `DumpDataCollector` use `Data::getContext()`.