### PR TITLE
[Console] Add Table helper missing return types

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -2744,31 +2744,6 @@ index 8ebc84376b..4af2691707 100644
 +    protected function writeError(OutputInterface $output, \Exception $error): void
      {
          if ($output instanceof SymfonyStyle) {
-diff --git a/src/Symfony/Component/Console/Helper/Table.php b/src/Symfony/Component/Console/Helper/Table.php
-index cf714873f5..e16ffaf97d 100644
---- a/src/Symfony/Component/Console/Helper/Table.php
-+++ b/src/Symfony/Component/Console/Helper/Table.php
-@@ -70,5 +70,5 @@ class Table
-      * @return void
-      */
--    public static function setStyleDefinition(string $name, TableStyle $style)
-+    public static function setStyleDefinition(string $name, TableStyle $style): void
-     {
-         self::$styles ??= self::initStyles();
-@@ -195,5 +195,5 @@ class Table
-      * @return $this
-      */
--    public function setRows(array $rows)
-+    public function setRows(array $rows): static
-     {
-         $this->rows = [];
-@@ -316,5 +316,5 @@ class Table
-      * @return void
-      */
--    public function render()
-+    public function render(): void
-     {
-         $divider = new TableSeparator();
 diff --git a/src/Symfony/Component/Console/Input/ArgvInput.php b/src/Symfony/Component/Console/Input/ArgvInput.php
 index 59f9217ec5..77b402b7d7 100644
 --- a/src/Symfony/Component/Console/Input/ArgvInput.php

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -66,10 +66,8 @@ class Table
 
     /**
      * Sets a style definition.
-     *
-     * @return void
      */
-    public static function setStyleDefinition(string $name, TableStyle $style)
+    public static function setStyleDefinition(string $name, TableStyle $style): void
     {
         self::$styles ??= self::initStyles();
 
@@ -194,7 +192,7 @@ class Table
     /**
      * @return $this
      */
-    public function setRows(array $rows)
+    public function setRows(array $rows): static
     {
         $this->rows = [];
 
@@ -312,10 +310,8 @@ class Table
      *     | 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
      *     | 960-425-059-0 | The Lord of the Rings | J. R. R. Tolkien |
      *     +---------------+-----------------------+------------------+
-     *
-     * @return void
      */
-    public function render()
+    public function render(): void
     {
         $divider = new TableSeparator();
         $isCellWithColspan = static fn ($cell) => $cell instanceof TableCell && $cell->getColspan() >= 2;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |  -
| License       | MIT
| Doc PR        | -

This adds return types to Console Table class helper
