### PR TITLE
[Serializer] Add versionning

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/Version.php
+++ b/src/Symfony/Component/Serializer/Annotation/Version.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+/**
+ * Annotation class for @Version().
+ *
+ * @Annotation
+ *
+ * @NamedArgumentConstructor
+ *
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Olivier Michaud <olivier@micoli.org>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+final class Version
+{
+    public function __construct()
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Annotation/VersionConstraint.php
+++ b/src/Symfony/Component/Serializer/Annotation/VersionConstraint.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @VersionConstraint().
+ *
+ * @Annotation
+ *
+ * @NamedArgumentConstructor
+ *
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Olivier Michaud <olivier@micoli.org>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+final class VersionConstraint
+{
+    public function __construct(private readonly ?string $since = null, private readonly ?string $until = null)
+    {
+        if ('' === $since) {
+            throw new InvalidArgumentException(sprintf('Parameter "since" of annotation "%s" must be a non-empty string.', self::class));
+        }
+        if ('' === $until) {
+            throw new InvalidArgumentException(sprintf('Parameter "until" of annotation "%s" must be a non-empty string.', self::class));
+        }
+        if (null === $since && null === $until) {
+            throw new InvalidArgumentException(sprintf('At least one of "since" or "until" properties of annotation "%s" have to be defined.', self::class));
+        }
+    }
+
+    public function isVersionCompatible(string $version): bool
+    {
+        if ($this->since) {
+            if (!version_compare($version, $this->since, '>=')) {
+                return false;
+            }
+        }
+        if ($this->until) {
+            if (!version_compare($version, $this->until, '<=')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add `Version` and  `VersionConstraint` annotation/attributes to help versioning on normalize/denormalize operations
+
 6.3
 ---
 

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Mapping;
 
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -78,6 +79,27 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public array $denormalizationContexts = [];
 
+    /**
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link isVersion()} instead.
+     */
+    public bool $version = false;
+
+    /**
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getVersionConstraint()} instead.
+     */
+    public ?VersionConstraint $versionConstraint = null;
+
+    /**
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link isVersionCompatible()} instead.
+     */
+    public ?\Closure $versionConstraintCallable = null;
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -142,6 +164,31 @@ class AttributeMetadata implements AttributeMetadataInterface
     public function isIgnored(): bool
     {
         return $this->ignore;
+    }
+
+    public function setVersion(bool $version): void
+    {
+        $this->version = $version;
+    }
+
+    public function isVersion(): bool
+    {
+        return $this->version;
+    }
+
+    public function setVersionConstraint(VersionConstraint $versionConstraint): void
+    {
+        $this->versionConstraint = $versionConstraint;
+    }
+
+    public function getVersionConstraint(): ?VersionConstraint
+    {
+        return $this->versionConstraint;
+    }
+
+    public function isVersionCompatible(string $version): bool
+    {
+        return !$this->versionConstraint || $this->versionConstraint->isVersionCompatible($version);
     }
 
     public function getNormalizationContexts(): array
@@ -225,6 +272,6 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public function __sleep(): array
     {
-        return ['name', 'groups', 'maxDepth', 'serializedName', 'serializedPath', 'ignore', 'normalizationContexts', 'denormalizationContexts'];
+        return ['name', 'groups', 'maxDepth', 'serializedName', 'serializedPath', 'ignore', 'normalizationContexts', 'denormalizationContexts', 'version', 'versionConstraint'];
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Mapping;
 
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
 
 /**
  * Stores metadata needed for serializing and deserializing attributes.
@@ -74,6 +75,20 @@ interface AttributeMetadataInterface
      * Gets if this attribute is ignored or not.
      */
     public function isIgnored(): bool;
+
+    /**
+     * Sets if this attribute is holding the version. Only one attribute can hold version at once.
+     */
+    public function setVersion(bool $version): void;
+
+    /**
+     * Gets if this attribute is holding the version.
+     */
+    public function isVersion(): bool;
+
+    public function setVersionConstraint(VersionConstraint $versionConstraint): void;
+
+    public function isVersionCompatible(string $version): bool;
 
     /**
      * Merges an {@see AttributeMetadataInterface} with in the current one.

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -552,4 +552,16 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
         return $this->classMetadataFactory->getMetadataFor($objectOrClass)->getAttributesMetadata()[$attribute] ?? null;
     }
+
+    /**
+     * @param array<string, AttributeMetadataInterface> $attributesMetadata
+     */
+    protected function isVersionCompatible(string $version, array $attributesMetadata, string $attributeName): bool
+    {
+        if (!isset($attributesMetadata[$attributeName])) {
+            return true;
+        }
+
+        return $attributesMetadata[$attributeName]->isVersionCompatible($version);
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Annotation/VersionConstraintTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/VersionConstraintTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Annotation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * @author Olivier Michaud <olivier@micoli.org>
+ */
+class VersionConstraintTest extends TestCase
+{
+    /**
+     * @dataProvider providesNormalizeVersionAndConstraints
+     */
+    public function testVersionConstraintLogic(bool $expectedResult, ?string $version, ?string $since, ?string $until)
+    {
+        $versionConstraint = new VersionConstraint(since: $since, until: $until);
+        $this->assertSame($expectedResult, $versionConstraint->isVersionCompatible($version));
+    }
+
+    public static function providesNormalizeVersionAndConstraints(): \Generator
+    {
+        yield 'Version in range' => [true, '1.2', '1.1', '1.5'];
+        yield 'Version below range with both limits' => [false, '0.9', '1.1', '1.5'];
+        yield 'Version below range only with lower limit' => [false, '0.9', '1.1', null];
+        yield 'Version in range only with upper limit' => [true, '0.9', null, '1.5'];
+        yield 'Version above range with both limits' => [false, '2.0', '1.1', '1.5'];
+        yield 'Version above range only with upper limit' => [false, '2.0', null, '1.5'];
+        yield 'Version in range only with low limit ' => [true, '2.0', '1.1', null];
+        yield 'No version to no limits' => [false, '', '1.1', '1.5'];
+    }
+
+    public function testSinceParameterNotEmptyString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter "since" of annotation "Symfony\Component\Serializer\Annotation\VersionConstraint" must be a non-empty string.');
+        new VersionConstraint(since: '', until: '2.0');
+    }
+
+    public function testUntilParameterNotEmptyString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter "until" of annotation "Symfony\Component\Serializer\Annotation\VersionConstraint" must be a non-empty string.');
+        new VersionConstraint(since: '1.1', until: '');
+    }
+
+    public function testBothSinceAndUntilParameterAreNull()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one of "since" or "until" properties of annotation "Symfony\Component\Serializer\Annotation\VersionConstraint" have to be defined.');
+        new VersionConstraint(since: null, until: null);
+    }
+
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/DoubleVersionDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/DoubleVersionDummy.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class DoubleVersionDummy
+{
+    private $foo;
+
+    /**
+     * @Version
+     */
+    public string $objectVersion1;
+
+    /**
+     * @Version
+     */
+    public string $objectVersion2;
+
+    /**
+     * @VersionConstraint(
+     *     since="1.1",
+     *     until="1.5"
+     * )
+     */
+    public ?string $versionedProperty;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/VersionDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/VersionDummy.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class VersionDummy
+{
+    private $foo;
+
+    /**
+     * @Version
+     */
+    public string $objectVersion;
+
+    /**
+     * @VersionConstraint(
+     *     since="1.1",
+     *     until="1.5"
+     * )
+     */
+    public ?string $versionedProperty;
+
+    /**
+     * @var string
+     * @VersionConstraint(
+     *     since="1.1",
+     *     until="1.5"
+     * )
+     */
+    public $versionedProperty2;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/VersionDummyWithNonNullableField.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/VersionDummyWithNonNullableField.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class VersionDummyWithNonNullableField
+{
+    private $foo;
+
+    /**
+     * @Version
+     */
+    public string $objectVersion;
+
+    /**
+     * @VersionConstraint(
+     *     since="1.1",
+     *     until="1.5"
+     * )
+     */
+    public string $versionedProperty;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/DoubleVersionDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/DoubleVersionDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class DoubleVersionDummy
+{
+    private $foo;
+
+    #[Version]
+    public string $objectVersion1;
+
+    #[Version]
+    public string $objectVersion2;
+
+    #[VersionConstraint(since: '1.1', until: '1.5')]
+    public ?string $versionedProperty;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/VersionDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/VersionDummy.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class VersionDummy
+{
+    private $foo;
+
+    #[Version]
+    public string $objectVersion;
+
+    #[VersionConstraint(since: '1.1', until: '1.5')]
+    public ?string $versionedProperty;
+
+    /**
+     * @var string
+     */
+    #[VersionConstraint(since: '1.1', until: '1.5')]
+    public $versionedProperty2;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/VersionDummyWithNonNullableField.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/VersionDummyWithNonNullableField.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class VersionDummyWithNonNullableField
+{
+    private $foo;
+
+    #[Version]
+    public string $objectVersion;
+
+    #[VersionConstraint(since: '1.1', until: '1.5')]
+    public string $versionedProperty;
+}

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
@@ -135,6 +135,41 @@ abstract class AnnotationLoaderTestCase extends TestCase
         $this->assertTrue($attributesMetadata['ignored2']->isIgnored());
     }
 
+    public function testLoadVersionConstraint()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace().'\VersionDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertTrue($attributesMetadata['versionedProperty']->isVersionCompatible('1.2'));
+        $this->assertFalse($attributesMetadata['versionedProperty']->isVersionCompatible('0.9'));
+        $this->assertFalse($attributesMetadata['versionedProperty']->isVersionCompatible('2.1'));
+    }
+
+    public function testLoadVersionConstraintWithNonNullableField()
+    {
+        $this->expectExceptionMessageMatches('!VersionDummyWithNonNullableField::versionedProperty\(\)" cannot be added\. Property should either have no typehint either be declared as nullable\.!');
+        $classMetadata = new ClassMetadata($this->getNamespace().'\VersionDummyWithNonNullableField');
+        $this->loader->loadClassMetadata($classMetadata);
+    }
+
+    public function testLoadVersion()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace().'\VersionDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertTrue($attributesMetadata['objectVersion']->isVersion());
+        $this->assertFalse($attributesMetadata['foo']->isVersion());
+    }
+
+    public function testLoadVersionWithError()
+    {
+        $this->expectExceptionMessageMatches('!DoubleVersionDummy::objectVersion2\(\)" cannot be added\. Version holder property can only be set once\.!');
+        $classMetadata = new ClassMetadata($this->getNamespace().'\DoubleVersionDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+    }
+
     public function testLoadContexts()
     {
         $this->assertLoadedContexts($this->getNamespace().'\ContextDummy', $this->getNamespace().'\ContextDummyParent');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #30848
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

- Add `version` annotation/attribute to be set on the property holding the version of the normalized representation (only one property can be set as `Version`)
- Add `VersionConstraint` annotation/attribute. That attribute control restriction on normalisation/denormalization depending on the value of the property that hold `Version` attribute. Inner properties are `since` and `until`. At least one of them has to be set.
- Either `Version.version`, `VersionConstraint.since` and `VersionConstraint.until` are expressed as semver string, and must be compliant with [version_compare](https://www.php.net/manual/fr/function.version-compare.php) function. A property restricted by a constraint is defined as : `notDefined` < `since|null` <= `defined` <= `until|null` < `notDefined`

Behavior and naming are inspired by https://jmsyst.com/libs/serializer/master/reference/annotations#since and https://jmsyst.com/libs/serializer/master/reference/annotations#until

Logic is as follow:
 - Normalization
    A restricted property by a `VersionConstraint` is not added to the normalized representation if the constraint is not satisfied 
 - Denormalization
    A restricted property by a `VersionConstraint` is set to null if the constraint is not satisfied or to the value if the constraint is satisfied

### Example of usage
```php
class VersionAwareObject
{
    private $foo;

    /**
     * @Version
     */
    public string $version;

    /**
     * @VersionConstraint(
     *     since="1.1",
     *     until="1.5"
     * )
     */
    public ?string $name;

    /**
     * @VersionConstraint(
     *     since="1.6"
     * )
     */
    public ?string $lastName;
}
```

I don't see any Breaking Changes up to now
