### PR TITLE
[VarDumper] Dumping DateTime throws error if getTimezone is false

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -27,7 +27,7 @@ class DateCaster
     public static function castDateTime(\DateTimeInterface $d, array $a, Stub $stub, bool $isNested, int $filter)
     {
         $prefix = Caster::PREFIX_VIRTUAL;
-        $location = $d->getTimezone()->getLocation();
+        $location = $d->getTimezone() ? $d->getTimezone()->getLocation() : null;
         $fromNow = (new \DateTime())->diff($d);
 
         $title = $d->format('l, F j, Y')

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -90,6 +90,52 @@ EODUMP;
         ];
     }
 
+    /**
+     * @dataProvider provideNoTimezoneDateTimes
+     */
+    public function testCastDateTimeNoTimezone($time, $xDate, $xInfos)
+    {
+        $stub = new Stub();
+        $date = new NoTimezoneDate($time);
+        $cast = DateCaster::castDateTime($date, Caster::castObject($date, \DateTime::class), $stub, false, 0);
+
+        $xDump = <<<EODUMP
+array:1 [
+  "\\x00~\\x00date" => $xDate
+]
+EODUMP;
+
+        $this->assertDumpEquals($xDump, $cast);
+
+        $xDump = <<<EODUMP
+Symfony\Component\VarDumper\Caster\ConstStub {
+  +type: 1
+  +class: "$xDate"
+  +value: "%A$xInfos%A"
+  +cut: 0
+  +handle: 0
+  +refCount: 0
+  +position: 0
+  +attr: []
+}
+EODUMP;
+
+        $this->assertDumpMatchesFormat($xDump, $cast["\0~\0date"]);
+    }
+
+    public static function provideNoTimezoneDateTimes()
+    {
+        return [
+            ['2017-04-30 00:00:00.000000', '2017-04-30 00:00:00.0 +00:00', 'Sunday, April 30, 2017'],
+            ['2017-04-30 00:00:00.100000', '2017-04-30 00:00:00.100 +00:00', 'Sunday, April 30, 2017'],
+            ['2017-04-30 00:00:00.120000', '2017-04-30 00:00:00.120 +00:00', 'Sunday, April 30, 2017'],
+            ['2017-04-30 00:00:00.123000', '2017-04-30 00:00:00.123 +00:00', 'Sunday, April 30, 2017'],
+            ['2017-04-30 00:00:00.123400', '2017-04-30 00:00:00.123400 +00:00', 'Sunday, April 30, 2017'],
+            ['2017-04-30 00:00:00.123450', '2017-04-30 00:00:00.123450 +00:00', 'Sunday, April 30, 2017'],
+            ['2017-04-30 00:00:00.123456', '2017-04-30 00:00:00.123456 +00:00', 'Sunday, April 30, 2017'],
+        ];
+    }
+
     public function testCastDateTimeWithAdditionalChildProperty()
     {
         $stub = new Stub();
@@ -405,5 +451,17 @@ EODUMP;
         $interval->invert = $invert;
 
         return $interval;
+    }
+}
+
+class NoTimezoneDate extends \DateTime
+{
+    /**
+     * @return \DateTimeZone|false
+     */
+    #[\ReturnTypeWillChange]
+    public function getTimezone()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch? | 5.4
| Bug fix? | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        |  
----
**TL;DR:**
In case you have a DateTime object that returns false when calling `getTimezone()`, an error is thrown in DateCaster.

**Description**
So I have encountered this case when I have tried to dump a mocked DateTime object. The mock will not have a timezone making the `getTimezone()` method return false. I know that this is not really a bug, as a DateTime object not having a DateTimeZone should not be happening, but it is possible in case someone extends the DateTime object and overrides the `getTimezone()` method.
The error thrown is 'The DatetimeInterface object has not been correctly initialized by its constructor'

**How to reproduce**
```
class A extends \DateTime {
    public function getTimezone(): \DateTimeZone|false
    {
        return false;
    }
}
```
Dump the A class will cause an error.

**Final notes**
Even though this a special case, I still think that you should be able to dump a mocked DateTime.
I hope the description and everything is ok as this is my first pr here.

Cheers!
