### PR TITLE
[DependencyInjection] Skip scanning scalar values in compiler passes when not needed

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -31,6 +31,7 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
      */
     protected $container;
     protected $currentId;
+    protected bool $skipScalars = false;
 
     private bool $processExpressions = false;
     private ExpressionLanguage $expressionLanguage;
@@ -77,6 +78,9 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
     {
         if (\is_array($value)) {
             foreach ($value as $k => $v) {
+                if ((!$v || \is_scalar($v)) && $this->skipScalars) {
+                    continue;
+                }
                 if ($isRoot) {
                     if ($v->hasTag('container.excluded')) {
                         continue;

--- a/src/Symfony/Component/DependencyInjection/Compiler/AliasDeprecatedPublicServicesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AliasDeprecatedPublicServicesPass.php
@@ -17,16 +17,9 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class AliasDeprecatedPublicServicesPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $aliases = [];
-
-    protected function processValue(mixed $value, bool $isRoot = false): mixed
-    {
-        if ($value instanceof Reference && isset($this->aliases[$id = (string) $value])) {
-            return new Reference($this->aliases[$id], $value->getInvalidBehavior());
-        }
-
-        return parent::processValue($value, $isRoot);
-    }
 
     public function process(ContainerBuilder $container): void
     {
@@ -55,5 +48,14 @@ final class AliasDeprecatedPublicServicesPass extends AbstractRecursivePass
         }
 
         parent::process($container);
+    }
+
+    protected function processValue(mixed $value, bool $isRoot = false): mixed
+    {
+        if ($value instanceof Reference && isset($this->aliases[$id = (string) $value])) {
+            return new Reference($this->aliases[$id], $value->getInvalidBehavior());
+        }
+
+        return parent::processValue($value, $isRoot);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -32,6 +32,8 @@ use Symfony\Component\ExpressionLanguage\Expression;
  */
 class AnalyzeServiceReferencesPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private ServiceReferenceGraph $graph;
     private ?Definition $currentDefinition = null;
     private bool $onlyConstructorArguments;

--- a/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  */
 final class AttributeAutoconfigurationPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private $classAttributeConfigurators = [];
     private $methodAttributeConfigurators = [];
     private $propertyAttributeConfigurators = [];

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -35,6 +35,8 @@ use Symfony\Component\VarExporter\ProxyHelper;
  */
 class AutowirePass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $types;
     private array $ambiguousServiceTypes;
     private array $autowiringAliases;

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredMethodsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredMethodsPass.php
@@ -21,6 +21,8 @@ use Symfony\Contracts\Service\Attribute\Required;
  */
 class AutowireRequiredMethodsPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         $value = parent::processValue($value, $isRoot);

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
@@ -24,6 +24,8 @@ use Symfony\Contracts\Service\Attribute\Required;
  */
 class AutowireRequiredPropertiesPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         $value = parent::processValue($value, $isRoot);

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckArgumentsValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckArgumentsValidityPass.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  */
 class CheckArgumentsValidityPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private bool $throwExceptions;
 
     public function __construct(bool $throwExceptions = true)

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
@@ -23,6 +23,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $serviceLocatorContextIds = [];
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -25,6 +25,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class CheckReferenceValidityPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if ($isRoot && $value instanceof Definition && ($value->isSynthetic() || $value->isAbstract())) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -41,6 +41,8 @@ use Symfony\Component\ExpressionLanguage\Expression;
  */
 final class CheckTypeDeclarationsPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private const SCALAR_TYPES = [
         'int' => true,
         'float' => true,

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -27,6 +27,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class DecoratorServicePass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     /**
      * @return void
      */

--- a/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
@@ -25,6 +25,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class DefinitionErrorExceptionPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $erroredDefinitions = [];
     private array $targetReferences = [];
     private array $sourceReferences = [];

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -24,6 +24,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class InlineServiceDefinitionsPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private ?AnalyzeServiceReferencesPass $analyzingPass;
     private array $cloningIds = [];
     private array $connectedIds = [];

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
@@ -31,6 +31,8 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
  */
 class RegisterServiceSubscribersPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if (!$value instanceof Definition || $value->isAbstract() || $value->isSynthetic() || !$value->hasTag('container.service_subscriber')) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RemoveUnusedDefinitionsPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $connectedIds = [];
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -24,6 +24,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $replacements;
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -28,6 +28,8 @@ use Symfony\Component\VarExporter\ProxyHelper;
  */
 class ResolveBindingsPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $usedBindings = [];
     private array $unusedBindings = [];
     private array $errorMessages = [];

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -27,6 +27,8 @@ use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceExce
  */
 class ResolveChildDefinitionsPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $currentPath;
 
     protected function processValue(mixed $value, bool $isRoot = false): mixed

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveEnvPlaceholdersPass.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class ResolveEnvPlaceholdersPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = false;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if (\is_string($value)) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveFactoryClassPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveFactoryClassPass.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  */
 class ResolveFactoryClassPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if ($value instanceof Definition && \is_array($factory = $value->getFactory()) && null === $factory[0]) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
@@ -23,6 +23,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ResolveHotPathPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private array $resolvedIds = [];
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -24,6 +24,8 @@ use Symfony\Component\VarExporter\ProxyHelper;
  */
 class ResolveNamedArgumentsPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if ($value instanceof AbstractArgument && $value->getText().'.' === $value->getTextWithContext()) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNoPreloadPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNoPreloadPass.php
@@ -24,6 +24,8 @@ class ResolveNoPreloadPass extends AbstractRecursivePass
 {
     private const DO_PRELOAD_TAG = '.container.do_preload';
 
+    protected bool $skipScalars = true;
+
     private array $resolvedIds = [];
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -23,6 +23,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
  */
 class ResolveParameterPlaceHoldersPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = false;
+
     private ParameterBagInterface $bag;
 
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ResolveReferencesToAliasesPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     /**
      * @return void
      */

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveServiceSubscribersPass.php
@@ -23,6 +23,8 @@ use Symfony\Contracts\Service\ServiceProviderInterface;
  */
 class ResolveServiceSubscribersPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private ?string $serviceLocator = null;
 
     protected function processValue(mixed $value, bool $isRoot = false): mixed

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveTaggedIteratorArgumentPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveTaggedIteratorArgumentPass.php
@@ -22,6 +22,8 @@ class ResolveTaggedIteratorArgumentPass extends AbstractRecursivePass
 {
     use PriorityTaggedServiceTrait;
 
+    protected bool $skipScalars = true;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if (!$value instanceof TaggedIteratorArgument) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
@@ -30,6 +30,8 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
 {
     use PriorityTaggedServiceTrait;
 
+    protected bool $skipScalars = true;
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if ($value instanceof ServiceLocatorArgument) {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -198,7 +198,7 @@ class ParameterBag implements ParameterBagInterface
             return $args;
         }
 
-        if (!\is_string($value) || 2 > \strlen($value)) {
+        if (!\is_string($value) || '' === $value || !str_contains($value, '%')) {
             return $value;
         }
 

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\TraceableValueResol
  */
 class TranslatorPathsPass extends AbstractRecursivePass
 {
+    protected bool $skipScalars = true;
+
     private int $level = 0;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While profiling an app with ~2600 auto-discovered services, I figured out that we have a way bigger calls to string process that logic would expect.

![image](https://github.com/symfony/symfony/assets/84887/a1ea542d-5fe3-4c68-8183-4d3de150ed1f)

![image](https://github.com/symfony/symfony/assets/84887/ca2788e1-f0dd-4c61-ad36-0eecbe3a0110)
