### PR TITLE
[HttpKernel] Skip corrupted CSV data in FileProfilerStorage

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -315,7 +315,15 @@ class FileProfilerStorage implements ProfilerStorageInterface
         }
 
         while ($line = fgets($handle)) {
-            [$csvToken, , , , $csvTime] = str_getcsv($line);
+            $values = str_getcsv($line);
+
+            if (7 !== \count($values)) {
+                // skip invalid lines
+                $offset += \strlen($line);
+                continue;
+            }
+
+            [$csvToken, , , , $csvTime] = $values;
 
             if ($csvTime >= $minimalProfileTimestamp) {
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Partially fixes #50942, improves/fixes on PR #50913, partially fixes #50816
| License       | MIT

Technically, part of this fix could go all the way back to 2.1, but since we're not sure why/how exactly the index.csv file is being corrupted in the first place, this PR should just serve as a stop-gap measure until the root cause can be identified.

A corrupted index.csv file is especially noticeable since 6.3, when the "Remove Expired Profiles" feature was added by #47352 .

RE: improves/fixes on PR #50913:
Warnings are (usually?) only escalated to errors in debug mode, so having a try/catch is a bit more overhead than I think is actually needed, and I believe just checking that the line read from the csv is not corrupted is the better/faster option. Granted, the profiler should really only be active in debug/non-production modes anyway, but "should" and reality usually don't align...

@alamirault @MatTheCat @benjaminfunk @Pelagoss @derrabus