### PR TITLE
[Messenger] Fix passing options set via tags to handler descriptors

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
@@ -21,7 +21,6 @@ use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SendinblueApiTransportTest extends TestCase
@@ -131,7 +130,6 @@ class SendinblueApiTransportTest extends TestCase
         $transport = new SendinblueApiTransport('ACCESS_KEY', $client);
         $transport->setPort(8984);
 
-        $dataPart = new DataPart('body');
         $mail = new Email();
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
@@ -141,7 +139,6 @@ class SendinblueApiTransportTest extends TestCase
             ->addCc('foo@bar.fr')
             ->addBcc('foo@bar.fr')
             ->addReplyTo('foo@bar.fr')
-            ->attachPart($dataPart)
         ;
 
         $message = $transport->send($mail);

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -115,18 +115,16 @@ class MessengerPass implements CompilerPassInterface
                         $options = ['method' => $options];
                     }
 
-                    if (!isset($options['from_transport']) && isset($tag['from_transport'])) {
-                        $options['from_transport'] = $tag['from_transport'];
-                    }
-
-                    $priority = $tag['priority'] ?? $options['priority'] ?? 0;
+                    $options += array_filter($tag);
+                    unset($options['handles']);
+                    $priority = $options['priority'] ?? 0;
                     $method = $options['method'] ?? '__invoke';
 
                     if (isset($options['bus'])) {
                         if (!\in_array($options['bus'], $busIds)) {
                             $messageLocation = isset($tag['handles']) ? 'declared in your tag attribute "handles"' : ($r->implementsInterface(MessageSubscriberInterface::class) ? sprintf('returned by method "%s::getHandledMessages()"', $r->getName()) : sprintf('used as argument type in method "%s::%s()"', $r->getName(), $method));
 
-                            throw new RuntimeException(sprintf('Invalid configuration "%s" for message "%s": bus "%s" does not exist.', $messageLocation, $message, $options['bus']));
+                            throw new RuntimeException(sprintf('Invalid configuration '.$messageLocation.' for message "%s": bus "%s" does not exist.', $message, $options['bus']));
                         }
 
                         $buses = [$options['bus']];
@@ -135,7 +133,7 @@ class MessengerPass implements CompilerPassInterface
                     if ('*' !== $message && !class_exists($message) && !interface_exists($message, false)) {
                         $messageLocation = isset($tag['handles']) ? 'declared in your tag attribute "handles"' : ($r->implementsInterface(MessageSubscriberInterface::class) ? sprintf('returned by method "%s::getHandledMessages()"', $r->getName()) : sprintf('used as argument type in method "%s::%s()"', $r->getName(), $method));
 
-                        throw new RuntimeException(sprintf('Invalid handler service "%s": class or interface "%s" "%s" not found.', $serviceId, $message, $messageLocation));
+                        throw new RuntimeException(sprintf('Invalid handler service "%s": class or interface "%s" '.$messageLocation.' not found.', $serviceId, $message));
                     }
 
                     if (!$r->hasMethod($method)) {

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -170,13 +170,15 @@ class MessengerPassTest extends TestCase
             $container,
             $commandBusHandlersLocatorDefinition->getArgument(0),
             MultipleBusesMessage::class,
-            [MultipleBusesMessageHandler::class]
+            [MultipleBusesMessageHandler::class],
+            [['bus' => $commandBusId]]
         );
         $this->assertHandlerDescriptor(
             $container,
             $commandBusHandlersLocatorDefinition->getArgument(0),
             DummyCommand::class,
-            [DummyCommandHandler::class]
+            [DummyCommandHandler::class],
+            [['bus' => $commandBusId]]
         );
 
         $queryBusHandlersLocatorDefinition = $container->getDefinition($queryBusId.'.messenger.handlers_locator');
@@ -185,13 +187,15 @@ class MessengerPassTest extends TestCase
             $container,
             $queryBusHandlersLocatorDefinition->getArgument(0),
             DummyQuery::class,
-            [DummyQueryHandler::class]
+            [DummyQueryHandler::class],
+            [['bus' => $queryBusId]]
         );
         $this->assertHandlerDescriptor(
             $container,
             $queryBusHandlersLocatorDefinition->getArgument(0),
             MultipleBusesMessage::class,
-            [MultipleBusesMessageHandler::class]
+            [MultipleBusesMessageHandler::class],
+            [['bus' => $queryBusId]]
         );
     }
 
@@ -442,7 +446,7 @@ class MessengerPassTest extends TestCase
     public function testItThrowsAnExceptionOnUnknownBus()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid configuration "returned by method "Symfony\Component\Messenger\Tests\DependencyInjection\HandlerOnUndefinedBus::getHandledMessages()"" for message "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage": bus "some_undefined_bus" does not exist.');
+        $this->expectExceptionMessage('Invalid configuration returned by method "Symfony\Component\Messenger\Tests\DependencyInjection\HandlerOnUndefinedBus::getHandledMessages()" for message "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage": bus "some_undefined_bus" does not exist.');
         $container = $this->getContainerBuilder();
         $container
             ->register(HandlerOnUndefinedBus::class, HandlerOnUndefinedBus::class)
@@ -455,7 +459,7 @@ class MessengerPassTest extends TestCase
     public function testUndefinedMessageClassForHandler()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandler": class or interface "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessage" "used as argument type in method "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandler::__invoke()"" not found.');
+        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandler": class or interface "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessage" used as argument type in method "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandler::__invoke()" not found.');
         $container = $this->getContainerBuilder();
         $container
             ->register(UndefinedMessageHandler::class, UndefinedMessageHandler::class)
@@ -468,7 +472,7 @@ class MessengerPassTest extends TestCase
     public function testUndefinedMessageClassForHandlerImplementingMessageHandlerInterface()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandlerViaHandlerInterface": class or interface "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessage" "used as argument type in method "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandlerViaHandlerInterface::__invoke()"" not found.');
+        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandlerViaHandlerInterface": class or interface "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessage" used as argument type in method "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandlerViaHandlerInterface::__invoke()" not found.');
         $container = $this->getContainerBuilder();
         $container
             ->register(UndefinedMessageHandlerViaHandlerInterface::class, UndefinedMessageHandlerViaHandlerInterface::class)
@@ -481,7 +485,7 @@ class MessengerPassTest extends TestCase
     public function testUndefinedMessageClassForHandlerImplementingMessageSubscriberInterface()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandlerViaSubscriberInterface": class or interface "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessage" "returned by method "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandlerViaSubscriberInterface::getHandledMessages()"" not found.');
+        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandlerViaSubscriberInterface": class or interface "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessage" returned by method "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandlerViaSubscriberInterface::getHandledMessages()" not found.');
         $container = $this->getContainerBuilder();
         $container
             ->register(UndefinedMessageHandlerViaSubscriberInterface::class, UndefinedMessageHandlerViaSubscriberInterface::class)
@@ -713,12 +717,12 @@ class MessengerPassTest extends TestCase
 
         $this->assertEquals([
             $commandBusId => [
-                DummyCommand::class => [[DummyCommandHandler::class, []]],
-                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, []]],
+                DummyCommand::class => [[DummyCommandHandler::class, ['bus' => $commandBusId]]],
+                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, ['bus' => $commandBusId]]],
             ],
             $queryBusId => [
-                DummyQuery::class => [[DummyQueryHandler::class, []]],
-                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, []]],
+                DummyQuery::class => [[DummyQueryHandler::class, ['bus' => $queryBusId]]],
+                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, ['bus' => $queryBusId]]],
             ],
             $emptyBus => [],
         ], $container->getDefinition('console.command.messenger_debug')->getArgument(0));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted while working on #50873