### PR TITLE
[DependencyInjection] Improve reporting named autowiring aliases

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -36,7 +36,7 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
         $tester->run(['command' => 'debug:autowiring']);
 
         $this->assertStringContainsString(HttpKernelInterface::class, $tester->getDisplay());
-        $this->assertStringContainsString('(http_kernel)', $tester->getDisplay());
+        $this->assertStringContainsString('alias:http_kernel', $tester->getDisplay());
     }
 
     public function testSearchArgument()

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * Allow using `#[Target]` with no arguments to state that a parameter must match a named autowiring alias
  * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
 
 6.3

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -448,14 +448,16 @@ class AutowirePass extends AbstractRecursivePass
             $type = implode($m[0], $types);
         }
 
-        $name = (array_filter($reference->getAttributes(), static fn ($a) => $a instanceof Target)[0] ?? null)?->name;
+        $name = $target = (array_filter($reference->getAttributes(), static fn ($a) => $a instanceof Target)[0] ?? null)?->name;
 
         if (null !== $name ??= $reference->getName()) {
-            if ($this->container->has($alias = $type.' $'.$name) && !$this->container->findDefinition($alias)->isAbstract()) {
+            $parsedName = (new Target($name))->getParsedName();
+
+            if ($this->container->has($alias = $type.' $'.$parsedName) && !$this->container->findDefinition($alias)->isAbstract()) {
                 return new TypedReference($alias, $type, $reference->getInvalidBehavior());
             }
 
-            if (null !== ($alias = $this->getCombinedAlias($type, $name) ?? null) && !$this->container->findDefinition($alias)->isAbstract()) {
+            if (null !== ($alias = $this->getCombinedAlias($type, $parsedName) ?? null) && !$this->container->findDefinition($alias)->isAbstract()) {
                 return new TypedReference($alias, $type, $reference->getInvalidBehavior());
             }
 
@@ -467,7 +469,7 @@ class AutowirePass extends AbstractRecursivePass
                 }
             }
 
-            if ($reference->getAttributes()) {
+            if (null !== $target) {
                 return null;
             }
         }
@@ -496,8 +498,10 @@ class AutowirePass extends AbstractRecursivePass
             $this->populateAvailableType($container, $id, $definition);
         }
 
+        $prev = null;
         foreach ($container->getAliases() as $id => $alias) {
-            $this->populateAutowiringAlias($id);
+            $this->populateAutowiringAlias($id, $prev);
+            $prev = $id;
         }
     }
 
@@ -596,13 +600,16 @@ class AutowirePass extends AbstractRecursivePass
             }
 
             $message = sprintf('has type "%s" but this class %s.', $type, $parentMsg ?: 'was not found');
-        } elseif ($reference->getAttributes()) {
-            $message = $label;
-            $label = sprintf('"#[Target(\'%s\')" on', $reference->getName());
         } else {
             $alternatives = $this->createTypeAlternatives($this->container, $reference);
-            $message = $this->container->has($type) ? 'this service is abstract' : 'no such service exists';
-            $message = sprintf('references %s "%s" but %s.%s', $r->isInterface() ? 'interface' : 'class', $type, $message, $alternatives);
+
+            if (null !== $target = (array_filter($reference->getAttributes(), static fn ($a) => $a instanceof Target)[0] ?? null)) {
+                $target = null !== $target->name ? "('{$target->name}')" : '';
+                $message = sprintf('has "#[Target%s]" but no such target exists.%s', $target, $alternatives);
+            } else {
+                $message = $this->container->has($type) ? 'this service is abstract' : 'no such service exists';
+                $message = sprintf('references %s "%s" but %s.%s', $r->isInterface() ? 'interface' : 'class', $type, $message, $alternatives);
+            }
 
             if ($r->isInterface() && !$alternatives) {
                 $message .= ' Did you create a class that implements this interface?';
@@ -630,8 +637,11 @@ class AutowirePass extends AbstractRecursivePass
         }
 
         $servicesAndAliases = $container->getServiceIds();
-        if (null !== ($autowiringAliases = $this->autowiringAliases[$type] ?? null) && !isset($autowiringAliases[''])) {
-            return sprintf(' Available autowiring aliases for this %s are: "$%s".', class_exists($type, false) ? 'class' : 'interface', implode('", "$', $autowiringAliases));
+        $autowiringAliases = $this->autowiringAliases[$type] ?? [];
+        unset($autowiringAliases['']);
+
+        if ($autowiringAliases) {
+            return sprintf(' Did you mean to target%s "%s" instead?', 1 < \count($autowiringAliases) ? ' one of' : '', implode('", "', $autowiringAliases));
         }
 
         if (!$container->has($type) && false !== $key = array_search(strtolower($type), array_map('strtolower', $servicesAndAliases))) {
@@ -673,7 +683,7 @@ class AutowirePass extends AbstractRecursivePass
         return null;
     }
 
-    private function populateAutowiringAlias(string $id): void
+    private function populateAutowiringAlias(string $id, string $target = null): void
     {
         if (!preg_match('/(?(DEFINE)(?<V>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))^((?&V)(?:\\\\(?&V))*+)(?: \$((?&V)))?$/', $id, $m)) {
             return;
@@ -683,6 +693,12 @@ class AutowirePass extends AbstractRecursivePass
         $name = $m[3] ?? '';
 
         if (class_exists($type, false) || interface_exists($type, false)) {
+            if (null !== $target && str_starts_with($target, '.'.$type.' $')
+                && (new Target($target = substr($target, \strlen($type) + 3)))->getParsedName() === $name
+            ) {
+                $name = $target;
+            }
+
             $this->autowiringAliases[$type][$name] = $name;
         }
     }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1382,13 +1382,21 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function registerAliasForArgument(string $id, string $type, string $name = null): Alias
     {
-        $name = (new Target($name ?? $id))->name;
+        $parsedName = (new Target($name ??= $id))->getParsedName();
 
-        if (!preg_match('/^[a-zA-Z_\x7f-\xff]/', $name)) {
-            throw new InvalidArgumentException(sprintf('Invalid argument name "%s" for service "%s": the first character must be a letter.', $name, $id));
+        if (!preg_match('/^[a-zA-Z_\x7f-\xff]/', $parsedName)) {
+            if ($id !== $name) {
+                $id = sprintf(' for service "%s"', $id);
+            }
+
+            throw new InvalidArgumentException(sprintf('Invalid argument name "%s"'.$id.': the first character must be a letter.', $name));
         }
 
-        return $this->setAlias($type.' $'.$name, $id);
+        if ($parsedName !== $name) {
+            $this->setAlias('.'.$type.' $'.$name, $type.' $'.$parsedName);
+        }
+
+        return $this->setAlias($type.' $'.$parsedName, $id);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\FooVariadic;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTargetAnonymous;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Component\ExpressionLanguage\Expression;
 
@@ -1240,12 +1241,27 @@ class AutowirePassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register(BarInterface::class, BarInterface::class);
-        $container->register(BarInterface::class.' $iamgeStorage', BarInterface::class);
+        $container->registerAliasForArgument('images.storage', BarInterface::class);
         $container->register('with_target', WithTarget::class)
             ->setAutowired(true);
 
         $this->expectException(AutowiringFailedException::class);
-        $this->expectExceptionMessage('Cannot autowire service "with_target": "#[Target(\'imageStorage\')" on argument "$bar" of method "Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget::__construct()"');
+        $this->expectExceptionMessage('Cannot autowire service "with_target": argument "$bar" of method "Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget::__construct()" has "#[Target(\'image.storage\')]" but no such target exists. Did you mean to target "images.storage" instead?');
+
+        (new AutowirePass())->process($container);
+    }
+
+    public function testArgumentWithTypoTargetAnonymous()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(BarInterface::class, BarInterface::class);
+        $container->registerAliasForArgument('bar', BarInterface::class);
+        $container->register('with_target', WithTargetAnonymous::class)
+            ->setAutowired(true);
+
+        $this->expectException(AutowiringFailedException::class);
+        $this->expectExceptionMessage('Cannot autowire service "with_target": argument "$baz" of method "Symfony\Component\DependencyInjection\Tests\Fixtures\WithTargetAnonymous::__construct()" has "#[Target(\'baz\')]" but no such target exists. Did you mean to target "bar" instead?');
 
         (new AutowirePass())->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -402,8 +402,8 @@ class RegisterServiceSubscribersPassTest extends TestCase
         (new AutowirePass())->process($container);
 
         $expected = [
-            'some.service' => new ServiceClosureArgument(new TypedReference('some.service', 'stdClass')),
-            'some_service' => new ServiceClosureArgument(new TypedReference('stdClass $some_service', 'stdClass')),
+            'some.service' => new ServiceClosureArgument(new TypedReference('stdClass $someService', 'stdClass')),
+            'some_service' => new ServiceClosureArgument(new TypedReference('stdClass $someService', 'stdClass')),
             'another_service' => new ServiceClosureArgument(new TypedReference('stdClass $anotherService', 'stdClass')),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1662,9 +1662,11 @@ class ContainerBuilderTest extends TestCase
 
         $container->registerAliasForArgument('Foo.bar_baz', 'Some\FooInterface');
         $this->assertEquals(new Alias('Foo.bar_baz'), $container->getAlias('Some\FooInterface $fooBarBaz'));
+        $this->assertEquals(new Alias('Some\FooInterface $fooBarBaz'), $container->getAlias('.Some\FooInterface $Foo.bar_baz'));
 
         $container->registerAliasForArgument('Foo.bar_baz', 'Some\FooInterface', 'Bar_baz.foo');
         $this->assertEquals(new Alias('Foo.bar_baz'), $container->getAlias('Some\FooInterface $barBazFoo'));
+        $this->assertEquals(new Alias('Some\FooInterface $barBazFoo'), $container->getAlias('.Some\FooInterface $Bar_baz.foo'));
     }
 
     public function testCaseSensitivity()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WithTargetAnonymous.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WithTargetAnonymous.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Target;
+
+class WithTargetAnonymous
+{
+    public function __construct(
+        #[Target]
+        BarInterface $baz
+    ) {
+    }
+}

--- a/src/Symfony/Component/Workflow/WorkflowInterface.php
+++ b/src/Symfony/Component/Workflow/WorkflowInterface.php
@@ -16,6 +16,8 @@ use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
 
 /**
+ * Describes a workflow instance.
+ *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  */
 interface WorkflowInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR started as a fix of #48707 to improve the error message reported when `#[Target]` is used with an invalid target, and ended up with many other related improvements:

- Allow using `#[Target]` with no arguments. This has the effect of throwing an exception if the name of the argument that has the attribute doesn't match a named autowiring alias.

- Improve the error message when a target doesn't match:

![image](https://github.com/symfony/symfony/assets/243674/e93bb23d-67e5-4c6f-9972-2d388124a7d9)

- Improve `debug:autowiring` to display the target name to use with `#[Target]`:

![image](https://github.com/symfony/symfony/assets/243674/951f5dae-9584-4cae-b60f-736afa824da0)
