### PR TITLE
[FrameworkBundle] remove support for preloading ESM using headers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 use Psr\Container\ContainerInterface;
 use Psr\Link\EvolvableLinkInterface;
 use Psr\Link\LinkInterface;
-use Symfony\Component\AssetMapper\ImportMap\ImportMapManager;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -97,7 +96,6 @@ abstract class AbstractController implements ServiceSubscriberInterface
             'security.csrf.token_manager' => '?'.CsrfTokenManagerInterface::class,
             'parameter_bag' => '?'.ContainerBagInterface::class,
             'web_link.http_header_serializer' => '?'.HttpHeaderSerializer::class,
-            'asset_mapper.importmap.manager' => '?'.ImportMapManager::class,
         ];
     }
 
@@ -412,7 +410,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     /**
      * @param LinkInterface[] $links
      */
-    protected function sendEarlyHints(iterable $links = [], Response $response = null, bool $preloadJavaScriptModules = false): Response
+    protected function sendEarlyHints(iterable $links = [], Response $response = null): Response
     {
         if (!$this->container->has('web_link.http_header_serializer')) {
             throw new \LogicException('You cannot use the "sendEarlyHints" method if the WebLink component is not available. Try running "composer require symfony/web-link".');
@@ -421,17 +419,6 @@ abstract class AbstractController implements ServiceSubscriberInterface
         $response ??= new Response();
 
         $populatedLinks = [];
-
-        if ($preloadJavaScriptModules) {
-            if (!$this->container->has('asset_mapper.importmap.manager')) {
-                throw new \LogicException('You cannot use the JavaScript modules method if the AssetMapper component is not available. Try running "composer require symfony/asset-mapper".');
-            }
-
-            foreach ($this->container->get('asset_mapper.importmap.manager')->getModulesToPreload() as $url) {
-                $populatedLinks[] = new Link('modulepreload', $url);
-            }
-        }
-
         foreach ($links as $link) {
             if ($link instanceof EvolvableLinkInterface && !$link->getRels()) {
                 $link = $link->withRel('preload');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -74,7 +74,6 @@ class AbstractControllerTest extends TestCase
             'security.token_storage' => '?Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface',
             'security.csrf.token_manager' => '?Symfony\\Component\\Security\\Csrf\\CsrfTokenManagerInterface',
             'web_link.http_header_serializer' => '?Symfony\\Component\\WebLink\\HttpHeaderSerializer',
-            'asset_mapper.importmap.manager' => '?Symfony\\Component\\AssetMapper\\ImportMap\\ImportMapManager',
         ];
 
         $this->assertEquals($expectedServices, $subscribed, 'Subscribed core services in AbstractController have changed');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Sorry to be that late on this one.
It looks like preloading ESM using HTTP headers (and so using 103 Early Hints) doesn't work, at least for now: https://github.com/WICG/import-maps/issues/273#issuecomment-1097276232

ImportMap must be defined before downloading any ESM, and by definition HTTP headers are sent before importmap definition (it's currently not possible to define importmap using headers).

I don't know why I didn't caught this during my previous testing session, but now I get this error in the console when using this feature (which, according to the previously mentioned issue, is expected):

```
An import map is added after module script load was triggered.
Uncaught TypeError: Failed to resolve module specifier "app". Relative references must start with either "/", "./", or "../".
```

This patch simply removes this feature, which is entirely non-functional and misleading for the end user.