### PR TITLE
[Form] Deprecate not configuring the `default_protocol` option of the `UrlType`

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -332,6 +332,10 @@ trait LazyGhostTrait
         }
 
         if ((Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['clone']) {
+            if ($this->lazyObjectState->skippedProperties) {
+                $this->initializeLazyObject();
+            }
+
             parent::__clone();
         }
     }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/MagicCloneClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/MagicCloneClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+class MagicCloneClass
+{
+    public ?int $id;
+    public bool $cloned;
+
+    public function __clone()
+    {
+        $this->id = null;
+        $this->cloned = true;
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/MagicCloneClassProxy.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/MagicCloneClassProxy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+use Symfony\Component\VarExporter\LazyGhostTrait;
+use Symfony\Component\VarExporter\LazyObjectInterface;
+
+class MagicCloneClassProxy extends MagicCloneClass  implements LazyObjectInterface
+{
+    use LazyGhostTrait;
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildStdClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildTestClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\LazyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\MagicClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\MagicCloneClassProxy;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ReadOnlyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\TestClass;
 
@@ -107,6 +108,23 @@ class LazyGhostTraitTest extends TestCase
 
         $clone = clone $clone;
         $this->assertTrue($clone->resetLazyObject());
+    }
+
+    public function testCloneIsInitializedIfNeeded()
+    {
+        $instance = MagicCloneClassProxy::createLazyGhost(function (MagicCloneClassProxy $ghost) {
+            if (1 === $ghost->id) {
+                $ghost->cloned = false;
+            } else {
+                $this->fail('Ghost must be initialized before its __clone method is called.');
+            }
+        }, ['id' => true]);
+        $instance->id = 1;
+
+        $clone = clone $instance;
+
+        $this->assertNull($clone->id);
+        $this->assertTrue($clone->cloned);
     }
 
     public function testSerialize()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Part of #50871 
| License       | MIT
| Doc PR        | N/A

You would expect an `<input type="url">` from the `UrlType`, but it is not possible as long as `default_protocol` has a value, because then you have to accept inputs that are not URLs (and you get an `<input type="text" inputmode="url">`).

In order to change `default_protocol` from `'http'` to `null` in 7.0, we must first deprecate not configuring it.

Don’t know how I can update tests though; all of `UrlTypeTest`’s parent test cases will trigger the deprecation :thinking: 
