### PR TITLE
[Finder] Fix children condition in ExcludeDirectoryFilterIterator

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -59,7 +59,7 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator implements \Recursi
     #[\ReturnTypeWillChange]
     public function accept()
     {
-        if ($this->isRecursive && isset($this->excludedDirs[$this->getFilename()]) && $this->isDir()) {
+        if (isset($this->excludedDirs[$this->getFilename()]) && $this->hasChildren()) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

see https://github.com/php/php-src/blob/6091603b5350c1ca0e792a6da604e25e2a0121c8/ext/spl/spl_directory.h#L113

Original `isDir` follow symlinks, so this PR has no effect, but it avoids expensive `isDir` call and makes the condition more correct.