### PR TITLE
[DependencyInjection] Don't ignore attributes on the actual decorator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -87,7 +87,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 $instanceofDef->setAbstract(true)->setParent($parent ?: '.abstract.instanceof.'.$id);
                 $parent = '.instanceof.'.$interface.'.'.$key.'.'.$id;
                 $container->setDefinition($parent, $instanceofDef);
-                $instanceofTags[] = $instanceofDef->getTags();
+                $instanceofTags[] = [$interface, $instanceofDef->getTags()];
                 $instanceofBindings = $instanceofDef->getBindings() + $instanceofBindings;
 
                 foreach ($instanceofDef->getMethodCalls() as $methodCall) {
@@ -126,8 +126,9 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
             // Don't add tags to service decorators
             $i = \count($instanceofTags);
             while (0 <= --$i) {
-                foreach ($instanceofTags[$i] as $k => $v) {
-                    if (null === $definition->getDecoratedService() || \in_array($k, $tagsToKeep, true)) {
+                [$interface, $tags] = $instanceofTags[$i];
+                foreach ($tags as $k => $v) {
+                    if (null === $definition->getDecoratedService() || $interface === $definition->getClass() || \in_array($k, $tagsToKeep, true)) {
                         foreach ($v as $v) {
                             if ($definition->hasTag($k) && \in_array($v, $definition->getTag($k))) {
                                 continue;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -318,6 +318,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $decorator->setDecoratedService('decorated');
         $decorator->setInstanceofConditionals([
             parent::class => (new ChildDefinition(''))->addTag('tag'),
+            self::class => (new ChildDefinition(''))->addTag('other-tag'),
         ]);
         $decorator->setAutoconfigured(true);
         $decorator->addTag('manual');
@@ -325,11 +326,18 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $container->registerForAutoconfiguration(parent::class)
             ->addTag('tag')
         ;
+        $container->registerForAutoconfiguration(self::class)
+            ->addTag('last-tag')
+        ;
 
         (new ResolveInstanceofConditionalsPass())->process($container);
         (new ResolveChildDefinitionsPass())->process($container);
 
-        $this->assertSame(['manual' => [[]]], $container->getDefinition('decorator')->getTags());
+        $this->assertSame([
+            'manual' => [[]],
+            'other-tag' => [[]],
+            'last-tag' => [[]],
+        ], $container->getDefinition('decorator')->getTags());
     }
 
     public function testDecoratorsKeepBehaviorDescribingTags()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49931
| License       | MIT
| Doc PR        | -

An attempt to fix #49931 without reintroducing the problem reported in #30391 and fixed by #30417. The idea here is that if the attribute is declared on the decorator itself, it shouldn't be ignored as it was explicitly added.