### PR TITLE
[DependencyInjection] Make better use of memory and CPU during auto-discovery

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -119,8 +119,26 @@ abstract class FileLoader extends BaseFileLoader
         $autoconfigureAttributes = new RegisterAutoconfigureAttributesPass();
         $autoconfigureAttributes = $autoconfigureAttributes->accept($prototype) ? $autoconfigureAttributes : null;
         $classes = $this->findClasses($namespace, $resource, (array) $exclude, $autoconfigureAttributes, $source);
-        // prepare for deep cloning
-        $serializedPrototype = serialize($prototype);
+
+        $getPrototype = static fn () => clone $prototype;
+        $serialized = serialize($prototype);
+
+        // avoid deep cloning if no definitions are nested
+        if (strpos($serialized, 'O:48:"Symfony\Component\DependencyInjection\Definition"', 55)
+            || strpos($serialized, 'O:53:"Symfony\Component\DependencyInjection\ChildDefinition"', 55)
+        ) {
+            // prepare for deep cloning
+            foreach (['Arguments', 'Properties', 'MethodCalls', 'Configurator', 'Factory', 'Bindings'] as $key) {
+                $serialized = serialize($prototype->{'get'.$key}());
+
+                if (strpos($serialized, 'O:48:"Symfony\Component\DependencyInjection\Definition"')
+                    || strpos($serialized, 'O:53:"Symfony\Component\DependencyInjection\ChildDefinition"')
+                ) {
+                    $getPrototype = static fn () => $getPrototype()->{'set'.$key}(unserialize($serialized));
+                }
+            }
+        }
+        unset($serialized);
 
         foreach ($classes as $class => $errorMessage) {
             if (null === $errorMessage && $autoconfigureAttributes) {
@@ -147,7 +165,7 @@ abstract class FileLoader extends BaseFileLoader
             if (interface_exists($class, false)) {
                 $this->interfaces[] = $class;
             } else {
-                $this->setDefinition($class, $definition = unserialize($serializedPrototype));
+                $this->setDefinition($class, $definition = $getPrototype());
                 if (null !== $errorMessage) {
                     $definition->addError($errorMessage);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While profiling an app with ~2600 auto-discovered services, I figured out that using `unserialize(serialize())` for deep cloning was a significant memory and CPU hog.

This patch skips deep-cloning when no definitions are nested in the prototype definition.

From 328 MB → 239 MB (-27%) as measured by Blackfire.io
From to 5.0s → 4.2s (-16%) (without Blackfire)

:rocket: 