### PR TITLE
[DependencyInjection] Introduce "list" env var processor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
  * Deprecate `#[MapDecorated]`, use `#[AutowireDecorated]` instead
  * Deprecate the `@required` annotation, use the `Symfony\Contracts\Service\Attribute\Required` attribute instead
  * Add `constructor` option to services declaration and to `#[Autoconfigure]`
+ * Add `list` env var processor
 
 6.2
 ---

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -45,6 +45,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             'file' => 'string',
             'float' => 'float',
             'int' => 'int',
+            'list' => 'array',
             'json' => 'array',
             'key' => 'bool|int|float|string|array',
             'url' => 'array',
@@ -249,8 +250,9 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             return base64_decode(strtr($env, '-_', '+/'));
         }
 
-        if ('json' === $prefix) {
-            $env = json_decode($env, true);
+
+        if ('json' === $prefix || 'list' === $prefix) {
+            $env = json_decode($prefix === 'list' ?  "[$env]" : $env, true);
 
             if (\JSON_ERROR_NONE !== json_last_error()) {
                 throw new RuntimeException(sprintf('Invalid JSON in env var "%s": ', $name).json_last_error_msg());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -39,6 +39,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'file' => ['string'],
             'float' => ['float'],
             'int' => ['int'],
+            'list' => ['array'],
             'json' => ['array'],
             'key' => ['bool', 'int', 'float', 'string', 'array'],
             'url' => ['array'],

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -724,6 +724,31 @@ CSV;
         ];
     }
 
+    /**
+     * @dataProvider validList
+     */
+    public function testGetEnvList($value, $processed)
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $result = $processor->getEnv('list', "foo", function ($name) use ($value) {
+            $this->assertSame('foo', $name);
+
+            return $value;
+        });
+
+        $this->assertSame($processed, $result);
+    }
+
+    public static function validList()
+    {
+        return [
+            ['1', [1]],
+            ['"1", 2, 3.0, 1e1', ["1", 2, 3.0, 10.0]],
+            [null, null],
+        ];
+    }
+
     public function testEnvLoader()
     {
         $_ENV['BAZ_ENV_LOADER'] = '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#18402

This MR allows to take an arbitrary list of values seperated by comma and parse it as an array with each item typed.
The implementation is just a hack that wrap the list with hooks and parse it as json

```
parameters:
    env(VALUES): 1,2.0,3.1,1e1
    values: '%env(list:VALUES)%' # array(4) { [0]=> int(1) [1]=> float(2) [2]=> float(3.1) [3]=> float(10) }
```