### PR TITLE
Improve return type of `getProvidedServices` in `ServiceProviderInterface`

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceProviderInterface.php
+++ b/src/Symfony/Contracts/Service/ServiceProviderInterface.php
@@ -39,7 +39,7 @@ interface ServiceProviderInterface extends ContainerInterface
      *  * ['foo' => '?'] means the container provides service name "foo" of unspecified type
      *  * ['bar' => '?Bar\Baz'] means the container provides a service "bar" of type Bar\Baz|null
      *
-     * @return string[] The provided service types, keyed by service names
+     * @return array<string, string> The provided service types, keyed by service names
      */
     public function getProvidedServices(): array;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | maybe
| New feature?  | no
| Deprecations? | no
| License       | MIT

This describes better the shape of the array it returns.
