### PR TITLE
[EventDispatcher][DX] add a way to call a listener directly before or after another one

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Attribute/AsEventListener.php
+++ b/src/Symfony/Component/EventDispatcher/Attribute/AsEventListener.php
@@ -24,6 +24,8 @@ class AsEventListener
         public ?string $method = null,
         public int $priority = 0,
         public ?string $dispatcher = null,
+        public ?string $before = null,
+        public ?string $after = null,
     ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | will be done if feature gets accepted

When hooking into the event system, it's a common need to define the priority compared to another existing listener:
```php
// should occur BEFORE "router_listener"
#[AsEventListener(event: KernelEvents::REQUEST, priority: 33)]

// OR

// should occur AFTER "router_listener"
#[AsEventListener(event: KernelEvents::REQUEST, priority: 31)]
```
This is not optimal: without the comment it is not clear why the listener has the given priority.

I'd like to propose another approach, and introduce a new way to handle priorities between listeners:
```php
#[AsEventListener(event: KernelEvents::REQUEST, before: 'router_listener')] // the listener will occur before "router_listener"
#[AsEventListener(event: KernelEvents::REQUEST, after: 'router_listener')] // the listener will occur after "router_listener"
```

The idea here is to rely on the priority system and to define the priority of the new listener based on its "before" or "after" attributes (the priority computation would be recursive if the given before/after listener should also occur before/after another one). 
In the proposed implementation, the priorities for all listeners using before/after are computed in `RegisterListenersPass` before we loop over the listeners.

Here are some rules:
- if a listener uses before/after, it must listen the same event than the listener which is referenced
- a listener cannot have a priority configured and use before/after
- a listener cannot self-reference itself in "before" and "after"
- a listener cannot declare at the same time "before" and "after"
- we should detect circular references

Here is a first draft PR of the implementation, it's missing a lot of stuff:
- tests
- ability to define before/after in php, xml, yaml
- doing the same thing with subscribers (?)
- certainly some edge cases are not handled correctly here

at this point, I'd like to have early feedback about the idea and if it has some chances to be accepted.
If so, I'd also like to know if the given implementation is the way to go? I'm also wondering if this system should also be applied at other places where priorities are involved  -  for now I'd only go for listeners/subscribers because it's the main obvious place where this could be useful.

thanks for your feedbacks!