### PR TITLE
[DependencyInjection] Fix autocasting null env values to empty string

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -390,7 +390,15 @@ class Container implements ContainerInterface, ResetInterface
             $prefix = 'string';
             $localName = $name;
         }
-        $processor = $processors->has($prefix) ? $processors->get($prefix) : new EnvVarProcessor($this);
+
+        if ($processors->has($prefix)) {
+            $processor = $processors->get($prefix);
+        } else {
+            $processor = new EnvVarProcessor($this);
+            if (false === $i) {
+                $prefix = '';
+            }
+        }
 
         $this->resolving[$envName] = true;
         try {

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -126,6 +126,12 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             }
         }
 
+        $returnNull = false;
+        if ('' === $prefix) {
+            $returnNull = true;
+            $prefix = 'string';
+        }
+
         if (false !== $i || 'string' !== $prefix) {
             $env = $getEnv($name);
         } elseif (isset($_ENV[$name])) {
@@ -177,6 +183,10 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if (null === $env) {
+            if ($returnNull) {
+                return null;
+            }
+
             if (!isset($this->getProvidedTypes()[$prefix])) {
                 throw new RuntimeException(sprintf('Unsupported env var prefix "%s".', $prefix));
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -763,12 +763,13 @@ CSV;
 
     /**
      * @testWith    ["", "string"]
+     *              [null, ""]
      *              [false, "bool"]
      *              [true, "not"]
      *              [0, "int"]
      *              [0.0, "float"]
      */
-    public function testGetEnvCastsNull($expected, string $prefix)
+    public function testGetEnvCastsNullBehavior($expected, string $prefix)
     {
         $processor = new EnvVarProcessor(new Container());
 
@@ -777,5 +778,18 @@ CSV;
                 return null;
             });
         }));
+    }
+
+    public function testGetEnvWithEmptyStringPrefixCastsToString()
+    {
+        $processor = new EnvVarProcessor(new Container());
+        unset($_ENV['FOO']);
+        $_ENV['FOO'] = 4;
+
+        try {
+            $this->assertSame('4', $processor->getEnv('', 'FOO', function () { $this->fail('Should not be called'); }));
+        } finally {
+            unset($_ENV['FOO']);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | -
| Deprecations? | -
| Tickets       | https://github.com/symfony/symfony/issues/50815#issuecomment-1612586382
| License       | MIT
| Doc PR        | -

This PR fixes autocasting `null` env values to `''`.
We continue to autocast all other values to string when there's no prefix.

It doesn't revert https://github.com/symfony/symfony/pull/50517, it just fixes an unintended side effect.

It doesn't fix https://github.com/symfony/symfony/issues/50815 request, it confirms the behavior: the solution for this issue would be to remove the `string:` prefix.

There's still no solution to have the "keep null as null" and "cast if not null" behavior. 