### PR TITLE
[Console] Add placeholders to ProgressBar for exact times

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -94,33 +94,44 @@ abstract class Helper implements HelperInterface
     /**
      * @return string
      */
-    public static function formatTime(int|float $secs)
+    public static function formatTime(int|float $secs, int $precision = 1)
     {
+        $secs = (int) floor($secs);
+
+        if (0 === $secs) {
+            return '< 1 sec';
+        }
+
         static $timeFormats = [
-            [0, '< 1 sec'],
-            [1, '1 sec'],
-            [2, 'secs', 1],
-            [60, '1 min'],
-            [120, 'mins', 60],
-            [3600, '1 hr'],
-            [7200, 'hrs', 3600],
-            [86400, '1 day'],
-            [172800, 'days', 86400],
+            [1, '1 sec', 'secs'],
+            [60, '1 min', 'mins'],
+            [3600, '1 hr', 'hrs'],
+            [86400, '1 day', 'days'],
         ];
 
+        $times = [];
         foreach ($timeFormats as $index => $format) {
-            if ($secs >= $format[0]) {
-                if ((isset($timeFormats[$index + 1]) && $secs < $timeFormats[$index + 1][0])
-                    || $index == \count($timeFormats) - 1
-                ) {
-                    if (2 == \count($format)) {
-                        return $format[1];
-                    }
+            $seconds = isset($timeFormats[$index + 1]) ? $secs % $timeFormats[$index + 1][0] : $secs;
 
-                    return floor($secs / $format[2]).' '.$format[1];
-                }
+            if (isset($times[$index - $precision])) {
+                unset($times[$index - $precision]);
             }
+
+            if (0 === $seconds) {
+                continue;
+            }
+
+            $unitCount = ($seconds / $format[0]);
+            $times[$index] = 1 === $unitCount ? $format[1] : $unitCount.' '.$format[2];
+
+            if ($secs === $seconds) {
+                break;
+            }
+
+            $secs -= $seconds;
         }
+
+        return implode(', ', array_reverse($times));
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -540,20 +540,20 @@ final class ProgressBar
 
                 return $display;
             },
-            'elapsed' => fn (self $bar) => Helper::formatTime(time() - $bar->getStartTime()),
+            'elapsed' => fn (self $bar) => Helper::formatTime(time() - $bar->getStartTime(), 2),
             'remaining' => function (self $bar) {
                 if (!$bar->getMaxSteps()) {
                     throw new LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
                 }
 
-                return Helper::formatTime($bar->getRemaining());
+                return Helper::formatTime($bar->getRemaining(), 2);
             },
             'estimated' => function (self $bar) {
                 if (!$bar->getMaxSteps()) {
                     throw new LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
                 }
 
-                return Helper::formatTime($bar->getEstimated());
+                return Helper::formatTime($bar->getEstimated(), 2);
             },
             'memory' => fn (self $bar) => Helper::formatMemory(memory_get_usage(true)),
             'current' => fn (self $bar) => str_pad($bar->getProgress(), $bar->getStepWidth(), ' ', \STR_PAD_LEFT),

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -228,7 +228,7 @@ class ProgressIndicator
         return [
             'indicator' => fn (self $indicator) => $indicator->indicatorValues[$indicator->indicatorCurrent % \count($indicator->indicatorValues)],
             'message' => fn (self $indicator) => $indicator->message,
-            'elapsed' => fn (self $indicator) => Helper::formatTime(time() - $indicator->startTime),
+            'elapsed' => fn (self $indicator) => Helper::formatTime(time() - $indicator->startTime, 2),
             'memory' => fn () => Helper::formatMemory(memory_get_usage(true)),
         ];
     }

--- a/src/Symfony/Component/Console/Tests/Helper/HelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperTest.php
@@ -20,26 +20,31 @@ class HelperTest extends TestCase
     public static function formatTimeProvider()
     {
         return [
-            [0,      '< 1 sec'],
-            [1,      '1 sec'],
-            [2,      '2 secs'],
-            [59,     '59 secs'],
-            [60,     '1 min'],
-            [61,     '1 min'],
-            [119,    '1 min'],
-            [120,    '2 mins'],
-            [121,    '2 mins'],
-            [3599,   '59 mins'],
-            [3600,   '1 hr'],
-            [7199,   '1 hr'],
-            [7200,   '2 hrs'],
-            [7201,   '2 hrs'],
-            [86399,  '23 hrs'],
-            [86400,  '1 day'],
-            [86401,  '1 day'],
-            [172799, '1 day'],
-            [172800, '2 days'],
-            [172801, '2 days'],
+            [0,      '< 1 sec', 1],
+            [0.95,   '< 1 sec', 1],
+            [1,      '1 sec', 1],
+            [2,      '2 secs', 2],
+            [59,     '59 secs', 1],
+            [59.21,  '59 secs', 1],
+            [60,     '1 min', 2],
+            [61,     '1 min, 1 sec', 2],
+            [119,    '1 min, 59 secs', 2],
+            [120,    '2 mins', 2],
+            [121,    '2 mins, 1 sec', 2],
+            [3599,   '59 mins, 59 secs', 2],
+            [3600,   '1 hr', 2],
+            [7199,   '1 hr, 59 mins', 2],
+            [7200,   '2 hrs', 2],
+            [7201,   '2 hrs', 2],
+            [86399,  '23 hrs, 59 mins', 2],
+            [86399,  '23 hrs, 59 mins, 59 secs', 3],
+            [86400,  '1 day', 2],
+            [86401,  '1 day', 2],
+            [172799, '1 day, 23 hrs', 2],
+            [172799, '1 day, 23 hrs, 59 mins, 59 secs', 4],
+            [172800, '2 days', 2],
+            [172801, '2 days', 2],
+            [172801, '2 days, 1 sec', 4],
         ];
     }
 
@@ -55,13 +60,10 @@ class HelperTest extends TestCase
 
     /**
      * @dataProvider formatTimeProvider
-     *
-     * @param int    $secs
-     * @param string $expectedFormat
      */
-    public function testFormatTime($secs, $expectedFormat)
+    public function testFormatTime(int|float $secs, string $expectedFormat, int $precision)
     {
-        $this->assertEquals($expectedFormat, Helper::formatTime($secs));
+        $this->assertEquals($expectedFormat, Helper::formatTime($secs, $precision));
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -1005,6 +1005,18 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         );
     }
 
+    public function testSetFormatWithTimes()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 15, 0);
+        $bar->setFormat('%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%/%remaining:-6s%');
+        $bar->start();
+        rewind($output->getStream());
+        $this->assertEquals(
+            ' 0/15 [>---------------------------]   0% < 1 sec/< 1 sec/< 1 sec',
+            stream_get_contents($output->getStream())
+        );
+    }
+
     public function testUnicode()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 10, 0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49927
| License       | MIT
| Doc PR        | symfony/symfony-docs#... TBD

This is an idea for exact times using ProgressBar based on the idea of @GromNaN in the issue  #49927.

Open to discuss this first way of implementing it.

I'll create the docs PR when the feature is agreed and there won't come up any bigger changes.

The Idea is to show the exact time in seconds, the ProgressBar will run / is running.
