### PR TITLE
[HttpClient] Remove final keyword on `AsyncResponse`

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class AsyncResponse implements ResponseInterface, StreamableInterface
+class AsyncResponse implements ResponseInterface, StreamableInterface
 {
     use CommonResponseTrait;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

In symfony < 6.3, it was possible to override HTTP response headers. See this [blog post](https://jolicode.com/blog/aggressive-caching-with-symfony-http-client) for a use case

With Symfony 6.3, this is not possible anymore. I created a reproducer here: https://github.com/lyrixx/test/tree/http-cache-pp

And @nicolas-grekas came with another solution: https://github.com/lyrixx/test/issues/11

So here we go!

