### PR TITLE
[TwigBridge] Change return type of Symfony\Bridge\Twig\AppVariable::getSession()

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\Twig;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -93,7 +93,7 @@ class AppVariable
     /**
      * Returns the current session.
      */
-    public function getSession(): ?Session
+    public function getSession(): ?SessionInterface
     {
         if (!isset($this->requestStack)) {
             throw new \RuntimeException('The "app.session" variable is not available.');

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\Twig;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -93,7 +93,7 @@ class AppVariable
     /**
      * Returns the current session.
      */
-    public function getSession(): ?SessionInterface
+    public function getSession(): ?FlashBagAwareSessionInterface
     {
         if (!isset($this->requestStack)) {
             throw new \RuntimeException('The "app.session" variable is not available.');

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -143,6 +143,10 @@ class AppVariable
             return [];
         }
 
+        if (!method_exists($session, 'getFlashBag')) {
+            return [];
+        }
+
         if (null === $types || '' === $types || [] === $types) {
             return $session->getFlashBag()->all();
         }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\Twig;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -93,7 +93,7 @@ class AppVariable
     /**
      * Returns the current session.
      */
-    public function getSession(): ?FlashBagAwareSessionInterface
+    public function getSession(): ?SessionInterface
     {
         if (!isset($this->requestStack)) {
             throw new \RuntimeException('The "app.session" variable is not available.');

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -143,6 +143,8 @@ class AppVariable
             return [];
         }
 
+        // In 7.0 (when symfony/http-foundation: 6.4 is required) this can be updated to
+        // check if the session is an instance of FlashBagAwareSessionInterface
         if (!method_exists($session, 'getFlashBag')) {
             return [];
         }


### PR DESCRIPTION
Change the return type of AppVariable.php getSession from 'Session' to 'SessionInterface', to be in line with the return type of getSession in http-foundation/Request.php

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50789
| License       | MIT
| Doc PR        | 
