### PR TITLE
[DependencyInjection] Skip errored definitions deep-referenced as runtime exceptions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
@@ -23,34 +25,101 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class DefinitionErrorExceptionPass extends AbstractRecursivePass
 {
+    private $erroredDefinitions = [];
+    private $targetReferences = [];
+    private $sourceReferences = [];
+
+    /**
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        try {
+            parent::process($container);
+
+            if (!$this->erroredDefinitions) {
+                return;
+            }
+
+            $runtimeIds = [];
+
+            foreach ($this->sourceReferences as $id => $sourceIds) {
+                foreach ($sourceIds as $sourceId => $isRuntime) {
+                    if (!$isRuntime) {
+                        continue 2;
+                    }
+                }
+
+                unset($this->erroredDefinitions[$id]);
+                $runtimeIds[$id] = $id;
+            }
+
+            if (!$this->erroredDefinitions) {
+                return;
+            }
+
+            foreach ($this->targetReferences as $id => $targetIds) {
+                if (!isset($this->sourceReferences[$id]) || isset($runtimeIds[$id]) || isset($this->erroredDefinitions[$id])) {
+                    continue;
+                }
+                foreach ($this->targetReferences[$id] as $targetId => $isRuntime) {
+                    foreach ($this->sourceReferences[$id] as $sourceId => $isRuntime) {
+                        if ($sourceId !== $targetId) {
+                            $this->sourceReferences[$targetId][$sourceId] = false;
+                            $this->targetReferences[$sourceId][$targetId] = false;
+                        }
+                    }
+                }
+
+                unset($this->sourceReferences[$id]);
+            }
+
+            foreach ($this->erroredDefinitions as $id => $definition) {
+                if (isset($this->sourceReferences[$id])) {
+                    continue;
+                }
+
+                // only show the first error so the user can focus on it
+                $errors = $definition->getErrors();
+
+                throw new RuntimeException(reset($errors));
+            }
+        } finally {
+            $this->erroredDefinitions = [];
+            $this->targetReferences = [];
+            $this->sourceReferences = [];
+        }
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function processValue($value, bool $isRoot = false)
     {
+        if ($value instanceof ArgumentInterface) {
+            parent::processValue($value->getValues());
+
+            return $value;
+        }
+
+        if ($value instanceof Reference && $this->currentId !== $targetId = (string) $value) {
+            if (ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE === $value->getInvalidBehavior()) {
+                $this->sourceReferences[$targetId][$this->currentId] ?? $this->sourceReferences[$targetId][$this->currentId] = true;
+                $this->targetReferences[$this->currentId][$targetId] ?? $this->targetReferences[$this->currentId][$targetId] = true;
+            } else {
+                $this->sourceReferences[$targetId][$this->currentId] = false;
+                $this->targetReferences[$this->currentId][$targetId] = false;
+            }
+
+            return $value;
+        }
+
         if (!$value instanceof Definition || !$value->hasErrors()) {
             return parent::processValue($value, $isRoot);
         }
 
-        if ($isRoot && !$value->isPublic()) {
-            $graph = $this->container->getCompiler()->getServiceReferenceGraph();
-            $runtimeException = false;
-            foreach ($graph->getNode($this->currentId)->getInEdges() as $edge) {
-                if (!$edge->getValue() instanceof Reference || ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE !== $edge->getValue()->getInvalidBehavior()) {
-                    $runtimeException = false;
-                    break;
-                }
-                $runtimeException = true;
-            }
-            if ($runtimeException) {
-                return parent::processValue($value, $isRoot);
-            }
-        }
+        $this->erroredDefinitions[$this->currentId] = $value;
 
-        // only show the first error so the user can focus on it
-        $errors = $value->getErrors();
-        $message = reset($errors);
-
-        throw new RuntimeException($message);
+        return parent::processValue($value);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50708
| License       | MIT
| Doc PR        | -

This solves the linked issue by not throwing a compile-time error when the service graph looks like this (when ServiceC has errors):

```
ServiceA ---(runtime-exception-on-invalid-ref)---> ServiceB ---(exception-on-invalid-ref)---> ServiceC
```