### PR TITLE
[Notifier] support local development for sns by adding sslmode option

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransportFactory.php
@@ -31,8 +31,10 @@ final class AmazonSnsTransportFactory extends AbstractTransportFactory
 
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
+        $sslmode = $dsn->getOption('sslmode', 'enable');
+        $protocol = $sslmode === 'disable' ? 'http' : 'https';
 
-        $options = null === $host ? [] : ['endpoint' => 'https://'.$host.($port ? ':'.$port : '')];
+        $options = null === $host ? [] : ['endpoint' => $protocol.'://'.$host.($port ? ':'.$port : '')];
 
         if ($dsn->getUser()) {
             $options += [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


When developing locally with AWS -> localstack we have to communicate via HTTP similarly to the SQS Transport for Messenger component.

https://github.com/symfony/amazon-sqs-messenger/blob/6.3/Transport/Connection.php#L50C14-L50C14
