### PR TITLE
[VarDumper] Add tests to demonstrate a bug when dumping ArrayObject with full stack fmk

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Integration/dump_data_collector.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Integration/dump_data_collector.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test integration with Symfony's DumpDataCollector
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+VarDumper::setHandler(function ($var, string $label = null) {
+    $dumper = new DumpDataCollector();
+    $cloner = new VarCloner();
+    $handler = function ($var, string $label = null) use ($dumper, $cloner) {
+        $var = $cloner->cloneVar($var);
+        if (null !== $label) {
+            $var = $var->withContext(['label' => $label]);
+        }
+
+        $dumper->dump($var);
+    };
+    VarDumper::setHandler($handler);
+    $handler($var, $label);
+});
+
+$schemas = new \ArrayObject();
+dump($schemas);
+$schemas['X'] = new \ArrayObject(['type' => 'object']);
+
+--EXPECTF--
+ArrayObject {#%d
+  -storage: []
+  flag::STD_PROP_LIST: false
+  flag::ARRAY_AS_PROPS: false
+  iteratorClass: "ArrayIterator"
+}

--- a/src/Symfony/Component/VarDumper/Tests/Integration/dump_data_collector2.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Integration/dump_data_collector2.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test integration with Symfony's DumpDataCollector
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+VarDumper::setHandler(function ($var, string $label = null) {
+    $dumper = new DumpDataCollector();
+    $cloner = new VarCloner();
+    $handler = function ($var, string $label = null) use ($dumper, $cloner) {
+        $var = $cloner->cloneVar($var);
+        if (null !== $label) {
+            $var = $var->withContext(['label' => $label]);
+        }
+
+        $dumper->dump($var);
+    };
+    VarDumper::setHandler($handler);
+    $handler($var, $label);
+});
+
+$schemas = new \ArrayObject();
+dump($schemas);
+$schemas['X'] = 'A';
+
+--EXPECTF--
+ArrayObject {#%d
+  -storage: []
+  flag::STD_PROP_LIST: false
+  flag::ARRAY_AS_PROPS: false
+  iteratorClass: "ArrayIterator"
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | not yet
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

I had hard time to find a very minimal reproducer!
I think the issue is here, where we update the stub: https://github.com/symfony/symfony/blob/43066ff98d158946f6b5f8473802c9301f0abf49/src/Symfony/Component/VarDumper/Cloner/Data.php#L425

I spent a bit too much time on this one, so I cannot go further. Sorry, this is the best I can dot ATM


<details><summary>Current errors</summary>
<p>

```
PHPUnit 9.6.9 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Tests/Integration
FF                                                                  2 / 2 (100%)

Time: 00:00.094, Memory: 10.00 MB

There were 2 failures:

1) /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Tests/Integration/dump_data_collector.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
-ArrayObject {#%d
-  -storage: []
-  flag::STD_PROP_LIST: false
-  flag::ARRAY_AS_PROPS: false
-  iteratorClass: "ArrayIterator"
-}
+tandard input code on line 31:
+ArrayObject {#24
+
+Fatal error: Uncaught TypeError: Illegal offset type in /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php:464
+Stack trace:
+#0 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php(340): Symfony\Component\VarDumper\Cloner\Data->getStub()
+#1 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php(440): Symfony\Component\VarDumper\Cloner\Data->dumpItem()
+#2 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php(402): Symfony\Component\VarDumper\Cloner\Data->dumpChildren()
+#3 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php(321): Symfony\Component\VarDumper\Cloner\Data->dumpItem()
+#4 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php(135): Symfony\Component\VarDumper\Cloner\Data->dump()
+#5 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php(290): Symfony\Component\VarDumper\Dumper\AbstractDumper->dump()
+#6 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php(253): Symfony\Component\HttpKernel\DataCollector\DumpDataCollector->doDump()
+#7 [internal function]: Symfony\Component\HttpKernel\DataCollector\DumpDataCollector->__destruct()
+#8 {main}
+  thrown in /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php on line 464

/home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Tests/Integration/dump_data_collector.phpt:38

2) /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Tests/Integration/dump_data_collector2.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
-ArrayObject {#%d
-  -storage: []
-  flag::STD_PROP_LIST: false
-  flag::ARRAY_AS_PROPS: false
-  iteratorClass: "ArrayIterator"
-}
+tandard input code on line 31:
+ArrayObject {#24
+
+Warning: Undefined array key "A" in /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php on line 464
+
+Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php:464
+Stack trace:
+#0 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php(340): Symfony\Component\VarDumper\Cloner\Data->getStub()
+#1 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php(440): Symfony\Component\VarDumper\Cloner\Data->dumpItem()
+#2 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php(402): Symfony\Component\VarDumper\Cloner\Data->dumpChildren()
+#3 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php(321): Symfony\Component\VarDumper\Cloner\Data->dumpItem()
+#4 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php(135): Symfony\Component\VarDumper\Cloner\Data->dump()
+#5 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php(290): Symfony\Component\VarDumper\Dumper\AbstractDumper->dump()
+#6 /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php(253): Symfony\Component\HttpKernel\DataCollector\DumpDataCollector->doDump()
+#7 [internal function]: Symfony\Component\HttpKernel\DataCollector\DumpDataCollector->__destruct()
+#8 {main}
+  thrown in /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Cloner/Data.php on line 464

/home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/VarDumper/Tests/Integration/dump_data_collector2.phpt:38

FAILURES!
Tests: 2, Assertions: 2, Failures: 2.
```

</p>
</details> 