### PR TITLE
[Serializer] Refactor tests to not extends ObjectNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -724,6 +724,27 @@ class AbstractObjectNormalizerTest extends TestCase
 
         $this->assertSame(['propertyWithoutNullSkipNullValues' => 'foo'], $data);
     }
+
+    public function testDefaultExcludeFromCacheKey()
+    {
+        $object = new DummyChild();
+        $object->bar = 'not called';
+
+        $normalizer = new class(null, null, null, null, null, [AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY => ['foo']]) extends AbstractObjectNormalizerDummy {
+            public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+            {
+                AbstractObjectNormalizerTest::assertContains('foo', $this->defaultContext[ObjectNormalizer::EXCLUDE_FROM_CACHE_KEY]);
+                $data->bar = 'called';
+
+                return true;
+            }
+        };
+
+        $serializer = new Serializer([$normalizer]);
+        $serializer->normalize($object);
+
+        $this->assertSame('called', $object->bar);
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -680,19 +680,6 @@ class ObjectNormalizerTest extends TestCase
         }]));
     }
 
-    public function testDefaultExcludeFromCacheKey()
-    {
-        $normalizer = new class(null, null, null, null, null, null, [ObjectNormalizer::EXCLUDE_FROM_CACHE_KEY => ['foo']]) extends ObjectNormalizer {
-            protected function isCircularReference($object, &$context): bool
-            {
-                ObjectNormalizerTest::assertContains('foo', $this->defaultContext[ObjectNormalizer::EXCLUDE_FROM_CACHE_KEY]);
-
-                return false;
-            }
-        };
-        $normalizer->normalize(new ObjectDummy());
-    }
-
     public function testThrowUnexpectedValueException()
     {
         $this->expectException(UnexpectedValueException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

see https://github.com/symfony/symfony/pull/50660#discussion_r1230006241
