### PR TITLE
Add trueAnswerRegex parameter to confirm function in SymfonyStyle

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -267,9 +267,9 @@ class SymfonyStyle extends OutputStyle
         return $this->askQuestion($question);
     }
 
-    public function confirm(string $question, bool $default = true): bool
+    public function confirm(string $question, bool $default = true, string $trueAnswerRegex = '/^y/i'): bool
     {
-        return $this->askQuestion(new ConfirmationQuestion($question, $default));
+        return $this->askQuestion(new ConfirmationQuestion($question, $default, $trueAnswerRegex));
     }
 
     public function choice(string $question, array $choices, mixed $default = null, bool $multiSelect = false): mixed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4<!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -


When using the SymfonyStyle confim method, i wanted to be able to customise the true regex,

from now when using the ->confirm the regex could not be customisable, this PR allow the parameter to be customisable

```php
 $io = new SymfonyStyle($input, $output);

$io->confirm(
    question: 'My question ?',
    default: false,
    trueAnswerRegex: '/^o/i'
)
```


