### PR TITLE
[WebProfilerBundle] Fix minify test after JS refactor

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Resources/MinifyTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Resources/MinifyTest.php
@@ -23,8 +23,12 @@ class MinifyTest extends TestCase
     public function testNoSingleLineComments()
     {
         $dir = \dirname(__DIR__, 2).'/Resources/views/Profiler';
-        $message = 'There cannot be any single line comment in this file. Consider using multiple line comment. ';
-        $this->assertTrue(2 === substr_count(file_get_contents($dir.'/base_js.html.twig'), '//'), $message);
-        $this->assertTrue(0 === substr_count(file_get_contents($dir.'/toolbar.css.twig'), '//'), $message);
+
+        foreach (glob($dir.'/*js.html.twig') as $jsFile) {
+            $fileContents = file_get_contents($dir.'/base_js.html.twig');
+            $fileContents = str_replace('\'//\'', '', $fileContents);
+
+            $this->assertEquals(0, substr_count($fileContents, '//'), 'There cannot be any single line comment in "'.$jsFile.'". Consider using multiple line comment. ');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This test makes sure the JS files are valid after we "minify" them by removing newlines. After the refactor of #50790, it was not updated correctly causing a red CI.

This fixes the test, and makes it more future proof.