### PR TITLE
[Command] Add default name

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -128,6 +128,9 @@ class Command
 
         if (null !== $name) {
             $this->setName($name);
+        } else {
+            trigger_deprecation('symfony/console', '6.4', 'Calling "%s()" without $name argument is deprecated. It must either be defined in "%s()" or via configuration.', __METHOD__);
+            $this->setName(get_called_class());
         }
 
         if ('' === $this->description) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes (kind of)
| New feature?  | yes (TODO)
| Deprecations? | yes (TODO)
| Tickets       | Fix https://github.com/symfony/symfony-docs/pull/17782
| License       | MIT
| Doc PR        | TODO

Regarding the sf doc PR, I propose to default to a name here before going full name on sfv7
Other option is, like proposed in the PR doc, adding more context in the exception message but to me it is not the best option

If accepted, will document doc and various upgrade/changelog files