### PR TITLE
[DependencyInjection] Fix support for `false` boolean env vars

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -146,7 +146,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         if (false !== $i || 'string' !== $prefix) {
             $env = $getEnv($name);
         } elseif ('' === ($env = $_ENV[$name] ?? (str_starts_with($name, 'HTTP_') ? null : ($_SERVER[$name] ?? null)))
-            || false === ($env = $env ?? getenv($name) ?? false) // null is a possible value because of thread safety issues
+            || (false !== $env && false === ($env = $env ?? getenv($name) ?? false)) // null is a possible value because of thread safety issues
         ) {
             foreach ($this->loadedVars as $vars) {
                 if (false !== ($env = ($vars[$name] ?? $env)) && '' !== $env) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

After upgrading `symfony/dependency-injection` package to version 6.3, some of our env vars couldn't be found anymore.

For some scripts, we are providing an adhoc default value to env vars by setting `$_SERVER` directly. However, since version 6.3 of the DependencyInjection component, setting an env var to `false` (the boolean value, like in the snippet below) doesn't work anymore, and Symfony reports that the variable cannot be found.

```php
$_SERVER['FOO'] = false;
```

It seems to be a side effect of the changes made in #48705.