### PR TITLE
[HttpClient] Fix JsonMockResponse annotation for "body" parameter

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
@@ -15,6 +15,9 @@ use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 
 class JsonMockResponse extends MockResponse
 {
+    /**
+     * @param mixed $body The json response body to encode
+     */
     public function __construct(mixed $body = [], array $info = [])
     {
         try {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Allow explicitly mixed type to allow not string types imposed by the MockResponse annotation (e.g.: int, boolean, null, ...) and avoid static code analysis errors.

