### PR TITLE
[DependencyInjection] Add `defined` prefix for env var processor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
+ * Add `defined` env var processor that returns `true` for defined and neither null nor empty env vars
 
 6.3
 ---

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -56,6 +56,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             'require' => 'bool|int|float|string|array',
             'enum' => \BackedEnum::class,
             'shuffle' => 'array',
+            'defined' => 'bool',
         ];
     }
 
@@ -101,6 +102,14 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             }
 
             return $backedEnumClassName::tryFrom($backedEnumValue) ?? throw new RuntimeException(sprintf('Enum value "%s" is not backed by "%s".', $backedEnumValue, $backedEnumClassName));
+        }
+
+        if ('defined' === $prefix) {
+            try {
+                return '' !== ($getEnv($name) ?? '');
+            } catch (EnvNotFoundException) {
+                return false;
+            }
         }
 
         if ('default' === $prefix) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -50,6 +50,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'require' => ['bool', 'int', 'float', 'string', 'array'],
             'enum' => [\BackedEnum::class],
             'shuffle' => ['array'],
+            'defined' => ['bool'],
         ];
 
         $this->assertSame($expected, $container->getParameterBag()->getProvidedTypes());

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -925,4 +925,21 @@ CSV;
             });
         }));
     }
+
+    /**
+     * @dataProvider provideGetEnvDefined
+     */
+    public function testGetEnvDefined(bool $expected, callable $callback)
+    {
+        $this->assertSame($expected, (new EnvVarProcessor(new Container()))->getEnv('defined', 'NO_SOMETHING', $callback));
+    }
+
+    public static function provideGetEnvDefined(): iterable
+    {
+        yield 'Defined' => [true, fn () => 'foo'];
+        yield 'Falsy but defined' => [true, fn () => '0'];
+        yield 'Empty string' => [false, fn () => ''];
+        yield 'Null' => [false, fn () => null];
+        yield 'Env var not defined' => [false, fn () => throw new EnvNotFoundException()];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

Allow to add a `defined` prefix:

```yaml
parameters:
  is_google_recaptcha_enabled: '%env(defined:GOOGLE_RECAPTCHA_SITE_KEY)%'
```

Returns `false` if the env var doesn't exist or if it's null or the empty string.
Returns `true` otherwise.