### PR TITLE
[Form] Support Translatable Enum

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/EnumType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EnumType.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * A choice type for native PHP enums.
@@ -29,7 +30,7 @@ final class EnumType extends AbstractType
             ->setAllowedTypes('class', 'string')
             ->setAllowedValues('class', enum_exists(...))
             ->setDefault('choices', static fn (Options $options): array => $options['class']::cases())
-            ->setDefault('choice_label', static fn (\UnitEnum $choice): string => $choice->name)
+            ->setDefault('choice_label', static fn (\UnitEnum $choice) => $choice instanceof TranslatableInterface ? $choice : $choice->name)
             ->setDefault('choice_value', static function (Options $options): ?\Closure {
                 if (!is_a($options['class'], \BackedEnum::class, true)) {
                     return null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
@@ -16,8 +16,11 @@ use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTestCase;
 use Symfony\Component\Form\Tests\Fixtures\Answer;
 use Symfony\Component\Form\Tests\Fixtures\Number;
 use Symfony\Component\Form\Tests\Fixtures\Suit;
+use Symfony\Component\Form\Tests\Fixtures\TranslatableTextAlign;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 class EnumTypeTest extends BaseTypeTestCase
 {
@@ -255,6 +258,20 @@ class EnumTypeTest extends BaseTypeTestCase
         $view = $form->createView();
 
         $this->assertSame('Yes', $view->children[0]->vars['label']);
+    }
+
+    public function testChoiceLabelTranslatable()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => true,
+            'class' => TranslatableTextAlign::class,
+        ]);
+
+        $view = $form->createView();
+
+        $this->assertInstanceOf(TranslatableInterface::class, $view->children[0]->vars['label']);
+        $this->assertEquals('Left', $view->children[0]->vars['label']->trans(new IdentityTranslator()));
     }
 
     protected function getTestOptions(): array

--- a/src/Symfony/Component/Form/Tests/Fixtures/TranslatableTextAlign.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TranslatableTextAlign.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum TranslatableTextAlign implements TranslatableInterface
+{
+    case Left;
+    case Center;
+    case Right;
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        return $translator->trans($this->name, locale: $locale);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/50919
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18599

This PR introduce support for Enum implementing `TranslatableInterface` in `EnumType`.

Example of use:

```php
$builder->add('textAlign', EnumType::class, [
    'class' => TextAlign::class,
])
```

```php

use Symfony\Contracts\Translation\TranslatableInterface;
use Symfony\Contracts\Translation\TranslatorInterface;

enum TextAlign: int implements TranslatableInterface
{
    case Left = 1;
    case Center = 2;
    case Right = 3;

    public function trans(TranslatorInterface $translator, string $locale = null): string
    {
        // Translate enum from name (Left, Center or Right)
        return $translator->trans($this->name, locale: $locale);

        // Translate enum from custom labels
        return match ($this) {
            self::Left   => $translator->trans('Left aligned', locale: $locale),
            self::Center => $translator->trans('Centered', locale: $locale),
            self::Right  => $translator->trans('Right aligned', locale: $locale),
        };
    }
}
```