### PR TITLE
[Messenger] Allow accessing all options on a handler descriptor

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `StopWorkerOnSignalsListener` in favor of using the `SignalableCommandInterface`
+ * Add `HandlerDescriptor::getOptions`
 
 6.3
 ---

--- a/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
@@ -73,4 +73,9 @@ final class HandlerDescriptor
     {
         return $this->options[$option] ?? null;
     }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandleDescriptorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandleDescriptorTest.php
@@ -45,6 +45,14 @@ class HandleDescriptorTest extends TestCase
             }
         }, 'class@anonymous%sHandleDescriptorTest.php%s::__invoke'];
     }
+
+    public function testGetOptions()
+    {
+        $options = ['option1' => 'value1', 'option2' => 'value2'];
+        $descriptor = new HandlerDescriptor(function () {}, $options);
+
+        $this->assertSame($options, $descriptor->getOptions());
+    }
 }
 
 class DummyCommandHandlerWithSpecificMethod


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Currently it's only possible to use `HandlerDescriptor::getOption` to retrieve options one by one.

In my situation, I want to inspect all the options, without knowing their name.
