### PR TITLE
[DoctrineBridge] add missing changelog mention for isSameDatabase arg…

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate `DoctrineDbalCacheAdapterSchemaSubscriber` in favor of `DoctrineDbalCacheAdapterSchemaListener`
  * Deprecate `MessengerTransportDoctrineSchemaSubscriber` in favor of `MessengerTransportDoctrineSchemaListener`
  * Deprecate `RememberMeTokenProviderDoctrineSchemaSubscriber` in favor of `RememberMeTokenProviderDoctrineSchemaListener`
+ * Add optional parameter `$isSameDatabase` to `DoctrineTokenProvider::configureSchema()`
 
 6.2
 ---

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add support for Relay PHP extension for Redis
  * Updates to allow Redis cluster connections using predis/predis:^2.0
+ * Add optional parameter `$isSameDatabase` to `DoctrineDbalAdapter::configureSchema()`
 
 6.1
 ---

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
    `StopWorkerOnSignalsListener` and make it configurable with SIGINT and
    SIGTERM by default
  * Add `RedispatchMessage` and `RedispatchMessageHandler`
+ * Add optional parameter `$isSameDatabase` to `DoctrineTransport::configureSchema()`
 
 6.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

$isSameDatabase parameter was introduced in https://github.com/symfony/symfony/pull/48059. It has been added in order to know whether the database used by doctrine is the same as the one used by the component when integrating the latter with doctrine migrations.

Also related to https://github.com/symfony/symfony/pull/50699 (UPGRADE mention) and #50689