### PR TITLE
[AssetMapper] Allow DirectoryResource for cache

### DIFF
--- a/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\AssetMapper\Factory;
 
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
 
@@ -59,7 +60,7 @@ class CachedMappedAssetFactory implements MappedAssetFactoryInterface
      */
     private function collectResourcesFromAsset(MappedAsset $mappedAsset): array
     {
-        $resources = array_map(fn (string $path) => new FileResource($path), $mappedAsset->getFileDependencies());
+        $resources = array_map(fn (string $path) => is_dir($path) ? new DirectoryResource($path) : new FileResource($path), $mappedAsset->getFileDependencies());
         $resources[] = new FileResource($mappedAsset->sourcePath);
 
         foreach ($mappedAsset->getDependencies() as $dependency) {

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\AssetMapper\Factory\CachedMappedAssetFactory;
 use Symfony\Component\AssetMapper\Factory\MappedAssetFactoryInterface;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -103,6 +104,7 @@ class CachedMappedAssetFactoryTest extends TestCase
 
         // just adding any file as an example
         $mappedAsset->addFileDependency(__DIR__.'/../fixtures/importmap.php');
+        $mappedAsset->addFileDependency(__DIR__.'/../fixtures/dir3');
 
         $factory = $this->createMock(MappedAssetFactoryInterface::class);
         $factory->expects($this->once())
@@ -117,13 +119,14 @@ class CachedMappedAssetFactoryTest extends TestCase
         $cachedFactory->createMappedAsset('file1.css', $sourcePath);
 
         $configCacheMetadata = $this->loadConfigCacheMetadataFor($mappedAsset);
-        $this->assertCount(4, $configCacheMetadata);
+        $this->assertCount(5, $configCacheMetadata);
         $this->assertInstanceOf(FileResource::class, $configCacheMetadata[0]);
-        $this->assertInstanceOf(FileResource::class, $configCacheMetadata[1]);
+        $this->assertInstanceOf(DirectoryResource::class, $configCacheMetadata[1]);
+        $this->assertInstanceOf(FileResource::class, $configCacheMetadata[2]);
         $this->assertSame(realpath(__DIR__.'/../fixtures/importmap.php'), $configCacheMetadata[0]->getResource());
-        $this->assertSame($mappedAsset->sourcePath, $configCacheMetadata[1]->getResource());
-        $this->assertSame($dependentOnContentAsset->sourcePath, $configCacheMetadata[2]->getResource());
-        $this->assertSame($deeplyNestedAsset->sourcePath, $configCacheMetadata[3]->getResource());
+        $this->assertSame($mappedAsset->sourcePath, $configCacheMetadata[2]->getResource());
+        $this->assertSame($dependentOnContentAsset->sourcePath, $configCacheMetadata[3]->getResource());
+        $this->assertSame($deeplyNestedAsset->sourcePath, $configCacheMetadata[4]->getResource());
     }
 
     private function loadConfigCacheMetadataFor(MappedAsset $mappedAsset): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | (needed for a bug fix)
| New feature?  | yes/no
| Deprecations? | no
| Tickets       | [None](https://github.com/symfony/ux/issues/961)
| License       | MIT
| Doc PR        | Not needed

Hi!

In StimulusBundle, one file is dynamically generated to contain the list of custom Stimulus controllers. This means the file's contents need to be regenerated in the `dev` environment whenever a new file is added to that directory. This PR allows the `fileDependencies` to also be a directory so that we can use a `DirectoryResource`.

This may not *quite* fit technically as a bug fix. However, as the component is experimental, this affects the `dev` environment only and it will allow for a pretty critical bug fix in StimulusBundle, I've characterized it as a bug fix for 6.3.

Thanks!