### PR TITLE
[FrameworkBundle][Validator] Add `framework.validation.disable_translation` option

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add new `framework.property_info.with_constructor_extractor` option to allow enabling or disabling the constructor extractor integration
  * Deprecate the `--show-arguments` option of the `container:debug` command, as arguments are now always shown
  * Add `RateLimiterFactoryInterface` as an alias of the `limiter` service
+ * Add `framework.validation.disable_translation` option
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1062,6 +1062,9 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->booleanNode('disable_translation')
+                            ->defaultFalse()
+                        ->end()
                         ->arrayNode('auto_mapping')
                             ->info('A collection of namespaces for which auto-mapping will be enabled by default, or null to opt-in with the EnableAutoMapping constraint.')
                             ->example([

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1724,6 +1724,10 @@ class FrameworkExtension extends Extension
             $validatorBuilder->addMethodCall('setMappingCache', [new Reference('validator.mapping.cache.adapter')]);
         }
 
+        if ($config['disable_translation'] ?? false) {
+            $validatorBuilder->addMethodCall('disableTranslation');
+        }
+
         $container->setParameter('validator.auto_mapping', $config['auto_mapping']);
         if (!$propertyInfoEnabled || !class_exists(PropertyInfoLoader::class)) {
             $container->removeDefinition('validator.property_info_loader');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -298,6 +298,7 @@
         <xsd:attribute name="enable-attributes" type="xsd:boolean" />
         <xsd:attribute name="static-method" type="xsd:boolean" />
         <xsd:attribute name="translation-domain" type="xsd:string" />
+        <xsd:attribute name="disable-translation" type="xsd:boolean" />
         <xsd:attribute name="strict-email" type="xsd:boolean" />
         <xsd:attribute name="email-validation-mode" type="email-validation-mode" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -775,6 +775,7 @@ class ConfigurationTest extends TestCase
                 'enable_attributes' => !class_exists(FullStack::class),
                 'static_method' => ['loadValidatorMetadata'],
                 'translation_domain' => 'validators',
+                'disable_translation' => false,
                 'mapping' => [
                     'paths' => [],
                 ],

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -107,7 +107,7 @@ class ExecutionContext implements ExecutionContextInterface
         private ValidatorInterface $validator,
         private mixed $root,
         private TranslatorInterface $translator,
-        private ?string $translationDomain = null,
+        private string|false|null $translationDomain = null,
     ) {
         $this->violations = new ConstraintViolationList();
         $this->cachedObjectsRefs = new \SplObjectStorage();
@@ -134,7 +134,9 @@ class ExecutionContext implements ExecutionContextInterface
     public function addViolation(string|\Stringable $message, array $parameters = []): void
     {
         $this->violations->add(new ConstraintViolation(
-            $this->translator->trans($message, $parameters, $this->translationDomain),
+            false === $this->translationDomain ?
+                strtr($message, $parameters) :
+                $this->translator->trans($message, $parameters, $this->translationDomain),
             $message,
             $parameters,
             $this->root,

--- a/src/Symfony/Component/Validator/Context/ExecutionContextFactory.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextFactory.php
@@ -25,7 +25,7 @@ class ExecutionContextFactory implements ExecutionContextFactoryInterface
 {
     public function __construct(
         private TranslatorInterface $translator,
-        private ?string $translationDomain = null,
+        private string|false|null $translationDomain = null,
     ) {
     }
 

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -99,6 +99,11 @@ class ValidatorBuilderTest extends TestCase
         $this->assertSame($this->builder, $this->builder->setTranslationDomain('TRANS_DOMAIN'));
     }
 
+    public function testDisableTranslation()
+    {
+        $this->assertSame($this->builder, $this->builder->disableTranslation());
+    }
+
     public function testGetValidator()
     {
         $this->assertInstanceOf(RecursiveValidator::class, $this->builder->getValidator());

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -50,7 +50,7 @@ class ValidatorBuilder
     private ?ContainerInterface $groupProviderLocator = null;
     private ?CacheItemPoolInterface $mappingCache = null;
     private ?TranslatorInterface $translator = null;
-    private ?string $translationDomain = null;
+    private string|false|null $translationDomain = null;
 
     /**
      * Adds an object initializer to the validator.
@@ -288,6 +288,16 @@ class ValidatorBuilder
     public function setTranslationDomain(?string $translationDomain): static
     {
         $this->translationDomain = $translationDomain;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function disableTranslation(): static
+    {
+        $this->translationDomain = false;
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

Follow-up of https://github.com/symfony/symfony/pull/48852 and after a suggestion of @javiereguiluz [here](https://github.com/symfony/symfony-docs/issues/18325#issuecomment-1604125926).