### PR TITLE
[FrameworkBundle][PhpUnitBridge] Configure doctrine/deprecations as expected

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -151,6 +151,11 @@ if ('disabled' === $getEnvVar('SYMFONY_DEPRECATIONS_HELPER')) {
     putenv('SYMFONY_DEPRECATIONS_HELPER=disabled');
 }
 
+if (!$getEnvVar('DOCTRINE_DEPRECATIONS')) {
+    putenv('DOCTRINE_DEPRECATIONS=trigger');
+    $_SERVER['DOCTRINE_DEPRECATIONS'] = $_ENV['DOCTRINE_DEPRECATIONS'] = 'trigger';
+}
+
 $COMPOSER = ($COMPOSER = getenv('COMPOSER_BINARY'))
     || file_exists($COMPOSER = $oldPwd.'/composer.phar')
     || ($COMPOSER = rtrim((string) ('\\' === \DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', shell_exec('where.exe composer.phar 2> NUL')) : shell_exec('which composer.phar 2> /dev/null'))))

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -95,6 +95,8 @@ class FrameworkBundle extends Bundle
      */
     public function boot()
     {
+        $_ENV['DOCTRINE_DEPRECATIONS'] = $_SERVER['DOCTRINE_DEPRECATIONS'] ??= 'trigger';
+
         $handler = ErrorHandler::register(null, false);
         $this->container->get('debug.error_handler_configurator')->configure($handler);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/doctrine/DoctrineBundle/issues/1662
| License       | MIT
| Doc PR        | -

Following https://github.com/doctrine/deprecations/pull/41, so that deprecations from Doctrine take the same code path as any other deprecations in Symfony apps.

Submitted to 6.3 to notify about the deprecations as early as possible but not too early to not trigger new deprecations in existing apps.