### PR TITLE
[ExpressionLanguage] Remove deprecated code paths

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -45,6 +45,11 @@ DoctrineBridge
  * DoctrineBridge now requires `doctrine/event-manager:^2`
  * Add parameter `$isSameDatabase` to `DoctrineTokenProvider::configureSchema()`
 
+ExpressionLanguage
+------------------
+
+ * The `in` and `not in` operators now use strict comparison
+
 Filesystem
 ----------
 

--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * The `in` and `not in` operators now use strict comparison
+
 6.3
 ---
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -269,7 +269,7 @@ class ExpressionLanguageTest extends TestCase
         $expressionLanguage = new ExpressionLanguage();
         $expression = 'foo.not in [bar]';
         $compiled = $expressionLanguage->compile($expression, ['foo', 'bar']);
-        $this->assertSame('\Symfony\Component\ExpressionLanguage\Node\BinaryNode::inArray($foo->not, [0 => $bar])', $compiled);
+        $this->assertSame('\in_array($foo->not, [0 => $bar], true)', $compiled);
 
         $result = $expressionLanguage->evaluate($expression, ['foo' => (object) ['not' => 'test'], 'bar' => 'test']);
         $this->assertTrue($result);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\ExpressionLanguage\Tests\Node;
 
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\ExpressionLanguage\Compiler;
 use Symfony\Component\ExpressionLanguage\Node\ArrayNode;
 use Symfony\Component\ExpressionLanguage\Node\BinaryNode;
@@ -21,8 +20,6 @@ use Symfony\Component\ExpressionLanguage\SyntaxError;
 
 class BinaryNodeTest extends AbstractNodeTestCase
 {
-    use ExpectDeprecationTrait;
-
     public static function getEvaluateData(): array
     {
         $array = new ArrayNode();
@@ -116,10 +113,10 @@ class BinaryNodeTest extends AbstractNodeTestCase
             ['pow(5, 2)', new BinaryNode('**', new ConstantNode(5), new ConstantNode(2))],
             ['("a" . "b")', new BinaryNode('~', new ConstantNode('a'), new ConstantNode('b'))],
 
-            ['\Symfony\Component\ExpressionLanguage\Node\BinaryNode::inArray("a", [0 => "a", 1 => "b"])', new BinaryNode('in', new ConstantNode('a'), $array)],
-            ['\Symfony\Component\ExpressionLanguage\Node\BinaryNode::inArray("c", [0 => "a", 1 => "b"])', new BinaryNode('in', new ConstantNode('c'), $array)],
-            ['!\Symfony\Component\ExpressionLanguage\Node\BinaryNode::inArray("c", [0 => "a", 1 => "b"])', new BinaryNode('not in', new ConstantNode('c'), $array)],
-            ['!\Symfony\Component\ExpressionLanguage\Node\BinaryNode::inArray("a", [0 => "a", 1 => "b"])', new BinaryNode('not in', new ConstantNode('a'), $array)],
+            ['\in_array("a", [0 => "a", 1 => "b"], true)', new BinaryNode('in', new ConstantNode('a'), $array)],
+            ['\in_array("c", [0 => "a", 1 => "b"], true)', new BinaryNode('in', new ConstantNode('c'), $array)],
+            ['!\in_array("c", [0 => "a", 1 => "b"], true)', new BinaryNode('not in', new ConstantNode('c'), $array)],
+            ['!\in_array("a", [0 => "a", 1 => "b"], true)', new BinaryNode('not in', new ConstantNode('a'), $array)],
 
             ['range(1, 3)', new BinaryNode('..', new ConstantNode(1), new ConstantNode(3))],
 
@@ -219,17 +216,17 @@ class BinaryNodeTest extends AbstractNodeTestCase
     }
 
     /**
-     * @group legacy
+     * @testWith [1]
+     *           ["true"]
      */
-    public function testInOperatorStrictness()
+    public function testInOperatorStrictness(mixed $value)
     {
         $array = new ArrayNode();
-        $array->addElement(new ConstantNode('a'));
+        $array->addElement(new ConstantNode('1'));
         $array->addElement(new ConstantNode(true));
 
-        $node = new BinaryNode('in', new ConstantNode('b'), $array);
+        $node = new BinaryNode('in', new ConstantNode($value), $array);
 
-        $this->expectDeprecation('Since symfony/expression-language 6.3: The "in" operator will use strict comparisons in Symfony 7.0. Loose match found with key "1" for value "b". Normalize the array parameter so it only has the expected types or implement loose matching in your own expression function.');
-        $this->assertTrue($node->evaluate([], []));
+        $this->assertFalse($node->evaluate([], []));
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/cache": "^6.4|^7.0",
         "symfony/service-contracts": "^2.5|^3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18486

- The `in` and `not in` operators now use strict comparison https://github.com/symfony/symfony/pull/49064
