### PR TITLE
Enable experimental mode for the PHP 8.3 build

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
           - php: '8.2'
             mode: low-deps
           - php: '8.3'
-            #mode: experimental
+            mode: experimental
       fail-fast: false
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Enabling experimental mode makes Composer ignore the upper boundary of PHP version constraints. We need this in order to install Laminas Code.