### PR TITLE
[Scheduler] Allow setting cron expression next run date timezone

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Allow setting timezone of next run date in CronExpressionTrigger
+
 6.3
 ---
 

--- a/src/Symfony/Component/Scheduler/RecurringMessage.php
+++ b/src/Symfony/Component/Scheduler/RecurringMessage.php
@@ -48,17 +48,17 @@ final class RecurringMessage
         return new self(new PeriodicalTrigger($frequency, $from, $until), $message);
     }
 
-    public static function cron(string $expression, object $message): self
+    public static function cron(string $expression, object $message, \DateTimeZone|string $timezone = null): self
     {
         if (!str_contains($expression, '#')) {
-            return new self(CronExpressionTrigger::fromSpec($expression), $message);
+            return new self(CronExpressionTrigger::fromSpec($expression, null, $timezone), $message);
         }
 
         if (!$message instanceof \Stringable) {
             throw new InvalidArgumentException('A message must be stringable to use "hashed" cron expressions.');
         }
 
-        return new self(CronExpressionTrigger::fromSpec($expression, (string) $message), $message);
+        return new self(CronExpressionTrigger::fromSpec($expression, (string) $message, $timezone), $message);
     }
 
     public static function trigger(TriggerInterface $trigger, object $message): self

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/CronExpressionTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/CronExpressionTriggerTest.php
@@ -96,4 +96,19 @@ class CronExpressionTriggerTest extends TestCase
         $this->assertSame('56 20 1 9 0', (string) CronExpressionTrigger::fromSpec('56 20 1 9 0', 'some context'));
         $this->assertSame('0 0 * * *', (string) CronExpressionTrigger::fromSpec('@daily'));
     }
+
+    public function testDefaultTimezone()
+    {
+        $now = new \DateTimeImmutable('Europe/Paris');
+        $trigger = CronExpressionTrigger::fromSpec('0 12 * * *');
+        $this->assertSame('Europe/Paris', $trigger->getNextRunDate($now)->getTimezone()->getName());
+    }
+
+    public function testTimezoneIsUsed()
+    {
+        $now = new \DateTimeImmutable('Europe/Paris');
+        $timezone = new \DateTimeZone('UTC');
+        $trigger = CronExpressionTrigger::fromSpec('0 12 * * *', null, $timezone);
+        $this->assertSame('UTC', $trigger->getNextRunDate($now)->getTimezone()->getName());
+    }
 }

--- a/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
@@ -46,9 +46,13 @@ final class CronExpressionTrigger implements TriggerInterface
         [0, 6],
     ];
 
+    private readonly ?string $timezone;
+
     public function __construct(
         private readonly CronExpression $expression = new CronExpression('* * * * *'),
+        \DateTimeZone|string $timezone = null,
     ) {
+        $this->timezone = $timezone instanceof \DateTimeZone ? $timezone->getName() : $timezone;
     }
 
     public function __toString(): string
@@ -56,26 +60,26 @@ final class CronExpressionTrigger implements TriggerInterface
         return $this->expression->getExpression();
     }
 
-    public static function fromSpec(string $expression = '* * * * *', string $context = null): self
+    public static function fromSpec(string $expression = '* * * * *', string $context = null, \DateTimeZone|string $timezone = null): self
     {
         if (!class_exists(CronExpression::class)) {
             throw new LogicException(sprintf('You cannot use "%s" as the "cron expression" package is not installed. Try running "composer require dragonmantank/cron-expression".', __CLASS__));
         }
 
         if (!str_contains($expression, '#')) {
-            return new self(new CronExpression($expression));
+            return new self(new CronExpression($expression), $timezone);
         }
 
         if (null === $context) {
             throw new LogicException('A context must be provided to use "hashed" cron expressions.');
         }
 
-        return new self(new CronExpression(self::parseHashed($expression, $context)));
+        return new self(new CronExpression(self::parseHashed($expression, $context)), $timezone);
     }
 
     public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable
     {
-        return \DateTimeImmutable::createFromInterface($this->expression->getNextRunDate($run));
+        return \DateTimeImmutable::createFromInterface($this->expression->getNextRunDate($run, timeZone: $this->timezone));
     }
 
     private static function parseHashed(string $expression, string $context): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        |  

Allow setting the timezone for the next run date derived from a cron expression.


This is my first contribution to an experimental component and therefor I am not familiar with the exact contribution guidelines.
As this component is experimental, I think it is ok to submit this PR against branch 6.3, right?

Im also not sure about the CHANGELOG.md entry I should make. Would I add this under the 6.3.1 section or where?
