### PR TITLE
[Doctrine][Serializer] Remove `ExpectDeprecationTrait` where it is not used

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -14,13 +14,10 @@ namespace Symfony\Bridge\Doctrine\Tests;
 use Doctrine\Common\EventSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
 
 class ContainerAwareEventManagerTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     private $container;
     private $evm;
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/UidNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/UidNormalizerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Normalizer\UidNormalizer;
 use Symfony\Component\Uid\AbstractUid;
@@ -26,8 +25,6 @@ use Symfony\Component\Uid\UuidV6;
 
 class UidNormalizerTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @var UidNormalizer
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

This unused code has been left by #50558 and #50575.

I think PHPStan should detect when the trait is imported but the method `expectDeprecation` is not used.

Other PR for 6.4 #50828