### PR TITLE
[Security] Allow custom scheme to be used as redirection URIs

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -148,7 +148,9 @@ class HttpUtils
      */
     public function generateUri(Request $request, string $path)
     {
-        if (str_starts_with($path, 'http') || !$path) {
+        $url = parse_url($path);
+
+        if ('' === $path || isset($url['scheme'], $url['host'])) {
             return $path;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #50500
| License       | MIT
| Doc PR        | not needed

ping @sdespont and @MatTheCat


This PR aims at fixing the redirection issue where only URLs starting with `http` are allowed.
With the modified behavior, it is now allowed to use any URL scheme. It will be possible to redirect to `android-app://com.google.android.gm/`.

~In addition, it prevents the redirection to the following URLs:~

* ~With path traversal e.g. `https://example.com/foo/../../.htpasswd`~
* ~With protocol-relative e.g. `//malicious.app/foo/bar`~
