### PR TITLE
[Validator] Add the `message` option to the `PasswordStrength` constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
@@ -40,13 +40,14 @@ final class PasswordStrength extends Constraint
 
     public int $minScore;
 
-    public function __construct(array $options = null, int $minScore = null, array $groups = null, mixed $payload = null)
+    public function __construct(array $options = null, int $minScore = null, array $groups = null, mixed $payload = null, string $message = null)
     {
         $options['minScore'] ??= self::STRENGTH_MEDIUM;
 
         parent::__construct($options, $groups, $payload);
 
         $this->minScore = $minScore ?? $this->minScore;
+        $this->message = $message ?? $this->message;
 
         if ($this->minScore < 1 || 4 < $this->minScore) {
             throw new ConstraintDefinitionException(sprintf('The parameter "minScore" of the "%s" constraint must be an integer between 1 and 4.', self::class));

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthTest.php
@@ -25,9 +25,10 @@ class PasswordStrengthTest extends TestCase
 
     public function testConstructorWithParameters()
     {
-        $constraint = new PasswordStrength(minScore: PasswordStrength::STRENGTH_STRONG);
+        $constraint = new PasswordStrength(minScore: PasswordStrength::STRENGTH_STRONG, message: 'This password should be strong.');
 
         $this->assertSame(PasswordStrength::STRENGTH_STRONG, $constraint->minScore);
+        $this->assertSame('This password should be strong.', $constraint->message);
     }
 
     public function testInvalidScoreOfZero()

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
@@ -77,5 +77,11 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
             'The password strength is too low. Please use a stronger password.',
             PasswordStrength::PASSWORD_STRENGTH_ERROR,
         ];
+        yield [
+            new PasswordStrength(message: 'This password should be strong.'),
+            'password',
+            'This password should be strong.',
+            PasswordStrength::PASSWORD_STRENGTH_ERROR,
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50651
| License       | MIT
| Doc PR        | No need