### PR TITLE
[TwigBundle] Allow omitting the `autoescape_service_method` option when `autoescape_service` is set to an invokable service id

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Allow omitting the `autoescape_service_method` option when `autoescape_service` is set to an invokable service id
+
 6.3
 ---
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -151,8 +151,8 @@ class TwigExtension extends Extension
             }
         }
 
-        if (isset($config['autoescape_service']) && isset($config['autoescape_service_method'])) {
-            $config['autoescape'] = [new Reference($config['autoescape_service']), $config['autoescape_service_method']];
+        if (isset($config['autoescape_service'])) {
+            $config['autoescape'] = [new Reference($config['autoescape_service']), $config['autoescape_service_method'] ?? '__invoke'];
         }
 
         $container->getDefinition('twig')->replaceArgument(1, array_intersect_key($config, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -