### PR TITLE
[Routing][SecurityBundle] Add `LogoutRouteLoader`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow an array of `pattern` in firewall configuration
  * Add `$badges` argument to `Security::login`
  * Deprecate the `require_previous_session` config option. Setting it has no effect anymore
+ * Add `LogoutRouteLoader`
 
 6.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\SecurityBundle\CacheWarmer\ExpressionCacheWarmer;
 use Symfony\Bundle\SecurityBundle\EventListener\FirewallListener;
+use Symfony\Bundle\SecurityBundle\Routing\LogoutRouteLoader;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
@@ -228,6 +229,13 @@ return static function (ContainerConfigurator $container) {
                 service('router')->nullOnInvalid(),
                 service('security.token_storage')->nullOnInvalid(),
             ])
+
+        ->set('security.route_loader.logout', LogoutRouteLoader::class)
+            ->args([
+                '%security.logout_uris%',
+                'security.logout_uris',
+            ])
+            ->tag('routing.route_loader')
 
         // Provisioning
         ->set('security.user.provider.missing', MissingUserProvider::class)

--- a/src/Symfony/Bundle/SecurityBundle/Routing/LogoutRouteLoader.php
+++ b/src/Symfony/Bundle/SecurityBundle/Routing/LogoutRouteLoader.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Routing;
+
+use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+final class LogoutRouteLoader
+{
+    /**
+     * @param array<string, string> $logoutUris    Logout URIs indexed by the corresponding firewall name
+     * @param string                $parameterName Name of the container parameter containing {@see $logoutUris}' value
+     */
+    public function __construct(
+        private readonly array $logoutUris,
+        private readonly string $parameterName,
+    ) {
+    }
+
+    public function __invoke(): RouteCollection
+    {
+        $collection = new RouteCollection();
+        $collection->addResource(new ContainerParametersResource([$this->parameterName => $this->logoutUris]));
+
+        $routeNames = [];
+        foreach ($this->logoutUris as $firewallName => $logoutPath) {
+            $routeName = '_logout_'.$firewallName;
+
+            if (isset($routeNames[$logoutPath])) {
+                $collection->addAlias($routeName, $routeNames[$logoutPath]);
+            } else {
+                $routeNames[$logoutPath] = $routeName;
+                $collection->add($routeName, new Route($logoutPath));
+            }
+        }
+
+        return $collection;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Routing/LogoutRouteLoaderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Routing/LogoutRouteLoaderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Routing\LogoutRouteLoader;
+use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class LogoutRouteLoaderTest extends TestCase
+{
+    public function testLoad()
+    {
+        $logoutPaths = [
+            'main' => '/logout',
+            'admin' => '/logout',
+        ];
+
+        $loader = new LogoutRouteLoader($logoutPaths, 'parameterName');
+        $collection = $loader();
+
+        self::assertInstanceOf(RouteCollection::class, $collection);
+        self::assertCount(1, $collection);
+        self::assertEquals(new Route('/logout'), $collection->get('_logout_main'));
+        self::assertCount(1, $collection->getAliases());
+        self::assertEquals('_logout_main', $collection->getAlias('_logout_admin')->getId());
+
+        $resources = $collection->getResources();
+        self::assertCount(1, $resources);
+
+        $resource = reset($resources);
+        self::assertInstanceOf(ContainerParametersResource::class, $resource);
+        self::assertSame(['parameterName' => $logoutPaths], $resource->getParameters());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50920
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/19000

#50920 is about avoiding for users to create logout routes. Given [we don’t want to allow bundles registering routes](https://github.com/symfony/symfony/issues/37786), I added a `LogoutRouteLoader` service bearing the `routing.route_loader` tag to be imported by the user. Such import could be added to the SecurityBundle recipe:

```yaml
# config/routes/security.yaml
logout:
    resource: security.route_loader.logout
    type: service
```

To invalidate routes when logout paths change, I stored them in a parameter so that the `ContainerParametersResourceChecker` can check the collection. Not sure if it’s okay or if a better way exists.