### PR TITLE
[Serializer] Remove abstract uid denormalization code

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -5,4 +5,8 @@ Symfony 6.4 and Symfony 7.0 will be released simultaneously at the end of Novemb
 release process, both versions will have the same features, but Symfony 7.0 won't include any deprecated features.
 To upgrade, make sure to resolve all deprecation notices.
 
-This file will be updated on the branch 7.0 for each deprecated feature that is removed.
+Serializer
+----------
+
+* Remove denormalization support for `AbstractUid` in `UidNormalizer`, use one of `AbstractUid` child class instead
+* Denormalizing to an abstract class in `UidNormalizer` now throws an `\Error`

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Remove denormalization support for `AbstractUid` in `UidNormalizer`, use one of `AbstractUid` child class instead
+ * Denormalizing to an abstract class in `UidNormalizer` now throws an `\Error`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -15,7 +15,6 @@ use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Uid\AbstractUid;
-use Symfony\Component\Uid\Uuid;
 
 final class UidNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {
@@ -70,32 +69,14 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         try {
-            if (AbstractUid::class === $type) {
-                trigger_deprecation('symfony/serializer', '6.1', 'Denormalizing to an abstract class in "%s" is deprecated.', __CLASS__);
-
-                return Uuid::fromString($data);
-            }
-
             return $type::fromString($data);
         } catch (\InvalidArgumentException|\TypeError) {
             throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('The data is not a valid "%s" string representation.', $type), $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
-        } catch (\Error $e) { // @deprecated remove this catch block in 7.0
-            if (str_starts_with($e->getMessage(), 'Cannot instantiate abstract class')) {
-                return $this->denormalize($data, AbstractUid::class, $format, $context);
-            }
-
-            throw $e;
         }
     }
 
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
-        if (AbstractUid::class === $type) {
-            trigger_deprecation('symfony/serializer', '6.1', 'Supporting denormalization for the "%s" type in "%s" is deprecated, use one of "%s" child class instead.', AbstractUid::class, __CLASS__, AbstractUid::class);
-
-            return true;
-        }
-
         return is_subclass_of($type, AbstractUid::class, true);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/UidNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/UidNormalizerTest.php
@@ -146,14 +146,9 @@ class UidNormalizerTest extends TestCase
         $this->assertFalse($this->normalizer->supportsDenormalization('foo', \stdClass::class));
     }
 
-    /**
-     * @group legacy
-     */
     public function testSupportOurAbstractUid()
     {
-        $this->expectDeprecation('Since symfony/serializer 6.1: Supporting denormalization for the "Symfony\Component\Uid\AbstractUid" type in "Symfony\Component\Serializer\Normalizer\UidNormalizer" is deprecated, use one of "Symfony\Component\Uid\AbstractUid" child class instead.');
-
-        $this->assertTrue($this->normalizer->supportsDenormalization('1ea6ecef-eb9a-66fe-b62b-957b45f17e43', AbstractUid::class));
+        $this->assertFalse($this->normalizer->supportsDenormalization('1ea6ecef-eb9a-66fe-b62b-957b45f17e43', AbstractUid::class));
     }
 
     public function testSupportCustomAbstractUid()
@@ -169,22 +164,18 @@ class UidNormalizerTest extends TestCase
         $this->assertEquals($class::fromString($uuidString), $this->normalizer->denormalize($uuidString, $class));
     }
 
-    /**
-     * @group legacy
-     */
     public function testDenormalizeOurAbstractUid()
     {
-        $this->expectDeprecation('Since symfony/serializer 6.1: Denormalizing to an abstract class in "Symfony\Component\Serializer\Normalizer\UidNormalizer" is deprecated.');
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot call abstract method Symfony\Component\Uid\AbstractUid::fromString()');
 
         $this->assertEquals(Uuid::fromString($uuidString = '1ea6ecef-eb9a-66fe-b62b-957b45f17e43'), $this->normalizer->denormalize($uuidString, AbstractUid::class));
     }
 
-    /**
-     * @group legacy
-     */
     public function testDenormalizeCustomAbstractUid()
     {
-        $this->expectDeprecation('Since symfony/serializer 6.1: Denormalizing to an abstract class in "Symfony\Component\Serializer\Normalizer\UidNormalizer" is deprecated.');
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot instantiate abstract class Symfony\Component\Serializer\Tests\Normalizer\TestAbstractCustomUid');
 
         $this->assertEquals(Uuid::fromString($uuidString = '1ea6ecef-eb9a-66fe-b62b-957b45f17e43'), $this->normalizer->denormalize($uuidString, TestAbstractCustomUid::class));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Removes the code that was deprecated in https://github.com/symfony/symfony/pull/44721