### PR TITLE
[FrameworkBundle] Show non-bundle extensions in `debug:config` & `config:dump` list view & completion

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -58,6 +58,47 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
     }
 
     /**
+     * @param OutputInterface|StyleInterface $output
+     */
+    protected function listNonBundleExtensions($output)
+    {
+        $title = 'Available registered non-bundle extension aliases';
+        $headers = ['Extension alias'];
+        $rows = [];
+
+        $kernel = $this->getApplication()->getKernel();
+
+        $bundleExtensions = [];
+        foreach ($kernel->getBundles() as $bundle) {
+            if ($extension = $bundle->getContainerExtension()) {
+                $bundleExtensions[\get_class($extension)] = true;
+            }
+        }
+
+        $extensions = $this->getContainerBuilder($kernel)->getExtensions();
+
+        foreach ($extensions as $alias => $extension) {
+            if (isset($bundleExtensions[\get_class($extension)])) {
+                continue;
+            }
+            $rows[] = [$alias];
+        }
+
+        if (!$rows) {
+            return;
+        }
+
+        if ($output instanceof StyleInterface) {
+            $output->title($title);
+            $output->table($headers, $rows);
+        } else {
+            $output->writeln($title);
+            $table = new Table($output);
+            $table->setHeaders($headers)->setRows($rows)->render();
+        }
+    }
+
+    /**
      * @return ExtensionInterface
      */
     protected function findExtension(string $name)

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -22,8 +22,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -88,14 +86,7 @@ EOF
 
         if (null === $name = $input->getArgument('name')) {
             $this->listBundles($errorIo);
-
-            $kernel = $this->getApplication()->getKernel();
-            if ($kernel instanceof ExtensionInterface
-                && ($kernel instanceof ConfigurationInterface || $kernel instanceof ConfigurationExtensionInterface)
-                && $kernel->getAlias()
-            ) {
-                $errorIo->table(['Kernel Extension'], [[$kernel->getAlias()]]);
-            }
+            $this->listNonBundleExtensions($errorIo);
 
             $errorIo->comment([
                 'Provide the name of a bundle as the first argument of this command to dump its default configuration. (e.g. <comment>config:dump-reference FrameworkBundle</comment>)',
@@ -163,6 +154,7 @@ EOF
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
         if ($input->mustSuggestArgumentValuesFor('name')) {
+            $suggestions->suggestValues($this->getAvailableExtensions());
             $suggestions->suggestValues($this->getAvailableBundles());
         }
 
@@ -171,13 +163,24 @@ EOF
         }
     }
 
+    private function getAvailableExtensions(): array
+    {
+        $kernel = $this->getApplication()->getKernel();
+
+        $extensions = [];
+        foreach ($this->getContainerBuilder($kernel)->getExtensions() as $alias => $extension) {
+            $extensions[] = $alias;
+        }
+
+        return $extensions;
+    }
+
     private function getAvailableBundles(): array
     {
         $bundles = [];
 
         foreach ($this->getApplication()->getKernel()->getBundles() as $bundle) {
             $bundles[] = $bundle->getName();
-            $bundles[] = $bundle->getContainerExtension()->getAlias();
         }
 
         return $bundles;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -27,6 +27,26 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
      * @testWith [true]
      *           [false]
      */
+    public function testShowList(bool $debug)
+    {
+        $tester = $this->createCommandTester($debug);
+        $ret = $tester->execute([]);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertStringContainsString('Available registered bundles with their extension alias if available', $tester->getDisplay());
+        $this->assertStringContainsString('  DefaultConfigTestBundle            default_config_test', $tester->getDisplay());
+        $this->assertStringContainsString('  ExtensionWithoutConfigTestBundle   extension_without_config_test', $tester->getDisplay());
+        $this->assertStringContainsString('  FrameworkBundle                    framework', $tester->getDisplay());
+        $this->assertStringContainsString('  TestBundle                         test', $tester->getDisplay());
+        $this->assertStringContainsString('Available registered non-bundle extension aliases', $tester->getDisplay());
+        $this->assertStringContainsString('  foo', $tester->getDisplay());
+        $this->assertStringContainsString('  test_dump', $tester->getDisplay());
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
     public function testDumpKernelExtension(bool $debug)
     {
         $tester = $this->createCommandTester($debug);
@@ -185,13 +205,9 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
 
     public static function provideCompletionSuggestions(): \Generator
     {
-        $name = ['default_config_test', 'extension_without_config_test', 'framework', 'test'];
+        $name = ['default_config_test', 'extension_without_config_test', 'framework', 'test', 'foo', 'test_dump'];
         yield 'name, no debug' => [false, [''], $name];
         yield 'name, debug' => [true, [''], $name];
-
-        $nameCamelCased = ['DefaultConfigTestBundle', 'ExtensionWithoutConfigTestBundle', 'FrameworkBundle', 'TestBundle'];
-        yield 'name (started CamelCase), no debug' => [false, ['Fra'], $nameCamelCased];
-        yield 'name (started CamelCase), debug' => [true, ['Fra'], $nameCamelCased];
 
         $nameWithPath = ['secret', 'router.resource', 'router.utf8', 'router.enabled', 'validation.enabled', 'default_locale'];
         yield 'name with existing path, no debug' => [false, ['framework', ''], $nameWithPath];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -27,6 +27,26 @@ class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
      * @testWith [true]
      *           [false]
      */
+    public function testShowList(bool $debug)
+    {
+        $tester = $this->createCommandTester($debug);
+        $ret = $tester->execute([]);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertStringContainsString('Available registered bundles with their extension alias if available', $tester->getDisplay());
+        $this->assertStringContainsString('  DefaultConfigTestBundle            default_config_test', $tester->getDisplay());
+        $this->assertStringContainsString('  ExtensionWithoutConfigTestBundle   extension_without_config_test', $tester->getDisplay());
+        $this->assertStringContainsString('  FrameworkBundle                    framework', $tester->getDisplay());
+        $this->assertStringContainsString('  TestBundle                         test', $tester->getDisplay());
+        $this->assertStringContainsString('Available registered non-bundle extension aliases', $tester->getDisplay());
+        $this->assertStringContainsString('  foo', $tester->getDisplay());
+        $this->assertStringContainsString('  test_dump', $tester->getDisplay());
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
     public function testDumpKernelExtension(bool $debug)
     {
         $tester = $this->createCommandTester($debug);
@@ -120,7 +140,7 @@ EOL
 
     public static function provideCompletionSuggestions(): iterable
     {
-        $name = ['DefaultConfigTestBundle', 'default_config_test', 'ExtensionWithoutConfigTestBundle', 'extension_without_config_test', 'FrameworkBundle', 'framework', 'TestBundle', 'test'];
+        $name = ['foo', 'default_config_test', 'extension_without_config_test', 'framework', 'test', 'test_dump', 'DefaultConfigTestBundle', 'ExtensionWithoutConfigTestBundle', 'FrameworkBundle', 'TestBundle'];
         yield 'name, no debug' => [false, [''], $name];
         yield 'name, debug' => [true, [''], $name];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follow up to #50546 (should be merged first), adds non-bundle extensions to `debug:config` & `config:dump` list views:

```php
class Kernel extends BaseKernel implements ExtensionInterface, ConfigurationInterface
{
    use MicroKernelTrait;

    protected function build(ContainerBuilder $container)
    {
        $container->registerExtension(new MyExtension());
    }

    public function getAlias()
    {
        return 'kernel';
    }

    // ...
}
```

![image](https://github.com/symfony/symfony/assets/2445045/5c75d33a-155c-4602-abf8-8babc72286b6)
