### PR TITLE
[Form] Add constraints_from_* options

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+6.4
+---
+ * Add `constraints_from_entity` and `constraints_from_property` option to `FormType`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ConstraintsFromListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ConstraintsFromListener.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Validator\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ConstraintsFromListener implements EventSubscriberInterface
+{
+    private ValidatorInterface $validator;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [FormEvents::POST_SUBMIT => 'validateConstraints'];
+    }
+
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    public function validateConstraints(FormEvent $event): void
+    {
+        $form = $event->getForm();
+
+        $entity = $form->getConfig()->getOption('constraints_from_entity');
+
+        if (null !== $entity) {
+            $property = $form->getConfig()->getOption('constraints_from_property') ?? $form->getName();
+
+            $violations = $this->validator->validatePropertyValue($entity, $property, $event->getData());
+            /** @var ConstraintViolationInterface $violation */
+            foreach ($violations as $violation) {
+                $form->addError(
+                    new FormError(
+                        $violation->getMessage(),
+                        $violation->getMessageTemplate(),
+                        $violation->getParameters(),
+                        $violation->getPlural()
+                    )
+                );
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Validator\EventListener\ConstraintsFromListener;
 use Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapper;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -42,6 +43,7 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $builder->addEventSubscriber(new ConstraintsFromListener($this->validator));
         $builder->addEventSubscriber(new ValidationListener($this->validator, $this->violationMapper));
     }
 
@@ -58,6 +60,8 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
         $resolver->setDefaults([
             'error_mapping' => [],
             'constraints' => [],
+            'constraints_from_entity' => null,
+            'constraints_from_property' => null,
             'invalid_message' => 'This value is not valid.',
             'invalid_message_parameters' => [],
             'allow_extra_fields' => false,
@@ -65,6 +69,8 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
         ]);
         $resolver->setAllowedTypes('constraints', [Constraint::class, Constraint::class.'[]']);
         $resolver->setNormalizer('constraints', $constraintsNormalizer);
+        $resolver->setAllowedTypes('constraints_from_entity', ['string', 'null']);
+        $resolver->setAllowedTypes('constraints_from_property', ['string', 'null']);
     }
 
     public static function getExtendedTypes(): iterable


### PR DESCRIPTION
Apply constraints to field from an entity not mapped by the form data_class.

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

**Use-cases:**
- DTO form like user registration with many entities concerned (user / address)

**Current usage:**
You set constraints in your entities then create a DTO but you must duplicate your constraints in your DTO object to valide your fields.

**New usage:**
You set constraints in your entities then create a DTO and link your DTO form fields to your entities properties.

**Usage:**

Add `constraints_from_entity` option on any form field (child of `FormType::class`).
If the entity related property name is different that the field name, you must provide `constraints_from_property` to declare the property name.

Works on (un)mapped field and (un)set `data_class` form.

```php
<?php
// App/Form/UserRegistrationType.php

namespace App\Form;

use App\Entity\User;
use App\Entity\Address;
use App\Form\Model\UserRegistration;
use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\Extension\Core\Type\TextType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\OptionsResolver\OptionsResolver;

class UserRegistrationType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add('username', TextType::class, [
                'label' => 'Your username',
                'constraints_from_entity' => User::class,
                // Not required if property name is same as the field name
                // 'constraints_from_property' => 'username' // Constraints from User::username
            ])
            ->add('zipCode', TextType::class, [
                'label' => 'Your zip/postal code',
                'constraints_from_entity' => Address::class,
                'constraints_from_property' => 'postalCode' // Constraints from Address::postalCode
            ]);
    }

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefaults([
            'data_class' => UserRegistration::class
        ]);
    }
}
```

**Notes:**
It's my first pull request, I hope I done all required things ;)