### PR TITLE
[Serializer] Fix deserializing nested arrays of objects with mixed keys

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -532,7 +532,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     $class = $collectionValueType->getClassName().'[]';
 
                     if (\count($collectionKeyType = $type->getCollectionKeyTypes()) > 0) {
-                        [$context['key_type']] = $collectionKeyType;
+                        $context['key_type'] = \count($collectionKeyType) > 1 ? $collectionKeyType : $collectionKeyType[0];
                     }
 
                     $context['value_type'] = $collectionValueType;

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -49,14 +49,15 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
 
         $type = substr($type, 0, -2);
 
-        $builtinType = isset($context['key_type']) ? $context['key_type']->getBuiltinType() : null;
+        $builtinTypes = array_map(static function (Type $keyType) {
+            return $keyType->getBuiltinType();
+        }, \is_array($keyType = $context['key_type'] ?? []) ? $keyType : [$keyType]);
+
         foreach ($data as $key => $value) {
             $subContext = $context;
             $subContext['deserialization_path'] = ($context['deserialization_path'] ?? false) ? sprintf('%s[%s]', $context['deserialization_path'], $key) : "[$key]";
 
-            if (null !== $builtinType && !('is_'.$builtinType)($key)) {
-                throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('The type of the key "%s" must be "%s" ("%s" given).', $key, $builtinType, get_debug_type($key)), $key, [$builtinType], $subContext['deserialization_path'] ?? null, true);
-            }
+            $this->validateKeyType($builtinTypes, $key, $subContext['deserialization_path']);
 
             $data[$key] = $this->denormalizer->denormalize($value, $type, $format, $subContext);
         }
@@ -101,5 +102,23 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
     public function hasCacheableSupportsMethod(): bool
     {
         return $this->denormalizer instanceof CacheableSupportsMethodInterface && $this->denormalizer->hasCacheableSupportsMethod();
+    }
+
+    /**
+     * @param mixed $key
+     */
+    private function validateKeyType(array $builtinTypes, $key, string $path): void
+    {
+        if (!$builtinTypes) {
+            return;
+        }
+
+        foreach ($builtinTypes as $builtinType) {
+            if (('is_'.$builtinType)($key)) {
+                return;
+            }
+        }
+
+        throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('The type of the key "%s" must be "%s" ("%s" given).', $key, implode('", "', $builtinTypes), get_debug_type($key)), $key, $builtinTypes, $path, true);
     }
 }

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -34,7 +34,7 @@
         "symfony/http-kernel": "^4.4|^5.0|^6.0",
         "symfony/mime": "^4.4|^5.0|^6.0",
         "symfony/property-access": "^5.4|^6.0",
-        "symfony/property-info": "^5.3.13|^6.0",
+        "symfony/property-info": "^5.4.24|^6.2.11",
         "symfony/uid": "^5.3|^6.0",
         "symfony/validator": "^4.4|^5.0|^6.0",
         "symfony/var-dumper": "^4.4|^5.0|^6.0",
@@ -47,7 +47,7 @@
         "phpdocumentor/type-resolver": "<1.4.0",
         "symfony/dependency-injection": "<4.4",
         "symfony/property-access": "<5.4",
-        "symfony/property-info": "<5.3.13",
+        "symfony/property-info": "<5.4.24|>=6,<6.2.11",
         "symfony/uid": "<5.3",
         "symfony/yaml": "<4.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50675
| License       | MIT
| Doc PR        | -

Currently an error is thrown when trying to deserialize the following nested array of objects:

```php
use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
use Symfony\Component\Serializer\Encoder\JsonEncoder;
use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
use Symfony\Component\Serializer\Serializer;

$serializer = new Serializer([
    new ObjectNormalizer(null, null, null, new PhpDocExtractor()),
    new ArrayDenormalizer(),
], ['json' => new JsonEncoder()]);

class Outer
{
    /**
     * @var array<int|string, Inner>
     */
    public array $inners;
}

class Inner
{
    public string $name;
}

$serializer->deserialize('{"inners": {"1": {"name": "One"}, "two": {"name": "Two"}}}', Outer::class, 'json');
```

```
Fatal error: Uncaught Symfony\Component\Serializer\Exception\NotNormalizableValueException:
The type of the key "two" must be "int" ("string" given).
```

The same happens when using generics, e.g. `ArrayCollection<Inner>`.