### PR TITLE
Revert "Respect isRetryable decision of the retry strategy for re-delivery"

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -123,8 +123,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
     private function shouldRetry(\Throwable $e, Envelope $envelope, RetryStrategyInterface $retryStrategy): bool
     {
-        $isRetryable = $retryStrategy->isRetryable($envelope, $e);
-        if ($isRetryable && $e instanceof RecoverableExceptionInterface) {
+        if ($e instanceof RecoverableExceptionInterface) {
             return true;
         }
 
@@ -133,7 +132,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
         if ($e instanceof HandlerFailedException) {
             $shouldNotRetry = true;
             foreach ($e->getNestedExceptions() as $nestedException) {
-                if ($isRetryable && $nestedException instanceof RecoverableExceptionInterface) {
+                if ($nestedException instanceof RecoverableExceptionInterface) {
                     return true;
                 }
 
@@ -151,7 +150,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
             return false;
         }
 
-        return $isRetryable;
+        return $retryStrategy->isRetryable($envelope, $e);
     }
 
     private function getRetryStrategyForTransport(string $alias): ?RetryStrategyInterface

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
@@ -63,32 +63,11 @@ class SendFailedMessageForRetryListenerTest extends TestCase
         $senderLocator->expects($this->once())->method('has')->willReturn(true);
         $senderLocator->expects($this->once())->method('get')->willReturn($sender);
         $retryStategy = $this->createMock(RetryStrategyInterface::class);
-        $retryStategy->expects($this->once())->method('isRetryable')->willReturn(true);
+        $retryStategy->expects($this->never())->method('isRetryable');
         $retryStategy->expects($this->once())->method('getWaitingTime')->willReturn(1000);
         $retryStrategyLocator = $this->createMock(ContainerInterface::class);
         $retryStrategyLocator->expects($this->once())->method('has')->willReturn(true);
         $retryStrategyLocator->expects($this->once())->method('get')->willReturn($retryStategy);
-
-        $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
-
-        $exception = new RecoverableMessageHandlingException('retry');
-        $envelope = new Envelope(new \stdClass());
-        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
-
-        $listener->onMessageFailed($event);
-    }
-
-    public function testRetryIsOnlyAllowedWhenPermittedByRetryStrategy()
-    {
-        $senderLocator = $this->createMock(ContainerInterface::class);
-        $senderLocator->expects($this->never())->method('has');
-        $senderLocator->expects($this->never())->method('get');
-        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
-        $retryStrategy->expects($this->once())->method('isRetryable')->willReturn(false);
-        $retryStrategy->expects($this->never())->method('getWaitingTime');
-        $retryStrategyLocator = $this->createMock(ContainerInterface::class);
-        $retryStrategyLocator->expects($this->once())->method('has')->willReturn(true);
-        $retryStrategyLocator->expects($this->once())->method('get')->willReturn($retryStrategy);
 
         $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Reverts #49063
| License       | MIT
| Doc PR        | 

Revert "[Messenger] Respect `isRetryable` decision of the retry strategy when deciding if failed message should be re-delivered"

This reverts #49063

The linked PR rendered `RecoverableExceptionInterface` useless - i.e. it would not retry indefinately as stated in the docs.

See the [discussion on the original PR](https://github.com/symfony/symfony/pull/49063#issuecomment-1571930211)