### PR TITLE
[HttpKernel] RequestPayloadValueResolver Add support for custom http status code

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Attribute;
 
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\Validator\Constraints\GroupSequence;
@@ -29,6 +30,7 @@ class MapQueryString extends ValueResolver
         public readonly array $serializationContext = [],
         public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
+        public readonly int $validationFailedStatusCode = Response::HTTP_NOT_FOUND,
     ) {
         parent::__construct($resolver);
     }

--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Attribute;
 
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\Validator\Constraints\GroupSequence;
@@ -30,6 +31,7 @@ class MapRequestPayload extends ValueResolver
         public readonly array $serializationContext = [],
         public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
+        public readonly int $validationFailedStatusCode = Response::HTTP_UNPROCESSABLE_ENTITY,
     ) {
         parent::__construct($resolver);
     }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * `BundleInterface` no longer extends `ContainerAwareInterface`
  * Add optional `$className` parameter to `ControllerEvent::getAttributes()`
  * Add native return types to `TraceableEventDispatcher` and to `MergeExtensionConfigurationPass`
+ * Add argument `$validationFailedStatusCode` to `#[MapQueryString]` and `#[MapRequestPayload]`
 
 6.3
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -88,10 +88,10 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
         foreach ($arguments as $i => $argument) {
             if ($argument instanceof MapQueryString) {
                 $payloadMapper = 'mapQueryString';
-                $validationFailedCode = Response::HTTP_NOT_FOUND;
+                $validationFailedCode = $argument->validationFailedStatusCode;
             } elseif ($argument instanceof MapRequestPayload) {
                 $payloadMapper = 'mapRequestPayload';
-                $validationFailedCode = Response::HTTP_UNPROCESSABLE_ENTITY;
+                $validationFailedCode = $argument->validationFailedStatusCode;
             } else {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | Will do if accepted

Reading this discussion https://github.com/symfony/symfony/pull/49134#issuecomment-1476251293 it looks like a good idea to have ability to customize http status code in case of a validation error. 

This MR does not create any BC's.

**MapQueryString** and **MapRequestPayload** attributes now have additional parameter `validationFailedStatusCode`, which allows to specify which http status code will be used if validation fails.
