### PR TITLE
[Mime] remove deprecated methods in Mime Component

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -83,6 +83,12 @@ Messenger
 
  * Add parameter `$isSameDatabase` to `DoctrineTransport::configureSchema()`
 
+Mime
+----
+
+ * Remove `Email::attachPart()` method, use `Email::addPart()` instead
+ * Parameter `$body` is now required (at least null) in `Message::setBody()`
+
 PropertyAccess
 --------------
 

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Remove `Email::attachPart()`, use `Email::addPart()` instead
+ * Argument `$body` is now required (at least null) in `Message::setBody()`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -358,18 +358,6 @@ class Email extends Message
 
     /**
      * @return $this
-     *
-     * @deprecated since Symfony 6.2, use addPart() instead
-     */
-    public function attachPart(DataPart $part): static
-    {
-        @trigger_deprecation('symfony/mime', '6.2', 'The "%s()" method is deprecated, use "addPart()" instead.', __METHOD__);
-
-        return $this->addPart($part);
-    }
-
-    /**
-     * @return $this
      */
     public function addPart(DataPart $part): static
     {

--- a/src/Symfony/Component/Mime/Message.php
+++ b/src/Symfony/Component/Mime/Message.php
@@ -42,11 +42,8 @@ class Message extends RawMessage
     /**
      * @return $this
      */
-    public function setBody(AbstractPart $body = null): static
+    public function setBody(?AbstractPart $body): static
     {
-        if (1 > \func_num_args()) {
-            trigger_deprecation('symfony/mime', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
-        }
         $this->body = $body;
 
         return $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | --
| License       | MIT
| Doc PR        | -

 * Remove `Email::attachPart()` method, use `Email::addPart()` instead
 * Parameter `$body` is now required (at least null) in `Message::setBody()`