### PR TITLE
[DoctrineBridge] Ignore invalid stores in `LockStoreSchemaListener` raised by `StoreFactory`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
 
@@ -28,12 +29,20 @@ final class LockStoreSchemaListener extends AbstractSchemaListener
     {
         $connection = $event->getEntityManager()->getConnection();
 
-        foreach ($this->stores as $store) {
-            if (!$store instanceof DoctrineDbalStore) {
-                continue;
+        $storesIterator = new \ArrayIterator($this->stores);
+        while ($storesIterator->valid()) {
+            try {
+                $store = $storesIterator->current();
+                if (!$store instanceof DoctrineDbalStore) {
+                    continue;
+                }
+
+                $store->configureSchema($event->getSchema(), $this->getIsSameDatabaseChecker($connection));
+            } catch (InvalidArgumentException) {
+                // no-op
             }
 
-            $store->configureSchema($event->getSchema(), $this->getIsSameDatabaseChecker($connection));
+            $storesIterator->next();
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

In our test environment, we're setting our `LOCK_DSN` env var at `null`. This works well in 6.2 but not in 6.3 anymore.

The version 6.3 of DoctrineBridge is bringing this BC break. Indeed, lock stores are being injected in `Symfony\Bridge\Doctrine\SchemaListener\LockStoreSchemaListener`. At runtime, the `StoreFactory` is used to instantiate stores when they are needed in `postGenerateSchema`.

Unfortunately, our `LOCK_DSN=null` doesn't match any case in `StoreFactory`, which has the effect to throw `Symfony\Component\Lock\Exception\InvalidArgumentException`, which is not catched in `LockStoreSchemaListener`.

This PR takes care of this: at this time, `LockStoreSchemaListener` only deals with `DoctrineDbalStore`. I think it is safe to ignore any instantiation problem that may occur in the `StoreFactory`.