### PR TITLE
[Serializer] Fix ignoring objects that only implement DenormalizableInterface

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -28,6 +28,7 @@ class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, Se
     {
         return [
             NormalizableInterface::class => __CLASS__ === static::class || $this->hasCacheableSupportsMethod(),
+            DenormalizableInterface::class => __CLASS__ === static::class || $this->hasCacheableSupportsMethod(),
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -50,6 +50,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\DenormalizableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne;
@@ -118,6 +119,14 @@ class SerializerTest extends TestCase
         $this->expectException(UnexpectedValueException::class);
         $serializer = new Serializer([$this->createMock(CustomNormalizer::class)]);
         $serializer->denormalize('foo', 'stdClass');
+    }
+
+    public function testDenormalizeOnObjectThatOnlySupportsDenormalization()
+    {
+        $serializer = new Serializer([new CustomNormalizer()]);
+
+        $obj = $serializer->denormalize('foo', (new DenormalizableDummy())::class, 'xml');
+        $this->assertInstanceOf(DenormalizableDummy::class, $obj);
     }
 
     public function testDenormalizeOnNormalizer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

When the https://github.com/symfony/symfony/pull/49291 optimization got introduced, the `DenormalizableInterface` type was left out of the `CustomNormalizer` normalizer's `getSupportedTypes` implementation.

This prevents us for example, implementing custom deserialization logic for API objects where we can't describe all deserialization rules via attributes.

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
