### PR TITLE
Hide definitions bearing the `container.excluded` tag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -106,6 +106,9 @@ class JsonDescriptor extends Descriptor
             if ($service instanceof Alias) {
                 $data['aliases'][$serviceId] = $this->getContainerAliasData($service);
             } elseif ($service instanceof Definition) {
+                if ($service->hasTag('container.excluded')) {
+                    continue;
+                }
                 $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments, $builder, $serviceId);
             } else {
                 $data['services'][$serviceId] = $service::class;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -162,6 +162,9 @@ class MarkdownDescriptor extends Descriptor
             if ($service instanceof Alias) {
                 $services['aliases'][$serviceId] = $service;
             } elseif ($service instanceof Definition) {
+                if ($service->hasTag('container.excluded')) {
+                    continue;
+                }
                 $services['definitions'][$serviceId] = $service;
             } else {
                 $services['services'][$serviceId] = $service;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -198,6 +198,10 @@ class TextDescriptor extends Descriptor
             }
 
             if ($definition instanceof Definition) {
+                if ($definition->hasTag('container.excluded')) {
+                    unset($serviceIds[$key]);
+                    continue;
+                }
                 if ($showTag) {
                     $tags = $definition->getTag($showTag);
                     foreach ($tags as $tag) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -294,6 +294,12 @@ class XmlDescriptor extends Descriptor
                 continue;
             }
 
+            if ($service instanceof Definition) {
+                if ($service->hasTag('container.excluded')) {
+                    continue;
+                }
+            }
+
             $serviceXML = $this->getContainerServiceDocument($service, $serviceId, null, $showArguments);
             $containerXML->appendChild($containerXML->ownerDocument->importNode($serviceXML->childNodes->item(0), true));
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ContainerExcluded.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ContainerExcluded.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+/**
+ * @author Maksim Vorozhtsov <myks1992@mail.ru>
+ */
+class ContainerExcluded
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\BackslashClass;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ContainerExcluded;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 
@@ -83,6 +84,19 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
 
         $tester->run(['command' => 'debug:container', 'name' => 'deprecated_alias', '--format' => 'txt']);
         $this->assertStringContainsString('[WARNING] The "deprecated_alias" alias is deprecated since foo/bar 1.9 and will be removed in 2.0', $tester->getDisplay());
+    }
+
+    public function testExcludedService()
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml']);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+
+        $tester->run(['command' => 'debug:container']);
+        $this->assertStringNotContainsString(ContainerExcluded::class, $tester->getDisplay());
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
@@ -33,3 +33,5 @@ services:
             - '%env(REAL)%'
             - '%env(int:key:2:json:JSON)%'
             - '%env(float:key:2:json:JSON)%'
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ContainerExcluded:
+        tags: ['container.excluded']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| | Depreciation? | no
| Tickets       | Fix #50417
| License       | MIT
| Doc PR        | -

Normally I test whether the exclusion rules from the service container of my bundles work correctly by just using the `debug:container` command and looking whether my excluded services occur in the last.
However, due to the latest changes in #46279 all folders and subfulders (excluded or not) are always in this list.

You need to open the definition to see if it was excluded:
<img width="1463" alt="Service Container" src="https://github.com/symfony/symfony/assets/31630905/609d75b7-3840-4c7d-b3ec-4c0d4bc158e6">

For example, `Command`, `Query`, `Entity` are folders, but they are specified as services in the container. 

This PR fixes this problem to ignore definitions bearing the container.excluded tag if those are to be hidden for Descriptors: `JsonDescriptor`,  `MarkdownDescriptor`, `TextDescriptor` and `XmlDescriptor`. 

After fixes problem:
<img width="1351" alt="Снимок экрана 2023-05-27 в 17 03 19" src="https://github.com/symfony/symfony/assets/31630905/e2aecdeb-9261-4d98-af10-a74db7f1e46a">
