### PR TITLE
[Finder] Fix initial directory is opened twice

### DIFF
--- a/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
@@ -15,16 +15,19 @@ use Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator;
 
 class RecursiveDirectoryIteratorTest extends IteratorTestCase
 {
+    protected function setUp(): void
+    {
+        if (!\in_array('ftp', stream_get_wrappers(), true) || !\ini_get('allow_url_fopen')) {
+            $this->markTestSkipped('Unsupported stream "ftp".');
+        }
+    }
+
     /**
      * @group network
      */
     public function testRewindOnFtp()
     {
-        try {
-            $i = new RecursiveDirectoryIterator('ftp://speedtest:speedtest@ftp.otenet.gr/', \RecursiveDirectoryIterator::SKIP_DOTS);
-        } catch (\UnexpectedValueException $e) {
-            $this->markTestSkipped('Unsupported stream "ftp".');
-        }
+        $i = new RecursiveDirectoryIterator('ftp://speedtest:speedtest@ftp.otenet.gr/', \RecursiveDirectoryIterator::SKIP_DOTS);
 
         $i->rewind();
 
@@ -36,11 +39,7 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
      */
     public function testSeekOnFtp()
     {
-        try {
-            $i = new RecursiveDirectoryIterator('ftp://speedtest:speedtest@ftp.otenet.gr/', \RecursiveDirectoryIterator::SKIP_DOTS);
-        } catch (\UnexpectedValueException $e) {
-            $this->markTestSkipped('Unsupported stream "ftp".');
-        }
+        $i = new RecursiveDirectoryIterator('ftp://speedtest:speedtest@ftp.otenet.gr/', \RecursiveDirectoryIterator::SKIP_DOTS);
 
         $contains = [
             'ftp://speedtest:speedtest@ftp.otenet.gr'.\DIRECTORY_SEPARATOR.'test100Mb.db',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50851
| License       | MIT
| Doc PR        | no

The issue was introduced in #8120 which was coded wrongly for several reasons:
- `seekable` support is about file/stream content seeking, not about rewind support, non-seekable stream handler can support rewind - it worked by coincidence
- the original code involved additional directory open (syscall), which is/was slow
- 1st rewind of DirectoryIterator is implicit, ie. it is not needed - again, skipping the rewind worked by coincidence
- 2nd+ rewind must fail if it is not supported, the original code silently skipped it

The test from #8120 is kept and is passing.

I also improved the ftp support detection to make the test stricter.

To support rewind for ftp I opened - https://github.com/php/php-src/issues/11597 - but this Symfony PR does not need it.