### PR TITLE
Mark class-constants as non-deprecated

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -38,8 +38,13 @@ use Symfony\Contracts\Service\ServiceProviderInterface;
  */
 class Security extends LegacySecurity
 {
+    /** @non-deprecated */
     public const ACCESS_DENIED_ERROR = SecurityRequestAttributes::ACCESS_DENIED_ERROR;
+
+    /** @non-deprecated */
     public const AUTHENTICATION_ERROR = SecurityRequestAttributes::AUTHENTICATION_ERROR;
+
+    /** @non-deprecated */
     public const LAST_USERNAME = SecurityRequestAttributes::LAST_USERNAME;
 
     public function __construct(private readonly ContainerInterface $container, private readonly array $authenticators = [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | none

Static analysis tools like PHPStan treat the `@deprecated` flag as inherited. So when a class constant is marked as deprecated, then the same class constant in an extending class is also marked deprecated unless it gets explicitly marked as `@non-deprecated`.

Without this flag PHPStan currenlty will return the message 

```
Fetching deprecated class constant LAST_USERNAME of class Symfony\Bundle\SecurityBundle\Security:                          
since Symfony 6.2, use \Symfony\Bundle\SecurityBundle\Security::LAST_USERNAME instead 
```
which is not really helpful as that is exactly what one did at that point.

By marking these class-constants as `@non-deprecated` PHPStan and other static analysis tools can recognize these class constants as being the rightly used ones.

For more information have a look at the discussion at https://github.com/phpstan/phpstan-deprecation-rules/issues/100