### PR TITLE
[Uid] Mark Uuid::v5, Uuid::fromString, Uuid::toRfc4122 as pure

### DIFF
--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -42,6 +42,9 @@ class Uuid extends AbstractUid
         }
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function fromString(string $uuid): static
     {
         if (22 === \strlen($uuid) && 22 === strspn($uuid, BinaryUtil::BASE58[''])) {
@@ -107,6 +110,9 @@ class Uuid extends AbstractUid
         return new UuidV4();
     }
 
+    /**
+     * @psalm-pure
+     */
     final public static function v5(self $namespace, string $name): UuidV5
     {
         // don't use uuid_generate_sha1(), some versions are buggy
@@ -152,6 +158,9 @@ class Uuid extends AbstractUid
         return uuid_parse($this->uid);
     }
 
+    /**
+     * @psalm-pure
+     */
     public function toRfc4122(): string
     {
         return $this->uid;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51001
| License       | MIT
| Doc PR        | n/a

The Problem is described in #51001.

Make it compatible for Psalm users.
