### PR TITLE
[DependencyInjection] Deprecate `ContainerAwareInterface`, `ContainerAwareTrait` and `ContainerAwareLoader`

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -8,31 +8,31 @@ git checkout src/Symfony/Contracts/Service/ResetInterface.php
 git checkout composer.json src/
 
 diff --git a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
-index ada5fcbd49..51af652f08 100644
+index 8b57ff111c..92febe31e8 100644
 --- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
 +++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
-@@ -51,5 +51,5 @@ class DoctrineDataCollector extends DataCollector
-      * @return void
+@@ -57,5 +57,5 @@ class DoctrineDataCollector extends DataCollector
+      * @deprecated since Symfony 6.4, use a DebugDataHolder instead.
       */
 -    public function addLogger(string $name, DebugStack $logger)
 +    public function addLogger(string $name, DebugStack $logger): void
      {
-         $this->loggers[$name] = $logger;
-@@ -59,5 +59,5 @@ class DoctrineDataCollector extends DataCollector
+         trigger_deprecation('symfony/doctrine-bridge', '6.4', '"%s()" is deprecated. Pass an instance of "%s" to the constructor instead.', __METHOD__, DebugDataHolder::class);
+@@ -67,5 +67,5 @@ class DoctrineDataCollector extends DataCollector
       * @return void
       */
 -    public function collect(Request $request, Response $response, \Throwable $exception = null)
 +    public function collect(Request $request, Response $response, \Throwable $exception = null): void
      {
          $this->data = [
-@@ -90,5 +90,5 @@ class DoctrineDataCollector extends DataCollector
+@@ -98,5 +98,5 @@ class DoctrineDataCollector extends DataCollector
       * @return void
       */
 -    public function reset()
 +    public function reset(): void
      {
          $this->data = [];
-@@ -119,5 +119,5 @@ class DoctrineDataCollector extends DataCollector
+@@ -127,5 +127,5 @@ class DoctrineDataCollector extends DataCollector
       * @return int
       */
 -    public function getQueryCount()
@@ -40,10 +40,10 @@ index ada5fcbd49..51af652f08 100644
      {
          return array_sum(array_map('count', $this->data['queries']));
 diff --git a/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php b/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
-index 4fa5057fe2..9e111adac5 100644
+index 448da935d9..06c97eb70c 100644
 --- a/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
 +++ b/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
-@@ -36,5 +36,5 @@ class ContainerAwareLoader extends Loader
+@@ -40,5 +40,5 @@ class ContainerAwareLoader extends Loader
       * @return void
       */
 -    public function addFixture(FixtureInterface $fixture)
@@ -202,10 +202,10 @@ index c096b558db..8d584900a9 100644
      {
          parent::configureOptions($resolver);
 diff --git a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
-index b2369e95d6..c33484608e 100644
+index d1a70f79d2..e052053918 100644
 --- a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
 +++ b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
-@@ -52,5 +52,5 @@ class DbalLogger implements SQLLogger
+@@ -56,5 +56,5 @@ class DbalLogger implements SQLLogger
       * @return void
       */
 -    protected function log(string $message, array $params)
@@ -502,7 +502,7 @@ index eadeafba55..4f1ca3bfef 100644
      {
          $configuration = new Configuration();
 diff --git a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
-index cdbb90a3a9..b137a12012 100644
+index 5083538709..82093403f1 100644
 --- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
 +++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
 @@ -56,5 +56,5 @@ class Application extends BaseApplication
@@ -512,7 +512,7 @@ index cdbb90a3a9..b137a12012 100644
 +    public function reset(): void
      {
          if ($this->kernel->getContainer()->has('services_resetter')) {
-@@ -144,5 +144,5 @@ class Application extends BaseApplication
+@@ -145,5 +145,5 @@ class Application extends BaseApplication
       * @return void
       */
 -    protected function registerCommands()
@@ -4127,20 +4127,20 @@ index 3ea2228b94..f1d7078383 100644
      {
          return require $file;
 diff --git a/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php b/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php
-index 084a321ab5..09fb37f3aa 100644
+index 9b3709c965..97b54712c9 100644
 --- a/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php
 +++ b/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php
-@@ -24,4 +24,4 @@ interface ContainerAwareInterface
+@@ -26,4 +26,4 @@ interface ContainerAwareInterface
       * @return void
       */
 -    public function setContainer(?ContainerInterface $container);
 +    public function setContainer(?ContainerInterface $container): void;
  }
 diff --git a/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php b/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
-index ac67b468c5..bc1e395810 100644
+index 4174fec8d0..f6a7b2da12 100644
 --- a/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
 +++ b/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
-@@ -27,5 +27,5 @@ trait ContainerAwareTrait
+@@ -31,5 +31,5 @@ trait ContainerAwareTrait
       * @return void
       */
 -    public function setContainer(ContainerInterface $container = null)
@@ -4698,7 +4698,7 @@ index f610b014a0..9458751c28 100644
 +    abstract protected function setNode(\DOMElement $node): void;
  }
 diff --git a/src/Symfony/Component/DomCrawler/Crawler.php b/src/Symfony/Component/DomCrawler/Crawler.php
-index 59eec3068c..b750e80938 100644
+index 274aeee5fc..ccf37dae8b 100644
 --- a/src/Symfony/Component/DomCrawler/Crawler.php
 +++ b/src/Symfony/Component/DomCrawler/Crawler.php
 @@ -96,5 +96,5 @@ class Crawler implements \Countable, \IteratorAggregate
@@ -8236,31 +8236,31 @@ index ed2189e4e7..28e90cdcf9 100644
  
      public function getMetadataBag(): MetadataBag;
 diff --git a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
-index 2ddf55f2cb..52049a92b4 100644
+index af21469b1c..7b024368c5 100644
 --- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
 +++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
-@@ -35,5 +35,5 @@ abstract class Bundle implements BundleInterface
+@@ -38,5 +38,5 @@ abstract class Bundle implements BundleInterface
       * @return void
       */
 -    public function boot()
 +    public function boot(): void
      {
      }
-@@ -42,5 +42,5 @@ abstract class Bundle implements BundleInterface
+@@ -45,5 +45,5 @@ abstract class Bundle implements BundleInterface
       * @return void
       */
 -    public function shutdown()
 +    public function shutdown(): void
      {
      }
-@@ -52,5 +52,5 @@ abstract class Bundle implements BundleInterface
+@@ -55,5 +55,5 @@ abstract class Bundle implements BundleInterface
       * @return void
       */
 -    public function build(ContainerBuilder $container)
 +    public function build(ContainerBuilder $container): void
      {
      }
-@@ -122,5 +122,5 @@ abstract class Bundle implements BundleInterface
+@@ -125,5 +125,5 @@ abstract class Bundle implements BundleInterface
       * @return void
       */
 -    public function registerCommands(Application $application)
@@ -8268,30 +8268,36 @@ index 2ddf55f2cb..52049a92b4 100644
      {
      }
 diff --git a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
-index 02cb9641db..abe408eb24 100644
+index fe200629f4..692c41ec53 100644
 --- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
 +++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
-@@ -28,5 +28,5 @@ interface BundleInterface extends ContainerAwareInterface
+@@ -29,5 +29,5 @@ interface BundleInterface extends ContainerAwareInterface
       * @return void
       */
 -    public function boot();
 +    public function boot(): void;
  
      /**
-@@ -35,5 +35,5 @@ interface BundleInterface extends ContainerAwareInterface
+@@ -36,5 +36,5 @@ interface BundleInterface extends ContainerAwareInterface
       * @return void
       */
 -    public function shutdown();
 +    public function shutdown(): void;
  
      /**
-@@ -44,5 +44,5 @@ interface BundleInterface extends ContainerAwareInterface
+@@ -45,5 +45,5 @@ interface BundleInterface extends ContainerAwareInterface
       * @return void
       */
 -    public function build(ContainerBuilder $container);
 +    public function build(ContainerBuilder $container): void;
  
      /**
+@@ -72,4 +72,4 @@ interface BundleInterface extends ContainerAwareInterface
+      * @return void
+      */
+-    public function setContainer(?ContainerInterface $container);
++    public function setContainer(?ContainerInterface $container): void;
+ }
 diff --git a/src/Symfony/Component/HttpKernel/CacheClearer/CacheClearerInterface.php b/src/Symfony/Component/HttpKernel/CacheClearer/CacheClearerInterface.php
 index 5ca4265624..1cb3611f8d 100644
 --- a/src/Symfony/Component/HttpKernel/CacheClearer/CacheClearerInterface.php
@@ -8964,7 +8970,7 @@ index 0f3630e7fe..ddf77b8a19 100644
      {
          return <<<'EOF'
 diff --git a/src/Symfony/Component/HttpKernel/Kernel.php b/src/Symfony/Component/HttpKernel/Kernel.php
-index 9d4c5f22b3..4030ab8b12 100644
+index c2d67c0f17..5c4841305b 100644
 --- a/src/Symfony/Component/HttpKernel/Kernel.php
 +++ b/src/Symfony/Component/HttpKernel/Kernel.php
 @@ -107,5 +107,5 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
@@ -10911,7 +10917,7 @@ index bde72c0eb0..3d6813e1d4 100644
      {
          if (!\is_array($config)) {
 diff --git a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
-index e92a5ea3d7..4a0af31349 100644
+index 0e740bdf6c..21b68e3600 100644
 --- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
 +++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
 @@ -54,5 +54,5 @@ EOF;

--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -1,12 +1,18 @@
 UPGRADE FROM 6.3 to 6.4
 =======================
 
+DependencyInjection
+-------------------
+
+ * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
+
 DoctrineBridge
 --------------
 
  * Deprecate `DbalLogger`, use a middleware instead
  * Deprecate not constructing `DoctrineDataCollector` with an instance of `DebugDataHolder`
  * Deprecate `DoctrineDataCollector::addLogger()`, use a `DebugDataHolder` instead
+ * Deprecate `ContainerAwareLoader`, use dependency injection in your fixtures instead
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate `DbalLogger`, use a middleware instead
  * Deprecate not constructing `DoctrineDataCollector` with an instance of `DebugDataHolder`
  * Deprecate `DoctrineDataCollector::addLogger()`, use a `DebugDataHolder` instead
+ * Deprecate `ContainerAwareLoader`, use dependency injection in your fixtures instead
 
 6.3
 ---

--- a/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
+++ b/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
@@ -16,12 +16,16 @@ use Doctrine\Common\DataFixtures\Loader;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+trigger_deprecation('symfony/dependency-injection', '6.4', '"%s" is deprecated, use dependency injection in your fixtures instead.', ContainerAwareLoader::class);
+
 /**
  * Doctrine data fixtures loader that injects the service container into
  * fixture objects that implement ContainerAwareInterface.
  *
  * Note: Use of this class requires the Doctrine data fixtures extension, which
  * is a suggested dependency for Symfony.
+ *
+ * @deprecated since Symfony 6.4, use dependency injection in your fixtures instead
  */
 class ContainerAwareLoader extends Loader
 {

--- a/src/Symfony/Bridge/Doctrine/Tests/DataFixtures/ContainerAwareLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataFixtures/ContainerAwareLoaderTest.php
@@ -16,6 +16,9 @@ use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\ContainerAwareFixture;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * @group legacy
+ */
 class ContainerAwareLoaderTest extends TestCase
 {
     public function testShouldSetContainerOnContainerAwareFixture()

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ContainerAwareFixture.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ContainerAwareFixture.php
@@ -16,6 +16,9 @@ use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * @deprecated since Symfony 6.4, to be removed in 7.0
+ */
 class ContainerAwareFixture implements FixtureInterface, ContainerAwareInterface
 {
     public ?ContainerInterface $container = null;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -115,6 +115,7 @@ class Application extends BaseApplication
         $command = parent::get($name);
 
         if ($command instanceof ContainerAwareInterface) {
+            trigger_deprecation('symfony/dependency-injection', '6.4', 'Relying on "%s" to get the container in "%s" is deprecated, register the command as a service and use dependency injection instead.', ContainerAwareInterface::class, get_debug_type($command));
             $command->setContainer($this->kernel->getContainer());
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -26,6 +26,7 @@ class ControllerResolver extends ContainerControllerResolver
         $controller = parent::instantiateController($class);
 
         if ($controller instanceof ContainerAwareInterface) {
+            trigger_deprecation('symfony/dependency-injection', '6.4', 'Relying on "%s" to get the container in "%s" is deprecated, register the controller as a service and use dependency injection instead.', ContainerAwareInterface::class, get_debug_type($controller));
             $controller->setContainer($this->container);
         }
         if ($controller instanceof AbstractController) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Psr\Container\ContainerInterface as Psr11ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver;
 use Symfony\Component\DependencyInjection\Container;
@@ -23,12 +24,18 @@ use Symfony\Component\HttpKernel\Tests\Controller\ContainerControllerResolverTes
 
 class ControllerResolverTest extends ContainerControllerResolverTest
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testGetControllerOnContainerAware()
     {
         $resolver = $this->createControllerResolver();
         $request = Request::create('/');
         $request->attributes->set('_controller', 'Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController::testAction');
 
+        $this->expectDeprecation('Since symfony/dependency-injection 6.4: Relying on "Symfony\Component\DependencyInjection\ContainerAwareInterface" to get the container in "Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController" is deprecated, register the controller as a service and use dependency injection instead.');
         $controller = $resolver->getController($request);
 
         $this->assertInstanceOf(ContainerAwareController::class, $controller[0]);
@@ -36,18 +43,25 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         $this->assertSame('testAction', $controller[1]);
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetControllerOnContainerAwareInvokable()
     {
         $resolver = $this->createControllerResolver();
         $request = Request::create('/');
         $request->attributes->set('_controller', 'Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController');
 
+        $this->expectDeprecation('Since symfony/dependency-injection 6.4: Relying on "Symfony\Component\DependencyInjection\ContainerAwareInterface" to get the container in "Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController" is deprecated, register the controller as a service and use dependency injection instead.');
         $controller = $resolver->getController($request);
 
         $this->assertInstanceOf(ContainerAwareController::class, $controller);
         $this->assertInstanceOf(ContainerInterface::class, $controller->getContainer());
     }
 
+    /**
+     * @group legacy
+     */
     public function testContainerAwareControllerGetsContainerWhenNotSet()
     {
         class_exists(AbstractControllerTest::class);
@@ -62,6 +76,7 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         $request = Request::create('/');
         $request->attributes->set('_controller', TestAbstractController::class.'::testAction');
 
+        $this->expectDeprecation('Since symfony/dependency-injection 6.4: Relying on "Symfony\Component\DependencyInjection\ContainerAwareInterface" to get the container in "Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController" is deprecated, register the controller as a service and use dependency injection instead.');
         $this->assertSame([$controller, 'testAction'], $resolver->getController($request));
         $this->assertSame($container, $controller->getContainer());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FragmentController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FragmentController.php
@@ -11,18 +11,14 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
 use Twig\Environment;
 
-class FragmentController implements ContainerAwareInterface
+class FragmentController
 {
-    use ContainerAwareTrait;
-
     public function indexAction(Environment $twig)
     {
         return new Response($twig->render('fragment.html.twig', ['bar' => new Bar()]));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/ProfilerController.php
@@ -11,14 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Response;
 
-class ProfilerController implements ContainerAwareInterface
+class ProfilerController
 {
-    use ContainerAwareTrait;
-
     public function indexAction()
     {
         return new Response('Hello');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SessionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SessionController.php
@@ -11,15 +11,16 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SessionController implements ContainerAwareInterface
+class SessionController
 {
-    use ContainerAwareTrait;
+    public function __construct(protected ContainerInterface $container)
+    {
+    }
 
     public function welcomeAction(Request $request, $name = null)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SubRequestController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SubRequestController.php
@@ -11,15 +11,16 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
-class SubRequestController implements ContainerAwareInterface
+class SubRequestController
 {
-    use ContainerAwareTrait;
+    public function __construct(private ContainerInterface $container)
+    {
+    }
 
     public function indexAction($handler)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SubRequestServiceResolutionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SubRequestServiceResolutionController.php
@@ -12,14 +12,15 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class SubRequestServiceResolutionController implements ContainerAwareInterface
+class SubRequestServiceResolutionController
 {
-    use ContainerAwareTrait;
+    public function __construct(private ContainerInterface $container)
+    {
+    }
 
     public function indexAction()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ControllerServiceResolution/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ControllerServiceResolution/config.yml
@@ -5,6 +5,7 @@ services:
     Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SubRequestServiceResolutionController:
         public: true
         tags: [controller.service_arguments]
+        arguments: ['@service_container']
 
     logger: { class: Psr\Log\NullLogger }
     Psr\Log\LoggerInterface: '@logger'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Session/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Session/config.yml
@@ -2,6 +2,14 @@ imports:
     - { resource: ./../config/default.yml }
 
 services:
+    _defaults:
+        bind:
+            Symfony\Component\DependencyInjection\ContainerInterface $container: '@service_container'
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SessionController:
+        tags:
+            - { name: controller.service_arguments }
+
     Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SubRequestController:
         tags:
             - { name: controller.service_arguments, action: indexAction, argument: handler, id: fragment.handler }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -21,7 +21,7 @@
         "ext-xml": "*",
         "symfony/cache": "^5.4|^6.0|^7.0",
         "symfony/config": "^6.1|^7.0",
-        "symfony/dependency-injection": "^6.3|^7.0",
+        "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^6.1|^7.0",
         "symfony/event-dispatcher": "^5.4|^6.0|^7.0",

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/SecuredPageBundle/Controller/AdminController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/SecuredPageBundle/Controller/AdminController.php
@@ -11,14 +11,10 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\SecuredPageBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Response;
 
-class AdminController implements ContainerAwareInterface
+class AdminController
 {
-    use ContainerAwareTrait;
-
     public function indexAction()
     {
         return new Response('admin');

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
+
 6.3
 ---
 

--- a/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\DependencyInjection;
  * ContainerAwareInterface should be implemented by classes that depends on a Container.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 6.4, use dependency injection instead
  */
 interface ContainerAwareInterface
 {

--- a/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+trigger_deprecation('symfony/dependency-injection', '6.4', '"%s" is deprecated, use dependency injection instead.', ContainerAwareTrait::class);
+
 /**
  * ContainerAware trait.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 6.4, use dependency injection instead
  */
 trait ContainerAwareTrait
 {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerAwareTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerAwareTraitTest.php
@@ -13,17 +13,16 @@ namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\ContainerAwareDummy;
 
+/**
+ * @group legacy
+ */
 class ContainerAwareTraitTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
-    /**
-     * @group legacy
-     */
     public function testSetContainerLegacy()
     {
         $container = $this->createMock(ContainerInterface::class);
@@ -33,7 +32,7 @@ class ContainerAwareTraitTest extends TestCase
 
         self::assertSame($container, $dummy->getContainer());
 
-        $this->expectDeprecation('Since symfony/dependency-injection 6.2: Calling "Symfony\Component\DependencyInjection\Tests\ContainerAwareDummy::setContainer()" without any arguments is deprecated, pass null explicitly instead.');
+        $this->expectDeprecation('Since symfony/dependency-injection 6.2: Calling "Symfony\Component\DependencyInjection\Tests\Fixtures\ContainerAwareDummy::setContainer()" without any arguments is deprecated, pass null explicitly instead.');
 
         $dummy->setContainer();
         self::assertNull($dummy->getContainer());
@@ -50,15 +49,5 @@ class ContainerAwareTraitTest extends TestCase
 
         $dummy->setContainer(null);
         self::assertNull($dummy->getContainer());
-    }
-}
-
-class ContainerAwareDummy implements ContainerAwareInterface
-{
-    use ContainerAwareTrait;
-
-    public function getContainer(): ?ContainerInterface
-    {
-        return $this->container;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ContainerAwareDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ContainerAwareDummy.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @deprecated since Symfony 6.4, to be removed in 7.0
+ */
+class ContainerAwareDummy implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getContainer(): ?ContainerInterface
+    {
+        return $this->container;
+    }
+}
+

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\HttpKernel\Bundle;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
@@ -24,12 +24,15 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
  */
 abstract class Bundle implements BundleInterface
 {
-    use ContainerAwareTrait;
-
     protected $name;
     protected $extension;
     protected $path;
     private string $namespace;
+
+    /**
+     * @var ContainerInterface|null
+     */
+    protected $container;
 
     /**
      * @return void
@@ -148,5 +151,10 @@ abstract class Bundle implements BundleInterface
         $pos = strrpos(static::class, '\\');
         $this->namespace = false === $pos ? '' : substr(static::class, 0, $pos);
         $this->name ??= false === $pos ? static::class : substr(static::class, $pos + 1);
+    }
+
+    public function setContainer(?ContainerInterface $container): void
+    {
+        $this->container = $container;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Bundle;
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
@@ -66,4 +67,9 @@ interface BundleInterface extends ContainerAwareInterface
      * The path should always be returned as a Unix path (with /).
      */
     public function getPath(): string;
+
+    /**
+     * @return void
+     */
+    public function setContainer(?ContainerInterface $container);
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -19,8 +19,6 @@ use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\ChildDefinition;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -545,9 +543,14 @@ class RegisterTestController
     }
 }
 
-class ContainerAwareRegisterTestController implements ContainerAwareInterface
+class ContainerAwareRegisterTestController
 {
-    use ContainerAwareTrait;
+    protected ?ContainerInterface $container;
+
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
 
     public function fooAction(ControllerDummy $bar)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

As discussed in https://github.com/symfony/symfony/pull/50578#discussion_r1224004179