### PR TITLE
[HttpFoundation] Default accessing structured request body to empty array

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1526,7 +1526,7 @@ class Request
     public function toArray(): array
     {
         if ('' === $content = $this->getContent()) {
-            throw new JsonException('Request body is empty.');
+            return [];
         }
 
         try {

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1279,9 +1279,7 @@ class RequestTest extends TestCase
     public function testToArrayEmpty()
     {
         $req = new Request();
-        $this->expectException(JsonException::class);
-        $this->expectExceptionMessage('Request body is empty.');
-        $req->toArray();
+        $this->assertSame([], $req->toArray());
     }
 
     public function testToArrayNonJson()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes-ish
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50647
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Similar like in PHP `$_POST` is always type array, and in Symfony `$request->request` is always array-able

The state can be checked by other means (headers, method, etc.), if nessecary