### PR TITLE
[Messenger Doctrine] Fixed regression by #50524 causing data loss

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -482,7 +482,7 @@ class Connection implements ResetInterface
         $comparator = $this->createComparator($schemaManager);
         $schemaDiff = $this->compareSchemas($comparator, method_exists($schemaManager, 'introspectSchema') ? $schemaManager->introspectSchema() : $schemaManager->createSchema(), $this->getSchema());
         $platform = $this->driverConnection->getDatabasePlatform();
-        $queries = method_exists($platform, 'getAlterSchemaSQL') ? $platform->getAlterSchemaSQL($schemaDiff) : $schemaDiff->toSaveSql($platform);
+        $queries = $schemaDiff->toSaveSql($platform);
 
         foreach ($queries as $sql) {
             if (method_exists($this->driverConnection, 'executeStatement')) {


### PR DESCRIPTION
Regression caused by #50524 

When using `$platform->getAlterSchemaSQL($schemaDiff)` instead of `$schemaDiff->toSaveSql($platform)` causes to call `\Doctrine\DBAL\Schema\SchemaDiff::_toSql($platform, false)` instead of `\Doctrine\DBAL\Schema\SchemaDiff::_toSql($platform, true)`.  When $saveMode=false the diff from the schema is getting remove, so actually all other tables ... in the DB are getting deleted

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no >
| License       | MIT


Follow up to #50716 which was closed automatically by mistake 😊 