### PR TITLE
[DoctrineBridge] add missing UPGRADE notes for #50689 and update tests

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 6.2 to 6.3
 =======================
 
+Cache
+-----
+
+ * `DoctrineDbalAdapter` now takes an optional `$isSameDatabase` parameter
+
 Console
 -------
 
@@ -22,6 +27,8 @@ DoctrineBridge
  * Deprecate `DoctrineDbalCacheAdapterSchemaSubscriber` in favor of `DoctrineDbalCacheAdapterSchemaListener`
  * Deprecate `MessengerTransportDoctrineSchemaSubscriber` in favor of `MessengerTransportDoctrineSchemaListener`
  * Deprecate `RememberMeTokenProviderDoctrineSchemaSubscriber` in favor of `RememberMeTokenProviderDoctrineSchemaListener`
+ * `DoctrineTransport` now takes an optional `$isSameDatabase` parameter
+ * `DoctrineTokenProvider` now takes an optional `$isSameDatabase` parameter
 
 Form
 ----

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
@@ -35,7 +35,7 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
         $dbalAdapter = $this->createMock(DoctrineDbalAdapter::class);
         $dbalAdapter->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, $dbalConnection);
+            ->with($schema, $dbalConnection, fn () => true);
 
         $subscriber = new DoctrineDbalCacheAdapterSchemaListener([$dbalAdapter]);
         $subscriber->postGenerateSchema($event);

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
@@ -38,7 +38,7 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
         $doctrineTransport = $this->createMock(DoctrineTransport::class);
         $doctrineTransport->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, $dbalConnection);
+            ->with($schema, $dbalConnection, fn () => true);
         $otherTransport = $this->createMock(TransportInterface::class);
         $otherTransport->expects($this->never())
             ->method($this->anything());

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
@@ -64,9 +64,9 @@ class DoctrineTransportTest extends TestCase
 
         $connection->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, $dbalConnection);
+            ->with($schema, $dbalConnection, static fn () => true);
 
-        $transport->configureSchema($schema, $dbalConnection);
+        $transport->configureSchema($schema, $dbalConnection, static fn () => true);
     }
 
     private function getTransport(SerializerInterface $serializer = null, Connection $connection = null): DoctrineTransport


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | 


`$isSameDatabase` parameter was introduced in https://github.com/symfony/symfony/pull/48059. It has been added in order to know whether the database used by doctrine is the same as the one used by the component when integrating the latter with doctrine migrations.

Also related to https://github.com/symfony/symfony/pull/50689