### PR TITLE
[SecurityBundle] Fix error message when using OIDC and web-token/jwt-core is not installed

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -34,10 +34,10 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
         );
 
         if (!ContainerBuilder::willBeAvailable('web-token/jwt-core', Algorithm::class, ['symfony/security-bundle'])) {
-            $container->register('security.access_token_handler.oidc.signature', Algorithm::class)
-                ->addError('You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "web-token/jwt-core".');
-            $container->register('security.access_token_handler.oidc.jwk', JWK::class)
-                ->addError('You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "web-token/jwt-core".');
+            $container->getDefinition('security.access_token_handler.oidc.signature', Algorithm::class)
+                ->addError('You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "composer require web-token/jwt-core".');
+            $container->getDefinition('security.access_token_handler.oidc.jwk', JWK::class)
+                ->addError('You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "composer require web-token/jwt-core".');
         }
 
         // @see Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SignatureAlgorithmFactory


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50491
| License       | MIT
| Doc PR        | -

Before:
> Service "security.access_token_handler.oidc.signature.ES256": Cannot replace arguments for class "Jose\Component\Signature\Algorithm\ES256" if none have been configured yet.  

After:
> You cannot use the "oidc" token handler since "web-token/jwt-core" is not installed. Try running "composer require web-token/jwt-core".

/cc @vincentchalamon 