### PR TITLE
[HttpFoundation] Make `SessionHandlerProxy` implement `SessionIdInterface`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -9,7 +9,8 @@ CHANGELOG
  * Add `UriSigner` from the HttpKernel component
  * Add `partitioned` flag to `Cookie` (CHIPS Cookie)
  * Add argument `bool $flush = true` to `Response::send()`
-* Make `MongoDbSessionHandler` instantiable with the mongodb extension directly
+ * Make `MongoDbSessionHandler` instantiable with the mongodb extension directly
+ * Make `SessionHandlerProxy` implement `SessionIdInterface`
 
 6.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Exception/SessionIdCreationException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/SessionIdCreationException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Exception;
+
+class SessionIdCreationException extends \RuntimeException
+{
+    public function __construct(string $message = 'Could not create a session id.', int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Proxy;
 
+use Symfony\Component\HttpFoundation\Exception\SessionIdCreationException;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
 
 /**
  * @author Drak <drak@zikula.org>
  */
-class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
+class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface, \SessionIdInterface
 {
     protected $handler;
 
@@ -72,5 +73,18 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
     public function updateTimestamp(#[\SensitiveParameter] string $sessionId, string $data): bool
     {
         return $this->handler instanceof \SessionUpdateTimestampHandlerInterface ? $this->handler->updateTimestamp($sessionId, $data) : $this->write($sessionId, $data);
+    }
+
+    public function create_sid(): string
+    {
+        if ($this->handler instanceof \SessionIdInterface) {
+            return $this->handler->create_sid();
+        }
+
+        if (!$id = session_create_id()) {
+            throw new SessionIdCreationException();
+        }
+
+        return $id;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -168,8 +168,26 @@ class SessionHandlerProxyTest extends TestCase
             [new SessionHandlerProxy(new StrictSessionHandler(new \SessionHandler()))],
         ];
     }
+
+    public function testCreateSid()
+    {
+        $mock = $this->createMock(SessionIdSessionHandler::class);
+        $mock->expects($this->once())
+            ->method('create_sid')
+            ->willReturn('a-valid-session-identifier');
+
+        $proxy = new SessionHandlerProxy($mock);
+        $this->assertSame('a-valid-session-identifier', $proxy->create_sid());
+
+        $this->proxy->create_sid();
+        $this->addToAssertionCount(1);
+    }
 }
 
 abstract class TestSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
+{
+}
+
+abstract class SessionIdSessionHandler implements \SessionHandlerInterface, \SessionIdInterface
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45186 and #50583
| License       | MIT
| Doc PR        | Not yet

Supersedes #47071

It is currently not easy to provide its own session ids because even if your handler implements `SessionIdInterface`, it will be wrapped in a `SessionHandlerProxy` which does not, so your `create_sid` method won’t be called.