### PR TITLE
[Security] Remove BC layer for HttpFoundation < 6.2

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -74,7 +74,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
     {
         return ($this->options['post_only'] ? $request->isMethod('POST') : true)
             && $this->httpUtils->checkRequestPath($request, $this->options['check_path'])
-            && ($this->options['form_only'] ? 'form' === (method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType()) : true);
+            && ($this->options['form_only'] ? 'form' === $request->getContentTypeFormat() : true);
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -66,7 +66,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
     {
         if (
             !str_contains($request->getRequestFormat() ?? '', 'json')
-            && !str_contains((method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType()) ?? '', 'json')
+            && !str_contains($request->getContentTypeFormat() ?? '', 'json')
         ) {
             return false;
         }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/security-core": "^6.3|^7.0",
-        "symfony/http-foundation": "^5.4|^6.0|^7.0",
+        "symfony/http-foundation": "^6.2|^7.0",
         "symfony/http-kernel": "^6.3|^7.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/property-access": "^5.4|^6.0|^7.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

In #45034, a condition was added to support `symfony/http-foundation < 6.2` or use the new `Request::getContentTypeFormat()` method when it exists.

I propose to update the minimum version of `symfony/http-foundation` required by `symfony/security-http: 6.4`.
`symfony/security-http: 6.4` already requires `symfony/http-kernel: ^6.3|^7.0` [which require](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/HttpKernel/composer.json) `symfony/http-foundation: ^6.2.7`

The legacy method `Request::getContentType()` will be removed in 7.0 by #50826