### PR TITLE
[DoctrineBridge][Messenger] Add test cases for `MariaDBPlatform`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -140,13 +141,15 @@ final class UlidTypeTest extends TestCase
         $this->assertEquals($expectedDeclaration, $this->type->getSqlDeclaration(['length' => 36], $platform));
     }
 
-    public static function provideSqlDeclarations(): array
+    public static function provideSqlDeclarations(): \Generator
     {
-        return [
-            [new PostgreSQLPlatform(), 'UUID'],
-            [new SqlitePlatform(), 'BLOB'],
-            [new MySQLPlatform(), 'BINARY(16)'],
-        ];
+        yield [new PostgreSQLPlatform(), 'UUID'];
+        yield [new SqlitePlatform(), 'BLOB'];
+        yield [new MySQLPlatform(), 'BINARY(16)'];
+
+        if (class_exists(MariaDBPlatform::class)) {
+            yield [new MariaDBPlatform(), 'BINARY(16)'];
+        }
     }
 
     public function testRequiresSQLCommentHint()

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -152,13 +153,15 @@ final class UuidTypeTest extends TestCase
         $this->assertEquals($expectedDeclaration, $this->type->getSqlDeclaration(['length' => 36], $platform));
     }
 
-    public static function provideSqlDeclarations(): array
+    public static function provideSqlDeclarations(): \Generator
     {
-        return [
-            [new PostgreSQLPlatform(), 'UUID'],
-            [new SqlitePlatform(), 'BLOB'],
-            [new MySQLPlatform(), 'BINARY(16)'],
-        ];
+        yield [new PostgreSQLPlatform(), 'UUID'];
+        yield [new SqlitePlatform(), 'BLOB'];
+        yield [new MySQLPlatform(), 'BINARY(16)'];
+
+        if (class_exists(MariaDBPlatform::class)) {
+            yield [new MariaDBPlatform(), 'BINARY(16)'];
+        }
     }
 
     public function testRequiresSQLCommentHint()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
@@ -394,6 +395,13 @@ class ConnectionTest extends TestCase
             'SELECT m.* FROM messenger_messages m WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) ORDER BY available_at ASC LIMIT 1 FOR UPDATE',
         ];
 
+        if (class_exists(MariaDBPlatform::class)) {
+            yield 'MariaDB' => [
+                new MariaDBPlatform(),
+                'SELECT m.* FROM messenger_messages m WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) ORDER BY available_at ASC LIMIT 1 FOR UPDATE',
+            ];
+        }
+
         yield 'SQL Server' => [
             new SQLServer2012Platform(),
             'SELECT m.* FROM messenger_messages m WITH (UPDLOCK, ROWLOCK) WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) ORDER BY available_at ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY  ',
@@ -478,6 +486,13 @@ class ConnectionTest extends TestCase
             new MySQL57Platform(),
             'SELECT m.* FROM messenger_messages m WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) LIMIT 50',
         ];
+
+        if (class_exists(MariaDBPlatform::class)) {
+            yield 'MariaDB' => [
+                new MariaDBPlatform(),
+                'SELECT m.* FROM messenger_messages m WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) LIMIT 50',
+            ];
+        }
 
         yield 'SQL Server' => [
             new SQLServer2012Platform(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Backport from #50571
| License       | MIT
| Doc PR        | N/A

This PR adds test cases specifically for DBAL's `MariaDBPlatform` class. DBAL 4 will change the inheritance hierarchy for MySQL-like platforms, so having those tests might safe us one fine day.