### PR TITLE
[PropertyAccess] Fix access to undefined "file" key when checking stack frames

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -470,7 +470,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                         [$trace] = $e->getTrace();
 
                         // handle uninitialized properties in PHP >= 7
-                        if (__FILE__ === $trace['file']
+                        if (__FILE__ === ($trace['file'] ?? null)
                             && $name === $trace['function']
                             && $object instanceof $trace['class']
                             && preg_match('/Return value (?:of .*::\w+\(\) )?must be of (?:the )?type (\w+), null returned$/', $e->getMessage(), $matches)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #50967
| License       | MIT
| Doc PR        | -

