### PR TITLE
[Finder] Fix phpdoc about glob syntax

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -164,8 +164,8 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * You can use patterns (delimited with / sign), globs or simple strings.
      *
-     *     $finder->name('*.php')
-     *     $finder->name('/\.php$/') // same as above
+     *     $finder->name('/\.php$/')
+     *     $finder->name('*.php') // same as above, without dot files
      *     $finder->name('test.php')
      *     $finder->name(['test.py', 'test.php'])
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes ? no ? just phpdoc
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42675
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


Closes #42675 cc @nicolas-grekas 