### PR TITLE
[Serializer] test: discriminator without matching property

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractWithDiscriminator.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractWithDiscriminator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+
+#[DiscriminatorMap(typeProperty: 'discr', mapping: ['concrete' => ConcreteWithDiscriminator::class])]
+abstract class AbstractWithDiscriminator
+{
+    /**
+     * @var int The id
+     */
+    public ?int $id = null;
+
+    /**
+     * @var string The dummy name
+     */
+    public string $name;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ConcreteWithDiscriminator.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ConcreteWithDiscriminator.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class ConcreteWithDiscriminator extends AbstractWithDiscriminator
+{
+    /**
+     * @var string a concrete thing
+     */
+    public string $instance;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

https://github.com/symfony/symfony/pull/50193 breaks a test on API Platform w/ Symfony  6.2.11 where the discriminator has no matching property. 

Fixture: https://github.com/api-platform/core/blob/main/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
Feature: https://github.com/api-platform/core/blob/main/features/main/crud_abstract.feature#L108-L132

This adds a failing test case, but I'm unsure whether our test case misuses the discriminator feature (does it require a property matching the discriminator ?) or if the #50193 fix breaks.

ping @HypeMC wdyt can you help me on that?

