### PR TITLE
[FrameworkBundle] Add missing monolog channel tag to the `messenger:failed:retry` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -181,9 +181,10 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('Receivers'),
                 service('messenger.routable_message_bus'),
                 service('event_dispatcher'),
-                service('logger'),
+                service('logger')->nullOnInvalid(),
             ])
             ->tag('console.command')
+            ->tag('monolog.logger', ['channel' => 'messenger'])
 
         ->set('console.command.messenger_failed_messages_show', FailedMessagesShowCommand::class)
             ->args([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Noticed this while working on #50787, similar to #49843.