### PR TITLE
[HttpKernel] Support backed enums in `#[MapQueryParameter]`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * Support backed enums in #[MapQueryParameter]
  * `BundleInterface` no longer extends `ContainerAwareInterface`
  * Add optional `$className` parameter to `ControllerEvent::getAttributes()`
  * Add native return types to `TraceableEventDispatcher` and to `MergeExtensionConfigurationPass`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50910
| License       | MIT
| Doc PR        | I think documentation about MapQueryParameter is missing

I had two options to introduce this feature. Extending `QueryParameterValueResolver` or extending `BackedEnumValueResolver`. Both options have it's prons and cons. Extending `QueryParameterValueResolver` is not consistent with DRY principle, but on the other hand does not mislead users about usage of `ValueResolverInterface` (`#[MapQueryParameter]`takes `resolver` argument but only `QueryParameterValueResolver` resolves value unless creating your own implementation of the interface).  I have chosen to extend  `QueryParameterValueResolver`. I think in the future separation of concerns should be introduced (resolving query params, resolving attributes etc.). For example by typing resolvers with new interface and using intersection types.


