### PR TITLE
[VarExporter] Initialize ghosts before calling their `__clone` method if they have skipped properties

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -332,6 +332,10 @@ trait LazyGhostTrait
         }
 
         if ((Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['clone']) {
+            if ($this->lazyObjectState->skippedProperties) {
+                $this->initializeLazyObject();
+            }
+
             parent::__clone();
         }
     }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/MagicCloneClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/MagicCloneClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+class MagicCloneClass
+{
+    public ?int $id;
+    public bool $cloned;
+
+    public function __clone()
+    {
+        $this->id = null;
+        $this->cloned = true;
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/MagicCloneClassProxy.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/MagicCloneClassProxy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+use Symfony\Component\VarExporter\LazyGhostTrait;
+use Symfony\Component\VarExporter\LazyObjectInterface;
+
+class MagicCloneClassProxy extends MagicCloneClass  implements LazyObjectInterface
+{
+    use LazyGhostTrait;
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildStdClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildTestClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\LazyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\MagicClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\MagicCloneClassProxy;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ReadOnlyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\TestClass;
 
@@ -107,6 +108,23 @@ class LazyGhostTraitTest extends TestCase
 
         $clone = clone $clone;
         $this->assertTrue($clone->resetLazyObject());
+    }
+
+    public function testCloneIsInitializedIfNeeded()
+    {
+        $instance = MagicCloneClassProxy::createLazyGhost(function (MagicCloneClassProxy $ghost) {
+            if (1 === $ghost->id) {
+                $ghost->cloned = false;
+            } else {
+                $this->fail('Ghost must be initialized before its __clone method is called.');
+            }
+        }, ['id' => true]);
+        $instance->id = 1;
+
+        $clone = clone $instance;
+
+        $this->assertNull($clone->id);
+        $this->assertTrue($clone->cloned);
     }
 
     public function testSerialize()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50874
| License       | MIT
| Doc PR        | N/A

When cloning an uninitialized ghost, there is an issue if the parent class’ `__clone` method changes data used by the initializer before it is initialized. This is illustrated in #50874 where unsetting a proxy’s identifier later causes the entity to be hydrated with wrong data.

There is no efficient way to detect such a case, but it can only happen if the parent implements `__clone` and its ghost has skipped properties (entity identifiers e.g.). Initializing the ghost before calling `__clone` then ensure it will be done properly.