### PR TITLE
[Messenger] Prevent `StopWorkerOnSignalsListener::$signals` to be assigned to null in case `SIGTERM` constant doesn't exist

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSignalsListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSignalsListener.php
@@ -29,7 +29,7 @@ class StopWorkerOnSignalsListener implements EventSubscriberInterface
         if (null === $signals && \defined('SIGTERM')) {
             $signals = [SIGTERM, SIGINT];
         }
-        $this->signals = $signals;
+        $this->signals = $signals ?? [];
         $this->logger = $logger;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50529
| License       | MIT
| Doc PR        | _NA_

Prevents the non-nullable property to be assigned to null :slightly_smiling_face: 