### PR TITLE
[VarExporter] Fix exporting classes with __serialize() but not __unserialize()

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -73,20 +73,29 @@ class Exporter
 
             $class = \get_class($value);
             $reflector = Registry::$reflectors[$class] ?? Registry::getClassReflector($class);
+            $properties = [];
 
             if ($reflector->hasMethod('__serialize')) {
                 if (!$reflector->getMethod('__serialize')->isPublic()) {
                     throw new \Error(sprintf('Call to %s method "%s::__serialize()".', $reflector->getMethod('__serialize')->isProtected() ? 'protected' : 'private', $class));
                 }
 
-                if (!\is_array($properties = $value->__serialize())) {
+                if (!\is_array($serializeProperties = $value->__serialize())) {
                     throw new \TypeError($class.'::__serialize() must return an array');
+                }
+
+                if ($reflector->hasMethod('__unserialize')) {
+                    $properties = $serializeProperties;
+                } else {
+                    foreach ($serializeProperties as $n => $v) {
+                        $c = \PHP_VERSION_ID >= 80100 && $reflector->hasProperty($n) && ($p = $reflector->getProperty($n))->isReadOnly() ? $p->class : 'stdClass';
+                        $properties[$c][$n] = $v;
+                    }
                 }
 
                 goto prepare_value;
             }
 
-            $properties = [];
             $sleep = null;
             $proto = Registry::$prototypes[$class];
 

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/__serialize-but-no-__unserialize.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/__serialize-but-no-__unserialize.php
@@ -1,0 +1,17 @@
+<?php
+
+return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
+    $o = [
+        clone (\Symfony\Component\VarExporter\Internal\Registry::$prototypes['Symfony\\Component\\VarExporter\\Tests\\__SerializeButNo__Unserialize'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('Symfony\\Component\\VarExporter\\Tests\\__SerializeButNo__Unserialize')),
+    ],
+    null,
+    [
+        'stdClass' => [
+            'foo' => [
+                'ccc',
+            ],
+        ],
+    ],
+    $o[0],
+    []
+);

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -247,6 +247,8 @@ class VarExporterTest extends TestCase
 
         yield ['__unserialize-but-no-__serialize', new __UnserializeButNo__Serialize()];
 
+        yield ['__serialize-but-no-__unserialize', new __SerializeButNo__Unserialize()];
+
         if (\PHP_VERSION_ID < 80100) {
             return;
         }
@@ -468,5 +470,22 @@ class __UnserializeButNo__Serialize
     public function __unserialize(array $data): void
     {
         $this->foo = $data['foo'];
+    }
+}
+
+class __SerializeButNo__Unserialize
+{
+    public $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'ccc';
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'foo' => $this->foo,
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | https://github.com/symfony/symfony/issues/51010
| License       | MIT
| Doc PR        | -