### PR TITLE
[FrameworkBundle][Routing] Throw error on debug:router when requirement matching no variable in path regex

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -107,6 +108,7 @@ EOF
             if (!$route) {
                 throw new InvalidArgumentException(sprintf('The route "%s" does not exist.', $name));
             }
+            $this->checkRouteValidity($route, $name);
 
             $helper->describe($io, $route, [
                 'format' => $input->getOption('format'),
@@ -168,5 +170,14 @@ EOF
     private function getAvailableFormatOptions(): array
     {
         return (new DescriptorHelper())->getFormats();
+    }
+
+    private function checkRouteValidity(Route $route, string $name): void
+    {
+        foreach (array_keys($route->getRequirements()) as $requirementName) {
+            if (!in_array($requirementName, $route->compile()->getPathVariables())) {
+                throw new \LogicException(sprintf('A requirement name ("%s" given) must match a path variable. You may have forgotten to add it, or there may be a typo in the configuration for route "%s" ?', $requirementName, $name));
+            }
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -208,6 +208,7 @@ class JsonDescriptor extends Descriptor
             'scheme' => $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY',
             'method' => $route->getMethods() ? implode('|', $route->getMethods()) : 'ANY',
             'class' => $route::class,
+            'variables' => $route->compile()->getVariables(),
             'defaults' => $route->getDefaults(),
             'requirements' => $route->getRequirements() ?: 'NO CUSTOM',
             'options' => $route->getOptions(),

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -52,6 +52,7 @@ class MarkdownDescriptor extends Descriptor
             ."\n".'- Scheme: '.($route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY')
             ."\n".'- Method: '.($route->getMethods() ? implode('|', $route->getMethods()) : 'ANY')
             ."\n".'- Class: '.$route::class
+            ."\n".'- Variables: '.$this->formatRouterConfig($route->compile()->getPathVariables())
             ."\n".'- Defaults: '.$this->formatRouterConfig($route->getDefaults())
             ."\n".'- Requirements: '.($route->getRequirements() ? $this->formatRouterConfig($route->getRequirements()) : 'NO CUSTOM')
             ."\n".'- Options: '.$this->formatRouterConfig($route->getOptions());

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -97,6 +97,7 @@ class TextDescriptor extends Descriptor
             ['Host Regex', '' !== $route->getHost() ? $route->compile()->getHostRegex() : ''],
             ['Scheme', $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY'],
             ['Method', $route->getMethods() ? implode('|', $route->getMethods()) : 'ANY'],
+            ['Path Variables', $this->formatRouterConfig($route->compile()->getPathVariables())],
             ['Requirements', $route->getRequirements() ? $this->formatRouterConfig($route->getRequirements()) : 'NO CUSTOM'],
             ['Class', $route::class],
             ['Defaults', $this->formatRouterConfig($defaults)],

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -194,6 +194,15 @@ class XmlDescriptor extends Descriptor
             }
         }
 
+        $variables = $route->compile()->getPathVariables();
+        if (!empty($variables)) {
+            $routeXML->appendChild($variablesXML = $dom->createElement('variables'));
+            foreach ($variables as $variable) {
+                $variablesXML->appendChild($variableXML = $dom->createElement('variable'));
+                $variableXML->appendChild(new \DOMText($variable));
+            }
+        }
+
         $originRequirements = $requirements = $route->getRequirements();
         unset($requirements['_scheme'], $requirements['_method']);
         if ($requirements) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50461 
| License       | MIT
| Doc PR        | -

Hello,
In the current state of Routing, a requirement matching no variable in the path is simply ignored.
This may lead to misconfiguration : if a typo is made in the requirement name, it will just be ignored, without any warning.

I am not sure where an error should appear. On compilation, it will break projects having a misconfiguration. To do lesser damage, I think of throwing it when debugging an only route, but I fear it may not be really useful then.
I you have any review/advice, I am looking for it ! :-)
