### PR TITLE
[Mailer] Make Response optional for AbstractApiTransport::doSendApi

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
@@ -24,9 +24,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 abstract class AbstractApiTransport extends AbstractHttpTransport
 {
-    abstract protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface;
+    abstract protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ?ResponseInterface;
 
-    protected function doSendHttp(SentMessage $message): ResponseInterface
+    protected function doSendHttp(SentMessage $message): ?ResponseInterface
     {
         try {
             $email = MessageConverter::toEmail($message->getOriginalMessage());

--- a/src/Symfony/Component/Mailer/Transport/AbstractHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractHttpTransport.php
@@ -62,13 +62,13 @@ abstract class AbstractHttpTransport extends AbstractTransport
         return $this;
     }
 
-    abstract protected function doSendHttp(SentMessage $message): ResponseInterface;
+    abstract protected function doSendHttp(SentMessage $message): ?ResponseInterface;
 
     protected function doSend(SentMessage $message): void
     {
         try {
             $response = $this->doSendHttp($message);
-            $message->appendDebug($response->getInfo('debug') ?? '');
+            $message->appendDebug($response?->getInfo('debug') ?? '');
         } catch (HttpTransportException $e) {
             $e->appendDebug($e->getResponse()->getInfo('debug') ?? '');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When sending an http/api request you might
- Sometimes want to not send any request for X reasons
- Use a custom httpClient to send the request

In both of these situations, there is no response to return.

Since the response is just used for debug purpose, returning the response should not be a requirement and could be optional.