### PR TITLE
[VarDumper] Add named arguments coverage of VarDumper's function

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -203,7 +203,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * feature #48678 [FrameworkBundle] Rename service `notifier.logger_notification_listener` to `notifier.notification_logger_listener` (ker0x)
  * feature #48516 [PhpUnitBridge] Add `enum_exists` mock (alexandre-daubois)
  * feature #48855 [Notifier] Add new Symfony Notifier for PagerDuty (stloyd)
- * feature #48876 [HttpKernel] Rename HttpStatus atribute to WithHttpStatus (fabpot)
+ * feature #48876 [HttpKernel] Rename HttpStatus attribute to WithHttpStatus (fabpot)
  * feature #48797 [FrameworkBundle] Add `extra` attribute for HttpClient Configuration (voodooism)
  * feature #48747 [HttpKernel] Allow using `#[WithLogLevel]` for setting custom log level for exceptions (angelov)
  * feature #48820 [HttpFoundation] ParameterBag::getEnum() (nikophil)

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_named_args.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_named_args.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test dd() with named args show label
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dd(label2: "dd() with label");
+
+--EXPECT--
+label2 "dd() with label"

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_named_args.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_named_args.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test dd() with named args show label
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dump("first dump", label1: "dump() with label");
+
+--EXPECT--
+1 "first dump"
+label1 "dump() with label"

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_without_args.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_without_args.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test dd() without args displays debug hint
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+dump();
+
+--EXPECT--
+🐛


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

Taking advantage of `.phpt` files added in 6.3 to add coverage on named arguments support of `dump` and `dd`.