### PR TITLE
[SecurityBundle] Do not translate `Bearer` header’s `error_description`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -33,7 +33,6 @@ return static function (ContainerConfigurator $container) {
                 null,
                 null,
             ])
-            ->call('setTranslator', [service('translator')->ignoreOnInvalid()])
 
         ->set('security.authenticator.access_token.chain_extractor', ChainAccessTokenExtractor::class)
             ->abstract()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50811
| License       | MIT
| Doc PR        | N/A

From [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3):

> the "error_description" attribute [provides] a human-readable explanation that is not meant to be displayed to end-users.

Not translating it avoids non-ASCII characters in `Bearer`’s value, which in turn avoid messing with [RFC 8187](https://www.rfc-editor.org/rfc/rfc8187.html) (fun read; thanks @derrabus!).

Not sure if and how this should be tested :thinking: 