### PR TITLE
Add missing return types and enforce return types on all methods

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -8,7 +8,7 @@ git checkout src/Symfony/Contracts/Service/ResetInterface.php
 git checkout composer.json src/
 
 diff --git a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
-index 8b57ff111c..92febe31e8 100644
+index 90dd0d5e27..87aaf595cd 100644
 --- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
 +++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
 @@ -57,5 +57,5 @@ class DoctrineDataCollector extends DataCollector
@@ -32,13 +32,41 @@ index 8b57ff111c..92febe31e8 100644
 +    public function reset(): void
      {
          $this->data = [];
-@@ -127,5 +127,5 @@ class DoctrineDataCollector extends DataCollector
+@@ -117,5 +117,5 @@ class DoctrineDataCollector extends DataCollector
+      * @return array
+      */
+-    public function getManagers()
++    public function getManagers(): array
+     {
+         return $this->data['managers'];
+@@ -125,5 +125,5 @@ class DoctrineDataCollector extends DataCollector
+      * @return array
+      */
+-    public function getConnections()
++    public function getConnections(): array
+     {
+         return $this->data['connections'];
+@@ -133,5 +133,5 @@ class DoctrineDataCollector extends DataCollector
       * @return int
       */
 -    public function getQueryCount()
 +    public function getQueryCount(): int
      {
          return array_sum(array_map('count', $this->data['queries']));
+@@ -141,5 +141,5 @@ class DoctrineDataCollector extends DataCollector
+      * @return array
+      */
+-    public function getQueries()
++    public function getQueries(): array
+     {
+         return $this->data['queries'];
+@@ -149,5 +149,5 @@ class DoctrineDataCollector extends DataCollector
+      * @return int
+      */
+-    public function getTime()
++    public function getTime(): int
+     {
+         $time = 0;
 diff --git a/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php b/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
 index 448da935d9..06c97eb70c 100644
 --- a/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
@@ -108,12 +136,12 @@ index 83bfffaf27..acbd7e4bc7 100644
      {
          $this->updateValidatorMappingFiles($container, 'xml', 'xml');
 diff --git a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
-index b6946cc4de..5b3ba9f915 100644
+index 43efdd1af7..ee2f6bc2f9 100644
 --- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
 +++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
-@@ -54,5 +54,5 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
-     }
- 
+@@ -57,5 +57,5 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
+      * @return void
+      */
 -    public function process(ContainerBuilder $container)
 +    public function process(ContainerBuilder $container): void
      {
@@ -154,6 +182,17 @@ index 80ee258438..e2c51954d0 100644
 +    public function addConfiguration(NodeDefinition $node): void
      {
          $node
+diff --git a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+index b9b309025d..d25ae768f2 100644
+--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
++++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+@@ -160,5 +160,5 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
+      * @return array{0:ClassMetadata<T>, 1:string}|null
+      */
+-    protected function getMetadata(string $class)
++    protected function getMetadata(string $class): ?array
+     {
+         // normalize class name
 diff --git a/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php b/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php
 index cff8b3b156..51e1f32e97 100644
 --- a/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php
@@ -288,6 +327,31 @@ index 5210e8eefa..0e842abb76 100644
 +    protected function configure(): void
      {
          if (!class_exists(ConsoleFormatter::class)) {
+diff --git a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+index 57a4c1c2b7..2fb70d7774 100644
+--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
++++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+@@ -133,5 +133,5 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
+      * @return void
+      */
+-    public function setOutput(OutputInterface $output)
++    public function setOutput(OutputInterface $output): void
+     {
+         $this->output = $output;
+@@ -154,5 +154,5 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
+      * @return void
+      */
+-    public function onCommand(ConsoleCommandEvent $event)
++    public function onCommand(ConsoleCommandEvent $event): void
+     {
+         $output = $event->getOutput();
+@@ -169,5 +169,5 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
+      * @return void
+      */
+-    public function onTerminate(ConsoleTerminateEvent $event)
++    public function onTerminate(ConsoleTerminateEvent $event): void
+     {
+         $this->close();
 diff --git a/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php b/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
 index 718be59c13..091f24a8f8 100644
 --- a/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
@@ -501,8 +565,26 @@ index eadeafba55..4f1ca3bfef 100644
 +    public function load(array $configs, ContainerBuilder $container): void
      {
          $configuration = new Configuration();
+diff --git a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+index 94b95e5029..c8a563163e 100644
+--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
++++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+@@ -32,5 +32,5 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
+      * @return void
+      */
+-    protected function listBundles(OutputInterface|StyleInterface $output)
++    protected function listBundles(OutputInterface|StyleInterface $output): void
+     {
+         $title = 'Available registered bundles with their extension alias if available';
+@@ -163,5 +163,5 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
+      * @return void
+      */
+-    public function validateConfiguration(ExtensionInterface $extension, mixed $configuration)
++    public function validateConfiguration(ExtensionInterface $extension, mixed $configuration): void
+     {
+         if (!$configuration) {
 diff --git a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
-index 5083538709..82093403f1 100644
+index 02709ba649..5a3e972793 100644
 --- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
 +++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
 @@ -56,5 +56,5 @@ class Application extends BaseApplication
@@ -519,17 +601,6 @@ index 5083538709..82093403f1 100644
 +    protected function registerCommands(): void
      {
          if ($this->commandsRegistered) {
-diff --git a/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php b/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
-index ccb61b1286..700d0f22d4 100644
---- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
-+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
-@@ -23,5 +23,5 @@ use Symfony\Component\HttpKernel\DataCollector\RouterDataCollector as BaseRouter
- class RouterDataCollector extends BaseRouterDataCollector
- {
--    public function guessRoute(Request $request, mixed $controller)
-+    public function guessRoute(Request $request, mixed $controller): string
-     {
-         if (\is_array($controller)) {
 diff --git a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
 index d0aca7a06b..aee4af1a43 100644
 --- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
@@ -670,7 +741,7 @@ index bda9ca9515..c0d1f91339 100644
      {
          if (!$container->hasParameter('workflow.has_guard_listeners')) {
 diff --git a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
-index 981a865672..b7e456ba54 100644
+index cb855a9c2c..a935ea8307 100644
 --- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
 +++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
 @@ -212,5 +212,5 @@ class FrameworkExtension extends Extension
@@ -680,7 +751,7 @@ index 981a865672..b7e456ba54 100644
 +    public function load(array $configs, ContainerBuilder $container): void
      {
          $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
-@@ -2901,5 +2901,5 @@ class FrameworkExtension extends Extension
+@@ -2904,5 +2904,5 @@ class FrameworkExtension extends Extension
       * @return void
       */
 -    public static function registerRateLimiter(ContainerBuilder $container, string $name, array $limiterConfig)
@@ -706,10 +777,10 @@ index 339b28e83c..448402d81e 100644
      {
          parent::build($container);
 diff --git a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
-index 3ab28a1f81..2ace764149 100644
+index f82e1fb209..36b4ddb6c9 100644
 --- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
 +++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
-@@ -132,5 +132,5 @@ trait MicroKernelTrait
+@@ -133,5 +133,5 @@ trait MicroKernelTrait
       * @return void
       */
 -    public function registerContainerConfiguration(LoaderInterface $loader)
@@ -999,7 +1070,7 @@ index a2c5815e4b..1c9721ccc6 100644
 +    public function addConfiguration(NodeDefinition $builder): void;
  }
 diff --git a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
-index ddb1d3cc92..18203f5104 100644
+index 8c52a645ea..ba3db6e606 100644
 --- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
 +++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
 @@ -82,5 +82,5 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
@@ -2745,7 +2816,7 @@ index 8ebc84376b..4af2691707 100644
      {
          if ($output instanceof SymfonyStyle) {
 diff --git a/src/Symfony/Component/Console/Helper/Table.php b/src/Symfony/Component/Console/Helper/Table.php
-index cf714873f5..e16ffaf97d 100644
+index db238c0fb8..85afdd4d31 100644
 --- a/src/Symfony/Component/Console/Helper/Table.php
 +++ b/src/Symfony/Component/Console/Helper/Table.php
 @@ -70,5 +70,5 @@ class Table
@@ -3169,7 +3240,7 @@ index 3a06311a8b..8204b8a744 100644
 +    abstract protected function doWrite(string $message, bool $newline): void;
  }
 diff --git a/src/Symfony/Component/Console/Output/OutputInterface.php b/src/Symfony/Component/Console/Output/OutputInterface.php
-index fb1557720f..8b31dee20c 100644
+index 19a8179011..6240e9493b 100644
 --- a/src/Symfony/Component/Console/Output/OutputInterface.php
 +++ b/src/Symfony/Component/Console/Output/OutputInterface.php
 @@ -40,5 +40,5 @@ interface OutputInterface
@@ -3186,21 +3257,21 @@ index fb1557720f..8b31dee20c 100644
 +    public function writeln(string|iterable $messages, int $options = 0): void;
  
      /**
-@@ -57,5 +57,5 @@ interface OutputInterface
+@@ -59,5 +59,5 @@ interface OutputInterface
       * @return void
       */
 -    public function setVerbosity(int $level);
 +    public function setVerbosity(int $level): void;
  
      /**
-@@ -89,5 +89,5 @@ interface OutputInterface
+@@ -93,5 +93,5 @@ interface OutputInterface
       * @return void
       */
 -    public function setDecorated(bool $decorated);
 +    public function setDecorated(bool $decorated): void;
  
      /**
-@@ -99,5 +99,5 @@ interface OutputInterface
+@@ -103,5 +103,5 @@ interface OutputInterface
       * @return void
       */
 -    public function setFormatter(OutputFormatterInterface $formatter);
@@ -3633,24 +3704,24 @@ index b4e982c457..521a9531f8 100644
      {
          return $this->tag;
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
-index 95251dec82..74c2b38eb8 100644
+index f18baa57c6..995705aeea 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
-@@ -40,5 +40,5 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
+@@ -41,5 +41,5 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
       * @return void
       */
 -    public function process(ContainerBuilder $container)
 +    public function process(ContainerBuilder $container): void
      {
          $this->container = $container;
-@@ -54,5 +54,5 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
+@@ -55,5 +55,5 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
       * @return void
       */
 -    protected function enableExpressionProcessing()
 +    protected function enableExpressionProcessing(): void
      {
          $this->processExpressions = true;
-@@ -74,5 +74,5 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
+@@ -75,5 +75,5 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
       * @return mixed
       */
 -    protected function processValue(mixed $value, bool $isRoot = false)
@@ -3658,10 +3729,10 @@ index 95251dec82..74c2b38eb8 100644
      {
          if (\is_array($value)) {
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
-index de033d9847..e515b6344c 100644
+index 4fea73217c..a8306cb860 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
-@@ -58,5 +58,5 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
+@@ -60,5 +60,5 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -3680,10 +3751,10 @@ index 3f070dcc0c..aa0e5186bf 100644
      {
          foreach ($container->findTaggedServiceIds('auto_alias') as $serviceId => $tags) {
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
-index f84a7faff0..fb0bb08933 100644
+index e28b60c6ea..a5b3d3d00b 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
-@@ -71,5 +71,5 @@ class AutowirePass extends AbstractRecursivePass
+@@ -73,5 +73,5 @@ class AutowirePass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -3713,10 +3784,10 @@ index c62345f26e..098772e2ef 100644
      {
          foreach ($container->getDefinitions() as $id => $definition) {
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
-index 8f828d3221..fb41bd49a3 100644
+index 7a6dd76879..27d718e142 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
-@@ -29,5 +29,5 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
+@@ -31,5 +31,5 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -3759,10 +3830,10 @@ index 2ad4a048ba..719267be1e 100644
 +    public function process(ContainerBuilder $container): void;
  }
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
-index d05878fe85..dc75d9ef10 100644
+index 92e1e2de4b..aa3e55d492 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
-@@ -31,5 +31,5 @@ class DecoratorServicePass extends AbstractRecursivePass
+@@ -33,5 +33,5 @@ class DecoratorServicePass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -3770,10 +3841,10 @@ index d05878fe85..dc75d9ef10 100644
      {
          $definitions = new \SplPriorityQueue();
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php b/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
-index b6ee648160..5682941b11 100644
+index dfba7fe3e1..3f05e2d35f 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
-@@ -33,5 +33,5 @@ class DefinitionErrorExceptionPass extends AbstractRecursivePass
+@@ -35,5 +35,5 @@ class DefinitionErrorExceptionPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -3792,10 +3863,10 @@ index 953b7f942e..96912701e5 100644
      {
          foreach ($container->getExtensions() as $extension) {
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
-index f4eb931412..0e5448aa91 100644
+index 57e14b77be..7f7450a79a 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
-@@ -41,5 +41,5 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
+@@ -43,5 +43,5 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -3935,10 +4006,10 @@ index 93c3fd2672..250a640d63 100644
      {
          foreach ($container->getAliases() as $id => $alias) {
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
-index df97a62f7e..60126d8d06 100644
+index d6ee5ea560..ebac675ef6 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
-@@ -30,5 +30,5 @@ class RemoveUnusedDefinitionsPass extends AbstractRecursivePass
+@@ -32,5 +32,5 @@ class RemoveUnusedDefinitionsPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -3946,10 +4017,10 @@ index df97a62f7e..60126d8d06 100644
      {
          try {
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
-index 808cde2081..83063d607d 100644
+index 46d615f834..e0d0dbfc62 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
-@@ -34,5 +34,5 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
+@@ -36,5 +36,5 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
       * @throws InvalidArgumentException if the service definition does not exist
       */
 -    public function process(ContainerBuilder $container)
@@ -3957,10 +4028,10 @@ index 808cde2081..83063d607d 100644
      {
          // First collect all alias targets that need to be replaced
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
-index 55a358efdf..be943ae655 100644
+index 68835d52aa..a6e75b89da 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
-@@ -36,5 +36,5 @@ class ResolveBindingsPass extends AbstractRecursivePass
+@@ -38,5 +38,5 @@ class ResolveBindingsPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -3990,10 +4061,10 @@ index da02622b21..395c5a1de6 100644
      {
          $stacks = [];
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php b/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
-index bffb9dab85..40e484f5a5 100644
+index 705bb837b9..1c66600cfa 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
-@@ -29,5 +29,5 @@ class ResolveHotPathPass extends AbstractRecursivePass
+@@ -31,5 +31,5 @@ class ResolveHotPathPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -4023,10 +4094,10 @@ index 7a2a69aa6a..7a265cc8aa 100644
      {
          $this->container = $container;
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNoPreloadPass.php b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNoPreloadPass.php
-index 3302dd2cd2..459c22434b 100644
+index fb7991229f..e683f90650 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNoPreloadPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNoPreloadPass.php
-@@ -30,5 +30,5 @@ class ResolveNoPreloadPass extends AbstractRecursivePass
+@@ -32,5 +32,5 @@ class ResolveNoPreloadPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -4034,10 +4105,10 @@ index 3302dd2cd2..459c22434b 100644
      {
          $this->container = $container;
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
-index c4a1412ff2..2bb03c253e 100644
+index a78a6e508e..c99cd0146f 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
-@@ -37,5 +37,5 @@ class ResolveParameterPlaceHoldersPass extends AbstractRecursivePass
+@@ -39,5 +39,5 @@ class ResolveParameterPlaceHoldersPass extends AbstractRecursivePass
       * @throws ParameterNotFoundException
       */
 -    public function process(ContainerBuilder $container)
@@ -4045,10 +4116,10 @@ index c4a1412ff2..2bb03c253e 100644
      {
          $this->bag = $container->getParameterBag();
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
-index 3176d405f8..0bbc25ba9e 100644
+index 16d0e9fcb0..7e0df0625f 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
-@@ -26,5 +26,5 @@ class ResolveReferencesToAliasesPass extends AbstractRecursivePass
+@@ -28,5 +28,5 @@ class ResolveReferencesToAliasesPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)
@@ -4589,7 +4660,7 @@ index 1ede090384..7b6b63c599 100644
      {
          throw new LogicException('Impossible to call remove() on a frozen ParameterBag.');
 diff --git a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
-index 6ba8a4cf7c..5e5e22bc09 100644
+index a7b0aaaedc..b65322e66f 100644
 --- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
 +++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
 @@ -35,5 +35,5 @@ class ParameterBag implements ParameterBagInterface
@@ -6168,24 +6239,24 @@ index 655ef6682f..0e525d09f6 100644
      {
          $compound = static fn (Options $options) => 'single_text' !== $options['widget'];
 diff --git a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
-index 32c58447cd..ec35f6ee41 100644
+index 9ec4c9cca4..28a33fb6d6 100644
 --- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
 +++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
-@@ -51,5 +51,5 @@ class DateTimeType extends AbstractType
+@@ -53,5 +53,5 @@ class DateTimeType extends AbstractType
       * @return void
       */
 -    public function buildForm(FormBuilderInterface $builder, array $options)
 +    public function buildForm(FormBuilderInterface $builder, array $options): void
      {
          $parts = ['year', 'month', 'day', 'hour'];
-@@ -200,5 +200,5 @@ class DateTimeType extends AbstractType
+@@ -217,5 +217,5 @@ class DateTimeType extends AbstractType
       * @return void
       */
 -    public function buildView(FormView $view, FormInterface $form, array $options)
 +    public function buildView(FormView $view, FormInterface $form, array $options): void
      {
          $view->vars['widget'] = $options['widget'];
-@@ -228,5 +228,5 @@ class DateTimeType extends AbstractType
+@@ -245,5 +245,5 @@ class DateTimeType extends AbstractType
       * @return void
       */
 -    public function configureOptions(OptionsResolver $resolver)
@@ -6193,24 +6264,24 @@ index 32c58447cd..ec35f6ee41 100644
      {
          $compound = static fn (Options $options) => 'single_text' !== $options['widget'];
 diff --git a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
-index 80023affcb..d6051f52d1 100644
+index 480afc315f..e9f6364b07 100644
 --- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
 +++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
-@@ -47,5 +47,5 @@ class DateType extends AbstractType
+@@ -49,5 +49,5 @@ class DateType extends AbstractType
       * @return void
       */
 -    public function buildForm(FormBuilderInterface $builder, array $options)
 +    public function buildForm(FormBuilderInterface $builder, array $options): void
      {
          $dateFormat = \is_int($options['format']) ? $options['format'] : self::DEFAULT_FORMAT;
-@@ -184,5 +184,5 @@ class DateType extends AbstractType
+@@ -201,5 +201,5 @@ class DateType extends AbstractType
       * @return void
       */
 -    public function finishView(FormView $view, FormInterface $form, array $options)
 +    public function finishView(FormView $view, FormInterface $form, array $options): void
      {
          $view->vars['widget'] = $options['widget'];
-@@ -224,5 +224,5 @@ class DateType extends AbstractType
+@@ -241,5 +241,5 @@ class DateType extends AbstractType
       * @return void
       */
 -    public function configureOptions(OptionsResolver $resolver)
@@ -6560,7 +6631,7 @@ index 40e7580d80..18c58e30c0 100644
      {
          $view->vars['pattern'] = null;
 diff --git a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
-index c7d5276960..25d2444547 100644
+index 623259f17a..1b7bd9a33f 100644
 --- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
 +++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
 @@ -38,5 +38,5 @@ class TimeType extends AbstractType
@@ -6570,14 +6641,14 @@ index c7d5276960..25d2444547 100644
 +    public function buildForm(FormBuilderInterface $builder, array $options): void
      {
          $parts = ['hour'];
-@@ -214,5 +214,5 @@ class TimeType extends AbstractType
+@@ -229,5 +229,5 @@ class TimeType extends AbstractType
       * @return void
       */
 -    public function buildView(FormView $view, FormInterface $form, array $options)
 +    public function buildView(FormView $view, FormInterface $form, array $options): void
      {
          $view->vars = array_replace($view->vars, [
-@@ -245,5 +245,5 @@ class TimeType extends AbstractType
+@@ -260,5 +260,5 @@ class TimeType extends AbstractType
       * @return void
       */
 -    public function configureOptions(OptionsResolver $resolver)
@@ -8400,7 +8471,7 @@ index efa1a4f737..752eb19faf 100644
 +    public function lateCollect(): void;
  }
 diff --git a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
-index 094683ccce..5582af522e 100644
+index 725b82b402..c246d912ad 100644
 --- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
 +++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
 @@ -199,5 +199,5 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
@@ -8466,21 +8537,21 @@ index 094683ccce..5582af522e 100644
 +    public function getResponseCookies(): ParameterBag
      {
          return new ParameterBag($this->data['response_cookies']->getValue());
-@@ -301,5 +301,5 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
+@@ -304,5 +304,5 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
       * @return bool
       */
 -    public function isJsonRequest()
 +    public function isJsonRequest(): bool
      {
          return 1 === preg_match('{^application/(?:\w+\++)*json$}i', $this->data['request_headers']['content-type']);
-@@ -309,5 +309,5 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
+@@ -312,5 +312,5 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
       * @return string|null
       */
 -    public function getPrettyJson()
 +    public function getPrettyJson(): ?string
      {
          $decoded = json_decode($this->getContent());
-@@ -344,5 +344,5 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
+@@ -347,5 +347,5 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
       * @return ParameterBag
       */
 -    public function getDotenvVars()
@@ -10825,7 +10896,7 @@ index e3fb17e81c..cd27f3e387 100644
      {
          $this->strictRequirements = $enabled;
 diff --git a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
-index decd2a2b1d..a37965ed5b 100644
+index 98af1febc5..eb9b1ae404 100644
 --- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
 +++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
 @@ -96,5 +96,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
@@ -10835,42 +10906,42 @@ index decd2a2b1d..a37965ed5b 100644
 +    public function setRouteAnnotationClass(string $class): void
      {
          $this->routeAnnotationClass = $class;
-@@ -148,5 +148,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
+@@ -164,5 +164,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
       * @return void
       */
 -    protected function addRoute(RouteCollection $collection, object $annot, array $globals, \ReflectionClass $class, \ReflectionMethod $method)
 +    protected function addRoute(RouteCollection $collection, object $annot, array $globals, \ReflectionClass $class, \ReflectionMethod $method): void
      {
          if ($annot->getEnv() && $annot->getEnv() !== $this->env) {
-@@ -241,5 +241,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
+@@ -257,5 +257,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
       * @return void
       */
 -    public function setResolver(LoaderResolverInterface $resolver)
 +    public function setResolver(LoaderResolverInterface $resolver): void
      {
      }
-@@ -254,5 +254,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
+@@ -270,5 +270,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
       * @return string
       */
 -    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
 +    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method): string
      {
          $name = str_replace('\\', '_', $class->name).'_'.$method->name;
-@@ -269,5 +269,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
+@@ -285,5 +285,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
       * @return array
       */
 -    protected function getGlobals(\ReflectionClass $class)
 +    protected function getGlobals(\ReflectionClass $class): array
      {
          $globals = $this->resetGlobals();
-@@ -354,5 +354,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
+@@ -370,5 +370,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
       * @return Route
       */
 -    protected function createRoute(string $path, array $defaults, array $requirements, array $options, ?string $host, array $schemes, array $methods, ?string $condition)
 +    protected function createRoute(string $path, array $defaults, array $requirements, array $options, ?string $host, array $schemes, array $methods, ?string $condition): Route
      {
          return new Route($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
-@@ -362,5 +362,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
+@@ -378,5 +378,5 @@ abstract class AnnotationClassLoader implements LoaderInterface
       * @return void
       */
 -    abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot);
@@ -12467,10 +12538,10 @@ index dd6ea3c831..faa71809ec 100644
      {
          if (!$container->hasDefinition('translator.default')) {
 diff --git a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
-index f7f954eea1..b93248a69a 100644
+index 1756e3c8c5..1e22616d91 100644
 --- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
 +++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
-@@ -44,5 +44,5 @@ class TranslatorPathsPass extends AbstractRecursivePass
+@@ -46,5 +46,5 @@ class TranslatorPathsPass extends AbstractRecursivePass
       * @return void
       */
 -    public function process(ContainerBuilder $container)

--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -73,11 +73,11 @@ foreach ($loader->getClassMap() as $class => $file) {
     $refl = new \ReflectionClass($class);
     foreach ($refl->getMethods() as $method) {
         if (
-            !$refl->isInterface()
-            || $method->getReturnType()
+            $method->getReturnType()
             || str_contains($method->getDocComment(), '@return')
             || str_starts_with($method->getName(), '__')
             || $method->getDeclaringClass()->getName() !== $class
+            || str_contains($method->getDeclaringClass()->getName(), '\\Test\\')
         ) {
             continue;
         }

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -150,7 +150,7 @@ jobs:
           git checkout src/Symfony/Contracts/Service/ResetInterface.php
           git diff --exit-code
 
-      - name: Check interface return types
+      - name: Check return types
         if: "matrix.php == '8.1' && ! matrix.mode"
         run: |
           php .github/patch-types.php lint

--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -113,11 +113,17 @@ class DoctrineDataCollector extends DataCollector
         }
     }
 
+    /**
+     * @return array
+     */
     public function getManagers()
     {
         return $this->data['managers'];
     }
 
+    /**
+     * @return array
+     */
     public function getConnections()
     {
         return $this->data['connections'];
@@ -131,11 +137,17 @@ class DoctrineDataCollector extends DataCollector
         return array_sum(array_map('count', $this->data['queries']));
     }
 
+    /**
+     * @return array
+     */
     public function getQueries()
     {
         return $this->data['queries'];
     }
 
+    /**
+     * @return int
+     */
     public function getTime()
     {
         $time = 0;

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -53,6 +53,9 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
         $this->tagPrefix = $tagPrefix;
     }
 
+    /**
+     * @return void
+     */
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasParameter($this->connectionsParameter)) {

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Form;
 
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException as LegacyMappingException;
 use Doctrine\Persistence\ManagerRegistry;
@@ -151,6 +152,13 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
         return null;
     }
 
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     *
+     * @return array{0:ClassMetadata<T>, 1:string}|null
+     */
     protected function getMetadata(string $class)
     {
         // normalize class name

--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -129,6 +129,8 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
 
     /**
      * Sets the console output to use for printing logs.
+     *
+     * @return void
      */
     public function setOutput(OutputInterface $output)
     {
@@ -148,6 +150,8 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * Before a command is executed, the handler gets activated and the console output
      * is set in order to know where to write the logs.
+     *
+     * @return void
      */
     public function onCommand(ConsoleCommandEvent $event)
     {
@@ -161,6 +165,8 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
 
     /**
      * After a command has been executed, it disables the output.
+     *
+     * @return void
      */
     public function onTerminate(ConsoleTerminateEvent $event)
     {

--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -130,6 +130,9 @@ trait ServerLogHandlerTrait
     {
     }
 
+    /**
+     * @return resource
+     */
     private function createSocket()
     {
         $socket = stream_socket_client($this->host, $errno, $errstr, 0, \STREAM_CLIENT_CONNECT | \STREAM_CLIENT_ASYNC_CONNECT | \STREAM_CLIENT_PERSISTENT, $this->context);

--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -134,7 +134,7 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
         return $this->profile ??= unserialize($this->data['profile'], ['allowed_classes' => ['Twig_Profiler_Profile', Profile::class]]);
     }
 
-    private function getComputedData(string $index)
+    private function getComputedData(string $index): mixed
     {
         $this->computed ??= $this->computeData($this->getProfile());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -28,6 +28,9 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
  */
 abstract class AbstractConfigCommand extends ContainerDebugCommand
 {
+    /**
+     * @return void
+     */
     protected function listBundles(OutputInterface|StyleInterface $output)
     {
         $title = 'Available registered bundles with their extension alias if available';
@@ -63,14 +66,14 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         $bundleExtensions = [];
         foreach ($kernel->getBundles() as $bundle) {
             if ($extension = $bundle->getContainerExtension()) {
-                $bundleExtensions[\get_class($extension)] = true;
+                $bundleExtensions[$extension::class] = true;
             }
         }
 
         $extensions = $this->getContainerBuilder($kernel)->getExtensions();
 
         foreach ($extensions as $alias => $extension) {
-            if (isset($bundleExtensions[\get_class($extension)])) {
+            if (isset($bundleExtensions[$extension::class])) {
                 continue;
             }
             $rows[] = [$alias];
@@ -156,6 +159,9 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         throw new LogicException($message);
     }
 
+    /**
+     * @return void
+     */
     public function validateConfiguration(ExtensionInterface $extension, mixed $configuration)
     {
         if (!$configuration) {

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpKernel\DataCollector\RouterDataCollector as BaseRouter
  */
 class RouterDataCollector extends BaseRouterDataCollector
 {
-    public function guessRoute(Request $request, mixed $controller)
+    public function guessRoute(Request $request, mixed $controller): string
     {
         if (\is_array($controller)) {
             $controller = $controller[0];

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1864,7 +1864,7 @@ class Configuration implements ConfigurationInterface
                                     ->normalizeKeys(false)
                                     ->variablePrototype()->end()
                                 ->end()
-                                ->append($this->addHttpClientRetrySection())
+                                ->append($this->createHttpClientRetrySection())
                             ->end()
                         ->end()
                         ->scalarNode('mock_response_factory')
@@ -2012,7 +2012,7 @@ class Configuration implements ConfigurationInterface
                                         ->normalizeKeys(false)
                                         ->variablePrototype()->end()
                                     ->end()
-                                    ->append($this->addHttpClientRetrySection())
+                                    ->append($this->createHttpClientRetrySection())
                                 ->end()
                             ->end()
                         ->end()
@@ -2022,7 +2022,7 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    private function addHttpClientRetrySection()
+    private function createHttpClientRetrySection(): ArrayNodeDefinition
     {
         $root = new NodeBuilder();
 
@@ -2226,7 +2226,7 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    private function addRemoteEventSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone)
+    private function addRemoteEventSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
             ->children()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2831,7 +2831,7 @@ class FrameworkExtension extends Extension
         }
     }
 
-    private function registerWebhookConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader)
+    private function registerWebhookConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void
     {
         if (!class_exists(WebhookController::class)) {
             throw new LogicException('Webhook support cannot be enabled as the component is not installed. Try running "composer require symfony/webhook".');
@@ -2852,7 +2852,7 @@ class FrameworkExtension extends Extension
         $controller->replaceArgument(1, new Reference($config['message_bus']));
     }
 
-    private function registerRemoteEventConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader)
+    private function registerRemoteEventConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void
     {
         if (!class_exists(RemoteEvent::class)) {
             throw new LogicException('RemoteEvent support cannot be enabled as the component is not installed. Try running "composer require symfony/remote-event".');

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -593,7 +593,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         return [$matcher, $listeners, $exceptionListener, null !== $logoutListenerId ? new Reference($logoutListenerId) : null, $firewallAuthenticationProviders];
     }
 
-    private function createContextListener(ContainerBuilder $container, string $contextKey, ?string $firewallEventDispatcherId)
+    private function createContextListener(ContainerBuilder $container, string $contextKey, ?string $firewallEventDispatcherId): string
     {
         if (isset($this->contextListeners[$contextKey])) {
             return $this->contextListeners[$contextKey];

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -242,7 +242,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
         ];
     }
 
-    private function &recursiveBuildPreliminaryFormTree(FormInterface $form, array &$outputByHash)
+    private function &recursiveBuildPreliminaryFormTree(FormInterface $form, array &$outputByHash): array
     {
         $hash = spl_object_hash($form);
 
@@ -259,7 +259,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
         return $output;
     }
 
-    private function &recursiveBuildFinalFormTree(FormInterface $form = null, FormView $view, array &$outputByHash)
+    private function &recursiveBuildFinalFormTree(FormInterface $form = null, FormView $view, array &$outputByHash): array
     {
         $viewHash = spl_object_hash($view);
         $formHash = null;

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\VarDumper\Caster\ClassStub;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -224,7 +225,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
         return $this->data['zend_opcache_enabled'];
     }
 
-    public function getBundles()
+    public function getBundles(): array|Data
     {
         return $this->data['bundles'];
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -67,12 +68,12 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         $this->currentRequest = null;
     }
 
-    public function getLogs()
+    public function getLogs(): Data|array
     {
         return $this->data['logs'] ?? [];
     }
 
-    public function getProcessedLogs()
+    public function getProcessedLogs(): array
     {
         if (null !== $this->processedLogs) {
             return $this->processedLogs;
@@ -115,7 +116,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         return $this->processedLogs = $logs;
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         $filters = [
             'channel' => [],
@@ -146,32 +147,32 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         return $filters;
     }
 
-    public function getPriorities()
+    public function getPriorities(): Data|array
     {
         return $this->data['priorities'] ?? [];
     }
 
-    public function countErrors()
+    public function countErrors(): int
     {
         return $this->data['error_count'] ?? 0;
     }
 
-    public function countDeprecations()
+    public function countDeprecations(): int
     {
         return $this->data['deprecation_count'] ?? 0;
     }
 
-    public function countWarnings()
+    public function countWarnings(): int
     {
         return $this->data['warning_count'] ?? 0;
     }
 
-    public function countScreams()
+    public function countScreams(): int
     {
         return $this->data['scream_count'] ?? 0;
     }
 
-    public function getCompilerLogs()
+    public function getCompilerLogs(): Data
     {
         return $this->cloneVar($this->getContainerCompilerLogs($this->data['compiler_logs_filepath'] ?? null));
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -185,12 +185,12 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $this->sessionUsages = [];
     }
 
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->data['method'];
     }
 
-    public function getPathInfo()
+    public function getPathInfo(): string
     {
         return $this->data['path_info'];
     }
@@ -267,31 +267,34 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         return new ParameterBag($this->data['response_cookies']->getValue());
     }
 
-    public function getSessionMetadata()
+    public function getSessionMetadata(): array
     {
         return $this->data['session_metadata']->getValue();
     }
 
-    public function getSessionAttributes()
+    public function getSessionAttributes(): array
     {
         return $this->data['session_attributes']->getValue();
     }
 
-    public function getStatelessCheck()
+    public function getStatelessCheck(): bool
     {
         return $this->data['stateless_check'];
     }
 
-    public function getSessionUsages()
+    public function getSessionUsages(): Data|array
     {
         return $this->data['session_usages'];
     }
 
-    public function getFlashes()
+    public function getFlashes(): array
     {
         return $this->data['flashes']->getValue();
     }
 
+    /**
+     * @return string|resource
+     */
     public function getContent()
     {
         return $this->data['content'];
@@ -315,27 +318,27 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         return \JSON_ERROR_NONE === json_last_error() ? json_encode($decoded, \JSON_PRETTY_PRINT) : null;
     }
 
-    public function getContentType()
+    public function getContentType(): string
     {
         return $this->data['content_type'];
     }
 
-    public function getStatusText()
+    public function getStatusText(): string
     {
         return $this->data['status_text'];
     }
 
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->data['status_code'];
     }
 
-    public function getFormat()
+    public function getFormat(): string
     {
         return $this->data['format'];
     }
 
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->data['locale'];
     }
@@ -358,7 +361,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         return $this->data['route'];
     }
 
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->data['identifier'];
     }
@@ -395,7 +398,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         return $this->data['redirect'] ?? false;
     }
 
-    public function getForwardToken()
+    public function getForwardToken(): ?string
     {
         return $this->data['forward_token'] ?? null;
     }

--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -27,7 +27,7 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
 {
     private array $traceableBuses = [];
 
-    public function registerBus(string $name, TraceableMessageBus $bus)
+    public function registerBus(string $name, TraceableMessageBus $bus): void
     {
         $this->traceableBuses[$name] = $bus;
     }

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -73,7 +73,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
         return $this->data[DataCollectorTranslator::MESSAGE_DEFINED] ?? 0;
     }
 
-    public function getLocale()
+    public function getLocale(): ?string
     {
         return !empty($this->data['locale']) ? $this->data['locale'] : null;
     }
@@ -81,7 +81,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
     /**
      * @internal
      */
-    public function getFallbackLocales()
+    public function getFallbackLocales(): Data|array
     {
         return (isset($this->data['fallback_locales']) && \count($this->data['fallback_locales']) > 0) ? $this->data['fallback_locales'] : [];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

In 6.3, we enforced return types on all interface methods. We're missing just a handful return types on non-interface methods (all fixed in this PR). As you can see, the added return types are either data collectors or methods introduced by 6.3 features.

In my opinion, we should start to enforce return types on all methods from 6.4 (either as PHPdoc - for `resource` and to avoid BC breaks - or PHP native declaration).