### PR TITLE
[Form] Deprecate not configuring the `default_protocol` option of the `UrlType`

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+* Deprecate not configuring the `default_protocol` option of the `UrlType`, it will default to `null` in 8.0
+
 7.0
 ---
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UrlType extends AbstractType
@@ -38,7 +39,11 @@ class UrlType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'default_protocol' => 'http',
+            'default_protocol' => static function (Options $options) {
+                trigger_deprecation('symfony/form', '7.1', 'Not configuring the "default_protocol" option when using the UrlType is deprecated. It will default to "null" in 8.0.');
+
+                return 'http';
+            },
             'invalid_message' => 'Please enter a valid URL.',
         ]);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -22,9 +22,9 @@ class TextTypeTest extends BaseTypeTestCase
 
     public function testSubmitNullReturnsNullWithEmptyDataAsString()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, 'name', [
+        $form = $this->factory->create(static::TESTED_TYPE, 'name', array_merge($this->getTestOptions(), [
             'empty_data' => '',
-        ]);
+        ]));
 
         $form->submit(null);
         $this->assertSame('', $form->getData());
@@ -48,9 +48,9 @@ class TextTypeTest extends BaseTypeTestCase
      */
     public function testSetDataThroughParamsWithZero($data, $dataAsString)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create(static::TESTED_TYPE, null, array_merge($this->getTestOptions(), [
             'data' => $data,
-        ]);
+        ]));
         $view = $form->createView();
 
         $this->assertFalse($form->isEmpty());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -11,14 +11,21 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class UrlTypeTest extends TextTypeTest
 {
+    use ExpectDeprecationTrait;
+
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\UrlType';
 
+    /**
+     * @group legacy
+     */
     public function testSubmitAddsDefaultProtocolIfNoneIsIncluded()
     {
+        $this->expectDeprecation('Since symfony/form 7.1: Not configuring the "default_protocol" option when using the UrlType is deprecated. It will default to "null" in 8.0.');
         $form = $this->factory->create(static::TESTED_TYPE, 'name');
 
         $form->submit('www.domain.com');
@@ -86,6 +93,7 @@ class UrlTypeTest extends TextTypeTest
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = 'http://empty')
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'default_protocol' => 'http',
             'empty_data' => $emptyData,
         ]);
         $form->submit(null);
@@ -94,5 +102,10 @@ class UrlTypeTest extends TextTypeTest
         $this->assertSame($expectedData, $form->getViewData());
         $this->assertSame($expectedData, $form->getNormData());
         $this->assertSame($expectedData, $form->getData());
+    }
+
+    protected function getTestOptions(): array
+    {
+        return ['default_protocol' => 'http'];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
@@ -20,7 +20,7 @@ class UrlTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(UrlType::class, null, $options);
+        return $this->factory->create(UrlType::class, null, $options + ['default_protocol' => 'http']);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/options-resolver": "^6.4|^7.0",
         "symfony/polyfill-ctype": "~1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Part of #50871 
| License       | MIT
| Doc PR        | N/A

You would expect an `<input type="url">` from the `UrlType`, but it is not possible as long as `default_protocol` has a value, because then you have to accept inputs that are not URLs (and you get an `<input type="text" inputmode="url">`).

In order to change `default_protocol` from `'http'` to `null` in 8.0, we must first deprecate not configuring it.
