### PR TITLE
[DoctrineBridge] Remove (wrong) PHPDoc on `ContainerAwareEventManager`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -63,9 +63,6 @@ class ContainerAwareEventManager extends EventManager
         }
     }
 
-    /**
-     * @return object[][]
-     */
     public function getListeners($event = null): array
     {
         if (null === $event) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR is a follow-up of the following discussion: https://github.com/symfony/symfony/pull/50575#discussion_r1221741882