### PR TITLE
[FrameworkBundle] Fix `debug:config` & `config:dump` in debug mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -50,7 +50,14 @@ trait BuildDebugContainerTrait
             $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
             $container->compile();
         } else {
-            (new XmlFileLoader($container = new ContainerBuilder(), new FileLocator()))->load($kernel->getContainer()->getParameter('debug.container.dump'));
+            $buildContainer = \Closure::bind(function () {
+                $containerBuilder = $this->getContainerBuilder();
+                $this->prepareContainer($containerBuilder);
+
+                return $containerBuilder;
+            }, $kernel, \get_class($kernel));
+            $container = $buildContainer();
+            (new XmlFileLoader($container, new FileLocator()))->load($kernel->getContainer()->getParameter('debug.container.dump'));
             $locatorPass = new ServiceLocatorTagPass();
             $locatorPass->process($container);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -176,12 +176,12 @@ EOF
 
         // Fall back to default config if the extension has one
 
-        if (!$extension instanceof ConfigurationExtensionInterface) {
+        if (!$extension instanceof ConfigurationExtensionInterface && !$extension instanceof ConfigurationInterface) {
             throw new \LogicException(sprintf('The extension with alias "%s" does not have configuration.', $extensionAlias));
         }
 
         $configs = $container->getExtensionConfig($extensionAlias);
-        $configuration = $extension->getConfiguration($configs, $container);
+        $configuration = $extension instanceof ConfigurationInterface ? $extension : $extension->getConfiguration($configs, $container);
         $this->validateConfiguration($extension, $configuration);
 
         return (new Processor())->processConfiguration($configuration, $configs);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -23,36 +23,53 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class ConfigDebugCommandTest extends AbstractWebTestCase
 {
-    private $application;
-
-    protected function setUp(): void
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpKernelExtension(bool $debug)
     {
-        $kernel = static::createKernel(['test_case' => 'ConfigDump', 'root_config' => 'config.yml']);
-        $this->application = new Application($kernel);
-        $this->application->doRun(new ArrayInput([]), new NullOutput());
+        $tester = $this->createCommandTester($debug);
+        $ret = $tester->execute(['name' => 'foo']);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertStringContainsString('foo:', $tester->getDisplay());
+        $this->assertStringContainsString('    foo: bar', $tester->getDisplay());
     }
 
-    public function testDumpBundleName()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpBundleName(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'TestBundle']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
         $this->assertStringContainsString('custom: foo', $tester->getDisplay());
     }
 
-    public function testDumpBundleOption()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpBundleOption(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'TestBundle', 'path' => 'custom']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
         $this->assertStringContainsString('foo', $tester->getDisplay());
     }
 
-    public function testParametersValuesAreResolved()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testParametersValuesAreResolved(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'framework']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
@@ -60,77 +77,105 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString('secret: test', $tester->getDisplay());
     }
 
-    public function testDefaultParameterValueIsResolvedIfConfigIsExisting()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDefaultParameterValueIsResolvedIfConfigIsExisting(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'framework']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $kernelCacheDir = $this->application->getKernel()->getContainer()->getParameter('kernel.cache_dir');
+        $kernelCacheDir = self::$kernel->getContainer()->getParameter('kernel.cache_dir');
         $this->assertStringContainsString(sprintf("dsn: 'file:%s/profiler'", $kernelCacheDir), $tester->getDisplay());
     }
 
-    public function testDumpExtensionConfigWithoutBundle()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpExtensionConfigWithoutBundle(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'test_dump']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
         $this->assertStringContainsString('enabled: true', $tester->getDisplay());
     }
 
-    public function testDumpUndefinedBundleOption()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpUndefinedBundleOption(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $tester->execute(['name' => 'TestBundle', 'path' => 'foo']);
 
         $this->assertStringContainsString('Unable to find configuration for "test.foo"', $tester->getDisplay());
     }
 
-    public function testDumpWithPrefixedEnv()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpWithPrefixedEnv(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $tester->execute(['name' => 'FrameworkBundle']);
 
         $this->assertStringContainsString("cookie_httponly: '%env(bool:COOKIE_HTTPONLY)%'", $tester->getDisplay());
     }
 
-    public function testDumpFallsBackToDefaultConfigAndResolvesParameterValue()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpFallsBackToDefaultConfigAndResolvesParameterValue(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'DefaultConfigTestBundle']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
         $this->assertStringContainsString('foo: bar', $tester->getDisplay());
     }
 
-    public function testDumpFallsBackToDefaultConfigAndResolvesEnvPlaceholder()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpFallsBackToDefaultConfigAndResolvesEnvPlaceholder(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'DefaultConfigTestBundle']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
         $this->assertStringContainsString("baz: '%env(BAZ)%'", $tester->getDisplay());
     }
 
-    public function testDumpThrowsExceptionWhenDefaultConfigFallbackIsImpossible()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpThrowsExceptionWhenDefaultConfigFallbackIsImpossible(bool $debug)
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The extension with alias "extension_without_config_test" does not have configuration.');
 
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $tester->execute(['name' => 'ExtensionWithoutConfigTestBundle']);
     }
 
     /**
      * @dataProvider provideCompletionSuggestions
      */
-    public function testComplete(array $input, array $expectedSuggestions)
+    public function testComplete(bool $debug, array $input, array $expectedSuggestions)
     {
-        $this->application->add(new ConfigDebugCommand());
+        $application = $this->createApplication($debug);
 
-        $tester = new CommandCompletionTester($this->application->get('debug:config'));
-
+        $application->add(new ConfigDebugCommand());
+        $tester = new CommandCompletionTester($application->get('debug:config'));
         $suggestions = $tester->complete($input);
 
         foreach ($expectedSuggestions as $expectedSuggestion) {
@@ -140,17 +185,32 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
 
     public static function provideCompletionSuggestions(): \Generator
     {
-        yield 'name' => [[''], ['default_config_test', 'extension_without_config_test', 'framework', 'test']];
+        $name = ['default_config_test', 'extension_without_config_test', 'framework', 'test'];
+        yield 'name, no debug' => [false, [''], $name];
+        yield 'name, debug' => [true, [''], $name];
 
-        yield 'name (started CamelCase)' => [['Fra'], ['DefaultConfigTestBundle', 'ExtensionWithoutConfigTestBundle', 'FrameworkBundle', 'TestBundle']];
+        $nameCamelCased = ['DefaultConfigTestBundle', 'ExtensionWithoutConfigTestBundle', 'FrameworkBundle', 'TestBundle'];
+        yield 'name (started CamelCase), no debug' => [false, ['Fra'], $nameCamelCased];
+        yield 'name (started CamelCase), debug' => [true, ['Fra'], $nameCamelCased];
 
-        yield 'name with existing path' => [['framework', ''], ['secret', 'router.resource', 'router.utf8', 'router.enabled', 'validation.enabled', 'default_locale']];
+        $nameWithPath = ['secret', 'router.resource', 'router.utf8', 'router.enabled', 'validation.enabled', 'default_locale'];
+        yield 'name with existing path, no debug' => [false, ['framework', ''], $nameWithPath];
+        yield 'name with existing path, debug' => [true, ['framework', ''], $nameWithPath];
     }
 
-    private function createCommandTester(): CommandTester
+    private function createCommandTester(bool $debug): CommandTester
     {
-        $command = $this->application->find('debug:config');
+        $command = $this->createApplication($debug)->find('debug:config');
 
         return new CommandTester($command);
+    }
+
+    private function createApplication(bool $debug): Application
+    {
+        $kernel = static::bootKernel(['debug' => $debug, 'test_case' => 'ConfigDump', 'root_config' => 'config.yml']);
+        $application = new Application($kernel);
+        $application->doRun(new ArrayInput([]), new NullOutput());
+
+        return $application;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -23,26 +23,27 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
 {
-    private $application;
-
-    protected function setUp(): void
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpKernelExtension(bool $debug)
     {
-        $kernel = static::createKernel(['test_case' => 'ConfigDump', 'root_config' => 'config.yml']);
-        $this->application = new Application($kernel);
-        $this->application->doRun(new ArrayInput([]), new NullOutput());
-    }
-
-    public function testDumpKernelExtension()
-    {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'foo']);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
         $this->assertStringContainsString('foo:', $tester->getDisplay());
         $this->assertStringContainsString('    bar', $tester->getDisplay());
     }
 
-    public function testDumpBundleName()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpBundleName(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'TestBundle']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
@@ -50,18 +51,26 @@ class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString('    custom:', $tester->getDisplay());
     }
 
-    public function testDumpExtensionConfigWithoutBundle()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpExtensionConfigWithoutBundle(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute(['name' => 'test_dump']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
         $this->assertStringContainsString('enabled:              true', $tester->getDisplay());
     }
 
-    public function testDumpAtPath()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpAtPath(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute([
             'name' => 'test',
             'path' => 'array',
@@ -79,9 +88,13 @@ EOL
             , $tester->getDisplay(true));
     }
 
-    public function testDumpAtPathXml()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testDumpAtPathXml(bool $debug)
     {
-        $tester = $this->createCommandTester();
+        $tester = $this->createCommandTester($debug);
         $ret = $tester->execute([
             'name' => 'test',
             'path' => 'array',
@@ -95,24 +108,40 @@ EOL
     /**
      * @dataProvider provideCompletionSuggestions
      */
-    public function testComplete(array $input, array $expectedSuggestions)
+    public function testComplete(bool $debug, array $input, array $expectedSuggestions)
     {
-        $this->application->add(new ConfigDumpReferenceCommand());
-        $tester = new CommandCompletionTester($this->application->get('config:dump-reference'));
-        $suggestions = $tester->complete($input, 2);
+        $application = $this->createApplication($debug);
+
+        $application->add(new ConfigDumpReferenceCommand());
+        $tester = new CommandCompletionTester($application->get('config:dump-reference'));
+        $suggestions = $tester->complete($input);
         $this->assertSame($expectedSuggestions, $suggestions);
     }
 
     public static function provideCompletionSuggestions(): iterable
     {
-        yield 'name' => [[''], ['DefaultConfigTestBundle', 'default_config_test', 'ExtensionWithoutConfigTestBundle', 'extension_without_config_test', 'FrameworkBundle', 'framework', 'TestBundle', 'test']];
-        yield 'option --format' => [['--format', ''], ['yaml', 'xml']];
+        $name = ['DefaultConfigTestBundle', 'default_config_test', 'ExtensionWithoutConfigTestBundle', 'extension_without_config_test', 'FrameworkBundle', 'framework', 'TestBundle', 'test'];
+        yield 'name, no debug' => [false, [''], $name];
+        yield 'name, debug' => [true, [''], $name];
+
+        $optionFormat = ['yaml', 'xml'];
+        yield 'option --format, no debug' => [false, ['--format', ''], $optionFormat];
+        yield 'option --format, debug' => [true, ['--format', ''], $optionFormat];
     }
 
-    private function createCommandTester(): CommandTester
+    private function createCommandTester(bool $debug): CommandTester
     {
-        $command = $this->application->find('config:dump-reference');
+        $command = $this->createApplication($debug)->find('config:dump-reference');
 
         return new CommandTester($command);
+    }
+
+    private function createApplication(bool $debug): Application
+    {
+        $kernel = static::createKernel(['debug' => $debug, 'test_case' => 'ConfigDump', 'root_config' => 'config.yml']);
+        $application = new Application($kernel);
+        $application->doRun(new ArrayInput([]), new NullOutput());
+
+        return $application;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47623
| License       | MIT
| Doc PR        | -

Displaying configs for extensions without a bundle using the `debug:config` & `config:dump-reference` commands works depending on whether debug is `true` or `false`. The reason behind this is the following code:

https://github.com/symfony/symfony/blob/b4128fdefea4ff95b27861bf65ba789d24868df1/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php#L42-L60

When debug is `true` the extensions are never loaded in the container, so the commands don't work.

There are even tests for these cases but they are all executed with debug `false`.

This PR aims to make the commands work with both debug `true` & `false`. Another problem is that these extensions are not visible in the list of available extensions and are not offered by the completion feature, but since those seem more like new features I've created a separate PR for 6.4: #50548