### PR TITLE
[Validator] Remove internal from methods on non-internal interfaces

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -123,106 +123,79 @@ interface ExecutionContextInterface
     public function getObject();
 
     /**
-     * Sets the currently validated value.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param mixed       $value        The validated value
      * @param object|null $object       The currently validated object
      * @param string      $propertyPath The property path to the current value
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
      */
     public function setNode($value, ?object $object, MetadataInterface $metadata = null, string $propertyPath);
 
     /**
-     * Sets the currently validated group.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string|null $group The validated group
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
      */
     public function setGroup(?string $group);
 
     /**
-     * Sets the currently validated constraint.
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      */
     public function setConstraint(Constraint $constraint);
 
     /**
-     * Marks an object as validated in a specific validation group.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string $cacheKey  The hash of the object
      * @param string $groupHash The group's name or hash, if it is group
      *                          sequence
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
      */
     public function markGroupAsValidated(string $cacheKey, string $groupHash);
 
     /**
-     * Returns whether an object was validated in a specific validation group.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string $cacheKey  The hash of the object
      * @param string $groupHash The group's name or hash, if it is group
      *                          sequence
      *
      * @return bool
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
      */
     public function isGroupValidated(string $cacheKey, string $groupHash);
 
     /**
-     * Marks a constraint as validated for an object.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string $cacheKey       The hash of the object
      * @param string $constraintHash The hash of the constraint
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
      */
     public function markConstraintAsValidated(string $cacheKey, string $constraintHash);
 
     /**
-     * Returns whether a constraint was validated for an object.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string $cacheKey       The hash of the object
      * @param string $constraintHash The hash of the constraint
      *
      * @return bool
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
      */
     public function isConstraintValidated(string $cacheKey, string $constraintHash);
 
     /**
-     * Marks that an object was initialized.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string $cacheKey The hash of the object
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
      *
      * @see ObjectInitializerInterface
      */
     public function markObjectAsInitialized(string $cacheKey);
 
     /**
-     * Returns whether an object was initialized.
+     * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string $cacheKey The hash of the object
      *
      * @return bool
-     *
-     * @internal Used by the validator engine. Should not be called by user
-     *           code.
      *
      * @see ObjectInitializerInterface
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

A method cannot be `@internal` on a public interface, as a userland class implementing the interface *must* define it. As such, we must follow the BC promise for them.