### PR TITLE
[Messenger] Deprecate `StopWorkerOnSignalsListener`

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -46,6 +46,11 @@ HttpKernel
  * `BundleInterface` no longer extends `ContainerAwareInterface`
  * Add native return types to `TraceableEventDispatcher` and to `MergeExtensionConfigurationPass`
 
+Messenger
+---------
+
+ * Deprecate `StopWorkerOnSignalsListener` in favor of using the `SignalableCommandInterface`
+
 MonologBridge
 -------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -202,6 +202,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('monolog.logger', ['channel' => 'messenger'])
 
         ->set('messenger.listener.stop_worker_signals_listener', StopWorkerOnSignalsListener::class)
+            ->deprecate('6.4', 'symfony/messenger', 'The "%service_id%" service is deprecated, use the "Symfony\Component\Console\Command\SignalableCommandInterface" instead.')
             ->args([
                 null,
                 service('logger')->ignoreOnInvalid(),
@@ -210,7 +211,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('monolog.logger', ['channel' => 'messenger'])
 
         ->alias('messenger.listener.stop_worker_on_sigterm_signal_listener', 'messenger.listener.stop_worker_signals_listener')
-            ->deprecate('6.3', 'symfony/messenger', 'The "%alias_id%" service is deprecated, use "messenger.listener.stop_worker_signals_listener" instead.')
+            ->deprecate('6.3', 'symfony/messenger', 'The "%alias_id%" service is deprecated, use the "Symfony\Component\Console\Command\SignalableCommandInterface" instead.')
 
         ->set('messenger.listener.stop_worker_on_stop_exception_listener', StopWorkerOnCustomStopExceptionListener::class)
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Deprecate `StopWorkerOnSignalsListener` in favor of using the `SignalableCommandInterface`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSignalsListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSignalsListener.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Messenger\EventListener;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 
 /**
  * @author Tobias Schultze <http://tobion.de>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @deprecated since Symfony 6.4, use the {@see SignalableCommandInterface} instead
  */
 class StopWorkerOnSignalsListener implements EventSubscriberInterface
 {

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
@@ -11,14 +11,15 @@
 
 namespace Symfony\Component\Messenger\EventListener;
 
-trigger_deprecation('symfony/messenger', '6.3', '"%s" is deprecated, use "%s" instead.', StopWorkerOnSigtermSignalListener::class, StopWorkerOnSignalsListener::class);
-
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
+
+trigger_deprecation('symfony/messenger', '6.3', '"%s" is deprecated, use the "%s" instead.', StopWorkerOnSigtermSignalListener::class, SignalableCommandInterface::class);
 
 /**
  * @author Tobias Schultze <http://tobion.de>
  *
- * @deprecated since Symfony 6.3, use the StopWorkerOnSignalsListener instead
+ * @deprecated since Symfony 6.3, use the {@see SignalableCommandInterface} instead
  */
 class StopWorkerOnSigtermSignalListener extends StopWorkerOnSignalsListener
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Followup to #50787.