### PR TITLE
[Clock] Fix MockClock::modify() on PHP 8.3

### DIFF
--- a/src/Symfony/Component/Clock/MockClock.php
+++ b/src/Symfony/Component/Clock/MockClock.php
@@ -49,7 +49,12 @@ final class MockClock implements ClockInterface
 
     public function modify(string $modifier): void
     {
-        if (false === $modifiedNow = @$this->now->modify($modifier)) {
+        try {
+            $modifiedNow = @$this->now->modify($modifier);
+        } catch (\DateMalformedStringException) {
+            $modifiedNow = false;
+        }
+        if (false === $modifiedNow) {
             throw new \InvalidArgumentException(sprintf('Invalid modifier: "%s". Could not modify MockClock.', $modifier));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -