### PR TITLE
[VarDumper] Use documentElement instead of body for JS flag

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -163,9 +163,7 @@ class HtmlDumper extends CliDumper
 <script>
 Sfdump = window.Sfdump || (function (doc) {
 
-if (doc.body instanceof HTMLElement) {
-    doc.body.classList.add('sf-js-enabled');
-}
+doc.documentElement.classList.add('sf-js-enabled');
 
 var rxEsc = /([.*+?^${}()|\[\]\/\\])/g,
     idRx = /\bsf-dump-\d+-ref[012]\w+\b/,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50487
| License       | MIT
| Doc PR        | ---

Fixes: #50487

Using `document.documentElement` allows to use the dumper outside of a `<html><body>...</body></html>` scenario.
