### PR TITLE
[Mailer] Open up visibility of `MailjetApiTransport::getPayload`

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -104,7 +104,7 @@ class MailjetApiTransport extends AbstractApiTransport
         return $response;
     }
 
-    private function getPayload(Email $email, Envelope $envelope): array
+    public function getPayload(Email $email, Envelope $envelope): array
     {
         $html = $email->getHtmlBody();
         if (null !== $html && \is_resource($html)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

Normally we use Mailer interface, but on few places we are using Mailjet API's bulk functionality. The way it works is pretty much to send `array{messages: list<array>}` via HTTP Client, so list of whatever output `getPayload` function here returns. However, since this is a private method, we had to copy almost whole transport. I think it would be good for users if they can reuse this transport for other use cases.