### PR TITLE
[Cache][DoctrineBridge][Lock][Messenger] Add parameter $isSameDatabase to configureSchema() methods

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -5,6 +5,11 @@ Symfony 6.4 and Symfony 7.0 will be released simultaneously at the end of Novemb
 release process, both versions will have the same features, but Symfony 7.0 won't include any deprecated features.
 To upgrade, make sure to resolve all deprecation notices.
 
+Cache
+-----
+
+ * Add parameter `$isSameDatabase` to `DoctrineDbalAdapter::configureSchema()`
+
 DoctrineBridge
 --------------
 
@@ -15,6 +20,17 @@ DoctrineBridge
  * Remove `DoctrineDataCollector::addLogger()`, use a `DebugDataHolder` instead
  * `ContainerAwareEventManager::getListeners()` must be called with an event name
  * DoctrineBridge now requires `doctrine/event-manager:^2`
+ * Add parameter `$isSameDatabase` to `DoctrineTokenProvider::configureSchema()`
+
+Lock
+----
+
+ * Add parameter `$isSameDatabase` to `DoctrineDbalStore::configureSchema()`
+
+Messenger
+---------
+
+ * Add parameter `$isSameDatabase` to `DoctrineTransport::configureSchema()`
 
 ProxyManagerBridge
 ------------------

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Remove `DoctrineDataCollector::addLogger()`, use a `DebugDataHolder` instead
  * `ContainerAwareEventManager::getListeners()` must be called with an event name
  * DoctrineBridge now requires `doctrine/event-manager:^2`
+ * Add parameter `$isSameDatabase` to `DoctrineTokenProvider::configureSchema()`
 
 6.4
 ---

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -179,16 +179,12 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
 
     /**
      * Adds the Table to the Schema if "remember me" uses this Connection.
-     *
-     * @param \Closure $isSameDatabase
      */
-    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */): void
+    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase): void
     {
         if ($schema->hasTable('rememberme_token')) {
             return;
         }
-
-        $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
 
         if ($forConnection !== $this->conn && !$isSameDatabase($this->conn->executeStatement(...))) {
             return;

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -117,16 +117,11 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
         }
     }
 
-    /**
-     * @param \Closure $isSameDatabase
-     */
-    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */): void
+    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase): void
     {
         if ($schema->hasTable($this->table)) {
             return;
         }
-
-        $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
 
         if ($forConnection !== $this->conn && !$isSameDatabase($this->conn->executeStatement(...))) {
             return;

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add parameter `$isSameDatabase` to `DoctrineDbalAdapter::configureSchema()`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add parameter `$isSameDatabase` to `DoctrineDbalStore::configureSchema()`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -199,7 +199,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
     public function createTable(): void
     {
         $schema = new Schema();
-        $this->configureSchema($schema);
+        $this->configureSchema($schema, static fn () => true);
 
         foreach ($schema->toSql($this->conn->getDatabasePlatform()) as $sql) {
             $this->conn->executeStatement($sql);
@@ -208,16 +208,12 @@ class DoctrineDbalStore implements PersistingStoreInterface
 
     /**
      * Adds the Table to the Schema if it doesn't exist.
-     *
-     * @param \Closure $isSameDatabase
      */
-    public function configureSchema(Schema $schema/* , \Closure $isSameDatabase */): void
+    public function configureSchema(Schema $schema, \Closure $isSameDatabase): void
     {
         if ($schema->hasTable($this->table)) {
             return;
         }
-
-        $isSameDatabase = 1 < \func_num_args() ? func_get_arg(1) : static fn () => true;
 
         if (!$isSameDatabase($this->conn->executeStatement(...))) {
             return;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -79,13 +79,9 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
 
     /**
      * Adds the Table to the Schema if this transport uses this connection.
-     *
-     * @param \Closure $isSameDatabase
      */
-    public function configureSchema(Schema $schema, DbalConnection $forConnection/* , \Closure $isSameDatabase */): void
+    public function configureSchema(Schema $schema, DbalConnection $forConnection, \Closure $isSameDatabase): void
     {
-        $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
-
         $this->connection->configureSchema($schema, $forConnection, $isSameDatabase);
     }
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add parameter `$isSameDatabase` to `DoctrineTransport::configureSchema()`
+
 6.3
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

$isSameDatabase parameter was introduced in https://github.com/symfony/symfony/pull/48059.
This PR aims to remove BC layer on configureSchema method and $isSameDatabase parameter

This parameter has been added in UPGRADE-6.3 in https://github.com/symfony/symfony/pull/50699