### PR TITLE
[DomCrawler][HttpFoundation] Add planned arguments to Crawler::innerText() and sendHeaders() methods

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -77,6 +77,11 @@ DoctrineBridge
  * DoctrineBridge now requires `doctrine/event-manager:^2`
  * Add parameter `$isSameDatabase` to `DoctrineTokenProvider::configureSchema()`
 
+DomCrawler
+----------
+
+ * Add argument `$normalizeWhitespace` to `Crawler::innerText()`
+
 ExpressionLanguage
 ------------------
 
@@ -129,6 +134,7 @@ HttpFoundation
  * Remove `Request::getContentType()`, use `Request::getContentTypeFormat()` instead
  * Throw an `InvalidArgumentException` when calling `Request::create()` with a malformed URI
  * Require explicit argument when calling `JsonResponse::setCallback()`, `Response::setExpires/setLastModified/setEtag()`, `MockArraySessionStorage/NativeSessionStorage::setMetadataBag()`, `NativeSessionStorage::setSaveHandler()`
+ * Add argument `$statusCode` to `Response::sendHeaders()` and `StreamedResponse::sendHeaders()`
 
 HttpClient
 ----------

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Add argument `$normalizeWhitespace` to `Crawler::innerText()`
+
 6.3
 ---
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -564,10 +564,8 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * @param bool $normalizeWhitespace Whether whitespaces should be trimmed and normalized to single spaces
      */
-    public function innerText(/* bool $normalizeWhitespace = true */): string
+    public function innerText(bool $normalizeWhitespace = true): string
     {
-        $normalizeWhitespace = 1 <= \func_num_args() ? func_get_arg(0) : true;
-
         foreach ($this->getNode(0)->childNodes as $childNode) {
             if (\XML_TEXT_NODE !== $childNode->nodeType) {
                 continue;

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Remove `Request::getContentType()`, use `Request::getContentTypeFormat()` instead
  * Throw an `InvalidArgumentException` when calling `Request::create()` with a malformed URI
  * Require explicit argument when calling `JsonResponse::setCallback()`, `Response::setExpires/setLastModified/setEtag()`, `MockArraySessionStorage/NativeSessionStorage::setMetadataBag()`, `NativeSessionStorage::setSaveHandler()`
+ * Add argument `$statusCode` to `Response::sendHeaders()` and `StreamedResponse::sendHeaders()`
 
 6.4
 ---

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -333,14 +333,13 @@ class Response
      *
      * @return $this
      */
-    public function sendHeaders(/* int $statusCode = null */): static
+    public function sendHeaders(int $statusCode = null): static
     {
         // headers have already been sent by the developer
         if (headers_sent()) {
             return $this;
         }
 
-        $statusCode = \func_num_args() > 0 ? func_get_arg(0) : null;
         $informationalResponse = $statusCode >= 100 && $statusCode < 200;
         if ($informationalResponse && !\function_exists('headers_send')) {
             // skip informational responses if not supported by the SAPI

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -59,17 +59,14 @@ class StreamedResponse extends Response
     /**
      * This method only sends the headers once.
      *
-     * @param null|positive-int $statusCode The status code to use, override the statusCode property if set and not null
-     *
      * @return $this
      */
-    public function sendHeaders(/* int $statusCode = null */): static
+    public function sendHeaders(int $statusCode = null): static
     {
         if ($this->headersSent) {
             return $this;
         }
 
-        $statusCode = \func_num_args() > 0 ? func_get_arg(0) : null;
         if ($statusCode < 100 || $statusCode >= 200) {
             $this->headersSent = true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -