### PR TITLE
[Mailer] [MailPace] Fix undefined array key in errors response

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MailPace/Tests/Transport/MailPaceApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailPace/Tests/Transport/MailPaceApiTransportTest.php
@@ -121,6 +121,57 @@ final class MailPaceApiTransportTest extends TestCase
         $transport->send($mail);
     }
 
+    public function testSendThrowsForErrorsResponse()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
+            return new MockResponse(json_encode([
+                'errors' => [
+                    'to' => [
+                        'contains a blocked address',
+                        'number of email addresses exceeds maximum volume',
+                    ],
+                    'attachments.name' => ['Extension file type blocked, see Docs for full list of allowed file types'],
+                ],
+            ]), [
+                'http_code' => 400,
+                'response_headers' => [
+                    'content-type' => 'application/json',
+                ],
+            ]);
+        });
+        $transport = new MailPaceApiTransport('KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email: to: contains a blocked address & number of email addresses exceeds maximum volume; attachments.name: Extension file type blocked, see Docs for full list of allowed file types (code 400).');
+        $transport->send($mail);
+    }
+
+    public function testSendThrowsForInternalServerErrorResponse()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
+            return new MockResponse('', ['http_code' => 500]);
+        });
+        $transport = new MailPaceApiTransport('KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email:  (code 500).');
+        $transport->send($mail);
+    }
+
     public function testTagAndMetadataHeaders()
     {
         $email = new Email();

--- a/src/Symfony/Component/Mailer/Bridge/MailPace/Transport/MailPaceApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailPace/Transport/MailPaceApiTransport.php
@@ -67,7 +67,20 @@ final class MailPaceApiTransport extends AbstractApiTransport
         }
 
         if (200 !== $statusCode) {
-            throw new HttpTransportException('Unable to send an email: '.$result['error'].sprintf(' (code %d).', $statusCode), $response);
+            $errorMessage = 'Unable to send an email: ';
+            if (isset($result['error'])) {
+                $errorMessage .= $result['error'];
+            } elseif (isset($result['errors'])) {
+                $errors = [];
+                foreach ($result['errors'] as $key => $val) {
+                    $errors[] = $key.': '.implode(' & ', $val);
+                }
+                $errorMessage .= implode('; ', $errors);
+            } else {
+                $errorMessage .= 'unknown error';
+            }
+            $errorMessage .= sprintf(' (code %d).', $statusCode);
+            throw new HttpTransportException($errorMessage, $response);
         }
 
         $sentMessage->setMessageId($result['id']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | -


This PR fixes a bug which occurs when MailPace returns an `errors` response instead of `error` (see https://docs.mailpace.com/reference/responses/ for possible responses).

Without this fix, the `errors` response leads to the following exception: `ErrorException: Undefined array key "error"`

I added two tests to verify that:
- responses with multiple errors are returned as readable error message
- empty responses generate a readable error message

To fix the bug I added a check for the existence of the `error`/`errors` key in the `$result` variable and a fallback just in case that both are not present.
