### PR TITLE
[Serializer] Handle type error constructing input

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -425,6 +425,28 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                     throw $e;
                 }
 
+                $message = $e->getMessage();
+
+                if (preg_match('/#\d+ \(\$([^)]+)\) must be of type ([^,]+), ([^,]+) given/', $message, $match)) {
+                    $message = sprintf(
+                        'The type of the "%s" parameter for class "%s" must be of type "%s" ("%s" given).',
+                        $match[1],
+                        $class,
+                        $match[2],
+                        $match[3],
+                    );
+                }
+
+                $exception = NotNormalizableValueException::createForUnexpectedDataType(
+                    $message,
+                    $data,
+                    [$class],
+                    $context['deserialization_path'] ?? null,
+                    true,
+                    previous: $e,
+                );
+                $context['not_normalizable_value_exceptions'][] = $exception;
+
                 return $reflectionClass->newInstanceWithoutConstructor();
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1021,6 +1021,15 @@ class SerializerTest extends TestCase
                 'useMessageForUser' => false,
                 'message' => 'The type of the "something" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor" must be one of "float" ("string" given).',
             ],
+            [
+                'currentType' => 'array',
+                'expectedTypes' => [
+                    'Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor',
+                ],
+                'path' => 'php74FullWithTypedConstructor',
+                'useMessageForUser' => true,
+                'message' => 'The type of the "something" parameter for class "Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor" must be of type "float" ("string" given).',
+            ],
             $classMetadataFactory ?
                 [
                     'currentType' => 'null',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues? | Fix #50904
| License       | MIT

When mapping a input to an object, for instance with:
```php
public function myApiRoute(#[MapQueryString] MyInput $input)
{
}
```

And `MyInput` has an hard-type:
```php
class MyInput
{
    public function __construct(
        public readonly ?string $id = null,
    ) {
    }
}
```

Then you try to call this route with invalid type: `/api/endpoint?id[]=abc`

The construction of `MyInput` will fail with a `TypeError` `MyInput::__construct(): Argument #1 ($id) must be of type ?string, array given`.

But this is caught in `AbstractNormalizer` then you get a 500 error (unhandled) `Typed property MyInput::id must not be accessed before initialization`.

With this PR, I propose to handle it instead as a 400 error  (bad request) `The type of the "id" parameter for class "MyInput" must be of type "?string" ("array" given).`