### PR TITLE
[Lock] add missing UPGRADE and CHANGELOG Lock mention #50689

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -101,6 +101,7 @@ Lock
 ----
 
  * Deprecate the `gcProbablity` option to fix a typo in its name, use the `gcProbability` option instead
+ * Add optional parameter `$isSameDatabase` to `DoctrineDbalStore::configureSchema()`
 
 Messenger
 ---------

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Create migration for lock table when DoctrineDbalStore is used
+ * Add optional parameter `$isSameDatabase` to `DoctrineDbalStore::configureSchema()`
  * Add support for Relay PHP extension for Redis
  * Renamed the `gcProbablity` option to `gcProbability` to fix a typo in its name
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

$isSameDatabase parameter for DoctrineDbalStore was added in https://github.com/symfony/symfony/pull/48999. 

Also related to https://github.com/symfony/symfony/pull/50689