### PR TITLE
Update return-type in Command.php

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -700,7 +700,7 @@ class Command
      * @throws LogicException           if no HelperSet is defined
      * @throws InvalidArgumentException if the helper is not defined
      */
-    public function getHelper(string $name): mixed
+    public function getHelper(string $name): HelperInterface
     {
         if (null === $this->helperSet) {
             throw new LogicException(sprintf('Cannot retrieve helper "%s" because there is no HelperSet defined. Did you forget to add your command to the application or to set the application on the command using the setApplication() method? You can also set the HelperSet directly using the setHelperSet() method.', $name));


### PR DESCRIPTION
Calling `Command::getHelper()` will either return an instance of `HelperInterface` or throw an `Exception`.

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

I was wondering by my IDE was acting up:

![](https://github.com/symfony/symfony/assets/47354551/92057ca9-f546-43c8-8f6f-8d99bed983e6)

Which was fixed by this docblock:

```php
 /** @var HelperInterface $helper */
$helper = $this->getHelper('question');
```

Looking further, I saw that `Command::getHelper()` will either return an instance of `\Symfony\Component\Console\Helper\HelperInterface` or throw an `\Symfony\Component\Console\Exception\InvalidArgumentException` when a question-helper was not found, thus making `mixed` obsolete.