### PR TITLE
[Validator] Validate all groups when special group name `*` is specified in `validate()` method

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add the special group name `*` which can be passed to `ValidatorInterface::validate()` to validate all constraints, regardless of their group.
+
 6.3
 ---
 

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -209,8 +209,10 @@ class GenericMetadata implements MetadataInterface
             foreach ($this->constraintsByGroup as $groupConstraints) {
                 $constraints = array_merge($constraints, $groupConstraints);
             }
+
             return $constraints;
         }
+
         return $this->constraintsByGroup[$group] ?? [];
     }
 

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -204,6 +204,13 @@ class GenericMetadata implements MetadataInterface
      */
     public function findConstraints(string $group): array
     {
+        if ('*' === $group) {
+            $constraints = [];
+            foreach ($this->constraintsByGroup as $groupConstraints) {
+                $constraints = array_merge($constraints, $groupConstraints);
+            }
+            return $constraints;
+        }
         return $this->constraintsByGroup[$group] ?? [];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -1114,6 +1114,29 @@ class RecursiveValidatorTest extends TestCase
         $this->assertCount(2, $violations);
     }
 
+    public function testValidateAllGroups()
+    {
+        $entity = new Entity();
+
+        $callback = function ($value, ExecutionContextInterface $context) {
+            $context->addViolation('Message');
+        };
+
+        $this->metadata->addConstraint(new Callback([
+            'callback' => $callback,
+            'groups' => 'Group 1',
+        ]));
+        $this->metadata->addConstraint(new Callback([
+            'callback' => $callback,
+            'groups' => 'Group 2',
+        ]));
+
+        $violations = $this->validate($entity, null, '*');
+
+        /* @var ConstraintViolationInterface[] $violations */
+        $this->assertCount(2, $violations);
+    }
+
     public function testReplaceDefaultGroupByGroupSequenceObject()
     {
         $entity = new Entity();

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -1136,7 +1136,6 @@ class RecursiveValidatorTest extends TestCase
 
         $violations = $this->validate($entity, null, '*');
 
-        /* @var ConstraintViolationInterface[] $violations */
         $this->assertCount(3, $violations);
     }
 

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -1136,6 +1136,7 @@ class RecursiveValidatorTest extends TestCase
 
         $violations = $this->validate($entity, null, '*');
 
+        /* @var ConstraintViolationInterface[] $violations */
         $this->assertCount(3, $violations);
     }
 

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -1130,11 +1130,14 @@ class RecursiveValidatorTest extends TestCase
             'callback' => $callback,
             'groups' => 'Group 2',
         ]));
+        $this->metadata->addConstraint(new Callback([
+            'callback' => $callback,
+        ]));
 
         $violations = $this->validate($entity, null, '*');
 
         /* @var ConstraintViolationInterface[] $violations */
-        $this->assertCount(2, $violations);
+        $this->assertCount(3, $violations);
     }
 
     public function testReplaceDefaultGroupByGroupSequenceObject()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49932
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18420

Adds a special group name `*` which can be used with the validator to validate all groups on the object being validated. This is comparable to how the group name `*` can be used on `Serializer` component, ref. https://symfony.com/doc/current/components/serializer.html#attributes-groups