### PR TITLE
[PhpUnitBridge] Ignore deprecations about the annotation mapping driver when it's not possible to move to the attribute driver yet

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -14,7 +14,7 @@ use Doctrine\Deprecations\Deprecation;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
 // Detect if we need to serialize deprecations to a file.
-if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true) && $file = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
+if (in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && $file = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
     DeprecationErrorHandler::collectDeprecations($file);
 
     return;
@@ -34,6 +34,11 @@ setlocale(\LC_ALL, 'C');
 
 if (class_exists(Deprecation::class)) {
     Deprecation::withoutDeduplication();
+
+    if (\PHP_VERSION_ID < 80000) {
+        // Ignore deprecations about the annotation mapping driver when it's not possible to move to the attribute driver yet
+        Deprecation::ignoreDeprecations('https://github.com/doctrine/orm/issues/10098');
+    }
 }
 
 if (!class_exists(AnnotationRegistry::class, false) && class_exists(AnnotationRegistry::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -