### PR TITLE
[Filesystem] Fix broken symlink tests Windows PHP 7.4+

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Filesystem\Tests;
 
 use Symfony\Component\Filesystem\Exception\InvalidArgumentException;
 use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Test class for Filesystem.
@@ -1095,18 +1096,18 @@ class FilesystemTest extends FilesystemTestCase
             $this->markTestSkipped('Windows does not support reading "broken" symlinks in PHP < 7.4.0');
         }
 
-        $file = $this->workspace.'/file';
-        $link = $this->workspace.'/link';
+        $file = Path::join($this->workspace, 'file');
+        $link = Path::join($this->workspace, 'link');
 
         touch($file);
         $this->filesystem->symlink($file, $link);
         $this->filesystem->remove($file);
 
-        $this->assertEquals($file, $this->filesystem->readlink($link));
+        $this->assertEquals($file, Path::normalize($this->filesystem->readlink($link)));
         $this->assertNull($this->filesystem->readlink($link, true));
 
         touch($file);
-        $this->assertEquals($file, $this->filesystem->readlink($link, true));
+        $this->assertEquals($file, Path::normalize($this->filesystem->readlink($link, true)));
     }
 
     public function testReadLinkDefaultPathDoesNotExist()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Followup to #50437
| License       | MIT
| Doc PR        | -

The test currently fail on windows with PHP >= 7.4

```
1) Symfony\Component\Filesystem\Tests\FilesystemTest::testReadBrokenLink
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'C:\…\Temp\1685536465.4767.1091468882/file'
+'C:\…\Temp\1685536465.4767.1091468882\file'

C:\…\src\Symfony\Component\Filesystem\Tests\FilesystemTest.php:1105
```