### PR TITLE
[Messenger] Fix exiting `messenger:failed:retry` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2098,6 +2098,16 @@ class FrameworkExtension extends Extension
             $container->getDefinition('messenger.transport.beanstalkd.factory')->addTag('messenger.transport_factory');
         }
 
+        if ($config['stop_worker_on_signals'] && $this->hasConsole()) {
+            $container->getDefinition('console.command.messenger_consume_messages')
+                ->replaceArgument(8, $config['stop_worker_on_signals']);
+            $container->getDefinition('console.command.messenger_failed_messages_retry')
+                ->replaceArgument(6, $config['stop_worker_on_signals']);
+        }
+
+        if ($this->hasConsole() && $container->hasDefinition('messenger.listener.stop_worker_signals_listener')) {
+            $container->getDefinition('messenger.listener.stop_worker_signals_listener')->clearTag('kernel.event_subscriber');
+        }
         if ($config['stop_worker_on_signals']) {
             $container->getDefinition('messenger.listener.stop_worker_signals_listener')->replaceArgument(0, $config['stop_worker_on_signals']);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -163,6 +163,7 @@ return static function (ContainerConfigurator $container) {
                 service('messenger.listener.reset_services')->nullOnInvalid(),
                 [], // Bus names
                 service('messenger.rate_limiter_locator')->nullOnInvalid(),
+                null,
             ])
             ->tag('console.command')
             ->tag('monolog.logger', ['channel' => 'messenger'])
@@ -194,6 +195,7 @@ return static function (ContainerConfigurator $container) {
                 service('event_dispatcher'),
                 service('logger')->nullOnInvalid(),
                 service('messenger.transport.native_php_serializer')->nullOnInvalid(),
+                null,
             ])
             ->tag('console.command')
             ->tag('monolog.logger', ['channel' => 'messenger'])

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "psr/cache": "^1.0|^2.0|^3.0",
-        "symfony/console": "^5.4|^6.0",
+        "symfony/console": "^6.3",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^5.4|^6.0",
@@ -37,6 +37,7 @@
         "symfony/validator": "^5.4|^6.0"
     },
     "conflict": {
+        "symfony/console": "<6.3",
         "symfony/event-dispatcher": "<5.4",
         "symfony/event-dispatcher-contracts": "<2.5",
         "symfony/framework-bundle": "<5.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

#49539 introduced a bug where it's impossible to exit the `messenger:failed:retry` command:

![Screenshot](https://github.com/symfony/symfony/assets/2445045/6d6d271b-b5f6-4d2f-a150-847ead22083b)

`Ctrl+C` doesn't work because the `StopWorkerOnSignalsListener` handles the signal but doesn't actually exit the command, so the only way to currently exit the command is to kill it by force.