### PR TITLE
[HttpClient] Fix int conversion for GenericRetryStrategy with floated multiplier

### DIFF
--- a/src/Symfony/Component/HttpClient/Retry/GenericRetryStrategy.php
+++ b/src/Symfony/Component/HttpClient/Retry/GenericRetryStrategy.php
@@ -102,7 +102,7 @@ class GenericRetryStrategy implements RetryStrategyInterface
         $delay = $this->delayMs * $this->multiplier ** $context->getInfo('retry_count');
 
         if ($this->jitter > 0) {
-            $randomness = $delay * $this->jitter;
+            $randomness = (int) ($delay * $this->jitter);
             $delay = $delay + random_int(-$randomness, +$randomness);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

When we use floated multiplier, we have a deprecated message from php 8.1:
```
Deprecated: Implicit conversion from float -288.99999999999994 to int loses precision
Deprecated: Implicit conversion from float 288.99999999999994 to int loses precision
```

This PR add a int conversion before use [random_int](php.net/random_int)() function.