### PR TITLE
[DependencyInjection] Support PHP 8.2 `true` and `null` type

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -308,6 +308,10 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
             if (false === $value) {
                 return;
             }
+        } elseif ('true' === $type) {
+            if (true === $value) {
+                return;
+            }
         } elseif ($reflectionType->isBuiltin()) {
             $checkFunction = sprintf('is_%s', $type);
             if ($checkFunction($value)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPa
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\FooObject;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\IntersectionConstructor;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\UnionConstructor;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\UnionConstructorPHP82;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\Waldo;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\WaldoFoo;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\Wobble;
@@ -862,6 +863,26 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $container->register('union', UnionConstructor::class)
             ->setFactory([UnionConstructor::class, 'create'])
             ->setArguments([false]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testUnionTypePassesWithTrue()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('unionTrue', UnionConstructorPHP82::class)
+            ->setFactory([UnionConstructorPHP82::class, 'createTrue'])
+            ->setArguments([true]);
+
+        $container->register('unionNull', UnionConstructorPHP82::class)
+            ->setFactory([UnionConstructorPHP82::class, 'createNull'])
+            ->setArguments([null]);
 
         (new CheckTypeDeclarationsPass(true))->process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/UnionConstructorPHP82.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/UnionConstructorPHP82.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass;
+
+class UnionConstructorPHP82
+{
+    public static function createTrue(array|true $arg): static
+    {
+        return new static(0);
+    }
+
+    public static function createNull(null $arg): static
+    {
+        return new static(0);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      |yes
| New feature?  |no 
| Deprecations? |no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

https://stitcher.io/blog/new-in-php-82#null,--true,-and-false-as-standalone-types-rfc
