### PR TITLE
[Mailer] File DNS transport

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+* Add file DSN used as `file://path/to/relative/file.txt` or `file:///path/to/abolute/file.txt`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.4
 ---
 
-* Add file DSN used as `file://path/to/relative/file.txt` or `file:///path/to/abolute/file.txt`
+* Add file DSN used as abolute paths (e.g. `file:///path/to/abolute/file.txt`)
 
 6.3
 ---

--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -86,6 +86,11 @@ class DsnTest extends TestCase
             'api://u%24er:pa%24s@mailgun?region=eu',
             new Dsn('api', 'mailgun', 'u$er', 'pa$s', null, ['region' => 'eu']),
         ];
+
+        yield 'file with absolute path' => [
+            'file:///absolute/path/to/file.txt',
+            new Dsn('file', 'null', null, null, null, [], '/absolute/path/to/file.txt'),
+        ];
     }
 
     public static function invalidDsnProvider(): iterable
@@ -101,8 +106,8 @@ class DsnTest extends TestCase
         ];
 
         yield [
-            'file:///some/path',
-            'The mailer DSN must contain a host (use "default" by default).',
+            'file://relative/path/to/file.txt',
+            'The mailer file DNS only works with absolute file paths.',
         ];
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/FileTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FileTransportFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Transport;
+
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\FileTransport;
+use Symfony\Component\Mailer\Transport\FileTransportFactory;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+class FileTransportFactoryTest extends TransportFactoryTestCase
+{
+    public function getFactory(): TransportFactoryInterface
+    {
+        return new FileTransportFactory(null, new MockHttpClient(), new NullLogger());
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [
+            new Dsn('file', 'default'),
+            true,
+        ];
+    }
+
+    public static function createProvider(): iterable
+    {
+        $tmpDir = sys_get_temp_dir();
+        $dsn = new Dsn('file', 'null', null, null, null, [], $tmpDir.'/file.txt');
+        yield [
+            new Dsn('file', 'null', null, null, null, [], $tmpDir.'/file.txt'),
+            new FileTransport($dsn, null, new NullLogger()),
+        ];
+    }
+
+    public function testDirectoryNotFound(): void
+    {
+        $dir = sys_get_temp_dir().'/path/does/not/exist';
+        $dsn = new Dsn('file', 'null', null, null, null, [], $dir.'/file.txt');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Directory $dir doesn't exist or is not writable");
+        (new FileTransportFactory())->create($dsn);
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/Transport/FileTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FileTransportFactoryTest.php
@@ -45,7 +45,7 @@ class FileTransportFactoryTest extends TransportFactoryTestCase
         ];
     }
 
-    public function testDirectoryNotFound(): void
+    public function testDirectoryNotFound()
     {
         $dir = sys_get_temp_dir().'/path/does/not/exist';
         $dsn = new Dsn('file', 'null', null, null, null, [], $dir.'/file.txt');

--- a/src/Symfony/Component/Mailer/Tests/Transport/FileTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FileTransportTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\FileTransport;
+use Symfony\Component\Mailer\Transport\NullTransport;
+
+class FileTransportTest extends TestCase
+{
+    public function testToString()
+    {
+        $file = sys_get_temp_dir().'/file.txt';
+        $dsn = new Dsn('file', 'null', null, null, null, [], $file);
+        $t = new FileTransport($dsn);
+        $this->assertEquals('file://'.$file, (string) $t);
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/Transport/FileTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FileTransportTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Mailer\Tests\Transport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\FileTransport;
-use Symfony\Component\Mailer\Transport\NullTransport;
 
 class FileTransportTest extends TestCase
 {

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -29,6 +29,7 @@ use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\FailoverTransport;
+use Symfony\Component\Mailer\Transport\FileTransportFactory;
 use Symfony\Component\Mailer\Transport\NativeTransportFactory;
 use Symfony\Component\Mailer\Transport\NullTransportFactory;
 use Symfony\Component\Mailer\Transport\RoundRobinTransport;
@@ -174,6 +175,8 @@ final class Transport
         }
 
         yield new NullTransportFactory($dispatcher, $client, $logger);
+
+        yield new FileTransportFactory($dispatcher, $client, $logger);
 
         yield new SendmailTransportFactory($dispatcher, $client, $logger);
 

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -47,7 +47,14 @@ final class Dsn
             throw new InvalidArgumentException('The mailer DSN must contain a scheme.');
         }
 
-        if (!isset($parsedDsn['host']) && 'file' !== $parsedDsn['scheme']) {
+        if ('file' === $parsedDsn['scheme']) {
+            if (!empty($parsedDsn['host'])) {
+                throw new InvalidArgumentException('The mailer file DNS only works with absolute file paths.');
+            }
+            $parsedDsn['host'] = 'null';
+        }
+
+        if (!isset($parsedDsn['host'])) {
             throw new InvalidArgumentException('The mailer DSN must contain a host (use "default" by default).');
         }
 
@@ -56,7 +63,7 @@ final class Dsn
         $port = $parsedDsn['port'] ?? null;
         parse_str($parsedDsn['query'] ?? '', $query);
 
-        return new self($parsedDsn['scheme'], $parsedDsn['host'] ?? 'default', $user, $password, $port, $query, $parsedDsn['path'] ?? null);
+        return new self($parsedDsn['scheme'], $parsedDsn['host'], $user, $password, $port, $query, $parsedDsn['path'] ?? null);
     }
 
     public function getScheme(): string

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -24,8 +24,9 @@ final class Dsn
     private ?string $password;
     private ?int $port;
     private array $options;
+    private ?string $path;
 
-    public function __construct(string $scheme, string $host, string $user = null, #[\SensitiveParameter] string $password = null, int $port = null, array $options = [])
+    public function __construct(string $scheme, string $host, string $user = null, #[\SensitiveParameter] string $password = null, int $port = null, array $options = [], string $path = null)
     {
         $this->scheme = $scheme;
         $this->host = $host;
@@ -33,6 +34,7 @@ final class Dsn
         $this->password = $password;
         $this->port = $port;
         $this->options = $options;
+        $this->path = $path;
     }
 
     public static function fromString(#[\SensitiveParameter] string $dsn): self
@@ -45,7 +47,7 @@ final class Dsn
             throw new InvalidArgumentException('The mailer DSN must contain a scheme.');
         }
 
-        if (!isset($parsedDsn['host'])) {
+        if (!isset($parsedDsn['host']) && 'file' !== $parsedDsn['scheme']) {
             throw new InvalidArgumentException('The mailer DSN must contain a host (use "default" by default).');
         }
 
@@ -54,7 +56,7 @@ final class Dsn
         $port = $parsedDsn['port'] ?? null;
         parse_str($parsedDsn['query'] ?? '', $query);
 
-        return new self($parsedDsn['scheme'], $parsedDsn['host'], $user, $password, $port, $query);
+        return new self($parsedDsn['scheme'], $parsedDsn['host'] ?? 'default', $user, $password, $port, $query, $parsedDsn['path'] ?? null);
     }
 
     public function getScheme(): string
@@ -85,5 +87,10 @@ final class Dsn
     public function getOption(string $key, mixed $default = null): mixed
     {
         return $this->options[$key] ?? $default;
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->path;
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/FileTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransport.php
@@ -31,6 +31,7 @@ final class FileTransport extends AbstractTransport
     {
         if (false !== file_put_contents($this->getFile(), $message->toString())) {
             $this->getLogger()->debug(sprintf('Email sent with "%s" transport', $this->getFile()));
+
             return;
         }
         $this->getLogger()->error(sprintf('Cannot send email using "%s" transport', $this->getFile()));

--- a/src/Symfony/Component/Mailer/Transport/FileTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransport.php
@@ -22,14 +22,18 @@ use Symfony\Component\Mailer\SentMessage;
  */
 final class FileTransport extends AbstractTransport
 {
-    public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, protected Dsn $dsn)
+    public function __construct(protected Dsn $dsn, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct($dispatcher, $logger);
     }
 
     protected function doSend(SentMessage $message): void
     {
-        file_put_contents($this->getFile(), $message->toString());
+        if (false !== file_put_contents($this->getFile(), $message->toString())) {
+            $this->getLogger()->debug(sprintf('Email sent with "%s" transport', $this->getFile()));
+            return;
+        }
+        $this->getLogger()->error(sprintf('Cannot send email using "%s" transport', $this->getFile()));
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Mailer/Transport/FileTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransport.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\SentMessage;
+
+use function _PHPStan_690619d82\RingCentral\Psr7\str;
+
+/**
+ * Sends the message to a file.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class FileTransport extends AbstractTransport
+{
+    public function __construct(EventDispatcherInterface $dispatcher = NULL, LoggerInterface $logger = NULL, protected Dsn $dsn)
+    {
+        parent::__construct($dispatcher, $logger);
+    }
+
+    protected function doSend(SentMessage $message): void
+    {
+        file_put_contents($this->getFile(), $message->toString());
+    }
+
+    public function __toString(): string
+    {
+        return $this->getFile();
+    }
+
+    private function getFile(): string
+    {
+        return $this->dsn->getScheme() . '://' . $this->dsn->getPath();
+    }
+}

--- a/src/Symfony/Component/Mailer/Transport/FileTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransport.php
@@ -18,7 +18,7 @@ use Symfony\Component\Mailer\SentMessage;
 /**
  * Sends the message to a file.
  *
- * @author Fabien Potencier <fabien@symfony.com>
+ * @author Claudiu Cristea <clau.cristea@gmail.com>
  */
 final class FileTransport extends AbstractTransport
 {

--- a/src/Symfony/Component/Mailer/Transport/FileTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransport.php
@@ -15,8 +15,6 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\SentMessage;
 
-use function _PHPStan_690619d82\RingCentral\Psr7\str;
-
 /**
  * Sends the message to a file.
  *
@@ -24,7 +22,7 @@ use function _PHPStan_690619d82\RingCentral\Psr7\str;
  */
 final class FileTransport extends AbstractTransport
 {
-    public function __construct(EventDispatcherInterface $dispatcher = NULL, LoggerInterface $logger = NULL, protected Dsn $dsn)
+    public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, protected Dsn $dsn)
     {
         parent::__construct($dispatcher, $logger);
     }
@@ -41,6 +39,6 @@ final class FileTransport extends AbstractTransport
 
     private function getFile(): string
     {
-        return $this->dsn->getScheme() . '://' . $this->dsn->getPath();
+        return $this->dsn->getScheme().'://'.$this->dsn->getPath();
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/FileTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransport.php
@@ -16,7 +16,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\SentMessage;
 
 /**
- * Sends the message to a file.
+ * Writes the message to a file.
  *
  * @author Claudiu Cristea <clau.cristea@gmail.com>
  */

--- a/src/Symfony/Component/Mailer/Transport/FileTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransportFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Transport;
+
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+
+/**
+ * @author ...
+ */
+final class FileTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        if ('file' === $dsn->getScheme()) {
+            return new FileTransport($this->dispatcher, $this->logger, $dsn);
+        }
+
+        throw new UnsupportedSchemeException($dsn, 'file', $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['file'];
+    }
+}

--- a/src/Symfony/Component/Mailer/Transport/FileTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransportFactory.php
@@ -15,7 +15,7 @@ use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 
 /**
- * @author ...
+ * @author Claudiu Cristea <clau.cristea@gmail.com>
  */
 final class FileTransportFactory extends AbstractTransportFactory
 {

--- a/src/Symfony/Component/Mailer/Transport/FileTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/FileTransportFactory.php
@@ -25,9 +25,9 @@ final class FileTransportFactory extends AbstractTransportFactory
             throw new UnsupportedSchemeException($dsn, 'file', $this->getSupportedSchemes());
         }
 
-        $dir = dirname($dsn->getPath());
+        $dir = \dirname($dsn->getPath());
         if (!is_dir($dir) || !is_writable($dir)) {
-            throw new InvalidArgumentException("Directory $dir doesn't exist or is not writable");
+            throw new InvalidArgumentException("Directory $dir doesn't exist or is not writable.");
         }
 
         return new FileTransport($dsn, $this->dispatcher, $this->logger);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #50961 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Provides a file DSN to be configured as `file://path/to/relative/file.txt` or `file:///path/to/abolute/file.txt`