### PR TITLE
[Security] Add native return type to `Firewall::getSubscribedEvents()`

### DIFF
--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * `UserValueResolver` no longer implements `ArgumentValueResolverInterface`
+ * Add native return type to `Firewall::getSubscribedEvents()` 
 
 6.3
 ---

--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -108,10 +108,7 @@ class Firewall implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest', 8],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Required to make #50852 green without breaking compat between v6 and v7.