### PR TITLE
[FrameworkBundle] Ignore missing directories in about command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -109,6 +109,10 @@ EOT
         if (is_file($path)) {
             $size = filesize($path) ?: 0;
         } else {
+            if (!is_dir($path)) {
+                return 'n/a';
+            }
+
             $size = 0;
             foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS | \RecursiveDirectoryIterator::FOLLOW_SYMLINKS)) as $file) {
                 if ($file->isReadable()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes IMHO
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This fixes our CI when `var/log` is missing.

Before:

```
In AboutCommand.php line 105:
                                                                                                              
  [UnexpectedValueException]                                                                                  
  RecursiveDirectoryIterator::__construct(/app/var/log): Failed to open directory: No such file or directory  
```

After:
```
  Cache directory      ./var/cache/prod (939 KiB)  
  Build directory      ./var/cache/prod (939 KiB)  
  Log directory        ./var/log (n/a)   
```