### PR TITLE
[AssetMapper] Add "=alias" syntax to importmap:require

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
@@ -56,6 +56,14 @@ For example:
     <info>php %command.full_name% lodash --preload</info>
     <info>php %command.full_name% "lodash@^4.15"</info>
 
+You can also require specific paths of a package:
+
+    <info>php %command.full_name% "chart.js/auto"</info>
+
+Or download one package/file, but alias its name in your import map:
+
+    <info>php %command.full_name% "vue/dist/vue.esm-bundler.js=vue"</info>
+
 The <info>preload</info> option will set the <info>preload</info> option in the importmap,
 which will tell the browser to preload the package. This should be used for all
 critical packages that are needed on page load.
@@ -114,7 +122,7 @@ EOT
                 $parts['version'] ?? null,
                 $input->getOption('download'),
                 $input->getOption('preload'),
-                null,
+                $parts['alias'] ?? $parts['package'],
                 isset($parts['registry']) && $parts['registry'] ? $parts['registry'] : null,
                 $path,
             );

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -115,10 +115,18 @@ class ImportMapManager
      */
     public static function parsePackageName(string $packageName): ?array
     {
-        // https://regex101.com/r/d99BEc/1
-        $regex = '/(?:(?P<registry>[^:\n]+):)?((?P<package>@?[^@\n]+))(?:@(?P<version>[^\s\n]+))?/';
+        // https://regex101.com/r/MDz0bN/1
+        $regex = '/(?:(?P<registry>[^:\n]+):)?((?P<package>@?[^=@\n]+))(?:@(?P<version>[^=\s\n]+))?(?:=(?P<alias>[^\s\n]+))?/';
 
-        return preg_match($regex, $packageName, $matches) ? $matches : null;
+        if (!preg_match($regex, $packageName, $matches)) {
+            return null;
+        }
+
+        if (isset($matches['version']) && '' === $matches['version']) {
+            unset($matches['version']);
+        }
+
+        return $matches;
     }
 
     private function buildImportMapJson(): void

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -379,14 +379,17 @@ class ImportMapManagerTest extends TestCase
     public function testParsePackageName(string $packageName, array $expectedReturn)
     {
         $parsed = ImportMapManager::parsePackageName($packageName);
-        // remove integer keys - they're noise
+        $this->assertIsArray($parsed);
 
-        if (\is_array($parsed)) {
-            $parsed = array_filter($parsed, function ($key) {
-                return !\is_int($key);
-            }, \ARRAY_FILTER_USE_KEY);
-        }
+        // remove integer keys - they're noise
+        $parsed = array_filter($parsed, fn ($key) => !\is_int($key), \ARRAY_FILTER_USE_KEY);
         $this->assertEquals($expectedReturn, $parsed);
+
+        $parsedWithAlias = ImportMapManager::parsePackageName($packageName.'=some_alias');
+        $this->assertIsArray($parsedWithAlias);
+        $parsedWithAlias = array_filter($parsedWithAlias, fn ($key) => !\is_int($key), \ARRAY_FILTER_USE_KEY);
+        $expectedReturnWithAlias = $expectedReturn + ['alias' => 'some_alias'];
+        $this->assertEquals($expectedReturnWithAlias, $parsedWithAlias, 'Asserting with alias');
     }
 
     public static function getPackageNameTests(): iterable
@@ -442,7 +445,7 @@ class ImportMapManagerTest extends TestCase
             ],
         ];
 
-        yield 'namespaced_package_with_registry' => [
+        yield 'namespaced_package_with_registry_no_version' => [
             'npm:@hotwired/stimulus',
             [
                 'package' => '@hotwired/stimulus',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | yes-ish
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Still TODO

I'm doing final testing against all of the UX packages. There is one edge-case where we need to require a specific package path - `vue/dist/vue.esm-bundler.js` - but alias it (i.e. make its key) set to something else - `vue` - in `importmap.php`. We need the command to support this so that https://github.com/symfony/flex/pull/975 can use it when installing UX packages.

Hopefully the last thing I come across - I've done a LOT of testing at this point.

Thanks!