### PR TITLE
[Contracts/Deprecation] Allow screaming

### DIFF
--- a/src/Symfony/Contracts/Deprecation/function.php
+++ b/src/Symfony/Contracts/Deprecation/function.php
@@ -11,7 +11,7 @@
 
 if (!function_exists('trigger_deprecation')) {
     /**
-     * Triggers a silenced deprecation notice.
+     * Triggers a (silenced) deprecation notice.
      *
      * @param string $package The name of the Composer package that is triggering the deprecation
      * @param string $version The version of the package that introduced the deprecation
@@ -22,6 +22,12 @@ if (!function_exists('trigger_deprecation')) {
      */
     function trigger_deprecation(string $package, string $version, string $message, mixed ...$args): void
     {
-        @trigger_error(($package || $version ? "Since $package $version: " : '').($args ? vsprintf($message, $args) : $message), \E_USER_DEPRECATED);
+        $error = ($package || $version ? "Since $package $version: " : '').($args ? vsprintf($message, $args) : $message);
+
+        if ((bool) ($_SERVER['SYMFONY_DEPRECATIONS_SCREAM'] ?? $_ENV['SYMFONY_DEPRECATIONS_SCREAM'] ?? false)) {
+            trigger_error($error, \E_USER_DEPRECATED);
+        } else {
+            @trigger_error($error, \E_USER_DEPRECATED);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This allows screaming deprecations, collected by symfony, using env var.

~Then in test env we can disable `framework.php_error.log` to handle them natively.~ This seems irrelevant, i think i misunderstood _"Use the application logger instead of the PHP logger for logging PHP errors."_.

Then in phpunit we can benefit from `displayDetailsOnTestsThatTriggerDeprecations`

Removing the `@` made it work.

But overriding the trigger_deprecation during test bootstrap did not work:

```
$ phpunit 
[15-Jun-2023 17:17:15 UTC] PHP Fatal error:  Cannot redeclare trigger_deprecation() (previously declared in /usr/local/etc/tools/vendor/symfony/deprecation-contracts/function.php:23) in /app/tests/bootstrap.php on line 5
```

