### PR TITLE
[DependencyInjection] Allow using $schema in yaml config files

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
+ * Added support for `$schema` in Yaml config files
 
 6.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -799,7 +799,7 @@ class YamlFileLoader extends FileLoader
         }
 
         foreach ($content as $namespace => $data) {
-            if (\in_array($namespace, ['imports', 'parameters', 'services']) || str_starts_with($namespace, 'when@')) {
+            if (\in_array($namespace, ['imports', 'parameters', 'services', '$schema']) || str_starts_with($namespace, 'when@')) {
                 continue;
             }
 
@@ -942,7 +942,7 @@ class YamlFileLoader extends FileLoader
     private function loadFromExtensions(array $content): void
     {
         foreach ($content as $namespace => $values) {
-            if (\in_array($namespace, ['imports', 'parameters', 'services']) || str_starts_with($namespace, 'when@')) {
+            if (\in_array($namespace, ['imports', 'parameters', 'services', '$schema']) || str_starts_with($namespace, 'when@')) {
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/schema.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/schema.yml
@@ -1,0 +1,3 @@
+$schema: 'https://some-schema.org/schema.json'
+parameters:
+    foo: bar

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -1181,4 +1181,13 @@ class YamlFileLoaderTest extends TestCase
         $definition = $container->getDefinition('static_constructor');
         $this->assertEquals((new Definition('stdClass'))->setFactory([null, 'create']), $definition);
     }
+
+    public function testSchemaInYaml()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('schema.yml');
+
+        $this->assertEquals('bar', $container->getParameter('foo'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50721
| License       | MIT
| Doc PR        | 

Allows to specify `$schema` in config files to have autocomplete in config files.

Example:

```yaml
$schema: 'https://raw.githubusercontent.com/shopware/platform/trunk/config-schema.json'
shopware:
  <Autocomplete Key>
```