### PR TITLE
[Messenger] Fix presenting "[OK] No failed messages were found."

### DIFF
--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -75,6 +76,8 @@ EOF
 
         if ($input->getOption('stats')) {
             $this->listMessagesPerClass($failureTransportName, $io, $input->getOption('max'));
+        } elseif ($input->getOption('max') === 0 && $receiver instanceof MessageCountAwareInterface && $receiver->getMessageCount() > 0) {
+            $io->comment('Nothing to present.');
         } elseif (null === $id = $input->getArgument('id')) {
             $this->listMessages($failureTransportName, $io, $input->getOption('max'), $input->getOption('class-filter'));
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

This improves DX - prevents from showing a message saying `[OK] No failed messages were found.` if they are but `--max=0`. Passing `--max=0` can be used to see the count of failed messages without deserializing and printing them.

<img width="452" alt="no-failed-messages-were-found" src="https://github.com/symfony/symfony/assets/3149753/18d159bd-cf0b-4292-bdbf-77e9304aac6a">
