### PR TITLE
[Validator] GH-50526: Reverting ExecutionContextInterface void return types in favor of docblock annotations.

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -123,29 +123,26 @@ interface ExecutionContextInterface
      *
      * @param object|null $object       The currently validated object
      * @param string      $propertyPath The property path to the current value
+     *
+     * @return void
      */
-    public function setNode(mixed $value, ?object $object, MetadataInterface $metadata = null, string $propertyPath): void;
+    public function setNode(mixed $value, ?object $object, MetadataInterface $metadata = null, string $propertyPath);
 
     /**
      * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string|null $group The validated group
+     *
+     * @return void
      */
-    public function setGroup(?string $group): void;
-
-    /**
-     * Warning: Should not be called by user code, to be used by the validator engine only.
-     */
-    public function setConstraint(Constraint $constraint): void;
+    public function setGroup(?string $group);
 
     /**
      * Warning: Should not be called by user code, to be used by the validator engine only.
      *
-     * @param string $cacheKey  The hash of the object
-     * @param string $groupHash The group's name or hash, if it is group
-     *                          sequence
+     * @return void
      */
-    public function markGroupAsValidated(string $cacheKey, string $groupHash): void;
+    public function setConstraint(Constraint $constraint);
 
     /**
      * Warning: Should not be called by user code, to be used by the validator engine only.
@@ -154,6 +151,16 @@ interface ExecutionContextInterface
      * @param string $groupHash The group's name or hash, if it is group
      *                          sequence
      *
+     * @return void
+     */
+    public function markGroupAsValidated(string $cacheKey, string $groupHash);
+
+    /**
+     * Warning: Should not be called by user code, to be used by the validator engine only.
+     *
+     * @param string $cacheKey  The hash of the object
+     * @param string $groupHash The group's name or hash, if it is group
+     *                          sequence
      */
     public function isGroupValidated(string $cacheKey, string $groupHash): bool;
 
@@ -162,15 +169,16 @@ interface ExecutionContextInterface
      *
      * @param string $cacheKey       The hash of the object
      * @param string $constraintHash The hash of the constraint
+     *
+     * @return void
      */
-    public function markConstraintAsValidated(string $cacheKey, string $constraintHash): void;
+    public function markConstraintAsValidated(string $cacheKey, string $constraintHash);
 
     /**
      * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string $cacheKey       The hash of the object
      * @param string $constraintHash The hash of the constraint
-     *
      */
     public function isConstraintValidated(string $cacheKey, string $constraintHash): bool;
 
@@ -187,7 +195,6 @@ interface ExecutionContextInterface
      * Warning: Should not be called by user code, to be used by the validator engine only.
      *
      * @param string $cacheKey The hash of the object
-     *
      *
      * @see ObjectInitializerInterface
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50526
| License       | MIT
| Doc PR        | 