### PR TITLE
[FrameworkBundle] Fixed parsing new JSON output of debug:config not possible

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -88,12 +88,25 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
      * @testWith [true]
      *           [false]
      */
+    public function testDumpWithoutTitleIsValidJson(bool $debug)
+    {
+        $tester = $this->createCommandTester($debug);
+        $ret = $tester->execute(['name' => 'TestBundle', '--format' => 'json']);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertJson($tester->getDisplay());
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
     public function testDumpWithUnsupportedFormat(bool $debug)
     {
         $tester = $this->createCommandTester($debug);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Supported formats are "yaml", "json"');
+        $this->expectExceptionMessage('Supported formats are "txt", "yaml", "json"');
 
         $tester->execute([
             'name' => 'test',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

See my comment to the original PR which introduced `debug:config --format=json`: https://github.com/symfony/symfony/pull/48457#issuecomment-1534780396

Currently, it's not possible to parse the JSON output (neither is the YAML) which makes `--format=json` kind of pointless. The argument against this - I guess - is that the JSON format was introduced to make the command independent from the YAML component but still, why is `--format` an option then?

So I guess by delivering an additional option, we can fix this issue and make it parsable.

(Maybe instead of having `--no-tilte` we should call it `parsable` in the first place so that if in the future there's something on top of the title, the option would still be valid?)
