### PR TITLE
[Serializer] Deprecate annotations in favor of attributes

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -71,3 +71,9 @@ Security
  * `UserValueResolver` no longer implements `ArgumentValueResolverInterface`
  * Make `PersistentToken` immutable
  * Deprecate accepting only `DateTime` for `TokenProviderInterface::updateToken()`, use `DateTimeInterface` instead
+
+Serializer
+----------
+
+ * Deprecate Doctrine annotations support in favor of native attributes
+ * Deprecate passing an annotation reader to the constructor of `AnnotationLoader`

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/SerializerModelFixture.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/SerializerModelFixture.php
@@ -9,9 +9,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  */
 class SerializerModelFixture
 {
-    /**
-     * @Groups({"read"})
-     */
+    #[Groups(['read'])]
     public $name = 'howdy';
 
     public $title = 'fixture';

--- a/src/Symfony/Bridge/Twig/Tests/Extension/SerializerExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SerializerExtensionTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Extension\SerializerExtension;
 use Symfony\Bridge\Twig\Extension\SerializerRuntime;
@@ -50,7 +49,7 @@ class SerializerExtensionTest extends TestCase
 
     private function getTwig(string $template): Environment
     {
-        $meta = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $meta = new ClassMetadataFactory(new AnnotationLoader());
         $runtime = new SerializerRuntime(new Serializer([new ObjectNormalizer($meta)], [new JsonEncoder(), new YamlEncoder()]));
 
         $mockRuntimeLoader = $this->createMock(RuntimeLoaderInterface::class);

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -21,7 +21,6 @@
         "twig/twig": "^2.13|^3.0.4"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.12|^2",
         "egulias/email-validator": "^2.1.10|^3|^4",
         "league/html-to-markdown": "^5.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
@@ -62,6 +61,7 @@
         "symfony/http-foundation": "<5.4",
         "symfony/http-kernel": "<6.2",
         "symfony/mime": "<6.2",
+        "symfony/serializer": "<6.2",
         "symfony/translation": "<5.4",
         "symfony/workflow": "<5.4"
     },

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IgnorePropertyDummy;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -24,14 +24,11 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
  */
 class SerializerExtractorTest extends TestCase
 {
-    /**
-     * @var SerializerExtractor
-     */
-    private $extractor;
+    private SerializerExtractor $extractor;
 
     protected function setUp(): void
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->extractor = new SerializerExtractor($classMetadataFactory);
     }
 
@@ -39,7 +36,7 @@ class SerializerExtractorTest extends TestCase
     {
         $this->assertEquals(
             ['collection'],
-            $this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', ['serializer_groups' => ['a']])
+            $this->extractor->getProperties(Dummy::class, ['serializer_groups' => ['a']])
         );
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -42,8 +42,8 @@ class Dummy extends ParentDummy
 
     /**
      * @var \DateTimeImmutable[]
-     * @Groups({"a", "b"})
      */
+    #[Groups(['a', 'b'])]
     public $collection;
 
     /**

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -31,13 +31,13 @@
         "symfony/cache": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "phpstan/phpdoc-parser": "^1.0",
-        "doctrine/annotations": "^1.10.4|^2"
+        "phpstan/phpdoc-parser": "^1.0"
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<5.2",
         "phpdocumentor/type-resolver": "<1.5.1",
-        "symfony/dependency-injection": "<5.4"
+        "symfony/dependency-injection": "<5.4",
+        "symfony/serializer": "<5.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\PropertyInfo\\": "" },

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Deprecate Doctrine annotations support in favor of native attributes
+ * Deprecate passing an annotation reader to the constructor of `AnnotationLoader`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -46,6 +46,9 @@ class AnnotationLoader implements LoaderInterface
     public function __construct(
         private readonly ?Reader $reader = null,
     ) {
+        if ($reader) {
+            trigger_deprecation('symfony/validator', '6.4', 'Passing a "%s" instance as argument 1 to "%s()" is deprecated, pass null or omit the parameter instead.', get_debug_type($reader), __METHOD__);
+        }
     }
 
     public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
@@ -163,10 +166,7 @@ class AnnotationLoader implements LoaderInterface
         return $loaded;
     }
 
-    /**
-     * @param \ReflectionClass|\ReflectionMethod|\ReflectionProperty $reflector
-     */
-    public function loadAnnotations(object $reflector): iterable
+    public function loadAnnotations(\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): iterable
     {
         foreach ($reflector->getAttributes() as $attribute) {
             if ($this->isKnownAttribute($attribute->getName())) {
@@ -193,13 +193,13 @@ class AnnotationLoader implements LoaderInterface
         }
 
         if ($reflector instanceof \ReflectionClass) {
-            yield from $this->reader->getClassAnnotations($reflector);
+            yield from $this->getClassAnnotations($reflector);
         }
         if ($reflector instanceof \ReflectionMethod) {
-            yield from $this->reader->getMethodAnnotations($reflector);
+            yield from $this->getMethodAnnotations($reflector);
         }
         if ($reflector instanceof \ReflectionProperty) {
-            yield from $this->reader->getPropertyAnnotations($reflector);
+            yield from $this->getPropertyAnnotations($reflector);
         }
     }
 
@@ -228,5 +228,50 @@ class AnnotationLoader implements LoaderInterface
         }
 
         return false;
+    }
+
+    /**
+     * @return object[]
+     */
+    private function getClassAnnotations(\ReflectionClass $reflector): array
+    {
+        if ($annotations = array_filter(
+            $this->reader->getClassAnnotations($reflector),
+            fn (object $annotation): bool => $this->isKnownAttribute($annotation::class),
+        )) {
+            trigger_deprecation('symfony/serializer', '6.4', 'Class "%s" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.', $reflector->getName());
+        }
+
+        return $annotations;
+    }
+
+    /**
+     * @return object[]
+     */
+    private function getMethodAnnotations(\ReflectionMethod $reflector): array
+    {
+        if ($annotations = array_filter(
+            $this->reader->getMethodAnnotations($reflector),
+            fn (object $annotation): bool => $this->isKnownAttribute($annotation::class),
+        )) {
+            trigger_deprecation('symfony/serializer', '6.4', 'Method "%s::%s()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.', $reflector->getDeclaringClass()->getName(), $reflector->getName());
+        }
+
+        return $annotations;
+    }
+
+    /**
+     * @return object[]
+     */
+    private function getPropertyAnnotations(\ReflectionProperty $reflector): array
+    {
+        if ($annotations = array_filter(
+            $this->reader->getPropertyAnnotations($reflector),
+            fn (object $annotation): bool => $this->isKnownAttribute($annotation::class),
+        )) {
+            trigger_deprecation('symfony/serializer', '6.4', 'Property "%s::$%s" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.', $reflector->getDeclaringClass()->getName(), $reflector->getName());
+        }
+
+        return $annotations;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/GroupDummy.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
 
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Tests\Fixtures\ChildOfGroupsAnnotationDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\GroupDummyInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummyInterface;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/GroupDummyInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/GroupDummyInterface.php
@@ -9,19 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
 
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Serializer\Annotation\Ignore;
 
 /**
- * @author Vadim Borodavko <vadim.borodavko@gmail.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class IgnorePropertyDummy
+interface GroupDummyInterface
 {
-    #[Groups(['a'])]
-    public $visibleProperty;
-
-    #[Groups(['a']), Ignore]
-    private $ignoredProperty;
+    /**
+     * @Groups({"a", "name_converter"})
+     */
+    public function getSymfony();
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
 
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Tests\Fixtures\ChildOfGroupsAnnotationDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\GroupDummyInterface;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummyChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummyChild.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
 
 class GroupDummyChild extends GroupDummy
 {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummyInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummyInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Serializer\Tests\Fixtures;
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
 
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -18,8 +18,6 @@ use Symfony\Component\Serializer\Annotation\Groups;
  */
 interface GroupDummyInterface
 {
-    /**
-     * @Groups({"a", "name_converter"})
-     */
+    #[Groups(['a', 'name_converter'])]
     public function getSymfony();
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageInterface.php
@@ -14,13 +14,12 @@ namespace Symfony\Component\Serializer\Tests\Fixtures;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 
 /**
- * @DiscriminatorMap(typeProperty="type", mapping={
- *    "one"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne",
- *    "two"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo"
- * })
- *
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'one' => DummyMessageNumberOne::class,
+    'two' => DummyMessageNumberTwo::class,
+])]
 interface DummyMessageInterface
 {
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberOne.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberOne.php
@@ -20,8 +20,6 @@ class DummyMessageNumberOne implements DummyMessageInterface
 {
     public $one;
 
-    /**
-     * @Groups({"two"})
-     */
+    #[Groups(['two'])]
     public $two;
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
@@ -19,9 +19,7 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
  */
 class OtherSerializedNameDummy
 {
-    /**
-     * @Groups({"a"})
-     */
+    #[Groups(['a'])]
     private $buz;
 
     public function setBuz($buz)
@@ -34,10 +32,7 @@ class OtherSerializedNameDummy
         return $this->buz;
     }
 
-    /**
-     * @Groups({"b"})
-     * @SerializedName("buz")
-     */
+    #[Groups(['b']), SerializedName('buz')]
     public function getBuzForExport()
     {
         return $this->buz.' Rocks';

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/invalid-ignore.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/invalid-ignore.yml
@@ -1,4 +1,4 @@
-'Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy':
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummy':
   attributes:
     ignored1:
       ignore: foo

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -4,7 +4,7 @@
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy">
         <attribute name="foo">
             <group>group1</group>
             <group>group2</group>
@@ -15,41 +15,41 @@
         </attribute>
     </class>
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy">
         <attribute name="foo" max-depth="2" />
         <attribute name="bar" max-depth="3" />
     </class>
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy">
         <attribute name="foo" serialized-name="baz" />
         <attribute name="bar" serialized-name="qux" />
     </class>
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy">
         <attribute name="three" serialized-path="[one][two]" />
         <attribute name="seven" serialized-path="[three][four]" />
     </class>
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathInConstructorDummy">
         <attribute name="three" serialized-path="[one][two]" />
     </class>
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy">
         <discriminator-map type-property="type">
-            <mapping type="first" class="Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild" />
-            <mapping type="second" class="Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondChild" />
+            <mapping type="first" class="Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild" />
+            <mapping type="second" class="Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild" />
         </discriminator-map>
 
         <attribute name="foo" />
     </class>
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummy">
         <attribute name="ignored1" ignore="true" />
         <attribute name="ignored2" ignore="true" />
         <attribute name="notIgnored" ignore="false" />
     </class>
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\ContextDummyParent">
         <attribute name="parentProperty">
             <normalization_context>
                 <entry name="prop">dummy_parent_value</entry>
@@ -62,7 +62,7 @@
         </attribute>
     </class>
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\ContextDummy">
         <attribute name="foo">
             <context>
                 <entry name="foo">value</entry>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -1,47 +1,47 @@
-'Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy':
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy':
   attributes:
     foo:
       groups: ['group1', 'group2']
     bar:
       groups: ['group2']
-'Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy':
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy':
   attributes:
     foo:
       max_depth: 2
     bar:
       max_depth: 3
-'Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy':
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy':
   attributes:
     foo:
       serialized_name: 'baz'
     bar:
       serialized_name: 'qux'
-'Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy':
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy':
   attributes:
     three:
       serialized_path: '[one][two]'
     seven:
       serialized_path: '[three][four]'
-'Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy':
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathInConstructorDummy':
   attributes:
     three:
       serialized_path: '[one][two]'
-'Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy':
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy':
   discriminator_map:
     type_property: type
     mapping:
-      first: 'Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild'
-      second: 'Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondChild'
+      first: 'Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild'
+      second: 'Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild'
   attributes:
     foo: ~
-'Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy':
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummy':
   attributes:
     ignored1:
       ignore: true
     ignored2:
       ignore: true
 
-Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent:
+Symfony\Component\Serializer\Tests\Fixtures\Attributes\ContextDummyParent:
   attributes:
     parentProperty:
       contexts:
@@ -50,7 +50,7 @@ Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent:
       contexts:
         - { normalization_context: { prop: dummy_parent_value } }
 
-Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummy:
+Symfony\Component\Serializer\Tests\Fixtures\Attributes\ContextDummy:
   attributes:
     foo:
       contexts:

--- a/src/Symfony/Component/Serializer/Tests/Mapping/ClassDiscriminatorMappingTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/ClassDiscriminatorMappingTest.php
@@ -13,9 +13,9 @@ namespace Symfony\Component\Serializer\Tests\Mapping;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondChild;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyThirdChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyThirdChild;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
@@ -11,23 +11,19 @@
 
 namespace Symfony\Component\Serializer\Tests\Mapping\Factory;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryCompiler;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathInConstructorDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 
 final class ClassMetadataFactoryCompilerTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $dumpPath;
+    private string $dumpPath;
 
     protected function setUp(): void
     {
@@ -41,7 +37,7 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
 
     public function testItDumpMetadata()
     {
-        $classMetatadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetatadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $dummyMetadata = $classMetatadataFactory->getMetadataFor(Dummy::class);
         $maxDepthDummyMetadata = $classMetatadataFactory->getMetadataFor(MaxDepthDummy::class);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryTest.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\Serializer\Tests\Mapping\Factory;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummyInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummyParent;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
 
 /**
@@ -32,18 +34,18 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testGetMetadataFor()
     {
-        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
-        $classMetadata = $factory->getMetadataFor('Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy');
+        $factory = new ClassMetadataFactory(new AnnotationLoader());
+        $classMetadata = $factory->getMetadataFor(GroupDummy::class);
 
-        $this->assertEquals(TestClassMetadataFactory::createClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations', true, true), $classMetadata);
+        $this->assertEquals(TestClassMetadataFactory::createClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Attributes', true, true), $classMetadata);
     }
 
     public function testHasMetadataFor()
     {
-        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
-        $this->assertTrue($factory->hasMetadataFor('Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy'));
-        $this->assertTrue($factory->hasMetadataFor('Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummyParent'));
-        $this->assertTrue($factory->hasMetadataFor('Symfony\Component\Serializer\Tests\Fixtures\GroupDummyInterface'));
+        $factory = new ClassMetadataFactory(new AnnotationLoader());
+        $this->assertTrue($factory->hasMetadataFor(GroupDummy::class));
+        $this->assertTrue($factory->hasMetadataFor(GroupDummyParent::class));
+        $this->assertTrue($factory->hasMetadataFor(GroupDummyInterface::class));
         $this->assertFalse($factory->hasMetadataFor('Dunglas\Entity'));
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CompiledClassMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CompiledClassMetadataFactoryTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Factory\CompiledClassMetadataFactory;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 
 /**

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
@@ -172,7 +172,7 @@ abstract class AnnotationLoaderTestCase extends TestCase
         $loader->loadClassMetadata($metadata);
     }
 
-    public function testIgnoreGetterWirhRequiredParameterIfIgnoreAnnotationIsUsed()
+    public function testIgnoreGetterWithRequiredParameterIfIgnoreAnnotationIsUsed()
     {
         $classMetadata = new ClassMetadata($this->getNamespace().'\IgnoreDummyAdditionalGetter');
         $this->getLoaderForContextMapping()->loadClassMetadata($classMetadata);
@@ -182,7 +182,7 @@ abstract class AnnotationLoaderTestCase extends TestCase
         self::assertArrayHasKey('extraValue2', $attributes);
     }
 
-    public function testIgnoreGetterWirhRequiredParameterIfIgnoreAnnotationIsNotUsed()
+    public function testIgnoreGetterWithRequiredParameterIfIgnoreAnnotationIsNotUsed()
     {
         $classMetadata = new ClassMetadata($this->getNamespace().'\IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations');
         $this->getLoaderForContextMapping()->loadClassMetadata($classMetadata);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderWithDoctrineAnnotationsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderWithDoctrineAnnotationsTest.php
@@ -12,10 +12,152 @@
 namespace Symfony\Component\Serializer\Tests\Mapping\Loader;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 
+/**
+ * @group legacy
+ */
 class AnnotationLoaderWithDoctrineAnnotationsTest extends AnnotationLoaderTestCase
 {
+    use ExpectDeprecationTrait;
+
+    protected function setUp(): void
+    {
+        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
+
+        parent::setUp();
+    }
+
+    public function testLoadClassMetadataReturnsTrueIfSuccessful()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$foo" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$bar" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$quux" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::setBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::getBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::isFooBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadClassMetadataReturnsTrueIfSuccessful();
+    }
+
+    public function testLoadGroups()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$foo" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$bar" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$quux" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::setBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::getBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::isFooBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadGroups();
+    }
+
+    public function testLoadDiscriminatorMap()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Class "Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadDiscriminatorMap();
+    }
+
+    public function testLoadMaxDepth()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy::$foo" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy::getBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadMaxDepth();
+    }
+
+    public function testLoadSerializedName()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy::$foo" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy::getBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadSerializedName();
+    }
+
+    public function testLoadSerializedPath()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy::$three" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy::getSeven()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadSerializedPath();
+    }
+
+    public function testLoadSerializedPathInConstructor()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy::$three" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadSerializedPathInConstructor();
+    }
+
+    public function testLoadClassMetadataAndMerge()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummyParent::$kevin" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummyParent::getCoopTilleuls()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$foo" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$bar" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::$quux" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::setBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::getBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy::isFooBar()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadClassMetadataAndMerge();
+    }
+
+    public function testLoadIgnore()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy::$ignored1" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy::getIgnored2()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadIgnore();
+    }
+
+    public function testLoadContexts()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent::$parentProperty" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent::$overriddenParentProperty" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummy::$foo" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummy::$bar" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummy::$overriddenParentProperty" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummy::getMethodWithContext()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadContexts();
+    }
+
+    public function testLoadContextsPropertiesPromoted()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent::$parentProperty" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent::$overriddenParentProperty" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyPromotedProperties::$foo" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyPromotedProperties::$bar" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Property "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyPromotedProperties::$overriddenParentProperty" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyPromotedProperties::getMethodWithContext()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testLoadContextsPropertiesPromoted();
+    }
+
+    public function testThrowsOnContextOnInvalidMethod()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\BadMethodContextDummy::badMethod()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testThrowsOnContextOnInvalidMethod();
+    }
+
+    public function testCanHandleUnrelatedIgnoredMethods()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\Entity45016::badIgnore()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testCanHandleUnrelatedIgnoredMethods();
+    }
+
+    public function testIgnoreGetterWithRequiredParameterIfIgnoreAnnotationIsUsed()
+    {
+        $this->expectDeprecation('Since symfony/serializer 6.4: Method "Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummyAdditionalGetter::getMyValue()" uses Doctrine Annotations to configure serialization, which is deprecated. Use PHP attributes instead.');
+
+        parent::testIgnoreGetterWithRequiredParameterIfIgnoreAnnotationIsUsed();
+    }
+
     protected function createLoader(): AnnotationLoader
     {
         return new AnnotationLoader(new AnnotationReader());

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/Features/ContextMappingTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/Features/ContextMappingTestTrait.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Serializer\Tests\Mapping\Loader\Features;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\ContextDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\ContextDummyParent;
 
 /**
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
@@ -29,7 +29,7 @@ trait ContextMappingTestTrait
         $this->assertLoadedContexts();
     }
 
-    public function assertLoadedContexts(string $dummyClass = ContextDummy::class, string $parentClass = ContextDummyParent::class)
+    public function assertLoadedContexts(string $dummyClass = ContextDummy::class, string $parentClass = ContextDummyParent::class): void
     {
         $loader = $this->getLoaderForContextMapping();
 

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -17,10 +17,15 @@ use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
 use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondChild;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathInConstructorDummy;
 use Symfony\Component\Serializer\Tests\Mapping\Loader\Features\ContextMappingTestTrait;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
 
@@ -31,20 +36,13 @@ class XmlFileLoaderTest extends TestCase
 {
     use ContextMappingTestTrait;
 
-    /**
-     * @var XmlFileLoader
-     */
-    private $loader;
-
-    /**
-     * @var ClassMetadata
-     */
-    private $metadata;
+    private XmlFileLoader $loader;
+    private ClassMetadata $metadata;
 
     protected function setUp(): void
     {
         $this->loader = new XmlFileLoader(__DIR__.'/../../Fixtures/serialization.xml');
-        $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy');
+        $this->metadata = new ClassMetadata(GroupDummy::class);
     }
 
     public function testInterface()
@@ -66,7 +64,7 @@ class XmlFileLoaderTest extends TestCase
 
     public function testMaxDepth()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy');
+        $classMetadata = new ClassMetadata(MaxDepthDummy::class);
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
@@ -76,7 +74,7 @@ class XmlFileLoaderTest extends TestCase
 
     public function testSerializedName()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy');
+        $classMetadata = new ClassMetadata(SerializedNameDummy::class);
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
@@ -86,7 +84,7 @@ class XmlFileLoaderTest extends TestCase
 
     public function testSerializedPath()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy');
+        $classMetadata = new ClassMetadata(SerializedPathDummy::class);
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
@@ -96,7 +94,7 @@ class XmlFileLoaderTest extends TestCase
 
     public function testSerializedPathInConstructor()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy');
+        $classMetadata = new ClassMetadata(SerializedPathInConstructorDummy::class);
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -19,10 +19,15 @@ use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
 use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondChild;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathInConstructorDummy;
 use Symfony\Component\Serializer\Tests\Mapping\Loader\Features\ContextMappingTestTrait;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
 
@@ -33,19 +38,13 @@ class YamlFileLoaderTest extends TestCase
 {
     use ContextMappingTestTrait;
 
-    /**
-     * @var YamlFileLoader
-     */
-    private $loader;
-    /**
-     * @var ClassMetadata
-     */
-    private $metadata;
+    private YamlFileLoader $loader;
+    private ClassMetadata $metadata;
 
     protected function setUp(): void
     {
         $this->loader = new YamlFileLoader(__DIR__.'/../../Fixtures/serialization.yml');
-        $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy');
+        $this->metadata = new ClassMetadata(GroupDummy::class);
     }
 
     public function testInterface()
@@ -80,7 +79,7 @@ class YamlFileLoaderTest extends TestCase
 
     public function testMaxDepth()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy');
+        $classMetadata = new ClassMetadata(MaxDepthDummy::class);
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
@@ -90,7 +89,7 @@ class YamlFileLoaderTest extends TestCase
 
     public function testSerializedName()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy');
+        $classMetadata = new ClassMetadata(SerializedNameDummy::class);
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
@@ -100,7 +99,7 @@ class YamlFileLoaderTest extends TestCase
 
     public function testSerializedPath()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy');
+        $classMetadata = new ClassMetadata(SerializedPathDummy::class);
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
@@ -110,7 +109,7 @@ class YamlFileLoaderTest extends TestCase
 
     public function testSerializedPathInConstructor()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathInConstructorDummy');
+        $classMetadata = new ClassMetadata(SerializedPathInConstructorDummy::class);
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();

--- a/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Mapping;
 
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -70,7 +71,7 @@ class TestClassMetadataFactory
 
     public static function createXmlCLassMetadata(): ClassMetadata
     {
-        $expected = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy');
+        $expected = new ClassMetadata(GroupDummy::class);
 
         $foo = new AttributeMetadata('foo');
         $foo->addGroup('group1');

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\NameConverter;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Serializer\Annotation\SerializedPath;
@@ -21,7 +20,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\OtherSerializedNameDummy;
 
 /**
@@ -39,9 +38,9 @@ final class MetadataAwareNameConverterTest extends TestCase
     /**
      * @dataProvider attributeProvider
      */
-    public function testNormalize($propertyName, $expected)
+    public function testNormalize(string|int $propertyName, string|int $expected)
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
 
@@ -51,14 +50,14 @@ final class MetadataAwareNameConverterTest extends TestCase
     /**
      * @dataProvider fallbackAttributeProvider
      */
-    public function testNormalizeWithFallback($propertyName, $expected)
+    public function testNormalizeWithFallback(string|int $propertyName, string|int $expected)
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $fallback = $this->createMock(NameConverterInterface::class);
         $fallback
             ->method('normalize')
-            ->willReturnCallback(fn ($propertyName) => strtoupper($propertyName))
+            ->willReturnCallback(static fn ($propertyName) => strtoupper($propertyName))
         ;
 
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory, $fallback);
@@ -69,9 +68,9 @@ final class MetadataAwareNameConverterTest extends TestCase
     /**
      * @dataProvider attributeProvider
      */
-    public function testDenormalize($expected, $propertyName)
+    public function testDenormalize(string|int $expected, string|int $propertyName)
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
 
@@ -81,14 +80,14 @@ final class MetadataAwareNameConverterTest extends TestCase
     /**
      * @dataProvider fallbackAttributeProvider
      */
-    public function testDenormalizeWithFallback($expected, $propertyName)
+    public function testDenormalizeWithFallback(string|int $expected, string|int $propertyName)
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $fallback = $this->createMock(NameConverterInterface::class);
         $fallback
             ->method('denormalize')
-            ->willReturnCallback(fn ($propertyName) => strtolower($propertyName))
+            ->willReturnCallback(static fn ($propertyName) => strtolower($propertyName))
         ;
 
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory, $fallback);
@@ -119,9 +118,9 @@ final class MetadataAwareNameConverterTest extends TestCase
     /**
      * @dataProvider attributeAndContextProvider
      */
-    public function testNormalizeWithGroups($propertyName, $expected, $context = [])
+    public function testNormalizeWithGroups(string $propertyName, string $expected, array $context = [])
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
 
@@ -131,16 +130,16 @@ final class MetadataAwareNameConverterTest extends TestCase
     /**
      * @dataProvider attributeAndContextProvider
      */
-    public function testDenormalizeWithGroups($expected, $propertyName, $context = [])
+    public function testDenormalizeWithGroups(string $expected, string $propertyName, array $context = [])
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
 
         $this->assertEquals($expected, $nameConverter->denormalize($propertyName, OtherSerializedNameDummy::class, null, $context));
     }
 
-    public static function attributeAndContextProvider()
+    public static function attributeAndContextProvider(): array
     {
         return [
             ['buz', 'buz', ['groups' => ['a']]],
@@ -154,7 +153,7 @@ final class MetadataAwareNameConverterTest extends TestCase
 
     public function testDenormalizeWithCacheContext()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
 
@@ -165,7 +164,7 @@ final class MetadataAwareNameConverterTest extends TestCase
 
     public function testDenormalizeWithNestedPathAndName()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Found SerializedName and SerializedPath annotations on property "foo" of class "Symfony\Component\Serializer\Tests\NameConverter\NestedPathAndName".');
@@ -174,7 +173,7 @@ final class MetadataAwareNameConverterTest extends TestCase
 
     public function testNormalizeWithNestedPathAndName()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Found SerializedName and SerializedPath annotations on property "foo" of class "Symfony\Component\Serializer\Tests\NameConverter\NestedPathAndName".');
@@ -184,10 +183,6 @@ final class MetadataAwareNameConverterTest extends TestCase
 
 class NestedPathAndName
 {
-    /**
-     * @SerializedName("five")
-     *
-     * @SerializedPath("[one][two][three]")
-     */
+    #[SerializedName('five'), SerializedPath('[one][two][three]')]
     public $foo;
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractNormalizerDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableConstructorArgumentDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableOptionalConstructorArgumentDummy;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
@@ -42,9 +41,9 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummySecondChildQuux;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectDummyWithContextAttribute;
@@ -76,7 +75,7 @@ class AbstractObjectNormalizerTest extends TestCase
     {
         $this->expectException(ExtraAttributesException::class);
         $this->expectExceptionMessage('Extra attributes are not allowed ("fooFoo" is unknown).');
-        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $factory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new AbstractObjectNormalizerDummy($factory);
         $normalizer->denormalize(
             ['fooFoo' => 'foo'],
@@ -90,7 +89,7 @@ class AbstractObjectNormalizerTest extends TestCase
     {
         $this->expectException(ExtraAttributesException::class);
         $this->expectExceptionMessage('Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).');
-        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $factory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new AbstractObjectNormalizerDummy($factory);
         $normalizer->denormalize(
             ['fooFoo' => 'foo', 'fooBar' => 'bar'],
@@ -228,7 +227,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar = new AlreadyPopulatedNestedDummy();
         $foobar->foo = 'foo';
         $foobar->bar = 'bar';
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
         $normalizer->normalize($foobar, 'any');
     }
@@ -240,7 +239,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar = new DuplicateValueNestedDummy();
         $foobar->foo = 'foo';
         $foobar->bar = 'bar';
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
         $normalizer->normalize($foobar, 'any');
     }
@@ -262,7 +261,7 @@ class AbstractObjectNormalizerTest extends TestCase
             'foo' => 'notfoo',
             'baz' => 'baz',
         ];
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
         $test = $normalizer->normalize($foobar, 'any');
         $this->assertSame($data, $test);
@@ -288,7 +287,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testNormalizeWithNestedAttributesInConstructor()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
 
         $test = $normalizer->normalize(new NestedDummyWithConstructor('foo', 'quux', 'notfoo', 'baz'), 'any');
@@ -306,7 +305,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testNormalizeWithNestedAttributesInConstructorAndDiscriminatorMap()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
 
         $test1 = $normalizer->normalize(new FirstNestedDummyWithConstructorAndDiscriminator('foo', 'notfoo', 'baz'), 'any');
@@ -449,7 +448,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeWithDiscriminatorMapUsesCorrectClassname()
     {
-        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $factory = new ClassMetadataFactory(new AnnotationLoader());
 
         $loaderMock = new class() implements ClassMetadataFactoryInterface {
             public function getMetadataFor($value): ClassMetadataInterface
@@ -484,7 +483,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeWithDiscriminatorMapAndObjectToPopulateUsesCorrectClassname()
     {
-        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $factory = new ClassMetadataFactory(new AnnotationLoader());
 
         $loaderMock = new class() implements ClassMetadataFactoryInterface {
             public function getMetadataFor($value): ClassMetadataInterface
@@ -683,7 +682,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeUsesContextAttributeForPropertiesInConstructorWithSeralizedName()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory), null, $extractor);
@@ -697,7 +696,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testNormalizeUsesContextAttributeForPropertiesInConstructorWithSerializedPath()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory), null, $extractor);
@@ -712,7 +711,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testNormalizeUsesContextAttributeForProperties()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory), null, $extractor);
@@ -792,27 +791,19 @@ class EmptyDummy
 
 class AlreadyPopulatedNestedDummy
 {
-    /**
-     * @SerializedPath("[one][two][three]")
-     */
+    #[SerializedPath('[one][two][three]')]
     public $foo;
 
-    /**
-     * @SerializedPath("[one][two]")
-     */
+    #[SerializedPath('[one][two]')]
     public $bar;
 }
 
 class DuplicateValueNestedDummy
 {
-    /**
-     * @SerializedPath("[one][two][three]")
-     */
+    #[SerializedPath('[one][two][three]')]
     public $foo;
 
-    /**
-     * @SerializedPath("[one][two][three]")
-     */
+    #[SerializedPath('[one][two][three]')]
     public $bar;
 
     public $baz;
@@ -820,19 +811,13 @@ class DuplicateValueNestedDummy
 
 class NestedDummy
 {
-    /**
-     * @SerializedPath("[one][two][three]")
-     */
+    #[SerializedPath('[one][two][three]')]
     public $foo;
 
-    /**
-     * @SerializedPath("[one][four]")
-     */
+    #[SerializedPath('[one][four]')]
     public $quux;
 
-    /**
-     * @SerializedPath("[foo]")
-     */
+    #[SerializedPath('[foo]')]
     public $notfoo;
 
     public $baz;
@@ -841,19 +826,13 @@ class NestedDummy
 class NestedDummyWithConstructor
 {
     public function __construct(
-        /**
-         * @SerializedPath("[one][two][three]")
-         */
+        #[SerializedPath('[one][two][three]')]
         public $foo,
 
-        /**
-         * @SerializedPath("[one][four]")
-         */
+        #[SerializedPath('[one][four]')]
         public $quux,
 
-        /**
-         * @SerializedPath("[foo]")
-         */
+        #[SerializedPath('[foo]')]
         public $notfoo,
 
         public $baz,
@@ -861,18 +840,14 @@ class NestedDummyWithConstructor
     }
 }
 
-/**
- * @DiscriminatorMap(typeProperty="type", mapping={
- *     "first" = FirstNestedDummyWithConstructorAndDiscriminator::class,
- *     "second" = SecondNestedDummyWithConstructorAndDiscriminator::class,
- * })
- */
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'first' => FirstNestedDummyWithConstructorAndDiscriminator::class,
+    'second' => SecondNestedDummyWithConstructorAndDiscriminator::class,
+])]
 abstract class AbstractNestedDummyWithConstructorAndDiscriminator
 {
     public function __construct(
-        /**
-         * @SerializedPath("[foo]")
-         */
+        #[SerializedPath('[foo]')]
         public $notfoo,
 
         public $baz,
@@ -883,9 +858,7 @@ abstract class AbstractNestedDummyWithConstructorAndDiscriminator
 class FirstNestedDummyWithConstructorAndDiscriminator extends AbstractNestedDummyWithConstructorAndDiscriminator
 {
     public function __construct(
-        /**
-         * @SerializedPath("[one][two][three]")
-         */
+        #[SerializedPath('[one][two][three]')]
         public $foo,
 
         $notfoo,
@@ -898,9 +871,7 @@ class FirstNestedDummyWithConstructorAndDiscriminator extends AbstractNestedDumm
 class SecondNestedDummyWithConstructorAndDiscriminator extends AbstractNestedDummyWithConstructorAndDiscriminator
 {
     public function __construct(
-        /**
-         * @SerializedPath("[one][four]")
-         */
+        #[SerializedPath('[one][four]')]
         public $quux,
 
         $notfoo,
@@ -912,14 +883,10 @@ class SecondNestedDummyWithConstructorAndDiscriminator extends AbstractNestedDum
 
 class DuplicateKeyNestedDummy
 {
-    /**
-     * @SerializedPath("[one][four]")
-     */
+    #[SerializedPath('[one][four]')]
     public $quux;
 
-    /**
-     * @SerializedName("quux")
-     */
+    #[SerializedName('quux')]
     public $notquux;
 }
 
@@ -946,7 +913,7 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
 {
     public function __construct()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         parent::__construct($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
     }
 
@@ -1110,10 +1077,7 @@ class AbstractObjectNormalizerCollectionDummy extends AbstractObjectNormalizer
 
 class ArrayDenormalizerDummy implements DenormalizerInterface, SerializerAwareInterface
 {
-    /**
-     * @var SerializerInterface|DenormalizerInterface
-     */
-    private $serializer;
+    private SerializerInterface&DenormalizerInterface $serializer;
 
     /**
      * @throws NotNormalizableValueException
@@ -1143,6 +1107,7 @@ class ArrayDenormalizerDummy implements DenormalizerInterface, SerializerAwareIn
 
     public function setSerializer(SerializerInterface $serializer): void
     {
+        \assert($serializer instanceof DenormalizerInterface);
         $this->serializer = $serializer;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Annotation\Context;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -34,7 +33,7 @@ trait ContextMetadataTestTrait
      */
     public function testContextMetadataNormalize(string $contextMetadataDummyClass)
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, null, null, new PhpDocExtractor());
         new Serializer([new DateTimeNormalizer(), $normalizer]);
 
@@ -57,7 +56,7 @@ trait ContextMetadataTestTrait
      */
     public function testContextMetadataContextDenormalize(string $contextMetadataDummyClass)
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, null, null, new PhpDocExtractor());
         new Serializer([new DateTimeNormalizer(), $normalizer]);
 
@@ -78,7 +77,7 @@ trait ContextMetadataTestTrait
         self::assertEquals('2011-07-28', $dummy->date->format('Y-m-d'), 'a specific denormalization context is used for this group');
     }
 
-    public function contextMetadataDummyProvider()
+    public function contextMetadataDummyProvider(): array
     {
         return [
             [ContextMetadataDummy::class],
@@ -88,7 +87,7 @@ trait ContextMetadataTestTrait
 
     public function testContextDenormalizeWithNameConverter()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter(), null, new PhpDocExtractor());
         new Serializer([new DateTimeNormalizer(), $normalizer]);
 
@@ -102,19 +101,17 @@ class ContextMetadataDummy
 {
     /**
      * @var \DateTime
-     *
-     * @Groups({ "extended", "simple" })
-     *
-     * @Context({ DateTimeNormalizer::FORMAT_KEY = \DateTimeInterface::RFC3339 })
-     * @Context(
-     *     normalizationContext = { DateTimeNormalizer::FORMAT_KEY = \DateTimeInterface::RFC3339_EXTENDED },
-     *     groups = {"extended"}
-     * )
-     * @Context(
-     *     denormalizationContext = { DateTimeNormalizer::FORMAT_KEY = "d/m/Y" },
-     *     groups = {"simple"}
-     * )
      */
+    #[Groups(['extended', 'simple'])]
+    #[Context([DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::RFC3339])]
+    #[Context(
+        normalizationContext: [DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::RFC3339_EXTENDED],
+        groups: ['extended'],
+    )]
+    #[Context(
+        denormalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'd/m/Y'],
+        groups: ['simple'],
+    )]
     public $date;
 }
 
@@ -122,19 +119,17 @@ class ContextChildMetadataDummy
 {
     /**
      * @var \DateTime
-     *
-     * @Groups({ "extended", "simple" })
-     *
-     * @DummyContextChild({ DateTimeNormalizer::FORMAT_KEY = \DateTimeInterface::RFC3339 })
-     * @DummyContextChild(
-     *     normalizationContext = { DateTimeNormalizer::FORMAT_KEY = \DateTimeInterface::RFC3339_EXTENDED },
-     *     groups = {"extended"}
-     * )
-     * @DummyContextChild(
-     *     denormalizationContext = { DateTimeNormalizer::FORMAT_KEY = "d/m/Y" },
-     *     groups = {"simple"}
-     * )
      */
+    #[Groups(['extended', 'simple'])]
+    #[Context([DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::RFC3339])]
+    #[Context(
+        normalizationContext: [DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::RFC3339_EXTENDED],
+        groups: ['extended'],
+    )]
+    #[Context(
+        denormalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'd/m/Y'],
+        groups: ['simple'],
+    )]
     public $date;
 }
 
@@ -142,8 +137,7 @@ class ContextMetadataNamingDummy
 {
     /**
      * @var \DateTime
-     *
-     * @Context({ DateTimeNormalizer::FORMAT_KEY = "d/m/Y" })
      */
+    #[Context([DateTimeNormalizer::FORMAT_KEY => 'd/m/Y'])]
     public $createdAt;
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/GroupsTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/GroupsTestTrait.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 
 /**
  * Test AbstractNormalizer::GROUPS.

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/MaxDepthTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/MaxDepthTestTrait.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy;
 
 /**
  * Covers AbstractObjectNormalizer::ENABLE_MAX_DEPTH and AbstractObjectNormalizer::MAX_DEPTH_HANDLER.

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/TypedPropertiesObject.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/TypedPropertiesObject.php
@@ -15,18 +15,12 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 class TypedPropertiesObject
 {
-    /**
-     * @Groups({"foo"})
-     */
+    #[Groups(['foo'])]
     public string $unInitialized;
 
-    /**
-     * @Groups({"foo"})
-     */
+    #[Groups(['foo'])]
     public string $initialized = 'value';
 
-    /**
-     * @Groups({"bar"})
-     */
+    #[Groups(['bar'])]
     public string $initialized2 = 'value';
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
@@ -28,8 +28,8 @@ use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\ClassWithIgnoreAttribute;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CacheableObjectAttributesTestTrait;
@@ -57,21 +57,15 @@ class GetSetMethodNormalizerTest extends TestCase
     use SkipUninitializedValuesTestTrait;
     use TypeEnforcementTestTrait;
 
-    /**
-     * @var GetSetMethodNormalizer
-     */
-    private $normalizer;
-    /**
-     * @var SerializerInterface
-     */
-    private $serializer;
+    private GetSetMethodNormalizer $normalizer;
+    private SerializerInterface&NormalizerInterface&MockObject $serializer;
 
     protected function setUp(): void
     {
         $this->createNormalizer();
     }
 
-    private function createNormalizer(array $defaultContext = [])
+    private function createNormalizer(array $defaultContext = []): void
     {
         $this->serializer = $this->createMock(SerializerNormalizer::class);
         $this->normalizer = new GetSetMethodNormalizer(null, null, null, null, null, $defaultContext);
@@ -233,21 +227,21 @@ class GetSetMethodNormalizerTest extends TestCase
 
     protected function getNormalizerForCallbacksWithPropertyTypeExtractor(): GetSetMethodNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new GetSetMethodNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory), $this->getCallbackPropertyTypeExtractor());
     }
 
     protected function getNormalizerForCallbacks(): GetSetMethodNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new GetSetMethodNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
     }
 
     protected function getNormalizerForCircularReference(array $defaultContext): GetSetMethodNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new GetSetMethodNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory), null, null, null, $defaultContext);
         new Serializer([$normalizer]);
 
@@ -261,7 +255,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     protected function getDenormalizerForConstructArguments(): GetSetMethodNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $denormalizer = new GetSetMethodNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
         new Serializer([$denormalizer]);
 
@@ -270,21 +264,21 @@ class GetSetMethodNormalizerTest extends TestCase
 
     protected function getNormalizerForGroups(): GetSetMethodNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new GetSetMethodNormalizer($classMetadataFactory);
     }
 
     protected function getDenormalizerForGroups(): GetSetMethodNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new GetSetMethodNormalizer($classMetadataFactory);
     }
 
     public function testGroupsNormalizeWithNameConverter()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
@@ -305,7 +299,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testGroupsDenormalizeWithNameConverter()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
@@ -320,13 +314,13 @@ class GetSetMethodNormalizerTest extends TestCase
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
                 'coop_tilleuls' => 'les-tilleuls.coop',
-            ], 'Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy', null, [GetSetMethodNormalizer::GROUPS => ['name_converter']])
+            ], GroupDummy::class, null, [GetSetMethodNormalizer::GROUPS => ['name_converter']])
         );
     }
 
     protected function getNormalizerForMaxDepth(): NormalizerInterface
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new GetSetMethodNormalizer($classMetadataFactory);
         $serializer = new Serializer([$normalizer]);
         $normalizer->setSerializer($serializer);
@@ -336,7 +330,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     protected function getDenormalizerForObjectToPopulate(): DenormalizerInterface
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new GetSetMethodNormalizer($classMetadataFactory, null, new PhpDocExtractor());
         new Serializer([$normalizer]);
 
@@ -360,7 +354,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     protected function getNormalizerForIgnoredAttributes(): GetSetMethodNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new GetSetMethodNormalizer($classMetadataFactory, null, new PhpDocExtractor());
         new Serializer([$normalizer]);
 
@@ -369,7 +363,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     protected function getDenormalizerForIgnoredAttributes(): GetSetMethodNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new GetSetMethodNormalizer($classMetadataFactory, null, new PhpDocExtractor());
         new Serializer([$normalizer]);
 
@@ -493,7 +487,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     protected function getNormalizerForSkipUninitializedValues(): NormalizerInterface
     {
-        return new GetSetMethodNormalizer(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())));
+        return new GetSetMethodNormalizer(new ClassMetadataFactory(new AnnotationLoader()));
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/MapDenormalizationTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/MapDenormalizationTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
@@ -210,7 +209,7 @@ class MapDenormalizationTest extends TestCase
             }
         };
 
-        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $factory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($factory, null, null, new PhpDocExtractor(), new ClassDiscriminatorFromClassMetadata($loaderMock));
         $serializer = new Serializer([$normalizer, new ArrayDenormalizer()]);
         $normalizer->setSerializer($serializer);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyPrivatePropertyWithoutGetter;
 use Symfony\Component\Serializer\Tests\Fixtures\FormatAndContextAwareNormalizer;
@@ -79,21 +79,15 @@ class ObjectNormalizerTest extends TestCase
     use SkipUninitializedValuesTestTrait;
     use TypeEnforcementTestTrait;
 
-    /**
-     * @var ObjectNormalizer
-     */
-    private $normalizer;
-    /**
-     * @var SerializerInterface
-     */
-    private $serializer;
+    private ObjectNormalizer $normalizer;
+    private SerializerInterface&NormalizerInterface&MockObject $serializer;
 
     protected function setUp(): void
     {
         $this->createNormalizer();
     }
 
-    private function createNormalizer(array $defaultContext = [], ClassMetadataFactoryInterface $classMetadataFactory = null)
+    private function createNormalizer(array $defaultContext = [], ClassMetadataFactoryInterface $classMetadataFactory = null): void
     {
         $this->serializer = $this->createMock(ObjectSerializerNormalizer::class);
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, null, null, null, null, null, $defaultContext);
@@ -342,7 +336,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getDenormalizerForAttributes(): ObjectNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, null, null, new ReflectionExtractor());
         new Serializer([$normalizer]);
 
@@ -368,7 +362,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeSameObjectWithDifferentAttributes()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->normalizer = new ObjectNormalizer($classMetadataFactory);
         $serializer = new Serializer([$this->normalizer]);
         $this->normalizer->setSerializer($serializer);
@@ -443,7 +437,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getDenormalizerForConstructArguments(): ObjectNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $denormalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
         $serializer = new Serializer([$denormalizer]);
         $denormalizer->setSerializer($serializer);
@@ -455,7 +449,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getNormalizerForGroups(): ObjectNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory);
         // instantiate a serializer with the normalizer to handle normalizing recursive structures
         new Serializer([$normalizer]);
@@ -465,14 +459,14 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getDenormalizerForGroups(): ObjectNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new ObjectNormalizer($classMetadataFactory);
     }
 
     public function testGroupsNormalizeWithNameConverter()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
@@ -493,7 +487,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testGroupsDenormalizeWithNameConverter()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
@@ -508,13 +502,13 @@ class ObjectNormalizerTest extends TestCase
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
                 'coop_tilleuls' => 'les-tilleuls.coop',
-            ], 'Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy', null, [ObjectNormalizer::GROUPS => ['name_converter']])
+            ], GroupDummy::class, null, [ObjectNormalizer::GROUPS => ['name_converter']])
         );
     }
 
     public function testGroupsDenormalizeWithMetaDataNameConverter()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
         $this->normalizer->setSerializer($this->serializer);
 
@@ -542,7 +536,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getDenormalizerForIgnoredAttributes(): ObjectNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, null, null, new ReflectionExtractor());
         new Serializer([$normalizer]);
 
@@ -553,7 +547,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getNormalizerForMaxDepth(): ObjectNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory);
         $serializer = new Serializer([$normalizer]);
         $normalizer->setSerializer($serializer);
@@ -565,7 +559,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getDenormalizerForObjectToPopulate(): ObjectNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new ObjectNormalizer($classMetadataFactory, null, null, new PhpDocExtractor());
         new Serializer([$normalizer]);
 
@@ -583,7 +577,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getNormalizerForSkipUninitializedValues(): ObjectNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new ObjectNormalizer($classMetadataFactory);
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
@@ -28,8 +27,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummyChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummyChild;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\PropertyCircularReferenceDummy;
@@ -59,22 +58,15 @@ class PropertyNormalizerTest extends TestCase
     use SkipUninitializedValuesTestTrait;
     use TypeEnforcementTestTrait;
 
-    /**
-     * @var PropertyNormalizer
-     */
-    private $normalizer;
-
-    /**
-     * @var SerializerInterface
-     */
-    private $serializer;
+    private PropertyNormalizer $normalizer;
+    private SerializerInterface $serializer;
 
     protected function setUp(): void
     {
         $this->createNormalizer();
     }
 
-    private function createNormalizer(array $defaultContext = [])
+    private function createNormalizer(array $defaultContext = []): void
     {
         $this->serializer = $this->createMock(SerializerInterface::class);
         $this->normalizer = new PropertyNormalizer(null, null, null, null, null, $defaultContext);
@@ -272,7 +264,7 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getDenormalizerForConstructArguments(): PropertyNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $denormalizer = new PropertyNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
         $serializer = new Serializer([$denormalizer]);
         $denormalizer->setSerializer($serializer);
@@ -282,21 +274,21 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getNormalizerForGroups(): PropertyNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new PropertyNormalizer($classMetadataFactory);
     }
 
     protected function getDenormalizerForGroups(): PropertyNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new PropertyNormalizer($classMetadataFactory);
     }
 
     public function testGroupsNormalizeWithNameConverter()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->normalizer = new PropertyNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
@@ -317,7 +309,7 @@ class PropertyNormalizerTest extends TestCase
 
     public function testGroupsDenormalizeWithNameConverter()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $this->normalizer = new PropertyNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
@@ -332,7 +324,7 @@ class PropertyNormalizerTest extends TestCase
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
                 'coop_tilleuls' => 'les-tilleuls.coop',
-            ], 'Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy', null, [PropertyNormalizer::GROUPS => ['name_converter']])
+            ], GroupDummy::class, null, [PropertyNormalizer::GROUPS => ['name_converter']])
         );
     }
 
@@ -361,7 +353,7 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getNormalizerForMaxDepth(): PropertyNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new PropertyNormalizer($classMetadataFactory);
         $serializer = new Serializer([$normalizer]);
         $normalizer->setSerializer($serializer);
@@ -371,7 +363,7 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getDenormalizerForObjectToPopulate(): PropertyNormalizer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $normalizer = new PropertyNormalizer($classMetadataFactory, null, new PhpDocExtractor());
         new Serializer([$normalizer]);
 
@@ -500,7 +492,7 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getNormalizerForSkipUninitializedValues(): NormalizerInterface
     {
-        return new PropertyNormalizer(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())));
+        return new PropertyNormalizer(new ClassMetadataFactory(new AnnotationLoader()));
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
@@ -47,9 +46,9 @@ use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Normalizer\UidNormalizer;
 use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
 use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild;
-use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild;
 use Symfony\Component\Serializer\Tests\Fixtures\DenormalizableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
@@ -720,7 +719,7 @@ class SerializerTest extends TestCase
 
     public function testUnionTypeDeserializable()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $serializer = new Serializer(
             [
@@ -752,7 +751,7 @@ class SerializerTest extends TestCase
 
     public function testUnionTypeDeserializableWithoutAllowedExtraAttributes()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $serializer = new Serializer(
             [
@@ -813,7 +812,7 @@ class SerializerTest extends TestCase
 
     private function serializerWithClassDiscriminator()
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader());
 
         return new Serializer([new ObjectNormalizer($classMetadataFactory, null, null, new ReflectionExtractor(), new ClassDiscriminatorFromClassMetadata($classMetadataFactory))], ['json' => new JsonEncoder()]);
     }
@@ -1279,11 +1278,11 @@ class SerializerTest extends TestCase
         }
     }
 
-    public static function provideCollectDenormalizationErrors()
+    public static function provideCollectDenormalizationErrors(): array
     {
         return [
             [null],
-            [new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()))],
+            [new ClassMetadataFactory(new AnnotationLoader())],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Follows #50888
| License       | MIT
| Doc PR        | symfony/symfony-docs#18589

This PR deprecates using Doctrine annotations to configure serialization. Attributes shall be used instead.

Existing applications can be migrated easily using [Rector](https://getrector.com/blog/how-to-upgrade-annotations-to-attributes).

Deprecation errors triggered by the bundles' functional tests will be resolved once https://github.com/symfony/symfony/pull/50888 is merged.