### PR TITLE
[DoctrineBridge] Load refreshed user proxy

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -15,6 +15,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
+use Doctrine\Persistence\Proxy;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -115,6 +116,10 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
 
                 throw $e;
             }
+        }
+
+        if ($refreshedUser instanceof Proxy && !$refreshedUser->__isInitialized()) {
+            $refreshedUser->__load();
         }
 
         return $refreshedUser;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50758
| License       | MIT
| Doc PR        | N/A

When [exiting impersonation](https://github.com/symfony/symfony/blob/529973b88db84aee4e962b2ba8bb1838bbbe6a38/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php#L210), the impersonator get refreshed in the original token. Problem is, the refreshed user can be a proxy if it is referenced by the impersonated. In that case, all its properties (except identifiers) will be `null` when it is unserialised by the `ContextListener`.

The refreshed user data will be needed anyways, so loading proxies in `EntityUserProvider::refreshUser` should not impact performance.