### PR TITLE
[Serializer] Fix type error not be accessed before initialization

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -39,7 +39,7 @@ class ClassMetadata implements ClassMetadataInterface
      *           class' serialized representation. Do not access it. Use
      *           {@link getClassDiscriminatorMapping()} instead.
      */
-    public ?ClassDiscriminatorMapping $classDiscriminatorMapping;
+    public ?ClassDiscriminatorMapping $classDiscriminatorMapping = null;
 
     /**
      * Constructs a metadata for the given class.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/shopware/platform/issues/3190
| License       | MIT
| Doc PR        | 

Make the property like in Symfony 6.2, with 6.3 it got the type hint but the default value was missing
