### PR TITLE
[DoctrineBridge] Remove outdated comment

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
@@ -57,9 +57,6 @@ class DoctrineChoiceLoader extends AbstractChoiceLoader
             : $this->manager->getRepository($this->class)->findAll();
     }
 
-    /**
-     * @internal to be remove in Symfony 6
-     */
     protected function doLoadValuesForChoices(array $choices): array
     {
         // Optimize performance for single-field identifiers. We already


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

Spotted by @nicolas-grekas.
To throw a proper exception the method has been kept. No need to keep the comment, and I guess no need to keep it internal.