### PR TITLE
[DependencyInjection] Allow extensions to register compiler passes

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -15,6 +15,7 @@ DependencyInjection
 -------------------
 
  * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
+ * Add `ExtensionInterface::build(ContainerBuilder $container): void` to register compiler passes from an extension
 
    *Before*
    ```php

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ExtensionWithoutConfigTestBundle/DependencyInjection/ExtensionWithoutConfigTestExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ExtensionWithoutConfigTestBundle/DependencyInjection/ExtensionWithoutConfigTestExtension.php
@@ -16,6 +16,10 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class ExtensionWithoutConfigTestExtension implements ExtensionInterface
 {
+    public function build(ContainerBuilder $container): void
+    {
+    }
+
     public function load(array $configs, ContainerBuilder $container): void
     {
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -78,7 +78,7 @@ class AppKernel extends Kernel implements ExtensionInterface, ConfigurationInter
         $loader->load($this->rootConfig);
     }
 
-    protected function build(ContainerBuilder $container): void
+    public function build(ContainerBuilder $container): void
     {
         $container->register('logger', NullLogger::class);
         $container->registerExtension(new TestDumpExtension());

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
  * Add `defined` env var processor that returns `true` for defined and neither null nor empty env vars
  * Add `#[AutowireLocator]` attribute
+ * Add `ExtensionInterface::build(ContainerBuilder $container): void` to register compiler passes from an extension
 
 6.3
 ---

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -209,6 +209,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         if (false !== $extension->getNamespace()) {
             $this->extensionsByNs[$extension->getNamespace()] = $extension;
         }
+
+        // @deprecated remove if statement in Symfony 7
+        if (method_exists($extension, 'build') && \is_callable([$extension, 'build'])) {
+            $extension->build($this);
+        }
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -28,6 +28,10 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
 {
     private array $processedConfigs = [];
 
+    public function build(ContainerBuilder $container): void
+    {
+    }
+
     /**
      * @return string|false
      */

--- a/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
@@ -16,6 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * ExtensionInterface is the interface implemented by container extension classes.
  *
+ * @method void build(ContainerBuilder $container) Called just before compilation, use this to register compiler passes
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface ExtensionInterface

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\RealServiceInstantiator;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
@@ -1326,6 +1327,17 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals([$second, $first], $configs);
     }
 
+    public function testExtensionBuild()
+    {
+        $container = new ContainerBuilder();
+
+        $container->registerExtension(new BuildExtension());
+
+        $container->compile();
+        $testpass = array_filter($container->getCompilerPassConfig()->getPasses(), fn ($pass) => $pass instanceof TestPass);
+        $this->assertCount(1, $testpass, 'The extension did not register a compiler pass.');
+    }
+
     public function testAbstractAlias()
     {
         $container = new ContainerBuilder();
@@ -2063,5 +2075,24 @@ class E
     {
         $this->first = $first;
         $this->second = $second;
+    }
+}
+
+class BuildExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new TestPass());
+    }
+}
+
+class TestPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/AcmeExtension.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/AcmeExtension.php
@@ -24,4 +24,8 @@ class AcmeExtension implements ExtensionInterface
     {
         return 'acme';
     }
+
+    public function build(ContainerBuilder $container): void
+    {
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/ProjectExtension.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/ProjectExtension.php
@@ -41,4 +41,8 @@ class ProjectExtension implements ExtensionInterface
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
     }
+
+    public function build(ContainerBuilder $container): void
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Without the bundle system, the DI extension is sometimes used for plugins/add-ons in projects. I've recently introduced this to the [phpdocumentor/guides](https://github.com/phpDocumentor/guides/blob/main/packages/guides-cli/src/DependencyInjection/ContainerFactory.php#L84-L94) package (which will probably be the new RST parser that we're going to use at symfony.com some time in the future).

To make the DI extension fully workable as a plugin class, it would be great if it could also register compiler passes. This PR introduces a new method for this purpose: `ExtensionInterface::build()` Most users will probably not get a deprecation, as `Extension` has a default implementation.

Build precedence is: `KernelInterface::build()` > `BundleInterface::build()` > `ExtensionInterface::build()`