### PR TITLE
[Cache] Fix RedisTrait::createConnection for cluster

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Traits;
+
+use PHPUnit\Framework\SkippedTestSuiteError;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Traits\RedisTrait;
+
+class RedisTraitTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!getenv('REDIS_CLUSTER_HOSTS')) {
+            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+        }
+    }
+
+    /**
+     * @dataProvider provideCreateConnection
+     */
+    public function testCreateConnection(string $dsn, string $expectedClass)
+    {
+        if (!class_exists($expectedClass)) {
+            throw new SkippedTestSuiteError(sprintf('The "%s" class is required.', $expectedClass));
+        }
+        if (!getenv('REDIS_CLUSTER_HOSTS')) {
+            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+        }
+
+        $mock = self::getObjectForTrait(RedisTrait::class);
+        $connection = $mock::createConnection($dsn);
+
+        self::assertInstanceOf($expectedClass, $connection);
+    }
+
+    public static function provideCreateConnection(): array
+    {
+        $hosts = array_map(function ($host) { return sprintf('host[%s]', $host); }, explode(' ', getenv('REDIS_CLUSTER_HOSTS')));
+
+        return [
+            [
+                sprintf('redis:?%s&redis_cluster=1', $hosts[0]),
+                'RedisCluster',
+            ],
+            [
+                sprintf('redis:?%s&redis_cluster=true', $hosts[0]),
+                'RedisCluster',
+            ],
+            [
+                sprintf('redis:?%s', $hosts[0]),
+                'Redis',
+            ],
+            [
+                'dsn' => sprintf('redis:?%s', implode('&', \array_slice($hosts, 0, 2))),
+                'RedisArray',
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -174,6 +174,11 @@ trait RedisTrait
             throw new CacheException(sprintf('Redis Sentinel support requires the "predis/predis" package or the "redis" extension v5.2 or higher: "%s".', $dsn));
         }
 
+        if (isset($params['lazy'])) {
+            $params['lazy'] = filter_var($params['lazy'], \FILTER_VALIDATE_BOOLEAN);
+        }
+        $params['redis_cluster'] = filter_var($params['redis_cluster'], \FILTER_VALIDATE_BOOLEAN);
+
         if ($params['redis_cluster'] && isset($params['redis_sentinel'])) {
             throw new InvalidArgumentException(sprintf('Cannot use both "redis_cluster" and "redis_sentinel" at the same time: "%s".', $dsn));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | No
| Deprecations? | No
| Tickets       | Fix #50509
| License       | MIT
| Doc PR        | N/A

When the dsn contains `redis_cluster=1` or `redis_cluster=true` the value was not properly parsed, and the class generated was not the expected RedisCluster.

The reason is that the PHP core function `match` make a `===` check. 

So, as the dsn is a string, the `$params['redis_cluster']` needs to be force to a bool