### PR TITLE
[Messenger] Don't mark `RedispatchMessage` as internal

### DIFF
--- a/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
+++ b/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
@@ -13,9 +13,6 @@ namespace Symfony\Component\Messenger\Message;
 
 use Symfony\Component\Messenger\Envelope;
 
-/**
- * @internal
- */
 final class RedispatchMessage
 {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

As discussed in https://github.com/symfony/symfony/pull/49734#issuecomment-1594344556, `RedispatchMessage` is meant to be used in your project, hence it shouldn't be marked as internal (which makes IDEs suggest not to use it).

