### PR TITLE
[Serializer] Fix Normalizer not utilizing converted name for index variadic param

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -358,12 +358,12 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                 $ignored = !$this->isAllowedAttribute($class, $paramName, $format, $context);
                 if ($constructorParameter->isVariadic()) {
                     if ($allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data))) {
-                        if (!\is_array($data[$paramName])) {
+                        if (!\is_array($data[$key])) {
                             throw new RuntimeException(sprintf('Cannot create an instance of "%s" from serialized data because the variadic parameter "%s" can only accept an array.', $class, $constructorParameter->name));
                         }
 
                         $variadicParameters = [];
-                        foreach ($data[$paramName] as $parameterKey => $parameterData) {
+                        foreach ($data[$key] as $parameterKey => $parameterData) {
                             $variadicParameters[$parameterKey] = $this->denormalizeParameter($reflectionClass, $constructorParameter, $paramName, $parameterData, $context, $format);
                         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -168,6 +169,7 @@ class AbstractNormalizerTest extends TestCase
 
     /**
      * @dataProvider getNormalizer
+     * @dataProvider getNormalizerWithCustomNameConverter
      */
     public function testObjectWithVariadicConstructorTypedArguments(AbstractNormalizer $normalizer)
     {
@@ -241,6 +243,25 @@ class AbstractNormalizerTest extends TestCase
         yield [new PropertyNormalizer(null, null, $extractor)];
         yield [new ObjectNormalizer()];
         yield [new ObjectNormalizer(null, null, null, $extractor)];
+    }
+
+    public static function getNormalizerWithCustomNameConverter()
+    {
+        $extractor = new PhpDocExtractor();
+        $nameConverter = new class() implements NameConverterInterface {
+            public function normalize(string $propertyName): string
+            {
+                return ucfirst($propertyName);
+            }
+
+            public function denormalize(string $propertyName): string
+            {
+                return lcfirst($propertyName);
+            }
+        };
+
+        yield [new PropertyNormalizer(null, $nameConverter, $extractor)];
+        yield [new ObjectNormalizer(null, $nameConverter, null, $extractor)];
     }
 
     public function testIgnore()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The AbstractNormalizer uses the wrong array index when setting variadic constructor parameters. It checks if the `$key` index (which is the normalized name) exists, but then tries to access the `$paramName` index (which is non-normalized name).

This becomes an issue when using a custom NameConverter, for example one that switches between PascalCase and camelCase. 
