### PR TITLE
[TwigBridge] Allow `twig:lint` to excludes dirs

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -57,6 +57,7 @@ class LintCommand extends Command
             ->addOption('format', null, InputOption::VALUE_REQUIRED, sprintf('The output format ("%s")', implode('", "', $this->getAvailableFormatOptions())))
             ->addOption('show-deprecations', null, InputOption::VALUE_NONE, 'Show deprecations as errors')
             ->addArgument('filename', InputArgument::IS_ARRAY, 'A file, a directory or "-" for reading from STDIN')
+            ->addOption('excludes', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Excluded directory', [])
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command lints a template and outputs to STDOUT
 the first encountered syntax error.
@@ -84,6 +85,7 @@ EOF
         $io = new SymfonyStyle($input, $output);
         $filenames = $input->getArgument('filename');
         $showDeprecations = $input->getOption('show-deprecations');
+        $excludes = $input->getOption('excludes');
         $this->format = $input->getOption('format') ?? (GithubActionReporter::isGithubActionEnvironment() ? 'github' : 'txt');
 
         if (['-'] === $filenames) {
@@ -121,7 +123,7 @@ EOF
         }
 
         try {
-            $filesInfo = $this->getFilesInfo($filenames);
+            $filesInfo = $this->getFilesInfo($filenames, $excludes);
         } finally {
             if ($showDeprecations) {
                 restore_error_handler();
@@ -131,11 +133,11 @@ EOF
         return $this->display($input, $output, $io, $filesInfo);
     }
 
-    private function getFilesInfo(array $filenames): array
+    private function getFilesInfo(array $filenames, array $excludes): array
     {
         $filesInfo = [];
         foreach ($filenames as $filename) {
-            foreach ($this->findFiles($filename) as $file) {
+            foreach ($this->findFiles($filename, $excludes) as $file) {
                 $filesInfo[] = $this->validate(file_get_contents($file), $file);
             }
         }
@@ -143,12 +145,12 @@ EOF
         return $filesInfo;
     }
 
-    protected function findFiles(string $filename): iterable
+    protected function findFiles(string $filename, array $excludes): iterable
     {
         if (is_file($filename)) {
             return [$filename];
         } elseif (is_dir($filename)) {
-            return Finder::create()->files()->in($filename)->name($this->namePatterns);
+            return Finder::create()->files()->in($filename)->name($this->namePatterns)->exclude($excludes);
         }
 
         throw new RuntimeException(sprintf('File or directory "%s" is not readable.', $filename));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Read PR desc
| License       | MIT
| Doc PR        | 

>**Note** if it is already possible somehow and I did not found, please feel free to answer and close PR

I added a twig file related to [data_collector](https://symfony.com/doc/current/profiler.html#creating-a-data-collector) and used a profiler_dump inside it (in dev env this function exists) ([PR doc pending](https://github.com/symfony/symfony-docs/pull/18470))

I do have a CI checks running this `twig:lint` on my `templates`, and since I’ve added the twig file inside it for a dev profiler data collector, it crashs with `>> Unknown "profiler_dump" function.`

(FYI i do have severals directories in this `templates/` I do not want to list them all)

This PR (opened just to see how it goes) adds an optional option as array to excludes dirs like `--excludes=data_collector`

before:

`APP_DEBUG=0 APP_ENV=preprod symfony console lint:twig templates` 🔴 

after:

`APP_DEBUG=0 APP_ENV=preprod symfony console lint:twig templates --excludes=data_collector` 🟢 