### PR TITLE
[Notifier] Fix Esendex messages serialization

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
@@ -60,8 +60,10 @@ final class EsendexTransport extends AbstractTransport
         $options = $message->getOptions()?->toArray() ?? [];
         $options['from'] = $message->getFrom() ?: $this->from;
         $options['messages'] = [
-            'to' => $message->getPhone(),
-            'body' => $message->getSubject(),
+            [
+                'to' => $message->getPhone(),
+                'body' => $message->getSubject(),
+            ],
         ];
         $options['accountreference'] ??= $this->accountReference;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #50892 
| License       | MIT

It seems that the "messages" is missing a dimension since 6.3 and its serialized as an object instead of an array of objects. 
