### PR TITLE
[FrameworkBundle] Deprecate doctrine/annotations integration

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -34,6 +34,8 @@ FrameworkBundle
 ---------------
 
  * Add native return type to `Translator` and to `Application::reset()`
+ * Deprecate the integration of Doctrine annotations, either uninstall the `doctrine/annotations` package or disable
+   the integration by setting `framework.annotations` to `false`
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add native return type to `Translator` and to `Application::reset()`
+ * Deprecate the integration of Doctrine annotations, either uninstall the `doctrine/annotations` package or disable the integration by setting `framework.annotations` to `false`
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -22,22 +22,26 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
  * and declared in DI bundle extensions using the addAnnotatedClassesToCache method.
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @deprecated since Symfony 6.4 without replacement
  */
 class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
 {
-    private Reader $annotationReader;
-    private ?string $excludeRegexp;
-    private bool $debug;
-
     /**
      * @param string $phpArrayFile The PHP file where annotations are cached
      */
-    public function __construct(Reader $annotationReader, string $phpArrayFile, string $excludeRegexp = null, bool $debug = false)
-    {
+    public function __construct(
+        private readonly Reader $annotationReader,
+        string $phpArrayFile,
+        private readonly ?string $excludeRegexp = null,
+        private readonly bool $debug = false,
+        /* bool $triggerDeprecation = true, */
+    ) {
+        if (\func_num_args() < 5 || func_get_arg(4)) {
+            trigger_deprecation('symfony/framework-bundle', '6.4', 'The "%s" class is deprecated without replacement.', __CLASS__);
+        }
+
         parent::__construct($phpArrayFile);
-        $this->annotationReader = $annotationReader;
-        $this->excludeRegexp = $excludeRegexp;
-        $this->debug = $debug;
     }
 
     protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter): bool

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1716,6 +1716,8 @@ class FrameworkExtension extends Extension
             throw new LogicException('Annotations cannot be enabled as the Doctrine Annotation library is not installed. Try running "composer require doctrine/annotations".');
         }
 
+        trigger_deprecation('symfony/framework-bundle', '6.4', 'Enabling the integration of Doctrine annotations is deprecated. Set the "framework.annotations.enabled" config option to false.');
+
         $loader->load('annotations.php');
 
         if ('none' === $config['cache']) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -23,6 +23,7 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('annotations.reader', AnnotationReader::class)
             ->call('addGlobalIgnoredName', ['required']) // @deprecated since Symfony 6.3
+            ->deprecate('symfony/framework-bundle', '6.4', 'The "%service_id%" service is deprecated without replacement.')
 
         ->set('annotations.cached_reader', PsrCachedReader::class)
             ->args([
@@ -32,6 +33,7 @@ return static function (ContainerConfigurator $container) {
             ])
             ->tag('annotations.cached_reader')
             ->tag('container.do_not_inline')
+            ->deprecate('symfony/framework-bundle', '6.4', 'The "%service_id%" service is deprecated without replacement.')
 
         ->set('annotations.filesystem_cache_adapter', FilesystemAdapter::class)
             ->args([
@@ -39,6 +41,7 @@ return static function (ContainerConfigurator $container) {
                 0,
                 abstract_arg('Cache-Directory'),
             ])
+            ->deprecate('symfony/framework-bundle', '6.4', 'The "%service_id%" service is deprecated without replacement.')
 
         ->set('annotations.cache_warmer', AnnotationsCacheWarmer::class)
             ->args([
@@ -46,7 +49,9 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.cache_dir').'/annotations.php',
                 '#^Symfony\\\\(?:Component\\\\HttpKernel\\\\|Bundle\\\\FrameworkBundle\\\\Controller\\\\(?!.*Controller$))#',
                 param('kernel.debug'),
+                false,
             ])
+            ->deprecate('symfony/framework-bundle', '6.4', 'The "%service_id%" service is deprecated without replacement.')
 
         ->set('annotations.cache_adapter', PhpArrayAdapter::class)
             ->factory([PhpArrayAdapter::class, 'create'])
@@ -55,7 +60,12 @@ return static function (ContainerConfigurator $container) {
                 service('cache.annotations'),
             ])
             ->tag('container.hot_path')
+            ->deprecate('symfony/framework-bundle', '6.4', 'The "%service_id%" service is deprecated without replacement.')
 
         ->alias('annotation_reader', 'annotations.reader')
-        ->alias(Reader::class, 'annotation_reader');
+            ->deprecate('symfony/framework-bundle', '6.4', 'The "%alias_id%" service alias is deprecated without replacement.')
+
+        ->alias(Reader::class, 'annotation_reader')
+            ->deprecate('symfony/framework-bundle', '6.4', 'The "%alias_id%" service alias is deprecated without replacement.')
+    ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -22,9 +23,14 @@ use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group legacy
+ */
 class AnnotationsCacheWarmerTest extends TestCase
 {
-    private $cacheDir;
+    use ExpectDeprecationTrait;
+
+    private string $cacheDir;
 
     protected function setUp(): void
     {
@@ -46,7 +52,10 @@ class AnnotationsCacheWarmerTest extends TestCase
         file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export([__CLASS__], true)));
         $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
         $reader = new AnnotationReader();
+
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: The "Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer" class is deprecated without replacement.');
         $warmer = new AnnotationsCacheWarmer($reader, $cacheFile);
+
         $warmer->warmUp($this->cacheDir);
         $this->assertFileExists($cacheFile);
 
@@ -66,7 +75,10 @@ class AnnotationsCacheWarmerTest extends TestCase
         file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export([__CLASS__], true)));
         $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
         $reader = new AnnotationReader();
+
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: The "Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer" class is deprecated without replacement.');
         $warmer = new AnnotationsCacheWarmer($reader, $cacheFile, null, true);
+
         $warmer->warmUp($this->cacheDir);
         $this->assertFileExists($cacheFile);
 
@@ -92,6 +104,8 @@ class AnnotationsCacheWarmerTest extends TestCase
         $this->assertFalse(class_exists($annotatedClass = 'C\C\C', false));
 
         file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export([$annotatedClass], true)));
+
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: The "Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer" class is deprecated without replacement.');
         $warmer = new AnnotationsCacheWarmer(new AnnotationReader(), tempnam($this->cacheDir, __FUNCTION__));
 
         spl_autoload_register($classLoader = function ($class) use ($annotatedClass) {
@@ -117,6 +131,7 @@ class AnnotationsCacheWarmerTest extends TestCase
         $this->assertFalse(class_exists($annotatedClass = 'AClassThatDoesNotExist_FWB_CacheWarmer_AnnotationsCacheWarmerTest', false));
 
         file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export([$annotatedClass], true)));
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: The "Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer" class is deprecated without replacement.');
         $warmer = new AnnotationsCacheWarmer(new AnnotationReader(), tempnam($this->cacheDir, __FUNCTION__));
 
         spl_autoload_register($classLoader = function ($class) use ($annotatedClass) {
@@ -134,6 +149,7 @@ class AnnotationsCacheWarmerTest extends TestCase
     public function testWarmupRemoveCacheMisses()
     {
         $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: The "Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer" class is deprecated without replacement.');
         $warmer = $this->getMockBuilder(AnnotationsCacheWarmer::class)
             ->setConstructorArgs([new AnnotationReader(), $cacheFile])
             ->onlyMethods(['doWarmUp'])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/Fixture/TestAppKernel.php
@@ -34,6 +34,7 @@ class TestAppKernel extends Kernel
     {
         $loader->load(static function (ContainerBuilder $container) {
             $container->loadFromExtension('framework', [
+                'annotations' => false,
                 'http_method_override' => false,
             ]);
         });

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -25,10 +25,8 @@ use Symfony\Component\Finder\Finder;
 
 class CacheClearCommandTest extends TestCase
 {
-    /** @var TestAppKernel */
-    private $kernel;
-    /** @var Filesystem */
-    private $fs;
+    private TestAppKernel $kernel;
+    private Filesystem $fs;
 
     protected function setUp(): void
     {
@@ -112,7 +110,7 @@ class CacheClearCommandTest extends TestCase
         $application->setCatchExceptions(false);
         $application->doRun($input, new NullOutput());
 
-        $this->assertTrue(is_file($this->kernel->getCacheDir().'/annotations.php'));
+        $this->assertTrue(is_file($this->kernel->getCacheDir().'/dummy.txt'));
     }
 
     public function testCacheIsWarmedWithOldContainer()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
@@ -15,6 +15,7 @@ use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
 class TestAppKernel extends Kernel
@@ -39,5 +40,22 @@ class TestAppKernel extends Kernel
     protected function build(ContainerBuilder $container): void
     {
         $container->register('logger', NullLogger::class);
+        $container->register(DummyFileCacheWarmer::class)
+            ->addTag('kernel.cache_warmer');
+    }
+}
+
+class DummyFileCacheWarmer implements CacheWarmerInterface
+{
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    public function warmUp(string $cacheDir): array
+    {
+        file_put_contents($cacheDir.'/dummy.txt', 'Hello');
+
+        return [];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/config.yml
@@ -1,3 +1,4 @@
 framework:
+    annotations: false
     http_method_override: false
     secret: test

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'assets' => [
         'version' => 'SomeVersionScheme',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_disabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'assets' => [
         'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_version_strategy_as_service.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_version_strategy_as_service.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'assets' => [
         'version_strategy' => 'assets.custom_version_strategy',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'cache' => [
         'pools' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'cache' => [
         'app' => 'cache.adapter.redis_tag_aware',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware_pool.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware_pool.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'cache' => [
         'app' => 'cache.redis_tag_aware.foo',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'csrf_protection' => true,
     'session' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf_needs_session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf_needs_session.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'csrf_protection' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/default_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/default_config.php
@@ -1,4 +1,6 @@
 <?php
 
 $container->loadFromExtension('framework', [
-    'http_method_override' => false,]);
+    'annotations' => false,
+    'http_method_override' => false,
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/esi_and_ssi_without_fragments.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/esi_and_ssi_without_fragments.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'fragments' => [
         'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/esi_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/esi_disabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'esi' => [
         'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/exceptions.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/exceptions.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'exceptions' => [
         BadRequestHttpException::class => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_csrf_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_csrf_disabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'csrf_protection' => false,
     'form' => [
         'csrf_protection' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_default_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_default_csrf.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_no_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_no_csrf.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'form' => [
         'csrf_protection' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/fragments_and_hinclude.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/fragments_and_hinclude.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'fragments' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -56,11 +56,7 @@ $container->loadFromExtension('framework', [
     'validation' => [
         'enabled' => true,
     ],
-    'annotations' => [
-        'cache' => 'file',
-        'debug' => true,
-        'file_cache_dir' => '%kernel.cache_dir%/annotations',
-    ],
+    'annotations' => false,
     'serializer' => [
         'enabled' => true,
         'enable_annotations' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'html_sanitizer' => [
         'sanitizers' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_allowed_link_and_media_hosts.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_allowed_link_and_media_hosts.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'html_sanitizer' => [
         'sanitizers' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_config.php
@@ -1,5 +1,6 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'html_sanitizer' => null]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_default_options.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'http_client' => [
         'max_host_connections' => 4,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_full_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_full_default_options.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'http_client' => [
         'default_options' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_mock_response_factory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_mock_response_factory.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'http_client' => [
         'default_options' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_override_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_override_default_options.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'http_client' => [
         'max_host_connections' => 4,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'http_client' => [
         'default_options' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_scoped_without_query_option.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_scoped_without_query_option.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'http_client' => [
         'scoped_clients' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_xml_key.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_xml_key.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'http_client' => [
         'default_options' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/legacy_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/legacy_annotations.php
@@ -1,0 +1,10 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'annotations' => [
+        'cache' => 'file',
+        'debug' => true,
+        'file_cache_dir' => '%kernel.cache_dir%/annotations',
+    ],
+    'http_method_override' => false,
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/legacy_translator_enabled_locales.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/legacy_translator_enabled_locales.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'secret' => 's3cr3t',
     'default_locale' => 'fr',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'mailer' => [
         'dsn' => 'smtp://example.com',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_disabled_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_disabled_message_bus.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'mailer' => [
         'dsn' => 'smtp://example.com',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_dsn.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_dsn.php
@@ -4,6 +4,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 return static function (ContainerConfigurator $container) {
     $container->extension('framework', [
+        'annotations' => false,
         'http_method_override' => false,
         'mailer' => [
             'dsn' => 'smtp://example.com',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_specific_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_specific_message_bus.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'mailer' => [
         'dsn' => 'smtp://example.com',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_transports.php
@@ -4,6 +4,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 return static function (ContainerConfigurator $container) {
     $container->extension('framework', [
+        'annotations' => false,
         'http_method_override' => false,
         'mailer' => [
             'transports' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger.php
@@ -4,6 +4,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'scheduler' => true,
     'messenger' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_disabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => false,
     'scheduler' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_middleware_factory_erroneous_format.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_middleware_factory_erroneous_format.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'buses' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'default_bus' => 'messenger.bus.commands',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_failure_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_failure_transports.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'transports' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_failure_transports_global.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_failure_transports_global.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'failure_transport' => 'failure_transport_global',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
@@ -4,6 +4,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => true,
     'messenger' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_transport.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_transport.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => true,
     'messenger' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_wildcard.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_wildcard.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => true,
     'messenger' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_single.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_single.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'routing' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => true,
     'messenger' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => true,
     'messenger' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_with_disabled_reset_on_message.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_with_disabled_reset_on_message.php
@@ -4,6 +4,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'reset_on_message' =>  false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_with_explict_reset_on_message_legacy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_with_explict_reset_on_message_legacy.php
@@ -4,6 +4,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'reset_on_message' =>  true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier.php
@@ -4,6 +4,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'enabled' => true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_with_disabled_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_with_disabled_message_bus.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_with_specific_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_with_specific_message_bus.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'messenger' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_mailer.php
@@ -4,6 +4,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'mailer' => [
         'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_messenger.php
@@ -4,6 +4,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'mailer' => [
         'dsn' => 'smtp://example.com',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_transports.php
@@ -4,6 +4,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'notifier' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_disabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'php_errors' => [
         'log' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_enabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'php_errors' => [
         'log' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_level.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_level.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'php_errors' => [
         'log' => 8,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_levels.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_levels.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'php_errors' => [
         'log' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'profiler' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler_collect_serializer_data.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler_collect_serializer_data.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'profiler' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'property_access' => [
         'magic_call' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_info.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'property_info' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/request.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/request.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'request' => [
         'formats' => [],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_disabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => [
         'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_enabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_legacy_cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_legacy_cache.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping.php
@@ -2,7 +2,7 @@
 
 $container->loadFromExtension('framework', [
     'http_method_override' => false,
-    'annotations' => ['enabled' => true],
+    'annotations' => false,
     'serializer' => [
         'enable_annotations' => true,
         'mapping' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping_without_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping_without_annotations.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'serializer' => [
         'enable_annotations' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_cookie_secure_auto.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_cookie_secure_auto.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/ssi_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/ssi_disabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'ssi' => [
         'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/translator_cache_dir_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/translator_cache_dir_disabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'translator' => [
         'cache_dir' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/translator_fallbacks.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/translator_fallbacks.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'translator' => [
         'fallbacks' => ['en', 'fr'],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_annotations.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'secret' => 's3cr3t',
     'validation' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_auto_mapping.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_auto_mapping.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'property_info' => ['enabled' => true],
     'validation' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_email_validation_mode.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_email_validation_mode.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'validation' => [
         'email_validation_mode' => 'html5',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_legacy_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_legacy_annotations.php
@@ -1,0 +1,15 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'annotations' => [
+        'enabled' => true,
+    ],
+    'http_method_override' => false,
+    'secret' => 's3cr3t',
+    'validation' => [
+        'enabled' => true,
+        'enable_annotations' => true,
+    ],
+]);
+
+$container->setAlias('validator.alias', 'validator')->setPublic(true);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_mapping.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_mapping.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'validation' => [
         'mapping' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_multiple_static_methods.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_multiple_static_methods.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'secret' => 's3cr3t',
     'validation' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_no_static_method.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_no_static_method.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'secret' => 's3cr3t',
     'validation' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_translation_domain.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_translation_domain.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'validation' => [
         'translation_domain' => 'messages',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/web_link.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/web_link.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'web_link' => ['enabled' => true],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/webhook.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'webhook' => ['enabled' => true],
     'http_client' => ['enabled' => true],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/webhook_without_serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/webhook_without_serializer.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'webhook' => ['enabled' => true],
     'http_client' => ['enabled' => true],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_not_valid.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_not_valid.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'my_workflow' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'article' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_multiple_transitions_with_same_name.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_multiple_transitions_with_same_name.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'article' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_no_events_to_dispatch.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_no_events_to_dispatch.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'my_workflow' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_events_to_dispatch.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_events_to_dispatch.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'my_workflow' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_support_and_support_strategy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_support_and_support_strategy.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'my_workflow' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_without_support_and_support_strategy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_without_support_and_support_strategy.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'my_workflow' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'article' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_enabled.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => null,
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled_named_workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled_named_workflows.php
@@ -3,6 +3,7 @@
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
+    'annotations' => false,
     'http_method_override' => false,
     'workflows' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/asset_mapper.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/asset_mapper.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:asset-mapper
             enabled="true"
             server="true"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:assets version="SomeVersionScheme" version-format="%%s?version=%%s">
             <framework:base-url>http://cdn.example.com</framework:base-url>
             <framework:package name="images_path" base-path="/foo" version-format="%%s-%%s" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_disabled.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:assets enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_version_strategy_as_service.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_version_strategy_as_service.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:assets version-strategy="assets.custom_version_strategy">
             <framework:base-url>http://cdn.example.com</framework:base-url>
         </framework:assets>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:cache>
             <framework:pool name="cache.foo" adapter="cache.adapter.apcu" default-lifetime="30" />
             <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:cache>
             <framework:app>cache.adapter.redis_tag_aware</framework:app>
         </framework:cache>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware_pool.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware_pool.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:cache>
             <framework:app>cache.redis_tag_aware.foo</framework:app>
             <framework:pool name="cache.redis_tag_aware.foo" adapter="cache.adapter.redis_tag_aware" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:csrf-protection />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf_disabled.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:csrf-protection enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf_needs_session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf_needs_session.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:csrf-protection />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/default_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/default_config.xml
@@ -5,5 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false" />
+    <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
+    </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/esi_and_ssi_without_fragments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/esi_and_ssi_without_fragments.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:fragments enabled="false" />
         <framework:esi enabled="true" />
         <framework:ssi enabled="true" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/esi_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/esi_disabled.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:esi enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/exceptions.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/exceptions.xml
@@ -6,6 +6,8 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
+
         <framework:exception
             class="Symfony\Component\HttpKernel\Exception\BadRequestHttpException"
             log-level="info"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/exceptions_legacy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/exceptions_legacy.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:exceptions>
             <framework:exception name="Symfony\Component\HttpKernel\Exception\BadRequestHttpException" log-level="info" status-code="422" />
             <framework:exception name="Symfony\Component\HttpKernel\Exception\NotFoundHttpException" log-level="info" status-code="0" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_disabled.xml
@@ -9,6 +9,7 @@
             https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
 >
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false"/>
         <framework:csrf-protection enabled="false"/>
         <framework:form enabled="true">
             <framework:csrf-protection enabled="true"/>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:csrf-protection field-name="_custom" />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:csrf-protection field-name="_custom_form" />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_default_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_default_csrf.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:form enabled="true" />
         <framework:session storage-factory-id="session.storage.factory.native" handler-id="null"/>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:form enabled="true">
             <framework:csrf-protection enabled="false" />
         </framework:form>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/fragments_and_hinclude.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/fragments_and_hinclude.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:fragments enabled="true" hinclude-default-template="global_hinclude_template"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -32,7 +32,7 @@
             <framework:path>%kernel.project_dir%/Fixtures/translations</framework:path>
         </framework:translator>
         <framework:validation enabled="true" />
-        <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" circular-reference-handler="my.circular.reference.handler" max-depth-handler="my.max.depth.handler">
             <framework:default-context>
                 <framework:enable_max_depth>true</framework:enable_max_depth>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer.xml
@@ -6,6 +6,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false">
+        <annotations enabled="false" />
         <html-sanitizer>
             <sanitizer name="custom"
                 allow-safe-elements="true"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_allowed_link_and_media_hosts.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_allowed_link_and_media_hosts.xml
@@ -6,6 +6,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false">
+        <annotations enabled="false" />
         <html-sanitizer>
             <sanitizer name="custom_default"/>
         </html-sanitizer>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_config.xml
@@ -6,6 +6,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false">
+        <annotations enabled="false" />
         <html-sanitizer />
     </config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_default_options.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:http-client max-host-connections="4">
             <framework:default-options />
             <framework:scoped-client

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_full_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_full_default_options.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:http-client>
             <framework:default-options
                     proxy="proxy.org"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_mock_response_factory.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_mock_response_factory.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:http-client mock-response-factory="my_response_factory">
             <framework:default-options />
         </framework:http-client>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_override_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_override_default_options.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:http-client max-host-connections="4">
             <framework:default-options>
                 <framework:header name="foo">bar</framework:header>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:http-client>
             <framework:default-options>
                 <framework:retry-failed

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_scoped_without_query_option.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_scoped_without_query_option.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:http-client>
             <framework:scoped-client
                 name="foo"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_xml_key.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_xml_key.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:http-client>
             <framework:default-options>
                 <framework:resolve host="host">127.0.0.1</framework:resolve>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/legacy_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/legacy_annotations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config http-method-override="false">
+        <framework:annotations enabled="true"
+                               cache="file"
+                               debug="true"
+                               file-cache-dir="%kernel.cache_dir%/annotations"
+        />
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/legacy_translator_enabled_locales.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/legacy_translator_enabled_locales.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config secret="s3cr3t" ide="file%%link%%format" default-locale="fr" http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:router resource="%kernel.project_dir%/config/routing.xml" type="xml" utf8="true" />
         <framework:translator enabled="true" fallback="fr" logging="true" cache-dir="%kernel.cache_dir%/translations">
             <framework:path>%kernel.project_dir%/Fixtures/translations</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:lock/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock_named.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock_named.xml
@@ -11,6 +11,7 @@
     </parameters>
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:lock>
             <framework:resource name="foo">semaphore</framework:resource>
             <framework:resource name="bar">flock</framework:resource>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_disabled_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_disabled_message_bus.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:mailer dsn="smtp://example.com" message-bus="false">
         </framework:mailer>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:mailer dsn="smtp://example.com">
             <framework:envelope>
                 <framework:sender>sender@example.org</framework:sender>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_specific_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_specific_message_bus.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:mailer dsn="smtp://example.com" message-bus="app.another_bus">
         </framework:mailer>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_transports.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:mailer>
             <framework:transport name="transport1">smtp://example1.com</framework:transport>
             <framework:transport name="transport2">smtp://example2.com</framework:transport>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:scheduler enabled="true" />
         <framework:messenger>
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_disabled.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger enabled="false" />
         <framework:scheduler enabled="false" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger default-bus="messenger.bus.commands">
             <framework:bus name="messenger.bus.commands" />
             <framework:bus name="messenger.bus.events">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_failure_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_failure_transports.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger>
             <framework:transport name="transport_1" dsn="null://" failure-transport="failure_transport_1" />
             <framework:transport name="transport_2" dsn="null://" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_failure_transports_global.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_failure_transports_global.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger failure-transport="failure_transport_global">
             <framework:transport name="transport_1" dsn="null://" failure-transport="failure_transport_1" />
             <framework:transport name="transport_2" dsn="null://" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_transport.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_transport.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_wildcard.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_wildcard.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_single.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_single.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger>
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage">
                 <framework:sender service="amqp" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_schedule.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_schedule.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger>
             <framework:transport name="schedule" dsn="schedule://default" />
         </framework:messenger>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="true" />
         <framework:messenger failure-transport="failed">
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_with_disabled_reset_on_message.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_with_disabled_reset_on_message.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger reset-on-message="false">
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage">
                 <framework:sender service="sender.bar" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_with_explict_reset_on_message_legacy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_with_explict_reset_on_message_legacy.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger reset-on-message="true">
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage">
                 <framework:sender service="sender.bar" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger enabled="true" />
         <framework:mailer dsn="smtp://example.com" />
         <framework:notifier enabled="true" notification-on-failed-messages="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_with_disabled_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_with_disabled_message_bus.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger enabled="true" />
         <framework:mailer dsn="smtp://example.com" />
         <framework:notifier enabled="true" message-bus="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_with_specific_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_with_specific_message_bus.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:messenger enabled="true" />
         <framework:mailer dsn="smtp://example.com" />
         <framework:notifier enabled="true" message-bus="app.another_bus">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_mailer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_mailer.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:mailer enabled="false" />
         <framework:messenger enabled="true" />
         <framework:notifier enabled="true" notification-on-failed-messages="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_messenger.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:mailer dsn="smtp://example.com" />
         <framework:messenger enabled="false" />
         <framework:notifier enabled="true" notification-on-failed-messages="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_transports.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
-        <framework:notifier enabled="true"></framework:notifier>
+        <framework:annotations enabled="false" />
+        <framework:notifier enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_disabled.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:php-errors log="false" throw="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_enabled.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:php-errors log="true" throw="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_level.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_level.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:php-errors log="8" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_levels.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_levels.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:php-errors>
             <framework:log type="8" logLevel="error" />
             <framework:log type="2" logLevel="error" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:profiler enabled="true" />
         <framework:serializer enabled="true" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler_collect_serializer_data.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler_collect_serializer_data.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:profiler enabled="true" collect-serializer-data="true" />
         <framework:serializer enabled="true" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_accessor.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_accessor.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false"/>
         <framework:property-access magic-call="true" magic-get="true" magic-set="false" throw-exception-on-invalid-index="true" throw-exception-on-invalid-property-path="false"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_info.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:property-info enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/rate_limiter.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/rate_limiter.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:rate-limiter>
             <framework:limiter
                 name="sliding_window"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/request.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/request.xml
@@ -6,6 +6,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:request />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/semaphore.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/semaphore.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:semaphore/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_disabled.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_enabled.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_legacy_cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_legacy_cache.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enabled="true" cache="foo"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping.xml
@@ -5,7 +5,7 @@
     xmlns:framework="http://symfony.com/schema/dic/symfony">
 
     <framework:config http-method-override="false">
-        <framework:annotations enabled="true" />
+        <framework:annotations enabled="false" />
         <framework:serializer enable-annotations="true">
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping_without_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping_without_annotations.xml
@@ -5,6 +5,7 @@
     xmlns:framework="http://symfony.com/schema/dic/symfony">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:serializer enable-annotations="false">
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:session storage-factory-id="session.storage.factory.native" handler-id="null"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_cookie_secure_auto.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_cookie_secure_auto.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:session storage-factory-id="session.storage.factory.native" handler-id="null" cookie-secure="auto" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/ssi_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/ssi_disabled.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:ssi enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/translator_cache_dir_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/translator_cache_dir_disabled.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config secret="s3cr3t" http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:translator enabled="true" fallback="fr" logging="true" cache-dir="null" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/translator_fallbacks.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/translator_fallbacks.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config secret="s3cr3t" http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:translator enabled="true">
             <framework:fallback>en</framework:fallback>
             <framework:fallback>fr</framework:fallback>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_annotations.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config secret="s3cr3t" http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:validation enabled="true" enable-annotations="true" />
     </framework:config>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_auto_mapping.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_auto_mapping.xml
@@ -4,6 +4,7 @@
            xmlns:framework="http://symfony.com/schema/dic/symfony">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:property-info enabled="true" />
         <framework:validation>
             <framework:auto-mapping namespace="App\">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_email_validation_mode.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_email_validation_mode.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:validation email-validation-mode="html5" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_legacy_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_legacy_annotations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config secret="s3cr3t" http-method-override="false">
+        <framework:annotations enabled="true" />
+        <framework:validation enabled="true" enable-annotations="true" />
+    </framework:config>
+
+    <services>
+        <service id="validator.alias" alias="validator" public="true" />
+    </services>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_mapping.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_mapping.xml
@@ -5,6 +5,7 @@
     xmlns:framework="http://symfony.com/schema/dic/symfony">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:validation>
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/validation_mapping/files</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_multiple_static_methods.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_multiple_static_methods.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config secret="s3cr3t" http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:validation enabled="true">
             <framework:static-method>loadFoo</framework:static-method>
             <framework:static-method>loadBar</framework:static-method>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_no_static_method.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_no_static_method.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config secret="s3cr3t" http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:validation enabled="true" static-method="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_translation_domain.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_translation_domain.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:validation translation-domain="messages" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/web_link.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/web_link.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:web-link enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/webhook.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/webhook.xml
@@ -7,6 +7,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:webhook enabled="true" />
         <framework:http-client enabled="true" />
         <framework:serializer enabled="true" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/webhook_without_serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/webhook_without_serializer.xml
@@ -7,6 +7,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:webhook enabled="true" />
         <framework:http-client enabled="true" />
         <framework:serializer enabled="false" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_not_valid.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_not_valid.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow name="my_workflow" type="state_machine">
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
             <framework:place name="first" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow name="article" type="workflow">
             <framework:initial-marking>draft</framework:initial-marking>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_multiple_transitions_with_same_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_multiple_transitions_with_same_name.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow name="article" type="workflow">
             <framework:initial-marking>draft</framework:initial-marking>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_no_events_to_dispatch.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_no_events_to_dispatch.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow name="my_workflow" type="state_machine">
             <framework:initial-marking>one</framework:initial-marking>
             <framework:marking-store type="method" property="state" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_specified_events_to_dispatch.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_specified_events_to_dispatch.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow name="my_workflow" type="state_machine">
             <framework:initial-marking>one</framework:initial-marking>
             <framework:marking-store type="method" property="state" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_support_and_support_strategy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_support_and_support_strategy.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow name="my_workflow" support-strategy="foobar" type="workflow">
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
             <framework:place name="first" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_without_support_and_support_strategy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_without_support_and_support_strategy.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow name="my_workflow" type="workflow">
             <framework:place name="first" />
             <framework:place name="last" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
@@ -7,6 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow name="article" type="workflow">
             <framework:audit-trail enabled="true"/>
             <framework:initial-marking>draft</framework:initial-marking>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_enabled.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_explicitly_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_explicitly_enabled.xml
@@ -6,6 +6,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow enabled="true" name="foo" type="workflow" initial-marking="bar">
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
             <framework:place>bar</framework:place>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_explicitly_enabled_named_workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_explicitly_enabled_named_workflows.xml
@@ -6,6 +6,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
+        <framework:annotations enabled="false" />
         <framework:workflow enabled="true" name="workflows" type="workflow">
             <framework:initial-marking>bar</framework:initial-marking>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     assets:
         version: SomeVersionScheme

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_disabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     assets:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_version_strategy_as_service.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_version_strategy_as_service.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     assets:
         version_strategy: assets.custom_version_strategy

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     cache:
         pools:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     cache:
         app: cache.adapter.redis_tag_aware

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware_pool.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware_pool.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     cache:
         app: cache.redis_tag_aware.foo

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     secret: s3cr3t
     csrf_protection: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf_needs_session.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf_needs_session.yml
@@ -1,3 +1,4 @@
 framework:
+    annotations: false
     http_method_override: false
     csrf_protection: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/default_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/default_config.yml
@@ -1,2 +1,3 @@
 framework:
+    annotations: false
     http_method_override: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/esi_and_ssi_without_fragments.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/esi_and_ssi_without_fragments.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     fragments:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/esi_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/esi_disabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     esi:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/exceptions.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/exceptions.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     exceptions:
         Symfony\Component\HttpKernel\Exception\BadRequestHttpException:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_csrf_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_csrf_disabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     csrf_protection: false
     form:
         csrf_protection: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_default_csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_default_csrf.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     session:
         storage_factory_id: session.storage.factory.native

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_no_csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_no_csrf.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     form:
         csrf_protection:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/fragments_and_hinclude.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/fragments_and_hinclude.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     fragments:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -45,10 +45,7 @@ framework:
         paths: ['%kernel.project_dir%/Fixtures/translations']
     validation:
         enabled: true
-    annotations:
-        cache:   file
-        debug:   true
-        file_cache_dir: '%kernel.cache_dir%/annotations'
+    annotations: false
     serializer:
          enabled:                    true
          enable_annotations:         true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     html_sanitizer:
         sanitizers:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_allowed_link_and_media_hosts.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_allowed_link_and_media_hosts.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     html_sanitizer:
         sanitizers:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_config.yml
@@ -1,3 +1,4 @@
 framework:
+    annotations: false
     http_method_override: false
     html_sanitizer: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_default_options.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     http_client:
         max_host_connections: 4

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_full_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_full_default_options.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     http_client:
         default_options:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_mock_response_factory.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_mock_response_factory.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     http_client:
         default_options: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_override_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_override_default_options.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     http_client:
         max_host_connections: 4

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     http_client:
         default_options:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_scoped_without_query_option.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_scoped_without_query_option.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     http_client:
         scoped_clients:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_xml_key.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_xml_key.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     http_client:
         default_options:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/legacy_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/legacy_annotations.yml
@@ -1,0 +1,7 @@
+framework:
+    annotations:
+        enabled: true
+        cache: file
+        debug: true
+        file_cache_dir: '%kernel.cache_dir%/annotations'
+    http_method_override: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock.yml
@@ -1,3 +1,4 @@
 framework:
+    annotations: false
     http_method_override: false
     lock: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_named.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_named.yml
@@ -2,6 +2,7 @@ parameters:
     env(REDIS_DSN): redis://paas.com
 
 framework:
+    annotations: false
     http_method_override: false
     lock:
         foo: semaphore

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_disabled_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_disabled_message_bus.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     mailer:
         dsn: 'smtp://example.com'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_dsn.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_dsn.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     mailer:
         dsn: 'smtp://example.com'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_specific_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_specific_message_bus.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     mailer:
         dsn: 'smtp://example.com'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_transports.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     mailer:
         transports:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     scheduler: true
     messenger:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_disabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger: false
     scheduler: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_middleware_factory_erroneous_format.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_middleware_factory_erroneous_format.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         buses:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         default_bus: messenger.bus.commands

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_failure_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_failure_transports.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         transports:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_failure_transports_global.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_failure_transports_global.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         failure_transport: failure_transport_global

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer: true
     messenger:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_transport.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_transport.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer: true
     messenger:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_wildcard.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_wildcard.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer: true
     messenger:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_single.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_single.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         routing:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_schedule.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_schedule.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         transports:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer: true
     messenger:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer: true
     messenger:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_with_disabled_reset_on_message.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_with_disabled_reset_on_message.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         reset_on_message: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_with_explict_reset_on_message_legacy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_with_explict_reset_on_message_legacy.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         reset_on_message: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_with_disabled_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_with_disabled_message_bus.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_with_specific_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_with_specific_message_bus.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     messenger:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_mailer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_mailer.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     mailer:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_messenger.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_messenger.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     mailer:
         dsn: 'smtp://example.com'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_transports.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     notifier:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_disabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     php_errors:
         throw: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_enabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     php_errors:
         log: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_level.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_level.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     php_errors:
         log: 8

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_levels.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_levels.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     php_errors:
         log:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     profiler:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler_collect_serializer_data.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler_collect_serializer_data.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     property_access:
         magic_call: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_info.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_info.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     property_info:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/request.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/request.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     request:
         formats: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore.yml
@@ -1,3 +1,4 @@
 framework:
+    annotations: false
     http_method_override: false
     semaphore: redis://localhost

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore_named.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore_named.yml
@@ -2,6 +2,7 @@ parameters:
     env(REDIS_DSN): redis://paas.com
 
 framework:
+    annotations: false
     http_method_override: false
     semaphore:
         foo: redis://paas.com

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_disabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_enabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_legacy_cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_legacy_cache.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping.yml
@@ -1,7 +1,6 @@
 framework:
     http_method_override: false
-    annotations:
-        enabled: true
+    annotations: false
     serializer:
         enable_annotations: true
         mapping:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping_without_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping_without_annotations.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     serializer:
         enable_annotations: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     session:
         storage_factory_id: session.storage.factory.native

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_cookie_secure_auto.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_cookie_secure_auto.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     session:
         storage_factory_id: session.storage.factory.native

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/ssi_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/ssi_disabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     ssi:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/translator_cache_dir_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/translator_cache_dir_disabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     translator:
         cache_dir: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/translator_fallbacks.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/translator_fallbacks.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     translator:
         fallbacks: [en, fr]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_annotations.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     secret: s3cr3t
     validation:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_auto_mapping.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_auto_mapping.yml
@@ -1,4 +1,5 @@
 framework:
+  annotations: false
   http_method_override: false
   property_info: { enabled: true }
   validation:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_email_validation_mode.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_email_validation_mode.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     validation:
         email_validation_mode: html5

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_legacy_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_legacy_annotations.yml
@@ -1,0 +1,13 @@
+framework:
+    annotations:
+        enabled: true
+    http_method_override: false
+    secret: s3cr3t
+    validation:
+        enabled:     true
+        enable_annotations: true
+
+services:
+    validator.alias:
+        alias: validator
+        public: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_mapping.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_mapping.yml
@@ -1,4 +1,5 @@
 framework:
+  annotations: false
   http_method_override: false
   validation:
     mapping:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_multiple_static_methods.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_multiple_static_methods.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     secret: s3cr3t
     validation:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_no_static_method.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_no_static_method.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     secret: s3cr3t
     validation:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_translation_domain.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_translation_domain.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     validation:
         translation_domain: messages

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/web_link.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/web_link.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     web_link:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/webhook.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/webhook.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     webhook:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/webhook_without_serializer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/webhook_without_serializer.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     webhook:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_not_valid.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_not_valid.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         my_workflow:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_guard_expression.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_guard_expression.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         article:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_multiple_transitions_with_same_name.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_multiple_transitions_with_same_name.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         article:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_no_events_to_dispatch.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_no_events_to_dispatch.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         my_workflow:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_specified_events_to_dispatch.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_specified_events_to_dispatch.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         my_workflow:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_support_and_support_strategy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_support_and_support_strategy.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         my_workflow:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_without_support_and_support_strategy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_without_support_and_support_strategy.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         my_workflow:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         article:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_enabled.yml
@@ -1,3 +1,4 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_explicitly_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_explicitly_enabled.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_explicitly_enabled_named_workflows.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_explicitly_enabled_named_workflows.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     workflows:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
-use Doctrine\Common\Annotations\Annotation;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerAwareInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
@@ -1227,9 +1226,9 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
-        $annotations = !class_exists(FullStack::class) && class_exists(Annotation::class);
+        $annotations = !class_exists(FullStack::class);
 
-        $this->assertCount($annotations ? 8 : 6, $calls);
+        $this->assertCount($annotations ? 7 : 6, $calls);
         $this->assertSame('setConstraintValidatorFactory', $calls[0][0]);
         $this->assertEquals([new Reference('validator.validator_factory')], $calls[0][1]);
         $this->assertSame('setTranslator', $calls[1][0]);
@@ -1241,7 +1240,6 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $i = 3;
         if ($annotations) {
             $this->assertSame('enableAnnotationMapping', $calls[++$i][0]);
-            $this->assertSame('setDoctrineAnnotationReader', $calls[++$i][0]);
         }
         $this->assertSame('addMethodMapping', $calls[++$i][0]);
         $this->assertSame(['loadValidatorMetadata'], $calls[$i][1]);
@@ -1256,9 +1254,14 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertInstanceOf(ValidatorInterface::class, $container->get('validator.alias'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testAnnotations()
     {
-        $container = $this->createContainerFromFile('full', [], true, false);
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: Enabling the integration of Doctrine annotations is deprecated. Set the "framework.annotations.enabled" config option to false.');
+
+        $container = $this->createContainerFromFile('legacy_annotations', [], true, false);
         $container->addCompilerPass(new TestAnnotationsPass());
         $container->compile();
 
@@ -1280,6 +1283,26 @@ abstract class FrameworkExtensionTestCase extends TestCase
     public function testValidationAnnotations()
     {
         $container = $this->createContainerFromFile('validation_annotations');
+
+        $calls = $container->getDefinition('validator.builder')->getMethodCalls();
+
+        $this->assertCount(7, $calls);
+        $this->assertSame('enableAnnotationMapping', $calls[4][0]);
+        $this->assertSame('addMethodMapping', $calls[5][0]);
+        $this->assertSame(['loadValidatorMetadata'], $calls[5][1]);
+        $this->assertSame('setMappingCache', $calls[6][0]);
+        $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[6][1]);
+        // no cache this time
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testValidationLegacyAnnotations()
+    {
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: Enabling the integration of Doctrine annotations is deprecated. Set the "framework.annotations.enabled" config option to false.');
+
+        $container = $this->createContainerFromFile('validation_legacy_annotations');
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
@@ -1305,15 +1328,14 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
-        $this->assertCount(9, $calls);
+        $this->assertCount(8, $calls);
         $this->assertSame('addXmlMappings', $calls[3][0]);
         $this->assertSame('addYamlMappings', $calls[4][0]);
         $this->assertSame('enableAnnotationMapping', $calls[5][0]);
-        $this->assertSame('setDoctrineAnnotationReader', $calls[6][0]);
-        $this->assertSame('addMethodMapping', $calls[7][0]);
-        $this->assertSame(['loadValidatorMetadata'], $calls[7][1]);
-        $this->assertSame('setMappingCache', $calls[8][0]);
-        $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[8][1]);
+        $this->assertSame('addMethodMapping', $calls[6][0]);
+        $this->assertSame(['loadValidatorMetadata'], $calls[6][1]);
+        $this->assertSame('setMappingCache', $calls[7][0]);
+        $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[7][1]);
 
         $xmlMappings = $calls[3][1][0];
         $this->assertCount(3, $xmlMappings);
@@ -1364,14 +1386,13 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
-        $annotations = !class_exists(FullStack::class) && class_exists(Annotation::class);
+        $annotations = !class_exists(FullStack::class);
 
-        $this->assertCount($annotations ? 7 : 5, $calls);
+        $this->assertCount($annotations ? 6 : 5, $calls);
         $this->assertSame('addXmlMappings', $calls[3][0]);
         $i = 3;
         if ($annotations) {
             $this->assertSame('enableAnnotationMapping', $calls[++$i][0]);
-            $this->assertSame('setDoctrineAnnotationReader', $calls[++$i][0]);
         }
         $this->assertSame('setMappingCache', $calls[++$i][0]);
         $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[$i][1]);
@@ -1583,11 +1604,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testSerializerMapping()
     {
-        $container = $this->createContainerFromFile('serializer_mapping', ['kernel.bundles_metadata' => ['TestBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/TestBundle']]]);
+        $container = $this->createContainerFromFile('serializer_mapping_without_annotations', ['kernel.bundles_metadata' => ['TestBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/TestBundle']]]);
         $projectDir = $container->getParameter('kernel.project_dir');
         $configDir = __DIR__.'/Fixtures/TestBundle/Resources/config';
         $expectedLoaders = [
-            new Definition(AnnotationLoader::class, [new Reference('annotation_reader', ContainerInterface::NULL_ON_INVALID_REFERENCE)]),
             new Definition(XmlFileLoader::class, [$configDir.'/serialization.xml']),
             new Definition(YamlFileLoader::class, [$configDir.'/serialization.yml']),
             new Definition(YamlFileLoader::class, [$projectDir.'/config/serializer/foo.yml']),
@@ -1840,11 +1860,11 @@ abstract class FrameworkExtensionTestCase extends TestCase
     public function testRemovesResourceCheckerConfigCacheFactoryArgumentOnlyIfNoDebug()
     {
         $container = $this->createContainer(['kernel.debug' => true]);
-        (new FrameworkExtension())->load([['http_method_override' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false]], $container);
         $this->assertCount(1, $container->getDefinition('config_cache_factory')->getArguments());
 
         $container = $this->createContainer(['kernel.debug' => false]);
-        (new FrameworkExtension())->load([['http_method_override' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false]], $container);
         $this->assertEmpty($container->getDefinition('config_cache_factory')->getArguments());
     }
 
@@ -1875,21 +1895,21 @@ abstract class FrameworkExtensionTestCase extends TestCase
     public function testRobotsTagListenerIsRegisteredInDebugMode()
     {
         $container = $this->createContainer(['kernel.debug' => true]);
-        (new FrameworkExtension())->load([['http_method_override' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false]], $container);
         $this->assertTrue($container->has('disallow_search_engine_index_response_listener'), 'DisallowRobotsIndexingListener should be registered');
 
         $definition = $container->getDefinition('disallow_search_engine_index_response_listener');
         $this->assertTrue($definition->hasTag('kernel.event_subscriber'), 'DisallowRobotsIndexingListener should have the correct tag');
 
         $container = $this->createContainer(['kernel.debug' => true]);
-        (new FrameworkExtension())->load([['http_method_override' => false, 'disallow_search_engine_index' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false, 'disallow_search_engine_index' => false]], $container);
         $this->assertFalse(
             $container->has('disallow_search_engine_index_response_listener'),
             'DisallowRobotsIndexingListener should not be registered when explicitly disabled'
         );
 
         $container = $this->createContainer(['kernel.debug' => false]);
-        (new FrameworkExtension())->load([['http_method_override' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false]], $container);
         $this->assertFalse($container->has('disallow_search_engine_index_response_listener'), 'DisallowRobotsIndexingListener should NOT be registered');
     }
 
@@ -2328,7 +2348,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         ], $data)));
     }
 
-    protected function createContainerFromFile($file, $data = [], $resetCompilerPasses = true, $compile = true, FrameworkExtension $extension = null)
+    protected function createContainerFromFile(string $file, array $data = [], bool $resetCompilerPasses = true, bool $compile = true, FrameworkExtension $extension = null)
     {
         $cacheKey = md5(static::class.$file.serialize($data));
         if ($compile && isset(self::$containerCache[$cacheKey])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -31,6 +31,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
         $this->expectException(\LogicException::class);
         $this->createContainerFromClosure(function ($container) {
             $container->loadFromExtension('framework', [
+                'annotations' => false,
                 'http_method_override' => false,
                 'assets' => [
                     'base_urls' => 'http://cdn.example.com',
@@ -45,6 +46,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
         $this->expectException(\LogicException::class);
         $this->createContainerFromClosure(function ($container) {
             $container->loadFromExtension('framework', [
+                'annotations' => false,
                 'http_method_override' => false,
                 'assets' => [
                     'packages' => [
@@ -64,6 +66,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
         $this->expectExceptionMessage('A transition from a place/state must have an unique name. Multiple transitions named "a_to_b" from place/state "a" were found on StateMachine "article".');
         $this->createContainerFromClosure(function ($container) {
             $container->loadFromExtension('framework', [
+                'annotations' => false,
                 'http_method_override' => false,
                 'workflows' => [
                     'article' => [
@@ -92,6 +95,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
     {
         $container = $this->createContainerFromClosure(function ($container) {
             $container->loadFromExtension('framework', [
+                'annotations' => false,
                 'http_method_override' => false,
                 'workflows' => [
                     'workflow_a' => [
@@ -150,6 +154,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
         try {
             $this->createContainerFromClosure(function (ContainerBuilder $container) {
                 $container->loadFromExtension('framework', [
+                    'annotations' => false,
                     'http_method_override' => false,
                     'lock' => false,
                     'rate_limiter' => [
@@ -165,6 +170,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
 
         $container = $this->createContainerFromClosure(function (ContainerBuilder $container) {
             $container->loadFromExtension('framework', [
+                'annotations' => false,
                 'http_method_override' => false,
                 'lock' => true,
                 'rate_limiter' => [
@@ -181,6 +187,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
     {
         $container = $this->createContainerFromClosure(function (ContainerBuilder $container) {
             $container->loadFromExtension('framework', [
+                'annotations' => false,
                 'http_method_override' => false,
                 'rate_limiter' => [
                     'without_lock' => ['policy' => 'fixed_window', 'limit' => 10, 'interval' => '1 hour', 'lock_factory' => null],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
@@ -20,17 +21,29 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class AutowiringTypesTest extends AbstractWebTestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testAnnotationReaderAutowiring()
     {
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: Enabling the integration of Doctrine annotations is deprecated. Set the "framework.annotations.enabled" config option to false.');
+
         static::bootKernel(['root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache']);
 
         $annotationReader = self::getContainer()->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(AnnotationReader::class, $annotationReader);
     }
 
+    /**
+     * @group legacy
+     */
     public function testCachedAnnotationReaderAutowiring()
     {
-        static::bootKernel();
+        $this->expectDeprecation('Since symfony/framework-bundle 6.4: Enabling the integration of Doctrine annotations is deprecated. Set the "framework.annotations.enabled" config option to false.');
+
+        static::bootKernel(['root_config' => 'with_annotations.yml', 'environment' => 'with_annotations']);
 
         $annotationReader = self::getContainer()->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(PsrCachedReader::class, $annotationReader);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/TestExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/TestExtension.php
@@ -25,8 +25,6 @@ class TestExtension extends Extension implements PrependExtensionInterface
     {
         $configuration = $this->getConfiguration($configs, $container);
         $this->processConfiguration($configuration, $configs);
-
-        $container->setAlias('test.annotation_reader', new Alias('annotation_reader', true));
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
@@ -36,7 +36,6 @@ class TestBundle extends Bundle
 
         $extension->setCustomConfig(new CustomConfig());
 
-        $container->addCompilerPass(new AnnotationReaderPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new CheckTypeDeclarationsPass(true), PassConfig::TYPE_AFTER_REMOVING, -100);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/routing.yml
@@ -1,4 +1,4 @@
 annotated_controller:
     prefix:   /annotated
     resource: "@TestBundle/Controller/AnnotatedController.php"
-    type:     annotation
+    type:     attribute

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/no_annotations_cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/no_annotations_cache.yml
@@ -4,4 +4,5 @@ imports:
 framework:
     http_method_override: false
     annotations:
+        enabled: true
         cache: none

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/with_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/with_annotations.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    annotations:
+        enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     secret:        test
     router:        { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -83,6 +83,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
     {
         $c->register('logger', NullLogger::class);
         $c->loadFromExtension('framework', [
+            'annotations' => false,
             'http_method_override' => false,
             'secret' => '$ecret',
             'router' => ['utf8' => true],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -120,6 +120,7 @@ class MicroKernelTraitTest extends TestCase
             protected function configureContainer(ContainerConfigurator $c): void
             {
                 $c->extension('framework', [
+                    'annotations' => false,
                     'http_method_override' => false,
                     'router' => ['utf8' => true],
                 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
@@ -101,6 +101,7 @@ class FlexStyleMicroKernel extends Kernel
                 ->arg('$halloween', '%halloween%');
 
         $c->extension('framework', [
+            'annotations' => false,
             'http_method_override' => false,
             'router' => ['utf8' => true],
         ]);

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -30,7 +30,7 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",
-        "symfony/routing": "^5.4|^6.0|^7.0"
+        "symfony/routing": "^6.1|^7.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13.1|^2",

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -145,7 +145,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
         ];
 
         $ext = new FrameworkExtension();
-        $ext->load(['framework' => ['http_method_override' => false, 'csrf_protection' => false, 'router' => ['resource' => 'dummy', 'utf8' => true]]], $container);
+        $ext->load(['framework' => ['annotations' => false, 'http_method_override' => false, 'csrf_protection' => false, 'router' => ['resource' => 'dummy', 'utf8' => true]]], $container);
 
         $ext = new SecurityExtension();
         $ext->load($config, $container);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     secret: test
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     secret: test
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -1,4 +1,5 @@
 framework:
+    annotations: false
     http_method_override: false
     secret: test
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -31,7 +31,6 @@
         "symfony/security-http": "^6.3|^7.0"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.10.4|^2",
         "symfony/asset": "^5.4|^6.0|^7.0",
         "symfony/browser-kit": "^5.4|^6.0|^7.0",
         "symfony/console": "^5.4|^6.0|^7.0",

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -64,6 +64,7 @@ class NoTemplatingEntryKernel extends Kernel
         $loader->load(function (ContainerBuilder $container) {
             $container
                 ->loadFromExtension('framework', [
+                    'annotations' => false,
                     'http_method_override' => false,
                     'secret' => '$ecret',
                     'form' => ['enabled' => false],

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -35,8 +35,7 @@
         "symfony/translation": "^5.4|^6.0|^7.0",
         "symfony/yaml": "^5.4|^6.0|^7.0",
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
-        "symfony/web-link": "^5.4|^6.0|^7.0",
-        "doctrine/annotations": "^1.10.4|^2"
+        "symfony/web-link": "^5.4|^6.0|^7.0"
     },
     "conflict": {
         "symfony/framework-bundle": "<5.4",

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -51,6 +51,7 @@ class WebProfilerBundleKernel extends Kernel
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $config = [
+            'annotations' => false,
             'http_method_override' => false,
             'secret' => 'foo-secret',
             'profiler' => ['only_exceptions' => false],

--- a/src/Symfony/Component/AssetMapper/Tests/fixtures/AssetMapperTestAppKernel.php
+++ b/src/Symfony/Component/AssetMapper/Tests/fixtures/AssetMapperTestAppKernel.php
@@ -36,6 +36,7 @@ class AssetMapperTestAppKernel extends Kernel
     {
         $loader->load(static function (ContainerBuilder $container) {
             $container->loadFromExtension('framework', [
+                'annotations' => false,
                 'http_method_override' => false,
                 'http_client' => true,
                 'assets' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

This PR deprecates the integration of the doctrine/annotations package in FrameworkBundle. Currently, the integration is enabled by default if `doctrine/annotations` is installed. This PR adds a runtime deprecation if the app does not explicitly disable it by setting:

```php
framework:
    annotations: false
```

The plan is to make this the default and only valid option in Symfony 7 and remove that setting entirely in Symfony 8. This change unlocks #49358 and similar PRs that remove support for Doctrine Annotations from components.