### PR TITLE
[DomCrawler] Fix Crawler::filter throw phpdoc

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -778,7 +778,7 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * @return static
      *
-     * @throws \RuntimeException if the CssSelector Component is not available
+     * @throws \LogicException if the CssSelector Component is not available
      */
     public function filter(string $selector)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | not really (phpdoc-fix)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The `Crawler::filter` method is calling
```
$converter = $this->createCssSelectorConverter();
```
which is throwing a `LogicException` since https://github.com/symfony/symfony/pull/28536

So the phpdoc should be
```
@throws \LogicException if the CssSelector Component is not available
```
and not
```
@throws \RuntimeException if the CssSelector Component is not available
```