### PR TITLE
[PhpUnitBridge] Kill the last concurrent process when it stales for more than 60s

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -66,11 +66,11 @@ class ProcessTest extends TestCase
         $cmd->run();
     }
 
+    /**
+     * @group transient-on-windows
+     */
     public function testThatProcessDoesNotThrowWarningDuringRun()
     {
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test is transient on Windows');
-        }
         @trigger_error('Test Error', \E_USER_NOTICE);
         $process = $this->getProcessForCode('sleep(3)');
         $process->run();
@@ -130,12 +130,11 @@ class ProcessTest extends TestCase
         $this->assertLessThan(15, microtime(true) - $start);
     }
 
+    /**
+     * @group transient-on-windows
+     */
     public function testWaitUntilSpecificOutput()
     {
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestIncomplete('This test is too transient on Windows, help wanted to improve it');
-        }
-
         $p = $this->getProcess([self::$phpBin, __DIR__.'/KillableProcessWithOutput.php']);
         $p->start();
 
@@ -1538,6 +1537,9 @@ class ProcessTest extends TestCase
         }
     }
 
+    /**
+     * @group transient-on-windows
+     */
     public function testNotTerminableInputPipe()
     {
         $process = $this->getProcess('echo foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Update PhpUnitBridge so that it kills the last phpunit process when it's stuck. Apparently this happens sometimes, for an undetermined reason (Windows). This also skips a blocking test on Windows.