### PR TITLE
[Process] Fix standard streams not available in PhpProcess scripts

### DIFF
--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -39,15 +39,17 @@ class PhpProcess extends Process
             $php = $executableFinder->find(false);
             $php = false === $php ? null : array_merge([$php], $executableFinder->findArguments());
         }
-        if ('phpdbg' === \PHP_SAPI) {
-            $file = tempnam(sys_get_temp_dir(), 'dbg');
-            file_put_contents($file, $script);
-            register_shutdown_function('unlink', $file);
-            $php[] = $file;
-            $script = null;
+
+        $file = tempnam(sys_get_temp_dir(), 'phpdbg' === \PHP_SAPI ? 'dbg' : 'cli');
+        if (false === $file) {
+            throw new RuntimeException('The system temp directory is not writable.');
         }
 
-        parent::__construct($php, $cwd, $env, $script, $timeout);
+        file_put_contents($file, $script);
+        register_shutdown_function('unlink', $file);
+        $php[] = $file;
+
+        parent::__construct($php, $cwd, $env, null, $timeout);
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/PhpProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpProcessTest.php
@@ -71,4 +71,15 @@ PHP;
 PHP
         );
     }
+
+    public function testStandardStreamsAreAvailableInTheProcess()
+    {
+        $process = new PhpProcess(<<<PHP
+<?php
+var_dump(\STDOUT);
+PHP);
+        $process->run();
+
+        $this->assertStringMatchesFormat('resource(%d) of type (stream)', $process->getOutput());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50063
| License       | MIT
| Doc PR        | _NA_

Although[ it's been fixed in PHP lately](https://github.com/php/php-src/commit/f6c0c60ef63c1e528dd3bd945c8f22270bbe3837), older versions are suffering this bug, including minimal version of PHP of every supported Symfony version.