### PR TITLE
Remove BC layers related to new methods and new parameters

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -1767,64 +1767,65 @@ index b7162d7706..3d41be7340 100644
      {
          if (isset($this->options[$option->getName()]) && !$option->equals($this->options[$option->getName()])) {
 diff --git a/src/Symfony/Component/Console/Input/InputInterface.php b/src/Symfony/Component/Console/Input/InputInterface.php
-index aaed5fd01d..e7de9bcdec 100644
+index ca22bdbba5..4f4b1306b4 100644
 --- a/src/Symfony/Component/Console/Input/InputInterface.php
 +++ b/src/Symfony/Component/Console/Input/InputInterface.php
-@@ -57,5 +57,5 @@ interface InputInterface
+@@ -54,5 +54,5 @@ interface InputInterface
       * @return mixed
       */
 -    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false);
 +    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false): mixed;
  
      /**
-@@ -66,5 +66,5 @@ interface InputInterface
+@@ -63,5 +63,5 @@ interface InputInterface
       * @throws RuntimeException
       */
 -    public function bind(InputDefinition $definition);
 +    public function bind(InputDefinition $definition): void;
  
      /**
-@@ -75,5 +75,5 @@ interface InputInterface
+@@ -72,5 +72,5 @@ interface InputInterface
       * @throws RuntimeException When not enough arguments are given
       */
 -    public function validate();
 +    public function validate(): void;
  
      /**
-@@ -91,5 +91,5 @@ interface InputInterface
+@@ -88,5 +88,5 @@ interface InputInterface
       * @throws InvalidArgumentException When argument given doesn't exist
       */
 -    public function getArgument(string $name);
 +    public function getArgument(string $name): mixed;
  
      /**
-@@ -100,5 +100,5 @@ interface InputInterface
+@@ -97,5 +97,5 @@ interface InputInterface
       * @throws InvalidArgumentException When argument given doesn't exist
       */
 -    public function setArgument(string $name, mixed $value);
 +    public function setArgument(string $name, mixed $value): void;
  
      /**
-@@ -121,5 +121,5 @@ interface InputInterface
+@@ -118,5 +118,5 @@ interface InputInterface
       * @throws InvalidArgumentException When option given doesn't exist
       */
 -    public function getOption(string $name);
 +    public function getOption(string $name): mixed;
  
      /**
-@@ -130,5 +130,5 @@ interface InputInterface
+@@ -127,5 +127,5 @@ interface InputInterface
       * @throws InvalidArgumentException When option given doesn't exist
       */
 -    public function setOption(string $name, mixed $value);
 +    public function setOption(string $name, mixed $value): void;
  
      /**
-@@ -147,4 +147,4 @@ interface InputInterface
+@@ -144,5 +144,5 @@ interface InputInterface
       * @return void
       */
 -    public function setInteractive(bool $interactive);
 +    public function setInteractive(bool $interactive): void;
- }
+ 
+     /**
 diff --git a/src/Symfony/Component/Console/Input/InputOption.php b/src/Symfony/Component/Console/Input/InputOption.php
 index c9e8aa82b6..ee7c119cd2 100644
 --- a/src/Symfony/Component/Console/Input/InputOption.php
@@ -3303,24 +3304,24 @@ index f4c6b29258..1402331f9e 100644
 +    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator): object;
  }
 diff --git a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
-index 86543c1e85..4772c08c3d 100644
+index 963715dd16..5089e994ea 100644
 --- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
 +++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
 @@ -99,5 +99,5 @@ abstract class FileLoader extends BaseFileLoader
       * @return void
       */
--    public function registerClasses(Definition $prototype, string $namespace, string $resource, string|array $exclude = null/* , string $source = null */)
-+    public function registerClasses(Definition $prototype, string $namespace, string $resource, string|array $exclude = null/* , string $source = null */): void
+-    public function registerClasses(Definition $prototype, string $namespace, string $resource, string|array $exclude = null, string $source = null)
++    public function registerClasses(Definition $prototype, string $namespace, string $resource, string|array $exclude = null, string $source = null): void
      {
          if (!str_ends_with($namespace, '\\')) {
-@@ -195,5 +195,5 @@ abstract class FileLoader extends BaseFileLoader
+@@ -194,5 +194,5 @@ abstract class FileLoader extends BaseFileLoader
       * @return void
       */
 -    public function registerAliasesForSinglyImplementedInterfaces()
 +    public function registerAliasesForSinglyImplementedInterfaces(): void
      {
          foreach ($this->interfaces as $interface) {
-@@ -211,5 +211,5 @@ abstract class FileLoader extends BaseFileLoader
+@@ -210,5 +210,5 @@ abstract class FileLoader extends BaseFileLoader
       * @return void
       */
 -    protected function setDefinition(string $id, Definition $definition)
@@ -4150,7 +4151,7 @@ index 241725b9c5..420932897f 100644
      {
          $token = $this->current;
 diff --git a/src/Symfony/Component/Filesystem/Filesystem.php b/src/Symfony/Component/Filesystem/Filesystem.php
-index a379ce1863..e2035fb337 100644
+index 55db9d91ac..26dcc0d6dc 100644
 --- a/src/Symfony/Component/Filesystem/Filesystem.php
 +++ b/src/Symfony/Component/Filesystem/Filesystem.php
 @@ -37,5 +37,5 @@ class Filesystem
@@ -4240,8 +4241,8 @@ index a379ce1863..e2035fb337 100644
 @@ -704,5 +704,5 @@ class Filesystem
       * @throws IOException If the file is not writable
       */
--    public function appendToFile(string $filename, $content/* , bool $lock = false */)
-+    public function appendToFile(string $filename, $content/* , bool $lock = false */): void
+-    public function appendToFile(string $filename, $content, bool $lock = false)
++    public function appendToFile(string $filename, $content, bool $lock = false): void
      {
          if (\is_array($content)) {
 diff --git a/src/Symfony/Component/Finder/Finder.php b/src/Symfony/Component/Finder/Finder.php
@@ -9270,50 +9271,51 @@ index a0154bd7ce..70c0d942e2 100644
      {
          if (!isset($this->elements[$offset])) {
 diff --git a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
-index 11f6ed405b..53e7b33451 100644
+index 9502b1a397..f676e0f7e6 100644
 --- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
 +++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
-@@ -33,5 +33,5 @@ interface PropertyPathInterface extends \Traversable
+@@ -31,5 +31,5 @@ interface PropertyPathInterface extends \Traversable
       * @return int
       */
 -    public function getLength();
 +    public function getLength(): int;
  
      /**
-@@ -45,5 +45,5 @@ interface PropertyPathInterface extends \Traversable
+@@ -43,5 +43,5 @@ interface PropertyPathInterface extends \Traversable
       * @return self|null
       */
 -    public function getParent();
 +    public function getParent(): ?\Symfony\Component\PropertyAccess\PropertyPathInterface;
  
      /**
-@@ -52,5 +52,5 @@ interface PropertyPathInterface extends \Traversable
+@@ -50,5 +50,5 @@ interface PropertyPathInterface extends \Traversable
       * @return list<string>
       */
 -    public function getElements();
 +    public function getElements(): array;
  
      /**
-@@ -63,5 +63,5 @@ interface PropertyPathInterface extends \Traversable
+@@ -61,5 +61,5 @@ interface PropertyPathInterface extends \Traversable
       * @throws Exception\OutOfBoundsException If the offset is invalid
       */
 -    public function getElement(int $index);
 +    public function getElement(int $index): string;
  
      /**
-@@ -74,5 +74,5 @@ interface PropertyPathInterface extends \Traversable
+@@ -72,5 +72,5 @@ interface PropertyPathInterface extends \Traversable
       * @throws Exception\OutOfBoundsException If the offset is invalid
       */
 -    public function isProperty(int $index);
 +    public function isProperty(int $index): bool;
  
      /**
-@@ -85,4 +85,4 @@ interface PropertyPathInterface extends \Traversable
+@@ -83,5 +83,5 @@ interface PropertyPathInterface extends \Traversable
       * @throws Exception\OutOfBoundsException If the offset is invalid
       */
 -    public function isIndex(int $index);
 +    public function isIndex(int $index): bool;
- }
+ 
+     /**
 diff --git a/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php b/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
 index 1c240b43da..a96fbefdb9 100644
 --- a/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
@@ -9672,7 +9674,7 @@ index 417f156415..75d770d852 100644
      {
          $this->request = $request;
 diff --git a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
-index d1cee21377..19e949fbc6 100644
+index 89ff907e66..d70c095349 100644
 --- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
 +++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
 @@ -66,5 +66,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
@@ -9689,7 +9691,7 @@ index d1cee21377..19e949fbc6 100644
 +    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider): void
      {
          $this->expressionLanguageProviders[] = $provider;
-@@ -259,5 +259,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
+@@ -248,5 +248,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
       * @return ExpressionLanguage
       */
 -    protected function getExpressionLanguage()
@@ -10713,17 +10715,17 @@ index 48e8c3fb54..a71c3ea476 100644
 +    public function setDenormalizer(DenormalizerInterface $denormalizer): void;
  }
 diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
-index e4d0ed9123..8a39d97f36 100644
+index 7cb1164034..b3feecc078 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
-@@ -47,5 +47,5 @@ interface DenormalizerInterface
+@@ -45,5 +45,5 @@ interface DenormalizerInterface
       * @throws ExceptionInterface       Occurs for all the other cases of errors
       */
 -    public function denormalize(mixed $data, string $type, string $format = null, array $context = []);
 +    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed;
  
      /**
-@@ -58,5 +58,5 @@ interface DenormalizerInterface
+@@ -56,5 +56,5 @@ interface DenormalizerInterface
       * @return bool
       */
 -    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []);
@@ -10763,17 +10765,17 @@ index 40a4fa0e8c..a1e2749aae 100644
      {
          $this->normalizer = $normalizer;
 diff --git a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
-index 01979d6fcf..e918540c83 100644
+index 8d9f751d93..1e4a883e6d 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
-@@ -39,5 +39,5 @@ interface NormalizerInterface
+@@ -37,5 +37,5 @@ interface NormalizerInterface
       * @throws ExceptionInterface         Occurs for all the other cases of errors
       */
 -    public function normalize(mixed $object, string $format = null, array $context = []);
 +    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
  
      /**
-@@ -49,5 +49,5 @@ interface NormalizerInterface
+@@ -47,5 +47,5 @@ interface NormalizerInterface
       * @return bool
       */
 -    public function supportsNormalization(mixed $data, string $format = null, array $context = []);
@@ -11695,36 +11697,37 @@ index 88f90a0cdb..fd6deb6eb1 100644
      {
          unset($this->violations[$offset]);
 diff --git a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
-index 1fdbf0bc3f..aad702453b 100644
+index 1c4acd87e4..bdf59f8db4 100644
 --- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
 +++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
-@@ -31,5 +31,5 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
+@@ -29,5 +29,5 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
       * @return void
       */
 -    public function add(ConstraintViolationInterface $violation);
 +    public function add(ConstraintViolationInterface $violation): void;
  
      /**
-@@ -38,5 +38,5 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
+@@ -36,5 +36,5 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
       * @return void
       */
 -    public function addAll(self $otherList);
 +    public function addAll(self $otherList): void;
  
      /**
-@@ -63,5 +63,5 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
+@@ -61,5 +61,5 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
       * @return void
       */
 -    public function set(int $offset, ConstraintViolationInterface $violation);
 +    public function set(int $offset, ConstraintViolationInterface $violation): void;
  
      /**
-@@ -72,4 +72,4 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
+@@ -70,5 +70,5 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
       * @return void
       */
 -    public function remove(int $offset);
 +    public function remove(int $offset): void;
- }
+ 
+     /**
 diff --git a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
 index a81d589f2b..87155e513c 100644
 --- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -12488,10 +12491,10 @@ index 241ce901b5..bde6394ec3 100644
      {
          $this->collectedData = [];
 diff --git a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
-index 02fbeb797c..79964d5ce2 100644
+index 854a83538c..2a1bc5f1f8 100644
 --- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
 +++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
-@@ -113,4 +113,4 @@ interface ConstraintViolationBuilderInterface
+@@ -116,4 +116,4 @@ interface ConstraintViolationBuilderInterface
       * @return void
       */
 -    public function addViolation();
@@ -13617,16 +13620,16 @@ index 98c2149330..2e85547efb 100644
      {
          if (!$this->connection->write($data) && $this->wrappedDumper) {
 diff --git a/src/Symfony/Component/VarDumper/VarDumper.php b/src/Symfony/Component/VarDumper/VarDumper.php
-index 2e1dad116c..abe2b0b229 100644
+index a89f2369bb..78905c797d 100644
 --- a/src/Symfony/Component/VarDumper/VarDumper.php
 +++ b/src/Symfony/Component/VarDumper/VarDumper.php
 @@ -43,5 +43,5 @@ class VarDumper
       * @return mixed
       */
--    public static function dump(mixed $var/* , string $label = null */)
-+    public static function dump(mixed $var/* , string $label = null */): mixed
+-    public static function dump(mixed $var, string $label = null)
++    public static function dump(mixed $var, string $label = null): mixed
      {
-         $label = 2 <= \func_num_args() ? func_get_arg(1) : null;
+         if (null === self::$handler) {
 diff --git a/src/Symfony/Component/VarExporter/Internal/Hydrator.php b/src/Symfony/Component/VarExporter/Internal/Hydrator.php
 index f665f6ee15..429db33d19 100644
 --- a/src/Symfony/Component/VarExporter/Internal/Hydrator.php

--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -16,6 +16,7 @@ Console
  * Remove `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
  * Passing null to `*Command::setApplication()`, `*FormatterStyle::setForeground/setBackground()`, `Helper::setHelpSet()`, `Input*::setDefault()` and `Question::setAutocompleterCallback/setValidator()` must be done explicitly
  * Remove `StringInput::REGEX_STRING`
+ * Add method `__toString()` to `InputInterface`
 
 DependencyInjection
 -------------------
@@ -28,6 +29,8 @@ DependencyInjection
  * Remove `PhpDumper` options `inline_factories_parameter` and `inline_class_loader_parameter`, use options `inline_factories` and `inline_class_loader` instead
  * Parameter names of `ParameterBag` cannot be numerics
  * Remove `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
+ * Add argument `$id` and `$asGhostObject` to `DumperInterface::isProxyCandidate()` and `getProxyCode()`
+ * Add argument `$source` to `FileLoader::registerClasses()`
 
 DoctrineBridge
 --------------
@@ -42,6 +45,16 @@ DoctrineBridge
  * DoctrineBridge now requires `doctrine/event-manager:^2`
  * Add parameter `$isSameDatabase` to `DoctrineTokenProvider::configureSchema()`
 
+Filesystem
+----------
+
+ * Add argument `$lock` to `Filesystem::appendToFile()`
+
+FrameworkBundle
+---------------
+
+ * Remove command `translation:update`, use `translation:extract` instead
+
 HttpFoundation
 --------------
 
@@ -55,6 +68,11 @@ HttpFoundation
  * Remove `Request::getContentType()`, use `Request::getContentTypeFormat()` instead
  * Throw an `InvalidArgumentException` when calling `Request::create()` with a malformed URI
 
+HttpKernel
+----------
+
+ * Add argument `$reflector` to `ArgumentResolverInterface::getArguments()` and `ArgumentMetadataFactoryInterface::createArgumentMetadata()`
+
 Lock
 ----
 
@@ -65,10 +83,26 @@ Messenger
 
  * Add parameter `$isSameDatabase` to `DoctrineTransport::configureSchema()`
 
+PropertyAccess
+--------------
+
+ * Add method `isNullSafe()` to `PropertyPathInterface`
+
 ProxyManagerBridge
 ------------------
 
  * Remove the bridge, use VarExporter's lazy objects instead
+
+Routing
+-------
+
+ * Add argument `$routeParameters` to `UrlMatcher::handleRouteRequirements()`
+
+Security
+--------
+
+ * Add argument `$badgeFqcn` to `Passport::addBadge()`
+ * Add argument `$lifetime` to `LoginLinkHandlerInterface::createLoginLink()`
 
 SecurityBundle
 --------------
@@ -78,11 +112,23 @@ SecurityBundle
 Serializer
 ----------
 
+ * Add method `getSupportedTypes()` to `DenormalizerInterface` and `NormalizerInterface`
  * Remove denormalization support for `AbstractUid` in `UidNormalizer`, use one of `AbstractUid` child class instead
  * Denormalizing to an abstract class in `UidNormalizer` now throws an `\Error`
  * Remove `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead
  * Remove `ContextAwareNormalizerInterface`, use `NormalizerInterface` instead
  * Remove `CacheableSupportsMethodInterface`, use `NormalizerInterface` and `DenormalizerInterface` instead
- * First argument of `ClassMetadata::setSerializedName()` is now required
- * Third argument `array $context = []` of the `NormalizerInterface::supportsNormalization()` is now required
- * Fourth argument `array $context = []` of the `DenormalizerInterface::supportsDenormalization()` is now required
+ * First argument of `AttributeMetadata::setSerializedName()` is now required
+ * Add argument `$context` to `NormalizerInterface::supportsNormalization()` and `DenormalizerInterface::supportsDenormalization()`
+
+Validator
+---------
+
+ * Add methods `getConstraint()`, `getCause()` and `__toString()` to `ConstraintViolationInterface`
+ * Add method `__toString()` to `ConstraintViolationListInterface`
+ * Add method `disableTranslation()` to `ConstraintViolationBuilderInterface`
+
+VarDumper
+---------
+
+ * Add argument `$label` to `VarDumper::dump()`

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Remove command `translation:update`, use `translation:extract` instead
+
 6.3
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -127,10 +127,6 @@ EOF
         $io = new SymfonyStyle($input, $output);
         $errorIo = $output instanceof ConsoleOutputInterface ? new SymfonyStyle($input, $output->getErrorOutput()) : $io;
 
-        if ('translation:update' === $input->getFirstArgument()) {
-            $errorIo->caution('Command "translation:update" is deprecated since version 5.4 and will be removed in Symfony 6.0. Use "translation:extract" instead.');
-        }
-
         $io = new SymfonyStyle($input, $output);
         $errorIo = $io->getErrorStyle();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -29,14 +29,6 @@ class TranslationUpdateCommandTest extends TestCase
     private $fs;
     private $translationDir;
 
-    public function testDumpMessagesAndCleanWithDeprecatedCommandName()
-    {
-        $tester = $this->createCommandTester(['messages' => ['foo' => 'foo']]);
-        $tester->execute(['command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true]);
-        $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
-        $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
-    }
-
     public function testDumpMessagesAndClean()
     {
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo']]);

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.0
 ---
 
+ * Add method `__toString()` to `InputInterface`
  * Remove `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
  * Passing null to `*Command::setApplication()`, `*FormatterStyle::setForeground/setBackground()`, `Helper::setHelpSet()`, `Input*::setDefault()` and `Question::setAutocompleterCallback/setValidator()` must be done explicitly
  * Remove `StringInput::REGEX_STRING`

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -18,9 +18,6 @@ use Symfony\Component\Console\Exception\RuntimeException;
  * InputInterface is the interface implemented by all input classes.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @method string __toString() Returns a stringified representation of the args passed to the command.
- *                             InputArguments MUST be escaped as well as the InputOption values passed to the command.
  */
 interface InputInterface
 {
@@ -147,4 +144,11 @@ interface InputInterface
      * @return void
      */
     public function setInteractive(bool $interactive);
+
+    /**
+     * Returns a stringified representation of the args passed to the command.
+     *
+     * InputArguments MUST be escaped as well as the InputOption values passed to the command.
+     */
+    public function __toString(): string;
 }

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -107,19 +107,6 @@ class ErrorListenerTest extends TestCase
         $listener->onConsoleTerminate($this->getConsoleTerminateEvent(new StringInput('test:run --foo=bar'), 255));
     }
 
-    public function testCommandNameIsDisplayedForNonStringableInput()
-    {
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger
-            ->expects($this->once())
-            ->method('debug')
-            ->with('Command "{command}" exited with code "{code}"', ['command' => 'test:run', 'code' => 255])
-        ;
-
-        $listener = new ErrorListener($logger);
-        $listener->onConsoleTerminate($this->getConsoleTerminateEvent($this->createMock(InputInterface::class), 255));
-    }
-
     private function getConsoleTerminateEvent(InputInterface $input, $exitCode)
     {
         return new ConsoleTerminateEvent(new Command('test:run'), $input, $this->createMock(OutputInterface::class), $exitCode);

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
  * Remove `PhpDumper` options `inline_factories_parameter` and `inline_class_loader_parameter`, use options `inline_factories` and `inline_class_loader` instead
  * Parameter names of `ParameterBag` cannot be numerics
  * Remove `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
+ * Add argument `$id` and `$asGhostObject` to `DumperInterface::isProxyCandidate()` and `getProxyCode()`
+ * Add argument `$source` to `FileLoader::registerClasses()`
 
 6.4
 ---

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
@@ -23,10 +23,9 @@ interface DumperInterface
     /**
      * Inspects whether the given definitions should produce proxy instantiation logic in the dumped container.
      *
-     * @param bool|null   &$asGhostObject Set to true after the call if the proxy is a ghost object
-     * @param string|null $id
+     * @param bool|null &$asGhostObject Set to true after the call if the proxy is a ghost object
      */
-    public function isProxyCandidate(Definition $definition/* , bool &$asGhostObject = null, string $id = null */): bool;
+    public function isProxyCandidate(Definition $definition, bool &$asGhostObject = null, string $id = null): bool;
 
     /**
      * Generates the code to be used to instantiate a proxy in the dumped factory code.
@@ -35,8 +34,6 @@ interface DumperInterface
 
     /**
      * Generates the code for the lazy proxy.
-     *
-     * @param string|null $id
      */
-    public function getProxyCode(Definition $definition/* , string $id = null */): string;
+    public function getProxyCode(Definition $definition, string $id = null): string;
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -98,7 +98,7 @@ abstract class FileLoader extends BaseFileLoader
      *
      * @return void
      */
-    public function registerClasses(Definition $prototype, string $namespace, string $resource, string|array $exclude = null/* , string $source = null */)
+    public function registerClasses(Definition $prototype, string $namespace, string $resource, string|array $exclude = null, string $source = null)
     {
         if (!str_ends_with($namespace, '\\')) {
             throw new InvalidArgumentException(sprintf('Namespace prefix must end with a "\\": "%s".', $namespace));
@@ -115,7 +115,6 @@ abstract class FileLoader extends BaseFileLoader
             throw new InvalidArgumentException('The exclude list must not contain an empty value.');
         }
 
-        $source = \func_num_args() > 4 ? func_get_arg(4) : null;
         $autoconfigureAttributes = new RegisterAutoconfigureAttributesPass();
         $autoconfigureAttributes = $autoconfigureAttributes->accept($prototype) ? $autoconfigureAttributes : null;
         $classes = $this->findClasses($namespace, $resource, (array) $exclude, $autoconfigureAttributes, $source);

--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add argument `$lock` to `Filesystem::appendToFile()`
+
 5.4
 ---
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -703,7 +703,7 @@ class Filesystem
      *
      * @throws IOException If the file is not writable
      */
-    public function appendToFile(string $filename, $content/* , bool $lock = false */)
+    public function appendToFile(string $filename, $content, bool $lock = false)
     {
         if (\is_array($content)) {
             throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be string or resource, array given.', __METHOD__));
@@ -714,8 +714,6 @@ class Filesystem
         if (!is_dir($dir)) {
             $this->mkdir($dir);
         }
-
-        $lock = \func_num_args() > 2 && func_get_arg(2);
 
         if (false === self::box('file_put_contents', $filename, $content, \FILE_APPEND | ($lock ? \LOCK_EX : 0))) {
             throw new IOException(sprintf('Failed to write file "%s": ', $filename).self::$lastError, 0, null, $filename);

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add argument `$reflector` to `ArgumentResolverInterface::getArguments()` and `ArgumentMetadataFactoryInterface::createArgumentMetadata()`
+
 6.4
 ---
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
@@ -24,9 +24,7 @@ interface ArgumentResolverInterface
     /**
      * Returns the arguments to pass to the controller.
      *
-     * @param \ReflectionFunctionAbstract|null $reflector
-     *
      * @throws \RuntimeException When no value could be provided for a required argument
      */
-    public function getArguments(Request $request, callable $controller/* , \ReflectionFunctionAbstract $reflector = null */): array;
+    public function getArguments(Request $request, callable $controller, \ReflectionFunctionAbstract $reflector = null): array;
 }

--- a/src/Symfony/Component/HttpKernel/Controller/TraceableArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/TraceableArgumentResolver.php
@@ -28,12 +28,8 @@ class TraceableArgumentResolver implements ArgumentResolverInterface
         $this->stopwatch = $stopwatch;
     }
 
-    /**
-     * @param \ReflectionFunctionAbstract|null $reflector
-     */
-    public function getArguments(Request $request, callable $controller/* , \ReflectionFunctionAbstract $reflector = null */): array
+    public function getArguments(Request $request, callable $controller, \ReflectionFunctionAbstract $reflector = null): array
     {
-        $reflector = 2 < \func_num_args() ? func_get_arg(2) : null;
         $e = $this->stopwatch->start('controller.get_arguments');
 
         try {

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactoryInterface.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactoryInterface.php
@@ -19,9 +19,7 @@ namespace Symfony\Component\HttpKernel\ControllerMetadata;
 interface ArgumentMetadataFactoryInterface
 {
     /**
-     * @param \ReflectionFunctionAbstract|null $reflector
-     *
      * @return ArgumentMetadata[]
      */
-    public function createArgumentMetadata(string|object|array $controller/* , \ReflectionFunctionAbstract $reflector = null */): array;
+    public function createArgumentMetadata(string|object|array $controller, \ReflectionFunctionAbstract $reflector = null): array;
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/TraceableArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/TraceableArgumentResolverTest.php
@@ -29,7 +29,7 @@ class TraceableArgumentResolverTest extends TestCase
         $stopwatch->method('start')->willReturn($stopwatchEvent);
 
         $resolver = new class() implements ArgumentResolverInterface {
-            public function getArguments(Request $request, callable $controller): array
+            public function getArguments(Request $request, callable $controller, ?\ReflectionFunctionAbstract $reflector = null): array
             {
                 throw new \Exception();
             }

--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add method `isNullSafe()` to `PropertyPathInterface`
+
 6.3
 ---
 

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -16,8 +16,6 @@ namespace Symfony\Component\PropertyAccess;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @method bool isNullSafe(int $index) Returns whether the element at the given index is null safe. Not implementing it is deprecated since Symfony 6.2
- *
  * @extends \Traversable<int, string>
  */
 interface PropertyPathInterface extends \Traversable
@@ -85,4 +83,9 @@ interface PropertyPathInterface extends \Traversable
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */
     public function isIndex(int $index);
+
+    /**
+     * Returns whether the element at the given index is null safe.
+     */
+    public function isNullSafe(int $index): bool;
 }

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add argument `$routeParameters` to `UrlMatcher::handleRouteRequirements()`
+
 6.4
 ---
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -216,19 +216,8 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
      *
      * @return array The first element represents the status, the second contains additional information
      */
-    protected function handleRouteRequirements(string $pathinfo, string $name, Route $route/* , array $routeParameters */): array
+    protected function handleRouteRequirements(string $pathinfo, string $name, Route $route, array $routeParameters): array
     {
-        if (\func_num_args() < 4) {
-            trigger_deprecation('symfony/routing', '6.1', 'The "%s()" method will have a new "array $routeParameters" argument in version 7.0, not defining it is deprecated.', __METHOD__);
-            $routeParameters = [];
-        } else {
-            $routeParameters = func_get_arg(3);
-
-            if (!\is_array($routeParameters)) {
-                throw new \TypeError(sprintf('"%s": Argument $routeParameters is expected to be an array, got "%s".', __METHOD__, get_debug_type($routeParameters)));
-            }
-        }
-
         // expression condition
         if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(), [
             'context' => $this->context,

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
@@ -66,21 +66,15 @@ class Passport
      * This method replaces the current badge if it is already set on this
      * passport.
      *
-     * @param string|null $badgeFqcn A FQCN to which the badge should be mapped to. 
-     *                                                        This allows replacing a built-in badge by a custom one using
-     *.                                                        e.g. addBadge(new MyCustomUserBadge(), UserBadge::class)
+     * @param string|null $badgeFqcn A FQCN to which the badge should be mapped to.
+     *                               This allows replacing a built-in badge by a custom one using
+     *                               e.g. addBadge(new MyCustomUserBadge(), UserBadge::class)
      *
      * @return $this
      */
-    public function addBadge(BadgeInterface $badge/* , string $badgeFqcn = null */): static
+    public function addBadge(BadgeInterface $badge, string $badgeFqcn = null): static
     {
-        $badgeFqcn = $badge::class;
-        if (2 === \func_num_args()) {
-            $badgeFqcn = func_get_arg(1);
-            if (!\is_string($badgeFqcn)) {
-                throw new \LogicException(sprintf('Second argument of "%s" must be a string.', __METHOD__));
-            }
-        }
+        $badgeFqcn ??= $badge::class;
 
         $this->badges[$badgeFqcn] = $badge;
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add argument `$badgeFqcn` to `Passport::addBadge()`
+ * Add argument `$lifetime` to `LoginLinkHandlerInterface::createLoginLink()`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -26,7 +26,7 @@ interface LoginLinkHandlerInterface
      *
      * @param int|null $lifetime When not null, the argument overrides any default lifetime previously set
      */
-    public function createLoginLink(UserInterface $user, Request $request = null /* , int $lifetime = null */): LoginLinkDetails;
+    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null): LoginLinkDetails;
 
     /**
      * Validates if this request contains a login link and returns the associated User.

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,14 +4,14 @@ CHANGELOG
 7.0
 ---
 
+ * Add method `getSupportedTypes()` to `DenormalizerInterface` and `NormalizerInterface`
  * Remove denormalization support for `AbstractUid` in `UidNormalizer`, use one of `AbstractUid` child class instead
  * Denormalizing to an abstract class in `UidNormalizer` now throws an `\Error`
  * Remove `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead
  * Remove `ContextAwareNormalizerInterface`, use `NormalizerInterface` instead
  * Remove `CacheableSupportsMethodInterface`, use `NormalizerInterface` and `DenormalizerInterface` instead
- * First argument of `ClassMetadata::setSerializedName()` is now required
- * Third argument `array $context = []` of the `NormalizerInterface::supportsNormalization()` is now required
- * Fourth argument `array $context = []` of the `DenormalizerInterface::supportsDenormalization()` is now required
+ * First argument of `AttributeMetadata::setSerializedName()` is now required
+ * Add argument `$context` to `NormalizerInterface::supportsNormalization()` and `DenormalizerInterface::supportsDenormalization()`
 
 6.3
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -21,8 +21,6 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
- *
- * @method getSupportedTypes(?string $format): array
  */
 interface DenormalizerInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -18,8 +18,6 @@ use Symfony\Component\Serializer\Exception\LogicException;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
- *
- * @method getSupportedTypes(?string $format): array
  */
 interface NormalizerInterface
 {

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add methods `getConstraint()`, `getCause()` and `__toString()` to `ConstraintViolationInterface`
+ * Add method `__toString()` to `ConstraintViolationListInterface`
+ * Add method `disableTranslation()` to `ConstraintViolationBuilderInterface`
+
 6.4
 ---
 

--- a/src/Symfony/Component/Validator/ConstraintViolationInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationInterface.php
@@ -30,10 +30,6 @@ namespace Symfony\Component\Validator;
  * element is still the person, but the property path is "address.street".
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- *
- * @method Constraint|null getConstraint() Returns the constraint whose validation caused the violation. Not implementing it is deprecated since Symfony 6.3.
- * @method mixed           getCause()      Returns the cause of the violation. Not implementing it is deprecated since Symfony 6.2.
- * @method string          __toString()    Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
  */
 interface ConstraintViolationInterface
 {
@@ -113,4 +109,19 @@ interface ConstraintViolationInterface
      * Returns a machine-digestible error code for the violation.
      */
     public function getCode(): ?string;
+
+    /**
+     * Returns the constraint whose validation caused the violation.
+     */
+    public function getConstraint(): ?Constraint;
+
+    /**
+     * Returns the cause of the violation.
+     */
+    public function getCause(): mixed;
+
+    /**
+     * Converts the violation into a string for debugging purposes.
+     */
+    public function __toString(): string;
 }

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -20,8 +20,6 @@ use Symfony\Component\Validator\Exception\OutOfBoundsException;
  *
  * @extends \ArrayAccess<int, ConstraintViolationInterface>
  * @extends \Traversable<int, ConstraintViolationInterface>
- *
- * @method string __toString() Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
  */
 interface ConstraintViolationListInterface extends \Traversable, \Countable, \ArrayAccess
 {
@@ -72,4 +70,9 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
      * @return void
      */
     public function remove(int $offset);
+
+    /**
+     * Converts the violation into a string for debugging purposes.
+     */
+    public function __toString(): string;
 }

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -20,8 +20,6 @@ namespace Symfony\Component\Validator\Violation;
  * execution context.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- *
- * @method $this disableTranslation()
  */
 interface ConstraintViolationBuilderInterface
 {
@@ -57,6 +55,11 @@ interface ConstraintViolationBuilderInterface
      * @return $this
      */
     public function setParameters(array $parameters): static;
+
+    /**
+     * @return $this
+     */
+    public function disableTranslation(): static;
 
     /**
      * Sets the translation domain which should be used for translating the

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add argument `$label` to `VarDumper::dump()`
+
 6.3
 ---
 

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -42,9 +42,8 @@ class VarDumper
      *
      * @return mixed
      */
-    public static function dump(mixed $var/* , string $label = null */)
+    public static function dump(mixed $var, string $label = null)
     {
-        $label = 2 <= \func_num_args() ? func_get_arg(1) : null;
         if (null === self::$handler) {
             self::register();
         }

--- a/src/Symfony/Contracts/HttpClient/Test/TestHttpServer.php
+++ b/src/Symfony/Contracts/HttpClient/Test/TestHttpServer.php
@@ -18,12 +18,9 @@ class TestHttpServer
 {
     private static $process = [];
 
-    /**
-     * @param string|null $workingDirectory
-     */
-    public static function start(int $port = 8057/* , string $workingDirectory = null */): Process
+    public static function start(int $port = 8057, string $workingDirectory = null): Process
     {
-        $workingDirectory = \func_get_args()[1] ?? __DIR__.'/Fixtures/web';
+        $workingDirectory ??= __DIR__.'/Fixtures/web';
 
         if (isset(self::$process[$port])) {
             self::$process[$port]->stop();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

 * Add method `__toString()` to `InputInterface`
 * Add argument `$id` and `$asGhostObject` to `DumperInterface::isProxyCandidate()` and `getProxyCode()`
 * Add argument `$source` to `FileLoader::registerClasses()`
 * Add argument `$lock` to `Filesystem::appendToFile()`
 * Remove command `translation:update`, use `translation:extract` instead
 * Add argument `$reflector` to `ArgumentResolverInterface::getArguments()` and `ArgumentMetadataFactoryInterface::createArgumentMetadata()`
 * Add method `isNullSafe()` to `PropertyPathInterface`
 * Add argument `$routeParameters` to `UrlMatcher::handleRouteRequirements()`
 * Add argument `$badgeFqcn` to `Passport::addBadge()`
 * Add argument `$lifetime` to `LoginLinkHandlerInterface::createLoginLink()`
 * Add method `getSupportedTypes()` to `DenormalizerInterface` and `NormalizerInterface`
 * Add methods `getConstraint()`, `getCause()` and `__toString()` to `ConstraintViolationInterface`
 * Add method `__toString()` to `ConstraintViolationListInterface`
 * Add method `disableTranslation()` to `ConstraintViolationBuilderInterface`
 * Add argument `$label` to `VarDumper::dump()`
