### PR TITLE
[HttpClient] declaring dynamic attribut in HttpClientTrait

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -28,6 +28,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 trait HttpClientTrait
 {
     private static int $CHUNK_SIZE = 16372;
+    
+    private array $defaultOptions = [];
 
     public function withOptions(array $options): static
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->

So as it is php8.2 does not like the HttpClientTrait as it considers that the defaultOptions should not be dynamic.
So this PR is here to declare it officially in the trait