### PR TITLE
[CssSelector] Tests on Xpath translator will always pass

### DIFF
--- a/src/Symfony/Component/CssSelector/Tests/XPath/Fixtures/ids.html
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/Fixtures/ids.html
@@ -45,4 +45,8 @@ c"></li>
 </div>
 <div id="foobar-div" foobar="ab bc
 cde"><span id="foobar-span"></span></div>
-</body></html>
+<section>
+    <span id="no-siblings-of-any-type"></span>
+</section>
+</body>
+</html>

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -114,7 +114,7 @@ class TranslatorTest extends TestCase
         $document->loadHTMLFile(__DIR__.'/Fixtures/ids.html');
         $document = simplexml_import_dom($document);
         $elements = $document->xpath($translator->cssToXPath($css));
-        $this->assertCount(\count($elementsId), $elementsId);
+        $this->assertCount(\count($elementsId), $elements);
         foreach ($elements as $element) {
             if (null !== $element->attributes()->id) {
                 $this->assertContains((string) $element->attributes()->id, $elementsId);
@@ -302,14 +302,14 @@ HTML
             ['li:nth-last-child(-n+1)', ['seventh-li']],
             ['li:nth-last-child(-n+3)', ['fifth-li', 'sixth-li', 'seventh-li']],
             ['ol:first-of-type', ['first-ol']],
-            ['ol:nth-child(1)', ['first-ol']],
+            ['ol:nth-child(4)', ['first-ol']],
             ['ol:nth-of-type(2)', ['second-ol']],
             ['ol:nth-last-of-type(1)', ['second-ol']],
-            ['span:only-child', ['foobar-span']],
+            ['span:only-child', ['foobar-span', 'no-siblings-of-any-type']],
             ['li div:only-child', ['li-div']],
             ['div *:only-child', ['li-div', 'foobar-span']],
             ['p:only-of-type', ['paragraph']],
-            [':only-of-type', ['html', 'li-div', 'foobar-span', 'paragraph']],
+            [':only-of-type', ['html', 'li-div', 'foobar-span', 'no-siblings-of-any-type']],
             ['div#foobar-div :only-of-type', ['foobar-span']],
             ['a:empty', ['name-anchor']],
             ['a:EMpty', ['name-anchor']],
@@ -318,8 +318,8 @@ HTML
             ['html:root', ['html']],
             ['li:root', []],
             ['* :root', []],
-            ['*:contains("link")', ['html', 'outer-div', 'tag-anchor', 'nofollow-anchor']],
-            [':CONtains("link")', ['html', 'outer-div', 'tag-anchor', 'nofollow-anchor']],
+            ['*:contains("link")', ['html', 'nil', 'outer-div', 'tag-anchor', 'nofollow-anchor']],
+            [':CONtains("link")', ['html', 'nil', 'outer-div', 'tag-anchor', 'nofollow-anchor']],
             ['*:contains("LInk")', []],  // case sensitive
             ['*:contains("e")', ['html', 'nil', 'outer-div', 'first-ol', 'first-li', 'paragraph', 'p-em']],
             ['*:contains("E")', []],  // case-sensitive


### PR DESCRIPTION
While working on another PR (https://github.com/symfony/symfony/pull/49388), I noticed that the assertion below will always pass as it is testing the count of the same array on both side.

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

Instead of
`$this->assertCount(\count($elementsId), $elementsId);`
It should be
`$this->assertCount(\count($elementsId), $elements);`

This PR should fix also numbers and/or Xpath translator issues from this fixed assertion. 

P.S.
This is the right PR for this issue (https://github.com/symfony/symfony/pull/50726)
