### PR TITLE
[Messenger] Introduce `HandlerDescriptorInterface`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -24,6 +24,8 @@ use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTranspor
 use Symfony\Component\Messenger\EventListener\StopWorkerOnCustomStopExceptionListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnSignalsListener;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
@@ -46,6 +48,9 @@ use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 
 return static function (ContainerConfigurator $container) {
+    $container->parameters()
+        ->set('.messenger.handler_descriptor_class', HandlerDescriptor::class);
+
     $container->services()
         ->alias(SerializerInterface::class, 'messenger.default_serializer')
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Introduce `HandlerDescriptorInterface`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlerDescriptorInterface;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
@@ -63,6 +64,7 @@ class MessengerPass implements CompilerPassInterface
         $definitions = [];
         $handlersByBusAndMessage = [];
         $handlerToOriginalServiceIdMapping = [];
+        $handlerDescriptorClass = $container->getParameter('.messenger.handler_descriptor_class') ?? HandlerDescriptor::class;
 
         foreach ($container->findTaggedServiceIds('messenger.message_handler', true) as $serviceId => $tags) {
             foreach ($tags as $tag) {
@@ -164,7 +166,7 @@ class MessengerPass implements CompilerPassInterface
             foreach ($handlersByMessage as $message => $handlers) {
                 $handlerDescriptors = [];
                 foreach ($handlers as $handler) {
-                    $definitions[$definitionId = '.messenger.handler_descriptor.'.ContainerBuilder::hash($bus.':'.$message.':'.$handler[0])] = (new Definition(HandlerDescriptor::class))->setArguments([new Reference($handler[0]), $handler[1]]);
+                    $definitions[$definitionId = '.messenger.handler_descriptor.'.ContainerBuilder::hash($bus.':'.$message.':'.$handler[0])] = (new Definition($handlerDescriptorClass))->setArguments([new Reference($handler[0]), $handler[1]]);
                     $handlerDescriptors[] = new Reference($definitionId);
                 }
 

--- a/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
@@ -12,11 +12,9 @@
 namespace Symfony\Component\Messenger\Handler;
 
 /**
- * Describes a handler and the possible associated options, such as `from_transport`, `bus`, etc.
- *
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-final class HandlerDescriptor
+final class HandlerDescriptor implements HandlerDescriptorInterface
 {
     private \Closure $handler;
     private string $name;

--- a/src/Symfony/Component/Messenger/Handler/HandlerDescriptorInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlerDescriptorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Handler;
+
+/**
+ * Describes a handler and the possible associated options, such as `from_transport`, `bus`, etc.
+ *
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ * @author Ruud Kamphuis <ruud@ticketswap.com>
+ */
+interface HandlerDescriptorInterface
+{
+    public function getHandler() : callable;
+
+    public function getName() : string;
+
+    public function getBatchHandler() : ?BatchHandlerInterface;
+
+    public function getOption(string $option) : mixed;
+}

--- a/src/Symfony/Component/Messenger/Handler/HandlersLocatorInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlersLocatorInterface.php
@@ -23,7 +23,7 @@ interface HandlersLocatorInterface
     /**
      * Returns the handlers for the given message name.
      *
-     * @return iterable<int, HandlerDescriptor>
+     * @return iterable<int, HandlerDescriptorInterface>
      */
     public function getHandlers(Envelope $envelope): iterable;
 }

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\Handler\Acknowledger;
-use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlerDescriptorInterface;
 use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
 use Symfony\Component\Messenger\Stamp\AckStamp;
 use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
@@ -132,7 +132,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
         return $stack->next()->handle($envelope, $stack);
     }
 
-    private function messageHasAlreadyBeenHandled(Envelope $envelope, HandlerDescriptor $handlerDescriptor): bool
+    private function messageHasAlreadyBeenHandled(Envelope $envelope, HandlerDescriptorInterface $handlerDescriptor): bool
     {
         /** @var HandledStamp $stamp */
         foreach ($envelope->all(HandledStamp::class) as $stamp) {

--- a/src/Symfony/Component/Messenger/Stamp/HandledStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/HandledStamp.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
-use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlerDescriptorInterface;
 
 /**
  * Stamp identifying a message handled by the `HandleMessageMiddleware` middleware
@@ -36,7 +36,7 @@ final class HandledStamp implements StampInterface
         $this->handlerName = $handlerName;
     }
 
-    public static function fromDescriptor(HandlerDescriptor $handler, mixed $result): self
+    public static function fromDescriptor(HandlerDescriptorInterface $handler, mixed $result): self
     {
         return new self($result, $handler->getName());
     }

--- a/src/Symfony/Component/Messenger/Stamp/NoAutoAckStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/NoAutoAckStamp.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
-use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlerDescriptorInterface;
 
 /**
  * Marker telling that ack should not be done automatically for this message.
@@ -20,12 +20,12 @@ final class NoAutoAckStamp implements NonSendableStampInterface
 {
     private $handlerDescriptor;
 
-    public function __construct(HandlerDescriptor $handlerDescriptor)
+    public function __construct(HandlerDescriptorInterface $handlerDescriptor)
     {
         $this->handlerDescriptor = $handlerDescriptor;
     }
 
-    public function getHandlerDescriptor(): HandlerDescriptor
+    public function getHandlerDescriptor(): HandlerDescriptorInterface
     {
         return $this->handlerDescriptor;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

The `HandlerDescriptor` class is final and therefore cannot be extended. To make this a bit more flexible we introduce the `HandlerDescriptorInterface` that is used everywhere.

It also introduces a `.messenger.handler_descriptor_class` parameter that's used in the MessengerPass. With this parameter it's possible to use a custom implementation of the `HandlersLocator`.

This is an alternative approach to https://github.com/symfony/symfony/pull/50980. That PR also describes reasonings for this. 