### PR TITLE
[Validator] Fix constraints merge for protected and public properties

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -356,17 +356,16 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
                     $constraint->addImplicitGroupName($this->getDefaultGroup());
                 }
 
+                $this->addPropertyMetadata($member);
+
                 if ($member instanceof MemberMetadata && !$member->isPrivate($this->name)) {
                     $property = $member->getPropertyName();
-                    $this->members[$property] = [$member];
 
                     if ($member instanceof PropertyMetadata) {
                         $this->properties[$property] = $member;
                     } elseif ($member instanceof GetterMetadata) {
                         $this->getters[$property] = $member;
                     }
-                } else {
-                    $this->addPropertyMetadata($member);
                 }
             }
         }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Annotation/EntityParent.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Annotation/EntityParent.php
@@ -20,6 +20,8 @@ class EntityParent implements EntityInterfaceA
     private $internal;
     private $data = 'Data';
     private $child;
+    protected $address;
+    public $nickname;
 
     /**
      * @NotNull

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -249,6 +249,70 @@ class ClassMetadataTest extends TestCase
         $this->assertEquals($constraints, $members[1]->getConstraints());
     }
 
+    public function testMergeConstraintsKeepsProtectedMembersSeparate()
+    {
+        $this->metadata->addPropertyConstraint('address', new ConstraintA());
+
+        $parent = new ClassMetadata(self::PARENTCLASS);
+        $parent->addPropertyConstraint('address', new ConstraintB());
+
+        $this->metadata->mergeConstraints($parent);
+
+        $constraints = [
+            new ConstraintA(['groups' => [
+                'Default',
+                'Entity',
+            ]]),
+        ];
+        $parentConstraints = [
+            new ConstraintB(['groups' => [
+                'Default',
+                'EntityParent',
+                'Entity',
+            ]]),
+        ];
+
+        $members = $this->metadata->getPropertyMetadata('address');
+
+        $this->assertCount(2, $members);
+        $this->assertEquals(self::CLASSNAME, $members[0]->getClassName());
+        $this->assertEquals($constraints, $members[0]->getConstraints());
+        $this->assertEquals(self::PARENTCLASS, $members[1]->getClassName());
+        $this->assertEquals($parentConstraints, $members[1]->getConstraints());
+    }
+
+    public function testMergeConstraintsKeepsPublicMembersSeparate()
+    {
+        $this->metadata->addPropertyConstraint('nickname', new ConstraintA());
+
+        $parent = new ClassMetadata(self::PARENTCLASS);
+        $parent->addPropertyConstraint('nickname', new ConstraintB());
+
+        $this->metadata->mergeConstraints($parent);
+
+        $constraints = [
+            new ConstraintA(['groups' => [
+                'Default',
+                'Entity',
+            ]]),
+        ];
+        $parentConstraints = [
+            new ConstraintB(['groups' => [
+                'Default',
+                'EntityParent',
+                'Entity',
+            ]]),
+        ];
+
+        $members = $this->metadata->getPropertyMetadata('nickname');
+
+        $this->assertCount(2, $members);
+        $this->assertEquals(self::CLASSNAME, $members[0]->getClassName());
+        $this->assertEquals($constraints, $members[0]->getConstraints());
+        $this->assertEquals(self::PARENTCLASS, $members[1]->getClassName());
+        $this->assertEquals($parentConstraints, $members[1]->getConstraints());
+    }
+
     public function testGetReflectionClass()
     {
         $reflClass = new \ReflectionClass(self::CLASSNAME);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

There was backward compatibility break in https://github.com/symfony/validator/commit/81772c16452f67357c1a7afdbb6cc4f3985ae67b.

When you have a parent class with a public or protected property that has a constraint, and a child class that also has a constraint for the same property, you need to merge them rather than override them.
