### PR TITLE
[DependencyInjection] Fix casting scalar env vars from null

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -181,10 +181,12 @@ class EnvVarProcessor implements EnvVarProcessorInterface
                 throw new RuntimeException(sprintf('Unsupported env var prefix "%s".', $prefix));
             }
 
-            return null;
+            if (!\in_array($prefix, ['string', 'bool', 'not', 'int', 'float'], true)) {
+                return null;
+            }
         }
 
-        if (!\is_scalar($env)) {
+        if (null !== $env && !\is_scalar($env)) {
             throw new RuntimeException(sprintf('Non-scalar env var "%s" cannot be cast to "%s".', $name, $prefix));
         }
 
@@ -199,7 +201,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if ('int' === $prefix) {
-            if (false === $env = filter_var($env, \FILTER_VALIDATE_INT) ?: filter_var($env, \FILTER_VALIDATE_FLOAT)) {
+            if (null !== $env && false === $env = filter_var($env, \FILTER_VALIDATE_INT) ?: filter_var($env, \FILTER_VALIDATE_FLOAT)) {
                 throw new RuntimeException(sprintf('Non-numeric env var "%s" cannot be cast to int.', $name));
             }
 
@@ -207,7 +209,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if ('float' === $prefix) {
-            if (false === $env = filter_var($env, \FILTER_VALIDATE_FLOAT)) {
+            if (null !== $env && false === $env = filter_var($env, \FILTER_VALIDATE_FLOAT)) {
                 throw new RuntimeException(sprintf('Non-numeric env var "%s" cannot be cast to float.', $name));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -839,8 +839,8 @@ class ContainerBuilderTest extends TestCase
         $container->register('foo', 'stdClass')
             ->setPublic(true)
             ->setProperties([
-            'fake' => '%env(int:FAKE)%',
-        ]);
+                'fake' => '%env(resolve:FAKE)%',
+            ]);
 
         $container->compile(true);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -760,4 +760,22 @@ CSV;
             ['blog//', 'https://symfony.com/blog//'],
         ];
     }
+
+    /**
+     * @testWith    ["", "string"]
+     *              [false, "bool"]
+     *              [true, "not"]
+     *              [0, "int"]
+     *              [0.0, "float"]
+     */
+    public function testGetEnvCastsNull($expected, string $prefix)
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $this->assertSame($expected, $processor->getEnv($prefix, 'default::FOO', static function () use ($processor) {
+            return $processor->getEnv('default', ':FOO', static function () {
+                return null;
+            });
+        }));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | https://github.com/symfony/symfony/issues/50415
| License       | MIT
| Doc PR        | -

Using a casting env var processor on `null` returns `null` (it doesn't cast) which is not what one could expect and not what is documented. We could allow it.