### PR TITLE
[Messenger] Make `HandleMessageMiddleware::callHandler` protected

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Make `HandleMessageMiddleware::callHandler` protected
+
 6.3
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

I made the following changes:
- make `callHandler` protected
- pass the HandlerDescriptor (can be used to read options from the handler)
- pass the Envelope (can be used to read more stamps)

This allows people to decorate the `HandleMessageMiddleware` and intercept the moment the handler is called.

I currently have the following use cases for this in my application:

1) Every handler can decide if they want to wrap their handling in a transaction. This is done by
   a custom `#[WrapInTransaction]` attribute. When the attribute is there, we wrap it in a database
   transaction. I know the `DoctrineTransactionMiddleware` exists in the Symfony Doctrine bridge,
   but that runs as middleware and cannot be toggled individually. It would be possible to modify it
   so that it only runs when the handler has it enabled using an option, but that only works for
   buses with only 1 handler. For an event bus, with multiple handlers, that won't be a solution.

2) Every handler can decide if they want to ignore certain exceptions that are thrown. This is done
   by a custom `#[IgnoreException]` attribute. For example the handler uses
   `#[IgnoreException(EventNotFoundException::class)]`. Whenever that exception is thrown, the
   exception is caught and ignored. The middleware thinks it's executed without issues.
