### PR TITLE
[Messenger] do not listen to signals if the pcntl extension is missing

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
@@ -24,6 +24,6 @@ class StopWorkerOnSigtermSignalListener extends StopWorkerOnSignalsListener
 {
     public function __construct(LoggerInterface $logger = null)
     {
-        parent::__construct([SIGTERM], $logger);
+        parent::__construct(\defined('SIGTERM') ? [SIGTERM] : [], $logger);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 