### PR TITLE
[Validator] Do not mock metadata factory on debug command tests

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
@@ -11,15 +11,13 @@
 
 namespace Symfony\Component\Validator\Tests\Command;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Validator\Command\DebugCommand;
-use Symfony\Component\Validator\Constraints\Email;
-use Symfony\Component\Validator\Constraints\Expression;
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
+use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
-use Symfony\Component\Validator\Mapping\PropertyMetadataInterface;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\Tests\Dummy\DummyClassOne;
 
 /**
@@ -29,42 +27,7 @@ class DebugCommandTest extends TestCase
 {
     public function testOutputWithClassArgument()
     {
-        $validator = $this->createMock(MetadataFactoryInterface::class);
-        $classMetadata = $this->createMock(ClassMetadataInterface::class);
-        $propertyMetadata = $this->createMock(PropertyMetadataInterface::class);
-
-        $validator
-            ->expects($this->once())
-            ->method('getMetadataFor')
-            ->with(DummyClassOne::class)
-            ->willReturn($classMetadata);
-
-        $classMetadata
-            ->expects($this->once())
-            ->method('getConstraints')
-            ->willReturn([new Expression('1 + 1 = 2')]);
-
-        $classMetadata
-            ->expects($this->once())
-            ->method('getConstrainedProperties')
-            ->willReturn([
-                'firstArgument',
-            ]);
-
-        $classMetadata
-            ->expects($this->once())
-            ->method('getPropertyMetadata')
-            ->with('firstArgument')
-            ->willReturn([
-                $propertyMetadata,
-            ]);
-
-        $propertyMetadata
-            ->expects($this->once())
-            ->method('getConstraints')
-            ->willReturn([new NotBlank(), new Email()]);
-
-        $command = new DebugCommand($validator);
+        $command = new DebugCommand(new LazyLoadingMetadataFactory(new AnnotationLoader(new AnnotationReader())));
 
         $tester = new CommandTester($command);
         $tester->execute(['class' => DummyClassOne::class], ['decorated' => false]);
@@ -74,28 +37,28 @@ class DebugCommandTest extends TestCase
 Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 -----------------------------------------------------
 
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
-| Property      | Name                                               | Groups  | Options                                                    |
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
-| -             | Symfony\Component\Validator\Constraints\Expression | Default | [                                                          |
-|               |                                                    |         |   "expression" => "1 + 1 = 2",                             |
-|               |                                                    |         |   "message" => "This value is not valid.",                 |
-|               |                                                    |         |   "payload" => null,                                       |
-|               |                                                    |         |   "values" => []                                           |
-|               |                                                    |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\NotBlank   | Default | [                                                          |
-|               |                                                    |         |   "allowNull" => false,                                    |
-|               |                                                    |         |   "message" => "This value should not be blank.",          |
-|               |                                                    |         |   "normalizer" => null,                                    |
-|               |                                                    |         |   "payload" => null                                        |
-|               |                                                    |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\Email      | Default | [                                                          |
-|               |                                                    |         |   "message" => "This value is not a valid email address.", |
-|               |                                                    |         |   "mode" => null,                                          |
-|               |                                                    |         |   "normalizer" => null,                                    |
-|               |                                                    |         |   "payload" => null                                        |
-|               |                                                    |         | ]                                                          |
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| Property | Name                                               | Groups                 | Options                                                    |
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| -        | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassOne | [                                                          |
+|          |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
+|          |                                                    |                        |   "message" => "This value is not valid.",                 |
+|          |                                                    |                        |   "payload" => null,                                       |
+|          |                                                    |                        |   "values" => []                                           |
+|          |                                                    |                        | ]                                                          |
+| code     | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassOne | [                                                          |
+|          |                                                    |                        |   "allowNull" => false,                                    |
+|          |                                                    |                        |   "message" => "This value should not be blank.",          |
+|          |                                                    |                        |   "normalizer" => null,                                    |
+|          |                                                    |                        |   "payload" => null                                        |
+|          |                                                    |                        | ]                                                          |
+| email    | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassOne | [                                                          |
+|          |                                                    |                        |   "message" => "This value is not a valid email address.", |
+|          |                                                    |                        |   "mode" => null,                                          |
+|          |                                                    |                        |   "normalizer" => null,                                    |
+|          |                                                    |                        |   "payload" => null                                        |
+|          |                                                    |                        | ]                                                          |
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
 
 TXT
             , $tester->getDisplay(true)
@@ -104,39 +67,7 @@ TXT
 
     public function testOutputWithPathArgument()
     {
-        $validator = $this->createMock(MetadataFactoryInterface::class);
-        $classMetadata = $this->createMock(ClassMetadataInterface::class);
-        $propertyMetadata = $this->createMock(PropertyMetadataInterface::class);
-
-        $validator
-            ->expects($this->exactly(2))
-            ->method('getMetadataFor')
-            ->withAnyParameters()
-            ->willReturn($classMetadata);
-
-        $classMetadata
-            ->method('getConstrainedProperties')
-            ->willReturn([
-                'firstArgument',
-            ]);
-
-        $classMetadata
-            ->expects($this->exactly(2))
-            ->method('getConstraints')
-            ->willReturn([new Expression('1 + 1 = 2')]);
-
-        $classMetadata
-            ->method('getPropertyMetadata')
-            ->with('firstArgument')
-            ->willReturn([
-                $propertyMetadata,
-            ]);
-
-        $propertyMetadata
-            ->method('getConstraints')
-            ->willReturn([new NotBlank(), new Email()]);
-
-        $command = new DebugCommand($validator);
+        $command = new DebugCommand(new LazyLoadingMetadataFactory(new AnnotationLoader(new AnnotationReader())));
 
         $tester = new CommandTester($command);
         $tester->execute(['class' => __DIR__.'/../Dummy'], ['decorated' => false]);
@@ -146,54 +77,54 @@ TXT
 Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 -----------------------------------------------------
 
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
-| Property      | Name                                               | Groups  | Options                                                    |
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
-| -             | Symfony\Component\Validator\Constraints\Expression | Default | [                                                          |
-|               |                                                    |         |   "expression" => "1 + 1 = 2",                             |
-|               |                                                    |         |   "message" => "This value is not valid.",                 |
-|               |                                                    |         |   "payload" => null,                                       |
-|               |                                                    |         |   "values" => []                                           |
-|               |                                                    |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\NotBlank   | Default | [                                                          |
-|               |                                                    |         |   "allowNull" => false,                                    |
-|               |                                                    |         |   "message" => "This value should not be blank.",          |
-|               |                                                    |         |   "normalizer" => null,                                    |
-|               |                                                    |         |   "payload" => null                                        |
-|               |                                                    |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\Email      | Default | [                                                          |
-|               |                                                    |         |   "message" => "This value is not a valid email address.", |
-|               |                                                    |         |   "mode" => null,                                          |
-|               |                                                    |         |   "normalizer" => null,                                    |
-|               |                                                    |         |   "payload" => null                                        |
-|               |                                                    |         | ]                                                          |
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| Property | Name                                               | Groups                 | Options                                                    |
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| -        | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassOne | [                                                          |
+|          |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
+|          |                                                    |                        |   "message" => "This value is not valid.",                 |
+|          |                                                    |                        |   "payload" => null,                                       |
+|          |                                                    |                        |   "values" => []                                           |
+|          |                                                    |                        | ]                                                          |
+| code     | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassOne | [                                                          |
+|          |                                                    |                        |   "allowNull" => false,                                    |
+|          |                                                    |                        |   "message" => "This value should not be blank.",          |
+|          |                                                    |                        |   "normalizer" => null,                                    |
+|          |                                                    |                        |   "payload" => null                                        |
+|          |                                                    |                        | ]                                                          |
+| email    | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassOne | [                                                          |
+|          |                                                    |                        |   "message" => "This value is not a valid email address.", |
+|          |                                                    |                        |   "mode" => null,                                          |
+|          |                                                    |                        |   "normalizer" => null,                                    |
+|          |                                                    |                        |   "payload" => null                                        |
+|          |                                                    |                        | ]                                                          |
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
 
 Symfony\Component\Validator\Tests\Dummy\DummyClassTwo
 -----------------------------------------------------
 
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
-| Property      | Name                                               | Groups  | Options                                                    |
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
-| -             | Symfony\Component\Validator\Constraints\Expression | Default | [                                                          |
-|               |                                                    |         |   "expression" => "1 + 1 = 2",                             |
-|               |                                                    |         |   "message" => "This value is not valid.",                 |
-|               |                                                    |         |   "payload" => null,                                       |
-|               |                                                    |         |   "values" => []                                           |
-|               |                                                    |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\NotBlank   | Default | [                                                          |
-|               |                                                    |         |   "allowNull" => false,                                    |
-|               |                                                    |         |   "message" => "This value should not be blank.",          |
-|               |                                                    |         |   "normalizer" => null,                                    |
-|               |                                                    |         |   "payload" => null                                        |
-|               |                                                    |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\Email      | Default | [                                                          |
-|               |                                                    |         |   "message" => "This value is not a valid email address.", |
-|               |                                                    |         |   "mode" => null,                                          |
-|               |                                                    |         |   "normalizer" => null,                                    |
-|               |                                                    |         |   "payload" => null                                        |
-|               |                                                    |         | ]                                                          |
-+---------------+----------------------------------------------------+---------+------------------------------------------------------------+
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| Property | Name                                               | Groups                 | Options                                                    |
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| -        | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassTwo | [                                                          |
+|          |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
+|          |                                                    |                        |   "message" => "This value is not valid.",                 |
+|          |                                                    |                        |   "payload" => null,                                       |
+|          |                                                    |                        |   "values" => []                                           |
+|          |                                                    |                        | ]                                                          |
+| code     | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassTwo | [                                                          |
+|          |                                                    |                        |   "allowNull" => false,                                    |
+|          |                                                    |                        |   "message" => "This value should not be blank.",          |
+|          |                                                    |                        |   "normalizer" => null,                                    |
+|          |                                                    |                        |   "payload" => null                                        |
+|          |                                                    |                        | ]                                                          |
+| email    | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassTwo | [                                                          |
+|          |                                                    |                        |   "message" => "This value is not a valid email address.", |
+|          |                                                    |                        |   "mode" => null,                                          |
+|          |                                                    |                        |   "normalizer" => null,                                    |
+|          |                                                    |                        |   "payload" => null                                        |
+|          |                                                    |                        | ]                                                          |
++----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
 
 TXT
             , $tester->getDisplay(true)

--- a/src/Symfony/Component/Validator/Tests/Dummy/DummyClassOne.php
+++ b/src/Symfony/Component/Validator/Tests/Dummy/DummyClassOne.php
@@ -11,6 +11,24 @@
 
 namespace Symfony\Component\Validator\Tests\Dummy;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @Assert\Expression(expression="1 + 1 = 2")
+ */
 class DummyClassOne
 {
+    /**
+     * @var string|null
+     *
+     * @Assert\NotBlank
+     */
+    public $code;
+
+    /**
+     * @var string|null
+     *
+     * @Assert\Email
+     */
+    public $email;
 }

--- a/src/Symfony/Component/Validator/Tests/Dummy/DummyClassTwo.php
+++ b/src/Symfony/Component/Validator/Tests/Dummy/DummyClassTwo.php
@@ -11,6 +11,24 @@
 
 namespace Symfony\Component\Validator\Tests\Dummy;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @Assert\Expression(expression="1 + 1 = 2")
+ */
 class DummyClassTwo
 {
+    /**
+     * @var string|null
+     *
+     * @Assert\NotBlank
+     */
+    public $code;
+
+    /**
+     * @var string|null
+     *
+     * @Assert\Email
+     */
+    public $email;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | not really, but it will be usefull to fix that command
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Before #48840 I think this one could improve the tests.