### PR TITLE
[FrameworkBundle] Prevent `cache:clear` to lose files on subsequent runs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -137,7 +137,7 @@ EOF
                 if ($output->isVerbose()) {
                     $io->comment('Warming up optional cache...');
                 }
-                $this->warmupOptionals($realCacheDir);
+                $this->warmupOptionals($realCacheDir, $realBuildDir);
             }
         } else {
             $fs->mkdir($warmupDir);
@@ -152,7 +152,7 @@ EOF
                     if ($output->isVerbose()) {
                         $io->comment('Warming up optional cache...');
                     }
-                    $this->warmupOptionals($realCacheDir);
+                    $this->warmupOptionals($useBuildDir ? $realCacheDir : $warmupDir, $warmupDir);
                 }
             }
 
@@ -247,15 +247,15 @@ EOF
         }
     }
 
-    private function warmupOptionals(string $realCacheDir): void
+    private function warmupOptionals(string $cacheDir, string $warmupDir): void
     {
         $kernel = $this->getApplication()->getKernel();
         $warmer = $kernel->getContainer()->get('cache_warmer');
         // non optional warmers already ran during container compilation
         $warmer->enableOnlyOptionalWarmers();
-        $preload = (array) $warmer->warmUp($realCacheDir);
+        $preload = (array) $warmer->warmUp($cacheDir);
 
-        if ($preload && file_exists($preloadFile = $realCacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
+        if ($preload && file_exists($preloadFile = $warmupDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
             Preloader::append($preloadFile, $preload);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50474 
| License       | MIT
| Doc PR        | N/A

See #50474 for the details and reproduction information.

