### PR TITLE
[ErrorHandler][Runtime] Don't mess with ini_set('assert.warning')

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Debug.php
+++ b/src/Symfony/Component/ErrorHandler/Debug.php
@@ -31,7 +31,6 @@ class Debug
 
         @ini_set('zend.assertions', 1);
         ini_set('assert.active', 1);
-        ini_set('assert.warning', 0);
         ini_set('assert.exception', 1);
 
         DebugClassLoader::enable();

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -665,6 +665,7 @@ class ErrorHandlerTest extends TestCase
             $this->markTestSkipped('zend.assertions is forcibly disabled');
         }
 
+        set_error_handler(function () {});
         $ini = [
             ini_set('zend.assertions', 1),
             ini_set('assert.active', 1),
@@ -673,6 +674,7 @@ class ErrorHandlerTest extends TestCase
             ini_set('assert.callback', null),
             ini_set('assert.exception', 0),
         ];
+        restore_error_handler();
 
         $logger = new BufferingLogger();
         $handler = new ErrorHandler($logger);

--- a/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
+++ b/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
@@ -32,7 +32,6 @@ class BasicErrorHandler
         if (0 <= \ini_get('zend.assertions')) {
             ini_set('zend.assertions', 1);
             ini_set('assert.active', $debug);
-            ini_set('assert.warning', 0);
             ini_set('assert.exception', 1);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

From https://wiki.php.net/rfc/assert-string-eval-cleanup#assertwarning:

> As of PHP 7, this setting only has an effect if assert.exception is disabled