### PR TITLE
[DependencyInjection] Add support for excluding services with declared custom attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+* Add support for excluding services with declared custom attribute (`ContainerBuilder::registerAttributeForExclusion`)
+
 7.0
 ---
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -132,6 +132,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     private array $autoconfiguredAttributes = [];
 
     /**
+     * @var array<class-string>
+     */
+    private array $exclusionAttributes = [];
+
+    /**
      * @var array<string, bool>
      */
     private array $removedIds = [];
@@ -1342,6 +1347,20 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
+     * Registers an attribute that will be used for excluding all services from classes it is declared on.
+     *
+     * @param class-string $attributeClass
+     */
+    public function registerAttributeForExclusion(string $attributeClass): void
+    {
+        if (\in_array($attributeClass, $this->exclusionAttributes)) {
+            return;
+        }
+
+        $this->exclusionAttributes[] = $attributeClass;
+    }
+
+    /**
      * Registers an autowiring alias that only binds to a specific argument name.
      *
      * The argument name is derived from $name if provided (from $id otherwise)
@@ -1384,6 +1403,14 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     public function getAutoconfiguredAttributes(): array
     {
         return $this->autoconfiguredAttributes;
+    }
+
+    /**
+     * @return array<class-string>
+     */
+    public function getExclusionAttributes(): array
+    {
+        return $this->exclusionAttributes;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\Compiler\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -134,7 +135,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * @var array<class-string>
      */
-    private array $exclusionAttributes = [];
+    private array $exclusionAttributes = [Exclude::class];
 
     /**
      * @var array<string, bool>

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -139,10 +139,9 @@ abstract class FileLoader extends BaseFileLoader
 
         foreach ($classes as $class => $errorMessage) {
             if (null === $errorMessage && $autoconfigureAttributes) {
-                $exclusionAttributes = $this->container->getExclusionAttributes();
-                $exclusionAttributes[] = Exclude::class;
-
                 $r = $this->container->getReflectionClass($class);
+                $exclusionAttributes = $this->container->getExclusionAttributes();
+
                 foreach ($exclusionAttributes as $attribute) {
                     if ($r->getAttributes($attribute)[0] ?? null) {
                         $this->addContainerExcludedTag($class, $source);

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -139,11 +139,17 @@ abstract class FileLoader extends BaseFileLoader
 
         foreach ($classes as $class => $errorMessage) {
             if (null === $errorMessage && $autoconfigureAttributes) {
+                $exclusionAttributes = $this->container->getExclusionAttributes();
+                $exclusionAttributes[] = Exclude::class;
+
                 $r = $this->container->getReflectionClass($class);
-                if ($r->getAttributes(Exclude::class)[0] ?? null) {
-                    $this->addContainerExcludedTag($class, $source);
-                    continue;
+                foreach ($exclusionAttributes as $attribute) {
+                    if ($r->getAttributes($attribute)[0] ?? null) {
+                        $this->addContainerExcludedTag($class, $source);
+                        continue 2;
+                    }
                 }
+
                 if ($this->env) {
                     $attribute = null;
                     foreach ($r->getAttributes(When::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Utils/ServiceWithAttributeForExclusion.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Utils/ServiceWithAttributeForExclusion.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Utils;
+
+#[ToBeExcluded]
+class ServiceWithAttributeForExclusion
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Utils/ToBeExcluded.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Utils/ToBeExcluded.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Utils;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ToBeExcluded
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -41,6 +41,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAs
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasMultiple;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\NotAService;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\ServiceWithAttributeForExclusion;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\ToBeExcluded;
 
 class FileLoaderTest extends TestCase
 {
@@ -162,6 +164,27 @@ class FileLoaderTest extends TestCase
         );
 
         $this->assertSame($autoconfigure, $container->getDefinition(NotAService::class)->hasTag('container.excluded'));
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testRegisterClassesWithAttributeMarkedForExclusion(bool $autoconfigure)
+    {
+        $container = new ContainerBuilder();
+
+        $container->registerAttributeForExclusion(ToBeExcluded::class);
+
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured($autoconfigure),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\\',
+            'Utils/*',
+        );
+
+        $this->assertSame($autoconfigure, $container->getDefinition(ServiceWithAttributeForExclusion::class)->hasTag('container.excluded'));
     }
 
     public function testRegisterClassesWithExcludeAsArray()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  /
| License       | MIT
| Doc PR        | TODO

Currently, if we want to exclude classes from registering as services in the container, we can add their namespace(s) in the app configuration, or use the `#[Exclude]`/`#[When('never')]` attributes on each of the classes.

When it comes to certain types of classes, eg. entities, they can be placed all around the apps in many different folders, which can result in many entries under the `exclude` configuration. It is also usual for us to have many entity classes, so adding the attribute to each of them can be error-prone.

However, classes of a same type may already have a common attribute declared on them - such as `Doctrine\ORM\Mapping\Entity`.

Because of that, I'm proposing a new way for excluding classes by making it possible to register any attribute for exclusion. 

Underneath, this is just extending the functionality for handling the classes with `#[Exclude]` attribute by additionally checking the list of attributes marked for exclusion.

**Usage:**

To exclude all classes with the `#[Entity]` attribute:

```php
use Doctrine\ORM\Mapping\Entity;
use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
use Symfony\Component\DependencyInjection\ContainerBuilder;
use Symfony\Component\HttpKernel\Kernel as BaseKernel;

class Kernel extends BaseKernel
{
    use MicroKernelTrait;

    protected function build(ContainerBuilder $container)
    {
        $container->registerAttributeForExclusion(Entity::class);
    }
}
```
