### PR TITLE
Add missing return types to magic methods

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -352,6 +352,17 @@ index 57a4c1c2b7..2fb70d7774 100644
 +    public function onTerminate(ConsoleTerminateEvent $event): void
      {
          $this->close();
+diff --git a/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php b/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
+index 39c4a7b49b..156ae4b7de 100644
+--- a/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
++++ b/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
+@@ -158,5 +158,5 @@ class ElasticsearchLogstashHandler extends AbstractHandler
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php b/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
 index 718be59c13..091f24a8f8 100644
 --- a/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
@@ -845,6 +856,39 @@ index bb5560a7b5..be86cbf98e 100644
 +    protected static function getContainer(): Container
      {
          if (!static::$booted) {
+diff --git a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+index 3f99eff48d..80888c4a71 100644
+--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
++++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+@@ -90,5 +90,5 @@ class AppKernel extends Kernel implements ExtensionInterface, ConfigurationInter
+     }
+ 
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         foreach ($this as $k => $v) {
+diff --git a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+index def880b231..a51078adbb 100644
+--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
++++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+@@ -69,5 +69,5 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
+     }
+ 
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+diff --git a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+index bf529a5804..b15729362b 100644
+--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
++++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+@@ -70,5 +70,5 @@ class FlexStyleMicroKernel extends Kernel
+     }
+ 
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
 index dac3b6394f..d319cb0824 100644
 --- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -1513,7 +1557,7 @@ index 6e4e1dffa3..bab8a91ca4 100644
      {
          unset(self::$valuesCache[$file]);
 diff --git a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
-index f64ac99c11..84d32fb424 100644
+index 187539accb..7562afb57a 100644
 --- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
 +++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
 @@ -283,5 +283,5 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
@@ -1523,6 +1567,13 @@ index f64ac99c11..84d32fb424 100644
 +    public function reset(): void
      {
          $this->commit();
+@@ -299,5 +299,5 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
 index 118b009099..ba388b3ad8 100644
 --- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -1599,8 +1650,41 @@ index 00e912686b..58872ec2bc 100644
 +    public function process(ContainerBuilder $container): void
      {
          if (!$container->hasDefinition('console.command.cache_pool_prune')) {
+diff --git a/src/Symfony/Component/Cache/Messenger/EarlyExpirationDispatcher.php b/src/Symfony/Component/Cache/Messenger/EarlyExpirationDispatcher.php
+index db2dd97d87..959a9355d2 100644
+--- a/src/Symfony/Component/Cache/Messenger/EarlyExpirationDispatcher.php
++++ b/src/Symfony/Component/Cache/Messenger/EarlyExpirationDispatcher.php
+@@ -38,5 +38,5 @@ class EarlyExpirationDispatcher
+      * @return mixed
+      */
+-    public function __invoke(callable $callback, CacheItem $item, bool &$save, AdapterInterface $pool, \Closure $setMetadata, LoggerInterface $logger = null)
++    public function __invoke(callable $callback, CacheItem $item, bool &$save, AdapterInterface $pool, \Closure $setMetadata, LoggerInterface $logger = null): mixed
+     {
+         if (!$item->isHit() || null === $message = EarlyExpirationMessage::create($this->reverseContainer, $callback, $item, $pool)) {
+diff --git a/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php b/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
+index 1b1939a023..edae224e94 100644
+--- a/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
++++ b/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
+@@ -32,5 +32,5 @@ class EarlyExpirationHandler implements MessageHandlerInterface
+      * @return void
+      */
+-    public function __invoke(EarlyExpirationMessage $message)
++    public function __invoke(EarlyExpirationMessage $message): void
+     {
+         $item = $message->getItem();
+diff --git a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+index 1fd3dab243..fabc069ca0 100644
+--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
++++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+@@ -287,5 +287,5 @@ trait AbstractAdapterTrait
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
-index 200406a564..0bad73fe6a 100644
+index 899dffc649..95a19daed7 100644
 --- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
 +++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
 @@ -81,5 +81,5 @@ trait FilesystemCommonTrait
@@ -1610,6 +1694,13 @@ index 200406a564..0bad73fe6a 100644
 +    protected function doUnlink(string $file): bool
      {
          return @unlink($file);
+@@ -175,5 +175,5 @@ trait FilesystemCommonTrait
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/Config/ConfigCacheInterface.php b/src/Symfony/Component/Config/ConfigCacheInterface.php
 index be7f0986c3..fa5347e34b 100644
 --- a/src/Symfony/Component/Config/ConfigCacheInterface.php
@@ -4552,6 +4643,24 @@ index f4c6b29258..1402331f9e 100644
 -    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator);
 +    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator): object;
  }
+diff --git a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+index fa44784caf..cf589be28d 100644
+--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
++++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+@@ -38,5 +38,5 @@ abstract class AbstractConfigurator
+      * @return mixed
+      */
+-    public function __call(string $method, array $args)
++    public function __call(string $method, array $args): mixed
+     {
+         if (method_exists($this, 'set'.$method)) {
+@@ -55,5 +55,5 @@ abstract class AbstractConfigurator
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
 index 86543c1e85..4772c08c3d 100644
 --- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -4660,7 +4769,7 @@ index 1ede090384..7b6b63c599 100644
      {
          throw new LogicException('Impossible to call remove() on a frozen ParameterBag.');
 diff --git a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
-index a7b0aaaedc..b65322e66f 100644
+index c1cd9087f0..a9efa77a6d 100644
 --- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
 +++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
 @@ -35,5 +35,5 @@ class ParameterBag implements ParameterBagInterface
@@ -4758,6 +4867,17 @@ index 18ddfde147..b8651648bd 100644
 +    public function resolveValue(mixed $value): mixed;
  
      /**
+diff --git a/src/Symfony/Component/DependencyInjection/ServiceLocator.php b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+index f36bfe5cbe..59131f8f51 100644
+--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
++++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+@@ -64,5 +64,5 @@ class ServiceLocator implements ServiceProviderInterface, \Countable
+      * @return mixed
+      */
+-    public function __invoke(string $id)
++    public function __invoke(string $id): mixed
+     {
+         return isset($this->factories[$id]) ? $this->get($id) : null;
 diff --git a/src/Symfony/Component/DependencyInjection/TypedReference.php b/src/Symfony/Component/DependencyInjection/TypedReference.php
 index 9b431cd65b..5fdb0643cd 100644
 --- a/src/Symfony/Component/DependencyInjection/TypedReference.php
@@ -5024,6 +5144,17 @@ index 681a2f7a23..07ca3531a1 100644
 +    protected function setNode(\DOMElement $node): void
      {
          if ('a' !== $node->nodeName && 'area' !== $node->nodeName && 'link' !== $node->nodeName) {
+diff --git a/src/Symfony/Component/ErrorHandler/BufferingLogger.php b/src/Symfony/Component/ErrorHandler/BufferingLogger.php
+index b33e079969..f8a18ef040 100644
+--- a/src/Symfony/Component/ErrorHandler/BufferingLogger.php
++++ b/src/Symfony/Component/ErrorHandler/BufferingLogger.php
+@@ -44,5 +44,5 @@ class BufferingLogger extends AbstractLogger
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
 index f1b982315c..ed8ad1fab4 100644
 --- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -7378,6 +7509,17 @@ index e0b96a5ac3..7982e0cab3 100644
 +    public function finishView(FormView $view, FormInterface $form, array $options): void;
  
      /**
+diff --git a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+index 828218a452..e3aee09140 100644
+--- a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
++++ b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+@@ -66,5 +66,5 @@ class OrderedHashMapIterator implements \Iterator
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/HttpClient/CachingHttpClient.php b/src/Symfony/Component/HttpClient/CachingHttpClient.php
 index 0b6e495806..8cef2cad7c 100644
 --- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -7389,6 +7531,17 @@ index 0b6e495806..8cef2cad7c 100644
 +    public function reset(): void
      {
          if ($this->client instanceof ResetInterface) {
+diff --git a/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php b/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
+index 4fafaf66e9..15d931a6f4 100644
+--- a/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
++++ b/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
+@@ -102,5 +102,5 @@ class ErrorChunk implements ChunkInterface
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/HttpClient/DecoratorTrait.php b/src/Symfony/Component/HttpClient/DecoratorTrait.php
 index 472437e465..1dfe39146b 100644
 --- a/src/Symfony/Component/HttpClient/DecoratorTrait.php
@@ -7422,6 +7575,17 @@ index 5d8a2dccff..300c56dc6d 100644
 +    public function reset(): void
      {
          $this->requestsCount = 0;
+diff --git a/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php b/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
+index c3e2b0aa9b..81d5ac2dd4 100644
+--- a/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
++++ b/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
+@@ -126,5 +126,5 @@ trait CommonResponseTrait
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/HttpClient/ScopingHttpClient.php b/src/Symfony/Component/HttpClient/ScopingHttpClient.php
 index a87171d2ca..cec8a6f027 100644
 --- a/src/Symfony/Component/HttpClient/ScopingHttpClient.php
@@ -8350,31 +8514,31 @@ index af21469b1c..7b024368c5 100644
      {
      }
 diff --git a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
-index fe200629f4..692c41ec53 100644
+index 400a9e0c92..870cbe80e5 100644
 --- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
 +++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
-@@ -29,5 +29,5 @@ interface BundleInterface extends ContainerAwareInterface
+@@ -28,5 +28,5 @@ interface BundleInterface
       * @return void
       */
 -    public function boot();
 +    public function boot(): void;
  
      /**
-@@ -36,5 +36,5 @@ interface BundleInterface extends ContainerAwareInterface
+@@ -35,5 +35,5 @@ interface BundleInterface
       * @return void
       */
 -    public function shutdown();
 +    public function shutdown(): void;
  
      /**
-@@ -45,5 +45,5 @@ interface BundleInterface extends ContainerAwareInterface
+@@ -44,5 +44,5 @@ interface BundleInterface
       * @return void
       */
 -    public function build(ContainerBuilder $container);
 +    public function build(ContainerBuilder $container): void;
  
      /**
-@@ -72,4 +72,4 @@ interface BundleInterface extends ContainerAwareInterface
+@@ -71,4 +71,4 @@ interface BundleInterface
       * @return void
       */
 -    public function setContainer(?ContainerInterface $container);
@@ -8433,7 +8597,7 @@ index 2f442cb536..d98909cfae 100644
 +    public function warmUp(string $cacheDir): array;
  }
 diff --git a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
-index 698ed31397..c5a3eea409 100644
+index 9a419c6791..b32f8fd51b 100644
 --- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
 +++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
 @@ -59,5 +59,5 @@ abstract class DataCollector implements DataCollectorInterface
@@ -8443,6 +8607,13 @@ index 698ed31397..c5a3eea409 100644
 +    protected function getCasters(): array
      {
          $casters = [
+@@ -86,5 +86,5 @@ abstract class DataCollector implements DataCollectorInterface
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+     }
 diff --git a/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php b/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
 index 8df94ccb8f..42288d8a02 100644
 --- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
@@ -9052,7 +9223,7 @@ index 0f3630e7fe..ddf77b8a19 100644
      {
          return <<<'EOF'
 diff --git a/src/Symfony/Component/HttpKernel/Kernel.php b/src/Symfony/Component/HttpKernel/Kernel.php
-index c2d67c0f17..5c4841305b 100644
+index 9ce3dca808..e39add2658 100644
 --- a/src/Symfony/Component/HttpKernel/Kernel.php
 +++ b/src/Symfony/Component/HttpKernel/Kernel.php
 @@ -107,5 +107,5 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
@@ -9118,6 +9289,13 @@ index c2d67c0f17..5c4841305b 100644
 +    protected function dumpContainer(ConfigCache $cache, ContainerBuilder $container, string $class, string $baseClass): void
      {
          // cache the container
+@@ -839,5 +839,5 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         if (\is_object($this->environment) || \is_object($this->debug)) {
 diff --git a/src/Symfony/Component/HttpKernel/KernelInterface.php b/src/Symfony/Component/HttpKernel/KernelInterface.php
 index 14a053ab30..737af1b649 100644
 --- a/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -9454,31 +9632,38 @@ index 9b356b10b2..68942b21dc 100644
 +    public function remove(Entry $entry): static;
  }
 diff --git a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
-index 2daa651b7a..95b9e73916 100644
+index 9a6af4a7a0..9ed949e383 100644
 --- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
 +++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
-@@ -67,5 +67,5 @@ class Connection extends AbstractConnection
+@@ -50,5 +50,5 @@ class Connection extends AbstractConnection
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+@@ -70,5 +70,5 @@ class Connection extends AbstractConnection
       * @return void
       */
 -    public function bind(string $dn = null, #[\SensitiveParameter] string $password = null)
 +    public function bind(string $dn = null, #[\SensitiveParameter] string $password = null): void
      {
          if (!$this->connection) {
-@@ -102,5 +102,5 @@ class Connection extends AbstractConnection
+@@ -105,5 +105,5 @@ class Connection extends AbstractConnection
       * @return void
       */
 -    public function setOption(string $name, array|string|int|bool $value)
 +    public function setOption(string $name, array|string|int|bool $value): void
      {
          if (!@ldap_set_option($this->connection, ConnectionOptions::getOption($name), $value)) {
-@@ -112,5 +112,5 @@ class Connection extends AbstractConnection
+@@ -115,5 +115,5 @@ class Connection extends AbstractConnection
       * @return array|string|int|null
       */
 -    public function getOption(string $name)
 +    public function getOption(string $name): array|string|int|null
      {
          if (!@ldap_get_option($this->connection, ConnectionOptions::getOption($name), $ret)) {
-@@ -124,5 +124,5 @@ class Connection extends AbstractConnection
+@@ -127,5 +127,5 @@ class Connection extends AbstractConnection
       * @return void
       */
 -    protected function configureOptions(OptionsResolver $resolver)
@@ -9545,6 +9730,17 @@ index 20f0922384..4eea54731e 100644
 +    public function applyOperations(string $dn, iterable $operations): static
      {
          $operationsMapped = [];
+diff --git a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+index fe87e74234..215b9498dc 100644
+--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
++++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+@@ -40,5 +40,5 @@ class Query extends AbstractQuery
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/Ldap/Entry.php b/src/Symfony/Component/Ldap/Entry.php
 index 0d008d8ecd..96b07b4845 100644
 --- a/src/Symfony/Component/Ldap/Entry.php
@@ -10091,6 +10287,17 @@ index 6c5605fa8e..56914f2e64 100644
 +    public function reset(): void
      {
          $this->events = new MessageEvents();
+diff --git a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+index 831f6f2845..7744627f3c 100644
+--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
++++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+@@ -381,5 +381,5 @@ class SmtpTransport extends AbstractTransport
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
 index 1a1305f5d8..95fb4347c3 100644
 --- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
@@ -10109,6 +10316,28 @@ index 1a1305f5d8..95fb4347c3 100644
 +    private function getReceiver(): MessageCountAwareInterface&ReceiverInterface
      {
          return $this->receiver ??= new AmazonSqsReceiver($this->connection, $this->serializer);
+diff --git a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+index fc19f73323..7464e7a3ba 100644
+--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
++++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+@@ -74,5 +74,5 @@ class Connection
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+diff --git a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+index 2adb31be54..b81e8d0865 100644
+--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
++++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+@@ -42,5 +42,5 @@ final class PostgreSqlConnection extends Connection
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
 index 04ad92d116..6606e2bbc4 100644
 --- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -10349,6 +10578,28 @@ index e636c2e8e5..4c0597d16f 100644
 +    public function ensureValidity(): void
      {
          if (!$this->headers->has('To') && !$this->headers->has('Cc') && !$this->headers->has('Bcc')) {
+diff --git a/src/Symfony/Component/Mime/Part/DataPart.php b/src/Symfony/Component/Mime/Part/DataPart.php
+index 4d5156d6e7..3d624ae649 100644
+--- a/src/Symfony/Component/Mime/Part/DataPart.php
++++ b/src/Symfony/Component/Mime/Part/DataPart.php
+@@ -150,5 +150,5 @@ class DataPart extends TextPart
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         $r = new \ReflectionProperty(AbstractPart::class, 'headers');
+diff --git a/src/Symfony/Component/Mime/Part/TextPart.php b/src/Symfony/Component/Mime/Part/TextPart.php
+index 01a684cca2..2500674d33 100644
+--- a/src/Symfony/Component/Mime/Part/TextPart.php
++++ b/src/Symfony/Component/Mime/Part/TextPart.php
+@@ -240,5 +240,5 @@ class TextPart extends AbstractPart
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         $r = new \ReflectionProperty(AbstractPart::class, 'headers');
 diff --git a/src/Symfony/Component/Mime/RawMessage.php b/src/Symfony/Component/Mime/RawMessage.php
 index aec398c588..687d4e2612 100644
 --- a/src/Symfony/Component/Mime/RawMessage.php
@@ -10519,31 +10770,38 @@ index ef54a3d2b0..d084e5ba24 100644
      {
          if (null === $this->getCommandLine()) {
 diff --git a/src/Symfony/Component/Process/Process.php b/src/Symfony/Component/Process/Process.php
-index 40dbd41620..ac31fdc922 100644
+index f330d405af..7299f09a22 100644
 --- a/src/Symfony/Component/Process/Process.php
 +++ b/src/Symfony/Component/Process/Process.php
-@@ -292,5 +292,5 @@ class Process implements \IteratorAggregate
+@@ -204,5 +204,5 @@ class Process implements \IteratorAggregate
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+@@ -295,5 +295,5 @@ class Process implements \IteratorAggregate
       * @throws LogicException   In case a callback is provided and output has been disabled
       */
 -    public function start(callable $callback = null, array $env = [])
 +    public function start(callable $callback = null, array $env = []): void
      {
          if ($this->isRunning()) {
-@@ -1147,5 +1147,5 @@ class Process implements \IteratorAggregate
+@@ -1150,5 +1150,5 @@ class Process implements \IteratorAggregate
       * @throws ProcessTimedOutException In case the timeout was reached
       */
 -    public function checkTimeout()
 +    public function checkTimeout(): void
      {
          if (self::STATUS_STARTED !== $this->status) {
-@@ -1188,5 +1188,5 @@ class Process implements \IteratorAggregate
+@@ -1191,5 +1191,5 @@ class Process implements \IteratorAggregate
       * @return void
       */
 -    public function setOptions(array $options)
 +    public function setOptions(array $options): void
      {
          if ($this->isRunning()) {
-@@ -1285,5 +1285,5 @@ class Process implements \IteratorAggregate
+@@ -1288,5 +1288,5 @@ class Process implements \IteratorAggregate
       * @return void
       */
 -    protected function updateStatus(bool $blocking)
@@ -10948,6 +11206,28 @@ index 98af1febc5..eb9b1ae404 100644
 +    abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void;
  
      /**
+diff --git a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+index 2ad6f57011..00cad97240 100644
+--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
++++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+@@ -47,5 +47,5 @@ class CollectionConfigurator
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+diff --git a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+index 9c92a7d722..21c3e5c3ae 100644
+--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
++++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+@@ -39,5 +39,5 @@ class ImportConfigurator
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
 diff --git a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
 index 24ec21bb5c..1dac35dc8e 100644
 --- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -12269,6 +12549,17 @@ index 6e550c61cf..5cb704fae0 100644
 +    public function setLocale(string $locale): void
      {
          $this->defaultLocale = $locale;
+diff --git a/src/Symfony/Component/String/UnicodeString.php b/src/Symfony/Component/String/UnicodeString.php
+index 851e087007..647d6f17a0 100644
+--- a/src/Symfony/Component/String/UnicodeString.php
++++ b/src/Symfony/Component/String/UnicodeString.php
+@@ -342,5 +342,5 @@ class UnicodeString extends AbstractUnicodeString
+      * @return void
+      */
+-    public function __wakeup()
++    public function __wakeup(): void
+     {
+         if (!\is_string($this->string)) {
 diff --git a/src/Symfony/Component/Templating/DelegatingEngine.php b/src/Symfony/Component/Templating/DelegatingEngine.php
 index bbe500549a..a1cce0e692 100644
 --- a/src/Symfony/Component/Templating/DelegatingEngine.php
@@ -12494,7 +12785,7 @@ index ba68635db7..fd3b32a02a 100644
      {
          $this
 diff --git a/src/Symfony/Component/Translation/DataCollectorTranslator.php b/src/Symfony/Component/Translation/DataCollectorTranslator.php
-index 0e584daad1..b7bb0c070d 100644
+index c503c9675d..dc4599027a 100644
 --- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
 +++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
 @@ -52,5 +52,5 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
@@ -12504,6 +12795,13 @@ index 0e584daad1..b7bb0c070d 100644
 +    public function setLocale(string $locale): void
      {
          $this->translator->setLocale($locale);
+@@ -99,5 +99,5 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
+      * @return mixed
+      */
+-    public function __call(string $method, array $args)
++    public function __call(string $method, array $args): mixed
+     {
+         return $this->translator->{$method}(...$args);
 diff --git a/src/Symfony/Component/Translation/DependencyInjection/TranslationDumperPass.php b/src/Symfony/Component/Translation/DependencyInjection/TranslationDumperPass.php
 index 2ece6ac7b3..1bac9cfb3e 100644
 --- a/src/Symfony/Component/Translation/DependencyInjection/TranslationDumperPass.php
@@ -12682,7 +12980,7 @@ index 7f2f96be64..266c7f48c9 100644
      {
          $this->delimiter = $delimiter;
 diff --git a/src/Symfony/Component/Translation/LoggingTranslator.php b/src/Symfony/Component/Translation/LoggingTranslator.php
-index e107bf223c..817940a626 100644
+index a7ad410a5e..30e5e5849c 100644
 --- a/src/Symfony/Component/Translation/LoggingTranslator.php
 +++ b/src/Symfony/Component/Translation/LoggingTranslator.php
 @@ -49,5 +49,5 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface,
@@ -12692,6 +12990,13 @@ index e107bf223c..817940a626 100644
 +    public function setLocale(string $locale): void
      {
          $prev = $this->translator->getLocale();
+@@ -90,5 +90,5 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface,
+      * @return mixed
+      */
+-    public function __call(string $method, array $args)
++    public function __call(string $method, array $args): mixed
+     {
+         return $this->translator->{$method}(...$args);
 diff --git a/src/Symfony/Component/Translation/MessageCatalogue.php b/src/Symfony/Component/Translation/MessageCatalogue.php
 index 379d947ce7..effc8dab3d 100644
 --- a/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -12963,38 +13268,45 @@ index acb00d7242..37cc40a06f 100644
      {
          $this
 diff --git a/src/Symfony/Component/Validator/Constraint.php b/src/Symfony/Component/Validator/Constraint.php
-index d53bbb196f..4eecf85f8e 100644
+index 6b077f242f..b7733f27f7 100644
 --- a/src/Symfony/Component/Validator/Constraint.php
 +++ b/src/Symfony/Component/Validator/Constraint.php
-@@ -236,5 +236,5 @@ abstract class Constraint
+@@ -197,5 +197,5 @@ abstract class Constraint
+      * @throws InvalidOptionsException If an invalid option name is given
+      */
+-    public function __set(string $option, mixed $value)
++    public function __set(string $option, mixed $value): void
+     {
+         if ('groups' === $option) {
+@@ -238,5 +238,5 @@ abstract class Constraint
       * @return void
       */
 -    public function addImplicitGroupName(string $group)
 +    public function addImplicitGroupName(string $group): void
      {
          if (null === $this->groups && \array_key_exists('groups', (array) $this)) {
-@@ -256,5 +256,5 @@ abstract class Constraint
+@@ -258,5 +258,5 @@ abstract class Constraint
       * @see __construct()
       */
 -    public function getDefaultOption()
 +    public function getDefaultOption(): ?string
      {
          return null;
-@@ -270,5 +270,5 @@ abstract class Constraint
+@@ -272,5 +272,5 @@ abstract class Constraint
       * @see __construct()
       */
 -    public function getRequiredOptions()
 +    public function getRequiredOptions(): array
      {
          return [];
-@@ -284,5 +284,5 @@ abstract class Constraint
+@@ -286,5 +286,5 @@ abstract class Constraint
       * @return string
       */
 -    public function validatedBy()
 +    public function validatedBy(): string
      {
          return static::class.'Validator';
-@@ -298,5 +298,5 @@ abstract class Constraint
+@@ -300,5 +300,5 @@ abstract class Constraint
       * @return string|string[] One or more constant values
       */
 -    public function getTargets()
@@ -13308,6 +13620,17 @@ index d1fe60a791..3d602f5e7b 100644
 +    public function validate(mixed $value, Constraint $constraint): void
      {
          if (!$constraint instanceof Expression) {
+diff --git a/src/Symfony/Component/Validator/Constraints/File.php b/src/Symfony/Component/Validator/Constraints/File.php
+index d780476fcc..b7e710ee24 100644
+--- a/src/Symfony/Component/Validator/Constraints/File.php
++++ b/src/Symfony/Component/Validator/Constraints/File.php
+@@ -134,5 +134,5 @@ class File extends Constraint
+      * @return void
+      */
+-    public function __set(string $option, mixed $value)
++    public function __set(string $option, mixed $value): void
+     {
+         if ('maxSize' === $option) {
 diff --git a/src/Symfony/Component/Validator/Constraints/FileValidator.php b/src/Symfony/Component/Validator/Constraints/FileValidator.php
 index 6346ad098f..ae4d95ed62 100644
 --- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -14741,10 +15064,17 @@ index 6a746b88e3..4c0940bd31 100644
      {
          $this->minDepth = $minDepth;
 diff --git a/src/Symfony/Component/VarDumper/Cloner/Data.php b/src/Symfony/Component/VarDumper/Cloner/Data.php
-index 928f72d7a8..4d638d2cc1 100644
+index 493d7dff5e..0fcc122596 100644
 --- a/src/Symfony/Component/VarDumper/Cloner/Data.php
 +++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
-@@ -266,5 +266,5 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
+@@ -125,5 +125,5 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
+      * @return mixed
+      */
+-    public function __get(string $key)
++    public function __get(string $key): mixed
+     {
+         if (null !== $data = $this->seek($key)) {
+@@ -269,5 +269,5 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
       * @return void
       */
 -    public function dump(DumperInterface $dumper)

--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -75,7 +75,9 @@ foreach ($loader->getClassMap() as $class => $file) {
         if (
             $method->getReturnType()
             || str_contains($method->getDocComment(), '@return')
-            || str_starts_with($method->getName(), '__')
+            || '__construct' === $method->getName()
+            || '__destruct' === $method->getName()
+            || '__clone' === $method->getName()
             || $method->getDeclaringClass()->getName() !== $class
             || str_contains($method->getDeclaringClass()->getName(), '\\Test\\')
         ) {

--- a/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
@@ -154,6 +154,9 @@ class ElasticsearchLogstashHandler extends AbstractHandler
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
@@ -24,12 +24,15 @@ final class WrappedListener
 {
     use TraceableListenerTrait;
 
+    /**
+     * @param callable(RequestEvent):void $listener
+     */
     public function __construct(callable $listener)
     {
         $this->listener = $listener;
     }
 
-    public function __invoke(RequestEvent $event)
+    public function __invoke(RequestEvent $event): void
     {
         $startTime = microtime(true);
         ($this->listener)($event);

--- a/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
@@ -39,7 +39,7 @@ class LazyFirewallContext extends FirewallContext
         return [$this];
     }
 
-    public function __invoke(RequestEvent $event)
+    public function __invoke(RequestEvent $event): void
     {
         $listeners = [];
         $request = $event->getRequest();

--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -295,6 +295,9 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Cache/Messenger/EarlyExpirationDispatcher.php
+++ b/src/Symfony/Component/Cache/Messenger/EarlyExpirationDispatcher.php
@@ -34,6 +34,9 @@ class EarlyExpirationDispatcher
         $this->callbackWrapper = null === $callbackWrapper ? null : $callbackWrapper(...);
     }
 
+    /**
+     * @return mixed
+     */
     public function __invoke(callable $callback, CacheItem $item, bool &$save, AdapterInterface $pool, \Closure $setMetadata, LoggerInterface $logger = null)
     {
         if (!$item->isHit() || null === $message = EarlyExpirationMessage::create($this->reverseContainer, $callback, $item, $pool)) {

--- a/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
+++ b/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
@@ -28,6 +28,9 @@ class EarlyExpirationHandler implements MessageHandlerInterface
         $this->reverseContainer = $reverseContainer;
     }
 
+    /**
+     * @return void
+     */
     public function __invoke(EarlyExpirationMessage $message)
     {
         $item = $message->getItem();

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -283,6 +283,9 @@ trait AbstractAdapterTrait
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -171,6 +171,9 @@ trait FilesystemCommonTrait
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Cache/Traits/ValueWrapper.php
+++ b/src/Symfony/Component/Cache/Traits/ValueWrapper.php
@@ -55,7 +55,7 @@ class ©
         return [$pack => $this->value] + ($this->metadata['tags'] ?? []);
     }
 
-    public function __unserialize(array $data)
+    public function __unserialize(array $data): void
     {
         $pack = array_key_first($data);
         $this->value = $data[$pack];

--- a/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
@@ -116,7 +116,7 @@ class ClassExistenceResource implements SelfCheckingResourceInterface
     /**
      * @internal
      */
-    public function __wakeup()
+    public function __wakeup(): void
     {
         if (\is_bool($this->exists)) {
             $this->exists = [$this->exists, null];

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -34,6 +34,9 @@ abstract class AbstractConfigurator
     /** @internal */
     protected Definition|Alias|null $definition = null;
 
+    /**
+     * @return mixed
+     */
     public function __call(string $method, array $args)
     {
         if (method_exists($this, 'set'.$method)) {
@@ -48,6 +51,9 @@ abstract class AbstractConfigurator
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -60,6 +60,9 @@ class ServiceLocator implements ServiceProviderInterface, \Countable
         }
     }
 
+    /**
+     * @return mixed
+     */
     public function __invoke(string $id)
     {
         return isset($this->factories[$id]) ? $this->get($id) : null;

--- a/src/Symfony/Component/ErrorHandler/BufferingLogger.php
+++ b/src/Symfony/Component/ErrorHandler/BufferingLogger.php
@@ -40,6 +40,9 @@ class BufferingLogger extends AbstractLogger
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
@@ -62,6 +62,9 @@ class OrderedHashMapIterator implements \Iterator
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
@@ -98,6 +98,9 @@ class ErrorChunk implements ChunkInterface
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -251,7 +251,7 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -144,7 +144,7 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }

--- a/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
@@ -122,6 +122,9 @@ trait CommonResponseTrait
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
@@ -49,7 +49,7 @@ class TraceableResponse implements ResponseInterface, StreamableInterface
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -82,6 +82,9 @@ abstract class DataCollector implements DataCollectorInterface
         return ['data'];
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -167,7 +167,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
     /**
      * @internal
      */
-    public function __wakeup()
+    public function __wakeup(): void
     {
         parent::__wakeup();
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -835,6 +835,9 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         return ['environment', 'debug'];
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         if (\is_object($this->environment) || \is_object($this->debug)) {

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -46,6 +46,9 @@ class Connection extends AbstractConnection
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -36,6 +36,9 @@ class Query extends AbstractQuery
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -54,7 +54,7 @@ final class Lock implements SharedLockInterface, LoggerAwareInterface
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -377,6 +377,9 @@ class SmtpTransport extends AbstractTransport
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -70,6 +70,9 @@ class Connection
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -38,6 +38,9 @@ final class PostgreSqlConnection extends Connection
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Messenger/Handler/RedispatchMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Handler/RedispatchMessageHandler.php
@@ -22,7 +22,7 @@ final class RedispatchMessageHandler
     ) {
     }
 
-    public function __invoke(RedispatchMessage $message)
+    public function __invoke(RedispatchMessage $message): void
     {
         $this->bus->dispatch($message->envelope, [new TransportNamesStamp($message->transportNames)]);
     }

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -146,6 +146,9 @@ class DataPart extends TextPart
         return ['_headers', '_parent', 'filename', 'mediaType'];
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         $r = new \ReflectionProperty(AbstractPart::class, 'headers');

--- a/src/Symfony/Component/Mime/Part/MessagePart.php
+++ b/src/Symfony/Component/Mime/Part/MessagePart.php
@@ -65,7 +65,7 @@ class MessagePart extends DataPart
         return ['message'];
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         $this->__construct($this->message);
     }

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -236,6 +236,9 @@ class TextPart extends AbstractPart
         return ['_headers', 'body', 'charset', 'subtype', 'disposition', 'name', 'encoding'];
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         $r = new \ReflectionProperty(AbstractPart::class, 'headers');

--- a/src/Symfony/Component/Process/Pipes/UnixPipes.php
+++ b/src/Symfony/Component/Process/Pipes/UnixPipes.php
@@ -40,7 +40,7 @@ class UnixPipes extends AbstractPipes
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }

--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -93,7 +93,7 @@ class WindowsPipes extends AbstractPipes
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -200,6 +200,9 @@ class Process implements \IteratorAggregate
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -43,6 +43,9 @@ class CollectionConfigurator
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -35,6 +35,9 @@ class ImportConfigurator
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -97,7 +97,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
         return $this->authenticator;
     }
 
-    public function __call($method, $args)
+    public function __call($method, $args): mixed
     {
         return $this->authenticator->{$method}(...$args);
     }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractListener.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
  */
 abstract class AbstractListener implements FirewallListenerInterface
 {
-    final public function __invoke(RequestEvent $event)
+    final public function __invoke(RequestEvent $event): void
     {
         if (false !== $this->supports($event->getRequest())) {
             $this->authenticate($event);

--- a/src/Symfony/Component/Semaphore/Semaphore.php
+++ b/src/Symfony/Component/Semaphore/Semaphore.php
@@ -51,7 +51,7 @@ final class Semaphore implements SemaphoreInterface, LoggerAwareInterface
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -338,6 +338,9 @@ class UnicodeString extends AbstractUnicodeString
         return $prefix === grapheme_extract($this->string, \strlen($prefix), \GRAPHEME_EXTR_MAXBYTES);
     }
 
+    /**
+     * @return void
+     */
     public function __wakeup()
     {
         if (!\is_string($this->string)) {

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -96,7 +96,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     }
 
     /**
-     * Passes through all unknown calls onto the translator object.
+     * @return mixed
      */
     public function __call(string $method, array $args)
     {

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -87,7 +87,7 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
     }
 
     /**
-     * Passes through all unknown calls onto the translator object.
+     * @return mixed
      */
     public function __call(string $method, array $args)
     {

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -192,6 +192,8 @@ abstract class Constraint
      * this method will be called at most once per constraint instance and
      * option name.
      *
+     * @return void
+     *
      * @throws InvalidOptionsException If an invalid option name is given
      */
     public function __set(string $option, mixed $value)

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -130,6 +130,9 @@ class File extends Constraint
         }
     }
 
+    /**
+     * @return void
+     */
     public function __set(string $option, mixed $value)
     {
         if ('maxSize' === $option) {

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -121,6 +121,9 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
         yield from $value;
     }
 
+    /**
+     * @return mixed
+     */
     public function __get(string $key)
     {
         if (null !== $data = $this->seek($key)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

I promise, these 72 methods really are the last methods that did not have a return type already :upside_down_face: 