### PR TITLE
[Intl] Fixed directory traversal in emoji compression tool

### DIFF
--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -84,7 +84,11 @@ jobs:
         run: |
           [ -f src/Symfony/Component/Intl/Resources/data/locales/en.php ]
           [ ! -f src/Symfony/Component/Intl/Resources/data/locales/en.php.gz ]
+          [ -f src/Symfony/Component/Intl/Resources/data/transliterator/emoji/emoji-en.php ]
+          [ ! -f src/Symfony/Component/Intl/Resources/data/transliterator/emoji/emoji-en.php.gz ]
           src/Symfony/Component/Intl/Resources/bin/compress
           [ ! -f src/Symfony/Component/Intl/Resources/data/locales/en.php ]
           [ -f src/Symfony/Component/Intl/Resources/data/locales/en.php.gz ]
+          [ ! -f src/Symfony/Component/Intl/Resources/data/transliterator/emoji/emoji-en.php ]
+          [ -f src/Symfony/Component/Intl/Resources/data/transliterator/emoji/emoji-en.php.gz ]
           ./phpunit src/Symfony/Component/Intl

--- a/src/Symfony/Component/Intl/Resources/bin/compress
+++ b/src/Symfony/Component/Intl/Resources/bin/compress
@@ -17,8 +17,15 @@ if (!extension_loaded('zlib')) {
     throw new Exception('This script requires the zlib extension.');
 }
 
-foreach (glob(dirname(__DIR__).'/data/*/*.php') as $file) {
-    if ('meta.php' === basename($file)) {
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator(
+        dirname(__DIR__).'/data',
+        FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::SKIP_DOTS
+    )
+);
+
+foreach ($iterator as $file) {
+    if ('php' !== $file->getExtension() || 'meta.php' === $file->getFilename()) {
         continue;
     }
 


### PR DESCRIPTION
When using the compression tool, the emoji data is not compressed properly due to directory traversal issues. It only goes one level deep in the `data' directory.

| Q             | A
| ------------- | ---
| Branch?       | 6.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #51029  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
