### PR TITLE
[HttpClient] Postpone symfony/http-foundation < 6.3 conflict

### DIFF
--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -30,6 +30,21 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
 {
     use HttpClientTrait;
 
+    private const PRIVATE_SUBNETS = [
+        '127.0.0.0/8',    // RFC1700 (Loopback)
+        '10.0.0.0/8',     // RFC1918
+        '192.168.0.0/16', // RFC1918
+        '172.16.0.0/12',  // RFC1918
+        '169.254.0.0/16', // RFC3927
+        '0.0.0.0/8',      // RFC5735
+        '240.0.0.0/4',    // RFC1112
+        '::1/128',        // Loopback
+        'fc00::/7',       // Unique Local Address
+        'fe80::/10',      // Link Local Address
+        '::ffff:0:0/96',  // IPv4 translations
+        '::/128',         // Unspecified address
+    ];
+
     private HttpClientInterface $client;
     private string|array|null $subnets;
 
@@ -59,7 +74,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets): void {
             static $lastPrimaryIp = '';
             if ($info['primary_ip'] !== $lastPrimaryIp) {
-                if ($info['primary_ip'] && IpUtils::checkIp($info['primary_ip'], $subnets ?? IpUtils::PRIVATE_SUBNETS)) {
+                if ($info['primary_ip'] && IpUtils::checkIp($info['primary_ip'], $subnets ?? self::PRIVATE_SUBNETS)) {
                     throw new TransportException(sprintf('IP "%s" is blocked for "%s".', $info['primary_ip'], $info['url']));
                 }
 

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -43,8 +43,7 @@
         "symfony/stopwatch": "^5.4|^6.0"
     },
     "conflict": {
-        "php-http/discovery": "<1.15",
-        "symfony/http-foundation": "<6.3"
+        "php-http/discovery": "<1.15"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpClient\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I'd like to postpone the conflict introduced in https://github.com/symfony/symfony/pull/49726 until 7.0.

The reason is that it was added for a very tiny particular case but it prevents bumping symfony/http-client to 6.3 for all Laravel users.
The current Laravel major version requires symfony/http-foundation:^6.2 and it won't change until February 2024 (it should be ^7.0) by then.