### PR TITLE
[Security] Add clock dependency to OidcTokenHandler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken
 
 use Jose\Component\Core\Algorithm;
 use Jose\Component\Core\JWK;
-use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SignatureAlgorithmFactory;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -28,26 +27,28 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
 {
     public function create(ContainerBuilder $container, string $id, array|string $config): void
     {
-        $tokenHandlerDefinition = $container->setDefinition($id, new ChildDefinition('security.access_token_handler.oidc'));
-        $tokenHandlerDefinition->replaceArgument(3, $config['claim']);
-        $tokenHandlerDefinition->replaceArgument(4, $config['audience']);
+        $tokenHandlerDefinition = $container->setDefinition($id, (new ChildDefinition('security.access_token_handler.oidc'))
+            ->replaceArgument(4, $config['claim'])
+            ->replaceArgument(5, $config['audience'])
+        );
 
-        // Create the signature algorithm and the JWK
         if (!ContainerBuilder::willBeAvailable('web-token/jwt-core', Algorithm::class, ['symfony/security-bundle'])) {
-            $container->register('security.access_token_handler.oidc.signature', 'stdClass')
-                ->addError('You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "web-token/jwt-core".');
-            $container->register('security.access_token_handler.oidc.jwk', 'stdClass')
-                ->addError('You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "web-token/jwt-core".');
-        } else {
             $container->register('security.access_token_handler.oidc.signature', Algorithm::class)
-                ->setFactory([SignatureAlgorithmFactory::class, 'create'])
-                ->setArguments([$config['signature']['algorithm']]);
+                ->addError('You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "web-token/jwt-core".');
             $container->register('security.access_token_handler.oidc.jwk', JWK::class)
-                ->setFactory([JWK::class, 'createFromJson'])
-                ->setArguments([$config['signature']['key']]);
+                ->addError('You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "web-token/jwt-core".');
         }
-        $tokenHandlerDefinition->replaceArgument(0, new Reference('security.access_token_handler.oidc.signature'));
-        $tokenHandlerDefinition->replaceArgument(1, new Reference('security.access_token_handler.oidc.jwk'));
+
+        if (\in_array($config['algorithm'], ['ES256', 'ES384', 'ES512'], true)) {
+            $tokenHandlerDefinition->replaceArgument(0, new Reference('security.access_token_handler.oidc.signature.'.$config['algorithm']));
+        } else {
+            $tokenHandlerDefinition->replaceArgument(0, (new ChildDefinition('security.access_token_handler.oidc.signature')))
+                ->replaceArgument(0, $config['algorithm']);
+        }
+
+        $tokenHandlerDefinition->replaceArgument(1, (new ChildDefinition('security.access_token_handler.oidc.jwk'))
+            ->replaceArgument(0, $config['key'])
+        );
     }
 
     public function getKey(): string
@@ -69,18 +70,13 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                         ->info('Audience set in the token, for validation purpose.')
                         ->defaultNull()
                     ->end()
-                    ->arrayNode('signature')
+                    ->scalarNode('algorithm')
+                        ->info('Algorithm used to sign the token.')
                         ->isRequired()
-                        ->children()
-                            ->scalarNode('algorithm')
-                                ->info('Algorithm used to sign the token.')
-                                ->isRequired()
-                            ->end()
-                            ->scalarNode('key')
-                                ->info('JSON-encoded JWK used to sign the token (must contain a "kty" key).')
-                                ->isRequired()
-                            ->end()
-                        ->end()
+                    ->end()
+                    ->scalarNode('key')
+                        ->info('JSON-encoded JWK used to sign the token (must contain a "kty" key).')
+                        ->isRequired()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SignatureAlgorithmFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SignatureAlgorithmFactory.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
 
-use Jose\Component\Core\Algorithm as SignatureAlgorithm;
+use Jose\Component\Core\Algorithm as AlgorithmInterface;
 use Jose\Component\Signature\Algorithm;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenHandler;
@@ -23,29 +23,21 @@ use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenHandler;
  */
 final class SignatureAlgorithmFactory
 {
-    public static function create(string $algorithm): SignatureAlgorithm
+    public static function create(string $algorithm): AlgorithmInterface
     {
         switch ($algorithm) {
             case 'ES256':
-                if (!class_exists(Algorithm\ES256::class)) {
-                    throw new \LogicException('You cannot use the "ES256" signature algorithm since "web-token/jwt-signature-algorithm-ecdsa" is not installed. Try running "composer require web-token/jwt-signature-algorithm-ecdsa".');
-                }
-
-                return new Algorithm\ES256();
             case 'ES384':
-                if (!class_exists(Algorithm\ES384::class)) {
-                    throw new \LogicException('You cannot use the "ES384" signature algorithm since "web-token/jwt-signature-algorithm-ecdsa" is not installed. Try running "composer require web-token/jwt-signature-algorithm-ecdsa".');
-                }
-
-                return new Algorithm\ES384();
             case 'ES512':
-                if (!class_exists(Algorithm\ES512::class)) {
-                    throw new \LogicException('You cannot use the "ES512" signature algorithm since "web-token/jwt-signature-algorithm-ecdsa" is not installed. Try running "composer require web-token/jwt-signature-algorithm-ecdsa".');
+                if (!class_exists(Algorithm::class.'\\'.$algorithm)) {
+                    throw new \LogicException(sprintf('You cannot use the "%s" signature algorithm since "web-token/jwt-signature-algorithm-ecdsa" is not installed. Try running "composer require web-token/jwt-signature-algorithm-ecdsa".', $algorithm));
                 }
 
-                return new Algorithm\ES512();
-            default:
-                throw new InvalidArgumentException(sprintf('Unsupported signature algorithm "%s". Only ES* algorithms are supported. If you want to use another algorithm, create your TokenHandler as a service.', $algorithm));
+                $algorithm = Algorithm::class.'\\'.$algorithm;
+
+                return new $algorithm();
         }
+
+        throw new InvalidArgumentException(sprintf('Unsupported signature algorithm "%s". Only ES* algorithms are supported. If you want to use another algorithm, create your TokenHandler as a service.', $algorithm));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -335,16 +335,8 @@
     </xsd:complexType>
 
     <xsd:complexType name="oidc">
-        <xsd:sequence>
-            <xsd:choice minOccurs="1" maxOccurs="1">
-                <xsd:element name="signature" type="oidc_signature" />
-            </xsd:choice>
-        </xsd:sequence>
         <xsd:attribute name="claim" type="xsd:string" />
         <xsd:attribute name="audience" type="xsd:string" />
-    </xsd:complexType>
-
-    <xsd:complexType name="oidc_signature">
         <xsd:attribute name="algorithm" type="xsd:string" use="required" />
         <xsd:attribute name="key" type="xsd:string" use="required" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -11,6 +11,12 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Jose\Component\Core\Algorithm;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\Algorithm\ES384;
+use Jose\Component\Signature\Algorithm\ES512;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SignatureAlgorithmFactory;
 use Symfony\Component\Security\Http\AccessToken\ChainAccessTokenExtractor;
 use Symfony\Component\Security\Http\AccessToken\FormEncodedBodyExtractor;
 use Symfony\Component\Security\Http\AccessToken\HeaderAccessTokenExtractor;
@@ -62,10 +68,37 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 abstract_arg('signature algorithm'),
-                abstract_arg('jwk'),
+                abstract_arg('signature key'),
                 service('logger')->nullOnInvalid(),
+                service('clock'),
                 'sub',
                 null,
             ])
+
+        ->set('security.access_token_handler.oidc.jwk', JWK::class)
+            ->abstract()
+            ->factory([JWK::class, 'createFromJson'])
+            ->args([
+                abstract_arg('signature key'),
+            ])
+
+        ->set('security.access_token_handler.oidc.signature', Algorithm::class)
+            ->abstract()
+            ->factory([SignatureAlgorithmFactory::class, 'create'])
+            ->args([
+                abstract_arg('signature algorithm'),
+            ])
+
+        ->set('security.access_token_handler.oidc.signature.ES256', ES256::class)
+            ->parent('security.access_token_handler.oidc.signature')
+            ->args(['index_0' => 'ES256'])
+
+        ->set('security.access_token_handler.oidc.signature.ES384', ES384::class)
+            ->parent('security.access_token_handler.oidc.signature')
+            ->args(['index_0' => 'ES384'])
+
+        ->set('security.access_token_handler.oidc.signature.ES512', ES512::class)
+            ->parent('security.access_token_handler.oidc.signature')
+            ->args(['index_0' => 'ES512'])
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
@@ -23,10 +23,9 @@ security:
                     oidc:
                         claim: 'username'
                         audience: 'Symfony OIDC'
-                        signature:
-                            algorithm: 'ES256'
-                            # tip: use https://mkjwk.org/ to generate a JWK
-                            key: '{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}'
+                        algorithm: 'ES256'
+                        # tip: use https://mkjwk.org/ to generate a JWK
+                        key: '{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}'
                 token_extractors: 'header'
                 realm: 'My API'
 

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.1",
         "composer-runtime-api": ">=2.1",
         "ext-xml": "*",
+        "symfony/clock": "^6.3",
         "symfony/config": "^6.1",
         "symfony/dependency-injection": "^6.2",
         "symfony/event-dispatcher": "^5.4|^6.0",
@@ -38,7 +39,7 @@
         "symfony/dom-crawler": "^5.4|^6.0",
         "symfony/expression-language": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
-        "symfony/framework-bundle": "^5.4|^6.0",
+        "symfony/framework-bundle": "^6.3",
         "symfony/ldap": "^5.4|^6.0",
         "symfony/process": "^5.4|^6.0",
         "symfony/rate-limiter": "^5.4|^6.0",
@@ -59,7 +60,7 @@
     "conflict": {
         "symfony/browser-kit": "<5.4",
         "symfony/console": "<5.4",
-        "symfony/framework-bundle": "<5.4",
+        "symfony/framework-bundle": "<6.3",
         "symfony/http-client": "<5.4",
         "symfony/ldap": "<5.4",
         "symfony/twig-bundle": "<5.4"

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
@@ -49,7 +49,7 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
 
             // UserLoader argument can be overridden by a UserProvider on AccessTokenAuthenticator::authenticate
             return new UserBadge($claims[$this->claim], fn () => $this->createUser($claims), $claims);
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             $this->logger?->error('An error occurred on OIDC server.', [
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -18,6 +18,7 @@ use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OidcUser;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenHandler;
@@ -55,6 +56,7 @@ class OidcTokenHandlerTest extends TestCase
             new ES256(),
             $this->getJWK(),
             $loggerMock,
+            new Clock(),
             $claim,
             self::AUDIENCE
         ))->getUserBadgeFrom($token);
@@ -88,6 +90,7 @@ class OidcTokenHandlerTest extends TestCase
             new ES256(),
             $this->getJWK(),
             $loggerMock,
+            new Clock(),
             'sub',
             self::AUDIENCE
         ))->getUserBadgeFrom($token);
@@ -146,6 +149,7 @@ class OidcTokenHandlerTest extends TestCase
             new ES256(),
             self::getJWK(),
             $loggerMock,
+            new Clock(),
             'email',
             self::AUDIENCE
         ))->getUserBadgeFrom($token);

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "symfony/cache": "^5.4|^6.0",
+        "symfony/clock": "^6.3",
         "symfony/expression-language": "^5.4|^6.0",
         "symfony/http-client-contracts": "^3.0",
         "symfony/rate-limiter": "^5.4|^6.0",
@@ -37,6 +38,7 @@
         "web-token/jwt-signature-algorithm-ecdsa": "^3.1"
     },
     "conflict": {
+        "symfony/clock": "<6.3",
         "symfony/event-dispatcher": "<5.4.9|>=6,<6.0.9",
         "symfony/http-client-contracts": "<3.0",
         "symfony/security-bundle": "<5.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

From "web-token/jwt-checker":
The parameter "$clock" will become mandatory in 4.0.0. Please set a valid PSR Clock implementation instead of "null".

Also fixing some other issues found meanwhile.