### PR TITLE
[VarDumper] enforce UTC timezone in test

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -25,6 +25,22 @@ class DateCasterTest extends TestCase
 {
     use VarDumperTestTrait;
 
+    private $previousTimezone;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->previousTimezone = date_default_timezone_get();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        date_default_timezone_set($this->previousTimezone);
+    }
+
     /**
      * @dataProvider provideDateTimes
      */
@@ -95,6 +111,8 @@ EODUMP;
      */
     public function testCastDateTimeNoTimezone($time, $xDate, $xInfos)
     {
+        date_default_timezone_set('UTC');
+
         $stub = new Stub();
         $date = new NoTimezoneDate($time);
         $cast = DateCaster::castDateTime($date, Caster::castObject($date, \DateTime::class), $stub, false, 0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This should fix the failing VarDumper tests on AppVeyor.