### PR TITLE
Run unit tests with PHP 8.3

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,11 +28,11 @@ jobs:
         include:
           - php: '7.2'
           - php: '7.4'
-          - php: '8.1'
-            mode: high-deps
-          - php: '8.1'
-            mode: low-deps
           - php: '8.2'
+            mode: high-deps
+          - php: '8.2'
+            mode: low-deps
+          - php: '8.3'
             #mode: experimental
       fail-fast: false
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -60,7 +60,7 @@
         "symfony/string": "^5.0|^6.0",
         "symfony/translation": "^5.3|^6.0",
         "symfony/twig-bundle": "^4.4|^5.0|^6.0",
-        "symfony/validator": "^5.2|^6.0",
+        "symfony/validator": "^5.3.11|^6.0",
         "symfony/workflow": "^5.2|^6.0",
         "symfony/yaml": "^4.4|^5.0|^6.0",
         "symfony/property-info": "^4.4|^5.0|^6.0",
@@ -93,7 +93,7 @@
         "symfony/translation": "<5.3",
         "symfony/twig-bridge": "<4.4",
         "symfony/twig-bundle": "<4.4",
-        "symfony/validator": "<5.2",
+        "symfony/validator": "<5.3.11",
         "symfony/web-profiler-bundle": "<4.4",
         "symfony/workflow": "<5.2"
     },

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.0.2|^2.0",
-        "symfony/console": "^4.4.30|^5.3.7|^6.0",
+        "symfony/console": "^4.4.30|^5.4.9|^6.0.9",
         "symfony/dotenv": "^5.1|^6.0",
         "symfony/http-foundation": "^4.4.30|^5.3.7|^6.0",
         "symfony/http-kernel": "^4.4.30|^5.3.7|^6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

It's that time of the year… PHP 8.3.0-alpha1 has been released, so we might start to test against that new version. Right now, it looks like PHP 8.3 will be a pretty boring release. The good kind of boring, of course!

This PR bumps the PHP 8.2 job to 8.3 and the high/low deps jobs from PHP 8.1 to 8.2. All dependency bumps in the component's composer.json files were done to fix test failures on the low-deps run.