### PR TITLE
[Messenger] Add auto stamp attribute and middleware

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -26,6 +26,7 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnSignalsListener;
 use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+use Symfony\Component\Messenger\Middleware\AutoStampMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
@@ -111,6 +112,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('router'),
             ])
+
+        ->set('messenger.middleware.auto_stamp_middleware', AutoStampMiddleware::class)
 
         // Discovery
         ->set('messenger.receiver_locator', ServiceLocator::class)

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsFifoStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsFifoStamp.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class AmazonSqsFifoStamp implements NonSendableStampInterface
 {
     private ?string $messageGroupId;

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceivedStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class AmazonSqsReceivedStamp implements NonSendableStampInterface
 {
     private string $id;

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsXrayTraceHeaderStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsXrayTraceHeaderStamp.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class AmazonSqsXrayTraceHeaderStamp implements NonSendableStampInterface
 {
     private string $traceId;

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceivedStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 /**
  * Stamp applied when a message is received from Amqp.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class AmqpReceivedStamp implements NonSendableStampInterface
 {
     private \AMQPEnvelope $amqpEnvelope;

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
  * @author Guillaume Gammelin <ggammelin@gmail.com>
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class AmqpStamp implements NonSendableStampInterface
 {
     private ?string $routingKey;

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/BeanstalkdReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/BeanstalkdReceivedStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 /**
  * @author Antonio Pauletich <antonio.pauletich95@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class BeanstalkdReceivedStamp implements NonSendableStampInterface
 {
     private string $id;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceivedStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 /**
  * @author Vincent Touzet <vincent.touzet@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class DoctrineReceivedStamp implements NonSendableStampInterface
 {
     private string $id;

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceivedStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 /**
  * @author Alexander Schranz <alexander@sulu.io>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class RedisReceivedStamp implements NonSendableStampInterface
 {
     private string $id;

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
    SIGTERM by default
  * Add `RedispatchMessage` and `RedispatchMessageHandler`
  * Add optional parameter `$isSameDatabase` to `DoctrineTransport::configureSchema()`
+ * Add `AutoStampMiddleware` that register envelope stamps from message attributes
 
 6.2
 ---

--- a/src/Symfony/Component/Messenger/Middleware/AutoStampMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/AutoStampMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Middleware that add stamps configured on message.
+ *
+ * @author Kerian Montes <kerianmontes@gmail.com>
+ */
+class AutoStampMiddleware implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $class = new \ReflectionClass($envelope->getMessage());
+        do {
+            foreach ($class->getAttributes(StampInterface::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                $envelope = $envelope->with($attribute->newInstance());
+            }
+        } while ($class = $class->getParentClass());
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/AckStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/AckStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Envelope;
 /**
  * Marker stamp for messages that can be ack/nack'ed.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class AckStamp implements NonSendableStampInterface
 {
     private $ack;

--- a/src/Symfony/Component/Messenger/Stamp/BusNameStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/BusNameStamp.php
@@ -16,6 +16,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class BusNameStamp implements StampInterface
 {
     private string $busName;

--- a/src/Symfony/Component/Messenger/Stamp/ConsumedByWorkerStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ConsumedByWorkerStamp.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * A marker that this message was consumed by a worker process.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class ConsumedByWorkerStamp implements NonSendableStampInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * Apply this stamp to delay delivery of your message on a transport.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class DelayStamp implements StampInterface
 {
     private int $delay;

--- a/src/Symfony/Component/Messenger/Stamp/DispatchAfterCurrentBusStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DispatchAfterCurrentBusStamp.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class DispatchAfterCurrentBusStamp implements NonSendableStampInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Exception\HandlerFailedException;
 /**
  * Stamp applied when a messages fails due to an exception in the handler.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class ErrorDetailsStamp implements StampInterface
 {
     private string $exceptionClass;

--- a/src/Symfony/Component/Messenger/Stamp/FlushBatchHandlersStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/FlushBatchHandlersStamp.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * Marker telling that any batch handlers bound to the envelope should be flushed.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class FlushBatchHandlersStamp implements NonSendableStampInterface
 {
     private $force;

--- a/src/Symfony/Component/Messenger/Stamp/HandledStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/HandledStamp.php
@@ -25,6 +25,7 @@ use Symfony\Component\Messenger\Handler\HandlerDescriptor;
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class HandledStamp implements StampInterface
 {
     private mixed $result;

--- a/src/Symfony/Component/Messenger/Stamp/HandlerArgumentsStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/HandlerArgumentsStamp.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * @author Jáchym Toušek <enumag@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class HandlerArgumentsStamp implements NonSendableStampInterface
 {
     public function __construct(

--- a/src/Symfony/Component/Messenger/Stamp/MessageDecodingFailedStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/MessageDecodingFailedStamp.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class MessageDecodingFailedStamp implements StampInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Stamp/NoAutoAckStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/NoAutoAckStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 /**
  * Marker telling that ack should not be done automatically for this message.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class NoAutoAckStamp implements NonSendableStampInterface
 {
     private $handlerDescriptor;

--- a/src/Symfony/Component/Messenger/Stamp/ReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ReceivedStamp.php
@@ -23,6 +23,7 @@ use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class ReceivedStamp implements NonSendableStampInterface
 {
     private string $transportName;

--- a/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Envelope;
 /**
  * Stamp applied when a messages needs to be redelivered.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class RedeliveryStamp implements StampInterface
 {
     private int $retryCount;

--- a/src/Symfony/Component/Messenger/Stamp/RouterContextStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RouterContextStamp.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class RouterContextStamp implements StampInterface
 {
     private string $baseUrl;

--- a/src/Symfony/Component/Messenger/Stamp/SentStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SentStamp.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class SentStamp implements NonSendableStampInterface
 {
     private string $senderClass;

--- a/src/Symfony/Component/Messenger/Stamp/SentToFailureTransportStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SentToFailureTransportStamp.php
@@ -16,6 +16,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class SentToFailureTransportStamp implements StampInterface
 {
     private string $originalReceiverName;

--- a/src/Symfony/Component/Messenger/Stamp/SerializedMessageStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SerializedMessageStamp.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class SerializedMessageStamp implements NonSendableStampInterface
 {
     public function __construct(private string $serializedMessage)

--- a/src/Symfony/Component/Messenger/Stamp/SerializerStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SerializerStamp.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class SerializerStamp implements StampInterface
 {
     private array $context;

--- a/src/Symfony/Component/Messenger/Stamp/TransportMessageIdStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/TransportMessageIdStamp.php
@@ -16,6 +16,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class TransportMessageIdStamp implements StampInterface
 {
     private mixed $id;

--- a/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * Stamp used to override the transport names specified in the Messenger routing configuration file.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class TransportNamesStamp implements StampInterface
 {
     private array $transportNames;

--- a/src/Symfony/Component/Messenger/Stamp/ValidationStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ValidationStamp.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
 /**
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class ValidationStamp implements StampInterface
 {
     private array|GroupSequence $groups;

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/AutoStampedMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/AutoStampedMessage.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ValidationStamp;
+
+#[DelayStamp(123)]
+#[ValidationStamp(['Default', 'Extra'])]
+class AutoStampedMessage
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/AutoStampMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/AutoStampMiddlewareTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\AutoStampMiddleware;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ValidationStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\AutoStampedMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class AutoStampMiddlewareTest extends MiddlewareTestCase
+{
+    public function testHandleWithoutAutoStampAndNextMiddleware()
+    {
+        $message = new DummyMessage('Hey');
+        $envelope = new Envelope($message);
+
+        (new AutoStampMiddleware())->handle($envelope, $this->getStackMock());
+        $this->assertCount(0, $envelope->all());
+    }
+
+    public function testHandleWithAutoStampAndNextMiddleware()
+    {
+        $message = new AutoStampedMessage();
+        $envelope = new Envelope($message);
+
+        $handledEnvelope = (new AutoStampMiddleware())->handle($envelope, $this->getStackMock());
+        $this->assertCount(2, $handledEnvelope->all());
+
+        $delayStamp = $handledEnvelope->last(DelayStamp::class);
+        $this->assertInstanceOf(DelayStamp::class, $delayStamp);
+        $this->assertSame(123, $delayStamp->getDelay());
+
+        $validationStamp = $handledEnvelope->last(ValidationStamp::class);
+        $this->assertInstanceOf(ValidationStamp::class, $validationStamp);
+        $this->assertSame(['Default', 'Extra'], $validationStamp->getGroups());
+    }
+}

--- a/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
+++ b/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
@@ -17,6 +17,7 @@ use Symfony\Component\Scheduler\Generator\MessageContext;
 /**
  * @experimental
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class ScheduledStamp implements NonSendableStampInterface
 {
     public function __construct(public readonly MessageContext $messageContext)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50800 
| License       | MIT
| Doc PR        | [symfony/symfony-docs#18461](https://github.com/symfony/symfony-docs/pull/18461)

Add `AutoStamp` attribute on message and configure messenger to enable `AutoStampMiddleware` to automatically add stamps on message.
No needs to pass them when dispatch message.
