### PR TITLE
[Console] Add `SignalMap` to map signal value to its name

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add `SignalMap` to map signal value to its name
+
 6.3
 ---
 

--- a/src/Symfony/Component/Console/SignalRegistry/SignalMap.php
+++ b/src/Symfony/Component/Console/SignalRegistry/SignalMap.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\SignalRegistry;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class SignalMap
+{
+    private static array $map;
+
+    public static function getSignalName(int $signal): ?string
+    {
+        if (!\extension_loaded('pcntl')) {
+            return null;
+        }
+
+        if (!isset(self::$map)) {
+            $r = new \ReflectionExtension('pcntl');
+            $c = $r->getConstants();
+            $map = array_filter($c, fn ($k) => str_starts_with($k, 'SIG') && !str_starts_with($k, 'SIG_'), \ARRAY_FILTER_USE_KEY);
+            self::$map = array_flip($map);
+        }
+
+        return self::$map[$signal] ?? null;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/SignalRegistry/SignalMapTest.php
+++ b/src/Symfony/Component/Console/Tests/SignalRegistry/SignalMapTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\SignalRegistry;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\SignalRegistry\SignalMap;
+
+class SignalMapTest extends TestCase
+{
+    /**
+     * @requires extension pcntl
+     *
+     * @testWith [2, "SIGINT"]
+     *           [9, "SIGKILL"]
+     *           [15, "SIGTERM"]
+     */
+    public function testSignalExists(int $signal, string $expected)
+    {
+        $this->assertSame($expected, SignalMap::getSignalName($signal));
+    }
+
+    public function testSignalDoesNotExist()
+    {
+        $this->assertNull(SignalMap::getSignalName(999999));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |


I'm migrating some code to use new SF features, but I have a very little regression. 

Before :

```php
    private function setUpSignals(): void
    {
        pcntl_signal(\SIGTERM, function () {
            $this->stop('SIGTERM');
        });
        pcntl_signal(\SIGINT, function () {
            $this->stop('SIGINT');
        });

        pcntl_async_signals(true);
    }
```

Now:

```php
    public function handleSignal(int $signal): void
    {
        // I need the following line
        $signal = SignalMap::getSignalName($signal);
        $this->stop("Signal {$signal} received.");
    }
```

As you can see, now in my log I have an int (`2`, `15`), and not anymore `SIGTERM`, `SIGINT`.