### PR TITLE
[HttpClient] Forward other call to the decorated service

### DIFF
--- a/src/Symfony/Component/HttpClient/UriTemplateHttpClient.php
+++ b/src/Symfony/Component/HttpClient/UriTemplateHttpClient.php
@@ -62,6 +62,11 @@ class UriTemplateHttpClient implements HttpClientInterface, ResetInterface
         return $clone;
     }
 
+    public function __call($name, $arguments)
+    {
+        return $this->client->{$name}(...$arguments);
+    }
+
     /**
      * @return \Closure(string $url, array $vars): string
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

I tried to update an application and I faced the following error:
```
Error: Call to undefined method Symfony\Component\HttpClient\UriTemplateHttpClient::setResponseFactory()
```

The error comes from here:

https://github.com/jolicode/monologue/blob/main/tests/Acceptance/AcceptenceTest.php#L50

