### PR TITLE
[AssetMapper] Fix unable to use asset mapper with CSP

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/ImportMapRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/ImportMapRuntime.php
@@ -22,8 +22,8 @@ class ImportMapRuntime
     {
     }
 
-    public function importmap(?string $entryPoint = 'app'): string
+    public function importmap(?string $entryPoint = 'app', array $attributes = []): string
     {
-        return $this->importMapRenderer->render($entryPoint);
+        return $this->importMapRenderer->render($entryPoint, $attributes);
     }
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -29,15 +29,16 @@ class ImportMapRenderer
     ) {
     }
 
-    public function render(string $entryPoint = null): string
+    public function render(string $entryPoint = null, array $attributes = []): string
     {
         $attributeString = '';
 
-        if (isset($this->scriptAttributes['src']) || isset($this->scriptAttributes['type'])) {
+        $attributes += $this->scriptAttributes;
+        if (isset($attributes['src']) || isset($attributes['type'])) {
             throw new \InvalidArgumentException(sprintf('The "src" and "type" attributes are not allowed on the <script> tag rendered by "%s".', self::class));
         }
 
-        foreach ($this->scriptAttributes as $name => $value) {
+        foreach ($attributes as $name => $value) {
             $attributeString .= ' ';
             if (true === $value) {
                 $attributeString .= $name;
@@ -70,7 +71,7 @@ class ImportMapRenderer
         }
 
         if (null !== $entryPoint) {
-            $output .= "\n<script type=\"module\">import '".str_replace("'", "\\'", $entryPoint)."';</script>";
+            $output .= "\n<script type=\"module\"$attributeString>import '".str_replace("'", "\\'", $entryPoint)."';</script>";
         }
 
         return $output;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | yes-ish
| Deprecations? | -
| Tickets       |  - 
| License       | MIT
| Doc PR        | - 

Currently not possible to use AssetMapper with dynamic `nonce` attribute when a Content Security Policy is enabled (`unsafe-inline` restricted)

This PR allow to pass `nonce` attr to script tag. Example usage

```twig
{{ importmap('app', {'nonce': csp_nonce('script')}) }}
```
