### PR TITLE
[FrameworkBundle] Fix secrets:list not displaying local vars

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
@@ -86,7 +86,7 @@ EOF
         }
 
         foreach ($localSecrets ?? [] as $name => $value) {
-            if (isset($rows[$name]) && !\in_array($value, ['', false, null], true)) {
+            if (isset($rows[$name])) {
                 $rows[$name][] = $dump($value);
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
@@ -52,9 +52,9 @@ class DotenvVault extends AbstractVault
     {
         $this->lastMessage = null;
         $this->validateName($name);
-        $v = \is_string($_SERVER[$name] ?? null) && !str_starts_with($name, 'HTTP_') ? $_SERVER[$name] : ($_ENV[$name] ?? null);
+        $v = $_ENV[$name] ?? (str_starts_with($name, 'HTTP_') ? null : ($_SERVER[$name] ?? null));
 
-        if (null === $v) {
+        if ('' === ($v ?? '')) {
             $this->lastMessage = sprintf('Secret "%s" not found in "%s".', $name, $this->getPrettyPath($this->dotenvFile));
 
             return null;
@@ -89,13 +89,13 @@ class DotenvVault extends AbstractVault
         $secrets = [];
 
         foreach ($_ENV as $k => $v) {
-            if (preg_match('/^\w+$/D', $k)) {
+            if ('' !== ($v ?? '') && preg_match('/^\w+$/D', $k)) {
                 $secrets[$k] = $reveal ? $v : null;
             }
         }
 
         foreach ($_SERVER as $k => $v) {
-            if (\is_string($v) && preg_match('/^\w+$/D', $k)) {
+            if ('' !== ($v ?? '') && preg_match('/^\w+$/D', $k)) {
                 $secrets[$k] = $reveal ? $v : null;
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsListCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsListCommandTest.php
@@ -14,16 +14,22 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Command\SecretsListCommand;
 use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Bundle\FrameworkBundle\Secrets\DotenvVault;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class SecretsListCommandTest extends TestCase
 {
+    /**
+     * @backupGlobals enabled
+     */
     public function testExecute()
     {
         $vault = $this->createMock(AbstractVault::class);
         $vault->method('list')->willReturn(['A' => 'a', 'B' => 'b', 'C' => null, 'D' => null, 'E' => null]);
-        $localVault = $this->createMock(AbstractVault::class);
-        $localVault->method('list')->willReturn(['A' => '', 'B' => 'A', 'C' => '', 'D' => false, 'E' => null]);
+
+        $_ENV = ['A' => '', 'B' => 'A', 'C' => '', 'D' => false, 'E' => null];
+        $localVault = new DotenvVault('/not/a/path');
+
         $command = new SecretsListCommand($vault, $localVault);
         $tester = new CommandTester($command);
         $this->assertSame(0, $tester->execute([]));
@@ -37,9 +43,9 @@ class SecretsListCommandTest extends TestCase
               Secret   Value    Local Value
              -------- -------- -------------
               A        "a"
-              B        "b"      "A"
+              B        "b"      ******
               C        ******
-              D        ******
+              D        ******   ******
               E        ******
              -------- -------- -------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

My patch in #50301 was not correct.