### PR TITLE
[EventDispatcher] Throw exception when listener method cannot be resolved

### DIFF
--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -115,7 +115,11 @@ class RegisterListenersPass implements CompilerPassInterface
                     ], function ($matches) { return strtoupper($matches[0]); }, $event['event']);
                     $event['method'] = preg_replace('/[^a-z0-9]/i', '', $event['method']);
 
-                    if (null !== ($class = $container->getDefinition($id)->getClass()) && ($r = $container->getReflectionClass($class, false)) && !$r->hasMethod($event['method']) && $r->hasMethod('__invoke')) {
+                    if (null !== ($class = $container->getDefinition($id)->getClass()) && ($r = $container->getReflectionClass($class, false)) && !$r->hasMethod($event['method'])) {
+                        if (!$r->hasMethod('__invoke')) {
+                            throw new InvalidArgumentException(sprintf('None of the "%s" or "__invoke" methods exist for the service "foo". Please define the "method" attribute on "kernel.event_listener" tags.', $event['method'], $id, $this->listenerTag));
+                        }
+                        
                         $event['method'] = '__invoke';
                     }
                 }

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -200,10 +200,20 @@ class RegisterListenersPassTest extends TestCase
     public function testInvokableEventListener()
     {
         $container = new ContainerBuilder();
-        $container->register('foo', \stdClass::class)->addTag('kernel.event_listener', ['event' => 'foo.bar']);
+        $container->setParameter('event_dispatcher.event_aliases', [AliasedEvent::class => 'aliased_event']);
+
+        $container->register('foo', \get_class(new class() {
+            public function onFooBar()
+            {
+            }
+        }))->addTag('kernel.event_listener', ['event' => 'foo.bar']);
         $container->register('bar', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => 'foo.bar']);
         $container->register('baz', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => 'event']);
-        $container->register('zar', \stdClass::class)->addTag('kernel.event_listener', ['event' => 'foo.bar_zar']);
+        $container->register('zar', \get_class(new class() {
+            public function onFooBarZar()
+            {
+            }
+        }))->addTag('kernel.event_listener', ['event' => 'foo.bar_zar']);
         $container->register('event_dispatcher', \stdClass::class);
 
         $registerListenersPass = new RegisterListenersPass();
@@ -245,6 +255,20 @@ class RegisterListenersPassTest extends TestCase
             ],
         ];
         $this->assertEquals($expectedCalls, $definition->getMethodCalls());
+    }
+
+    public function testItThrowsAnExceptionIfTagIsMissingMethodAndClassHasNoValidMethod()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('None of the "onFooBar" or "__invoke" methods exist for the service "foo". Please define the "method" attribute on "kernel.event_listener" tags.');
+
+        $container = new ContainerBuilder();
+
+        $container->register('foo', \stdClass::class)->addTag('kernel.event_listener', ['event' => 'foo.bar']);
+        $container->register('event_dispatcher', \stdClass::class);
+
+        $registerListenersPass = new RegisterListenersPass();
+        $registerListenersPass->process($container);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | not needed

while working on #50687 I've discovered bugs on how the method for listener is resolved:

Given this code:
```php
#[AsEventListener(event: KernelEvents::REQUEST, priority: 5)]
class MyListenerNotInvokable
{
    public function someMethod(RequestEvent $event): void {}
}
```
A listener on `MyListenerNotInvokable::onKernelRequest()` is registered, and then an error is dispatched at runtime when the event is dispatched: `Error: Call to undefined method App\EventListener\MyListenerNotInvokable::onKernelRequest()`

The problem comes from [this code](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php#L85-L95): since the `method` is omitted in tag definition, we "camelize" the event's name. We then try to fallback on `__invoke` but because it does not exist, the wrong method name is kept.

this PR fixes this behavior by throwing an exception at compile time if neither the camlized method exist, not the `__invoke` method.

ping @GromNaN 