### PR TITLE
[Scheduler] Fix `PeriodicalTrigger` from argument for stateful run dates

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
@@ -179,8 +179,13 @@ class PeriodicalTriggerTest extends TestCase
         ];
         yield [
             $trigger,
-            new \DateTimeImmutable('2020-02-20T01:59:59.999999+02:00'),
+            new \DateTimeImmutable('2020-02-20T01:40:00+02:00'),
             new \DateTimeImmutable('2020-02-20T02:00:00+02:00'),
+        ];
+        yield [
+            $trigger,
+            new \DateTimeImmutable('2020-02-20T01:59:00+02:00'),
+            new \DateTimeImmutable('2020-02-20T02:09:00+02:00'),
         ];
         yield [
             $trigger,

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -88,18 +88,20 @@ class PeriodicalTrigger implements TriggerInterface, \Stringable
     public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable
     {
         if ($this->intervalInSeconds) {
-            if ($this->from > $run) {
-                return $this->from;
-            }
             if ($this->until <= $run) {
                 return null;
             }
 
-            $from = $this->from->format('U.u');
+            $fromDate = min($this->from, $run);
+            $from = $fromDate->format('U.u');
             $delta = $run->format('U.u') - $from;
             $recurrencesPassed = floor($delta / $this->intervalInSeconds);
             $nextRunTimestamp = sprintf('%.6F', ($recurrencesPassed + 1) * $this->intervalInSeconds + $from);
-            $nextRun = \DateTimeImmutable::createFromFormat('U.u', $nextRunTimestamp, $this->from->getTimezone());
+            $nextRun = \DateTimeImmutable::createFromFormat('U.u', $nextRunTimestamp, $fromDate->getTimezone());
+
+            if ($this->from > $nextRun) {
+                return $this->from;
+            }
 
             return $this->until > $nextRun ? $nextRun : null;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50669 
| License       | MIT
| Doc PR        | -

Summary: Unless you provide the `from` argument (with a date in the past), caching will not work for the `PeriodicalTrigger`.

If the `from` argument is not passed to the `RecurringMessage::every` method, it will, fallback to `new \DateTimeImmutable()`. If you use a stateful schedule and you restart the consumer (either manually or using a time limit), the cached last-executed date will always be overridden by the moment you restart the scheduler due to `if ($this->from > $run) {`.
