### PR TITLE
[HttpKernel] Customise error code on validation error occurred in #[MapRequestPayload]

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add native return type to `Translator` and to `Application::reset()`
+ * Allow customizing HTTP status code on validation error occurred in `#[MapRequestPayload]`
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -139,6 +139,15 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('error_controller')
                 ->end()
                 ->booleanNode('handle_all_throwables')->info('HttpKernel will handle all kinds of \Throwable')->end()
+                ->arrayNode('map_request_payload')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('status_code_on_error')
+                            ->info('HTTP status code to be returned on error occurred while parsing the request payload.')
+                            ->defaultNull()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -280,6 +280,7 @@ class FrameworkExtension extends Extension
         $container->getDefinition('locale_listener')->replaceArgument(3, $config['set_locale_from_accept_language']);
         $container->getDefinition('response_listener')->replaceArgument(1, $config['set_content_language_from_locale']);
         $container->getDefinition('http_kernel')->replaceArgument(4, $config['handle_all_throwables'] ?? false);
+        $container->getDefinition('argument_resolver.request_payload')->replaceArgument(3, $config['map_request_payload']['status_code_on_error']);
 
         // If the slugger is used but the String component is not available, we should throw an error
         if (!ContainerBuilder::willBeAvailable('symfony/string', SluggerInterface::class, ['symfony/framework-bundle'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -68,6 +68,7 @@ return static function (ContainerConfigurator $container) {
                 service('serializer'),
                 service('validator')->nullOnInvalid(),
                 service('translator')->nullOnInvalid(),
+                abstract_arg('The "map_request_payload.status_code_on_error" config value'),
             ])
             ->tag('controller.targeted_value_resolver', ['name' => RequestPayloadValueResolver::class])
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -739,6 +739,9 @@ class ConfigurationTest extends TestCase
             'remote-event' => [
                 'enabled' => false,
             ],
+            'map_request_payload' => [
+                'status_code_on_error' => null,
+            ],
         ];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
@@ -349,6 +349,24 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 422,
         ];
     }
+
+    public function testMapRequestPayloadError400()
+    {
+        $client = self::createClient(['test_case' => 'ApiAttributesTest']);
+
+        $client->request(
+            'POST',
+            '/map-request-body-error-400',
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/json', 'CONTENT_TYPE' => 'application/json'],
+            json_encode([]),
+        );
+
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
 }
 
 class WithMapQueryStringController
@@ -385,6 +403,16 @@ class WithMapRequestPayloadController
             </response>
             XML
         );
+    }
+}
+
+class WithMapRequestPayloadError400Controller
+{
+    public function __invoke(
+        #[MapRequestPayload(statusCodeOnError: Response::HTTP_BAD_REQUEST)] ?RequestBody $body,
+        Request $request,
+    ): Response {
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/routing.yml
@@ -5,3 +5,7 @@ map_query_string:
 map_request_body:
     path: /map-request-body.{_format}
     controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapRequestPayloadController
+
+map_request_body_error_400:
+    path: /map-request-body-error-400
+    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapRequestPayloadError400Controller

--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
@@ -30,6 +30,7 @@ class MapRequestPayload extends ValueResolver
         public readonly array $serializationContext = [],
         public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
+        public readonly ?int $statusCodeOnError = null,
     ) {
         parent::__construct($resolver);
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -59,6 +59,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
         private readonly SerializerInterface&DenormalizerInterface $serializer,
         private readonly ?ValidatorInterface $validator = null,
         private readonly ?TranslatorInterface $translator = null,
+        private readonly ?int $statusCodeOnError = null,
     ) {
     }
 
@@ -91,7 +92,9 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 $validationFailedCode = Response::HTTP_NOT_FOUND;
             } elseif ($argument instanceof MapRequestPayload) {
                 $payloadMapper = 'mapRequestPayload';
-                $validationFailedCode = $argument->statusCodeOnError ?? Response::HTTP_UNPROCESSABLE_ENTITY;
+                $validationFailedCode = $argument->statusCodeOnError
+                    ?? $this->statusCodeOnError
+                    ?? Response::HTTP_UNPROCESSABLE_ENTITY;
             } else {
                 continue;
             }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -91,7 +91,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 $validationFailedCode = Response::HTTP_NOT_FOUND;
             } elseif ($argument instanceof MapRequestPayload) {
                 $payloadMapper = 'mapRequestPayload';
-                $validationFailedCode = Response::HTTP_UNPROCESSABLE_ENTITY;
+                $validationFailedCode = $argument->statusCodeOnError ?? Response::HTTP_UNPROCESSABLE_ENTITY;
             } else {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50992 
| License       | MIT
| Doc PR        | TBD

This pull request proposes to allow customising HTTP status code that will be returned from `#[MapRequestPayload]` value resolver.

Users can customise by two methods:

1. **Use the argument in the attribute**
   ```php
   #[MapRequestPayload(statusCodeOnError: Response::HTTP_BAD_REQUEST)]
   ```

2. **Use framework configuration for global**
   ```yaml
   framework:
       map_request_payload:
           status_code_on_error: 400
   ```
