### PR TITLE
[Messenger] Batch delivery

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.1
 ---
 
+ * Add support to pull a batch of messages in one go (`batch_size` option)
  * Use `SKIP LOCKED` in the doctrine transport for MySQL, PostgreSQL and MSSQL
 
 5.1.0

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -46,9 +46,9 @@ class DoctrineIntegrationTest extends TestCase
     public function testConnectionSendAndGet()
     {
         $this->connection->send('{"message": "Hi"}', ['type' => DummyMessage::class]);
-        $encoded = $this->connection->get();
-        $this->assertEquals('{"message": "Hi"}', $encoded['body']);
-        $this->assertEquals(['type' => DummyMessage::class], $encoded['headers']);
+        $encodedList = $this->connection->get()[0];
+        $this->assertEquals('{"message": "Hi"}', $encodedList['body']);
+        $this->assertEquals(['type' => DummyMessage::class], $encodedList['headers']);
     }
 
     public function testSendWithDelay()
@@ -100,7 +100,7 @@ class DoctrineIntegrationTest extends TestCase
             'available_at' => $this->formatDateTime(new \DateTimeImmutable('2019-03-15 12:30:00', new \DateTimeZone('UTC'))),
         ]);
 
-        $encoded = $this->connection->get();
+        $encoded = $this->connection->get()[0];
         $this->assertEquals('{"message": "Hi available"}', $encoded['body']);
     }
 
@@ -165,7 +165,7 @@ class DoctrineIntegrationTest extends TestCase
             'available_at' => $this->formatDateTime(new \DateTimeImmutable('2019-03-15 12:30:00', new \DateTimeZone('UTC'))),
         ]);
 
-        $next = $this->connection->get();
+        $next = $this->connection->get()[0];
         $this->assertEquals('{"message": "Hi requeued"}', $next['body']);
         $this->connection->reject($next['id']);
     }
@@ -173,10 +173,12 @@ class DoctrineIntegrationTest extends TestCase
     public function testTheTransportIsSetupOnGet()
     {
         $this->assertFalse($this->driverConnection->createSchemaManager()->tablesExist(['messenger_messages']));
-        $this->assertNull($this->connection->get());
+        $result = $this->connection->get();
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
 
         $this->connection->send('the body', ['my' => 'header']);
-        $envelope = $this->connection->get();
+        $envelope = $this->connection->get()[0];
         $this->assertEquals('the body', $envelope['body']);
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlIntegrationTest.php
@@ -58,10 +58,10 @@ class DoctrinePostgreSqlIntegrationTest extends TestCase
     {
         $this->connection->send('{"message": "Hi"}', ['type' => DummyMessage::class]);
 
-        $encoded = $this->connection->get();
+        $encoded = $this->connection->get()[0];
         $this->assertEquals('{"message": "Hi"}', $encoded['body']);
         $this->assertEquals(['type' => DummyMessage::class], $encoded['headers']);
 
-        $this->assertNull($this->connection->get());
+        $this->assertEmpty($this->connection->get());
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
@@ -36,7 +36,7 @@ class DoctrineReceiverTest extends TestCase
 
         $doctrineEnvelope = $this->createDoctrineEnvelope();
         $connection = $this->createMock(Connection::class);
-        $connection->method('get')->willReturn($doctrineEnvelope);
+        $connection->method('get')->willReturn([$doctrineEnvelope]);
 
         $receiver = new DoctrineReceiver($connection, $serializer);
         $actualEnvelopes = $receiver->get();
@@ -64,7 +64,7 @@ class DoctrineReceiverTest extends TestCase
 
         $doctrineEnvelop = $this->createDoctrineEnvelope();
         $connection = $this->createMock(Connection::class);
-        $connection->method('get')->willReturn($doctrineEnvelop);
+        $connection->method('get')->willReturn([$doctrineEnvelop]);
         $connection->expects($this->once())->method('reject');
 
         $receiver = new DoctrineReceiver($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
@@ -46,7 +46,7 @@ class DoctrineTransportTest extends TestCase
         ];
 
         $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
-        $connection->method('get')->willReturn($doctrineEnvelope);
+        $connection->method('get')->willReturn([$doctrineEnvelope]);
 
         $envelopes = $transport->get();
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception as DBALException;
@@ -43,6 +44,7 @@ class Connection implements ResetInterface
     protected const DEFAULT_OPTIONS = [
         'table_name' => 'messenger_messages',
         'queue_name' => 'default',
+        'batch_size' => 1,
         'redeliver_timeout' => 3600,
         'auto_setup' => true,
     ];
@@ -63,6 +65,8 @@ class Connection implements ResetInterface
     protected ?float $queueEmptiedAt = null;
 
     private bool $autoSetup;
+    /** @var int[] */
+    private array $lastDeliveredButNotYetHandledEnvelopesIds = [];
 
     public function __construct(array $configuration, DBALConnection $driverConnection)
     {
@@ -151,7 +155,7 @@ class Connection implements ResetInterface
         return $this->driverConnection->lastInsertId();
     }
 
-    public function get(): ?array
+    public function get(): array
     {
         if ($this->driverConnection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             try {
@@ -166,7 +170,7 @@ class Connection implements ResetInterface
         try {
             $query = $this->createAvailableMessagesQueryBuilder()
                 ->orderBy('available_at', 'ASC')
-                ->setMaxResults(1);
+                ->setMaxResults($this->configuration['batch_size']);
 
             if ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
                 $query->select('m.id');
@@ -200,40 +204,45 @@ class Connection implements ResetInterface
                 $sql .= ' '.$this->driverConnection->getDatabasePlatform()->getWriteLockSQL();
             }
 
-            $doctrineEnvelope = $this->executeQuery(
+            $doctrineEnvelopeList = $this->executeQuery(
                 $sql,
                 $query->getParameters(),
                 $query->getParameterTypes()
-            )->fetchAssociative();
+            )->fetchAllAssociative();
 
-            if (false === $doctrineEnvelope) {
+            if ([] === $doctrineEnvelopeList) {
                 $this->driverConnection->commit();
                 $this->queueEmptiedAt = microtime(true) * 1000;
 
-                return null;
+                return [];
             }
             // Postgres can "group" notifications having the same channel and payload
             // We need to be sure to empty the queue before blocking again
             $this->queueEmptiedAt = null;
 
-            $doctrineEnvelope = $this->decodeEnvelopeHeaders($doctrineEnvelope);
+            $this->lastDeliveredButNotYetHandledEnvelopesIds = $this->extractDoctrineEnvelopeListIds($doctrineEnvelopeList);
 
             $queryBuilder = $this->driverConnection->createQueryBuilder()
                 ->update($this->configuration['table_name'])
                 ->set('delivered_at', '?')
-                ->where('id = ?');
-            $now = new \DateTimeImmutable('UTC');
-            $this->executeStatement($queryBuilder->getSQL(), [
-                $now,
-                $doctrineEnvelope['id'],
-            ], [
-                Types::DATETIME_IMMUTABLE,
-            ]);
+                ->where($this->driverConnection->createQueryBuilder()->expr()->in('id', '?'));
+            $this->executeStatement(
+                $queryBuilder->getSQL(),
+                [
+                    new \DateTimeImmutable('UTC'),
+                    $this->lastDeliveredButNotYetHandledEnvelopesIds,
+                ],
+                [
+                    Types::DATETIME_IMMUTABLE,
+                    class_exists(ArrayParameterType::class) ? ArrayParameterType::INTEGER : Types::SIMPLE_ARRAY,
+                ]
+            );
 
             $this->driverConnection->commit();
 
-            return $doctrineEnvelope;
+            return $this->decodeDoctrineEnvelopeListHeaders($doctrineEnvelopeList);
         } catch (\Throwable $e) {
+            $this->lastDeliveredButNotYetHandledEnvelopesIds = [];
             $this->driverConnection->rollBack();
 
             if ($this->autoSetup && $e instanceof TableNotFoundException) {
@@ -247,6 +256,7 @@ class Connection implements ResetInterface
 
     public function ack(string $id): bool
     {
+        $this->removeHandledFromDeliveredList($id);
         try {
             if ($this->driverConnection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
                 return $this->driverConnection->update($this->configuration['table_name'], ['delivered_at' => '9999-12-31 23:59:59'], ['id' => $id]) > 0;
@@ -336,6 +346,27 @@ class Connection implements ResetInterface
     public function getExtraSetupSqlForTable(Table $createdTable): array
     {
         return [];
+    }
+
+    public function undeliverNotHandled(): void
+    {
+        if (0 === \count($this->lastDeliveredButNotYetHandledEnvelopesIds)) {
+            return;
+        }
+
+        $queryBuilder = $this->driverConnection->createQueryBuilder()
+            ->update($this->configuration['table_name'])
+            ->set('delivered_at', 'NULL')
+            ->where($this->driverConnection->createQueryBuilder()->expr()->in('id', '?'));
+        $this->executeStatement(
+            $queryBuilder->getSQL(),
+            [
+                $this->lastDeliveredButNotYetHandledEnvelopesIds,
+            ],
+            [
+                ArrayParameterType::INTEGER,
+            ]
+        );
     }
 
     private function createAvailableMessagesQueryBuilder(): QueryBuilder
@@ -509,5 +540,54 @@ class Connection implements ResetInterface
         } catch (DBALException) {
             return $sql;
         }
+    }
+
+    /**
+     * @return int[]
+     */
+    public function extractDoctrineEnvelopeListIds(array $doctrineEnvelopeList): array
+    {
+        return array_map(
+            function ($doctrineEnvelopeRow) {
+                return $doctrineEnvelopeRow['id'];
+            },
+            $doctrineEnvelopeList
+        );
+    }
+
+    /**
+     * @param array<array{
+     *     id: int,
+     *     body: string,
+     *     headers: string,
+     *     queue_name: string,
+     *     created_at: string,
+     *     available_at: string,
+     *     delivered_at: string
+     * }> $doctrineEnvelopeList
+     *
+     * @return array<array{
+     *     id: int,
+     *     body: string,
+     *     headers: array,
+     *     queue_name: string,
+     *     created_at: string,
+     *     available_at: string,
+     *     delivered_at: string
+     * }>
+     */
+    public function decodeDoctrineEnvelopeListHeaders(array $doctrineEnvelopeList): array
+    {
+        $doctrineEnvelopeListWithDecodedHeaders = [];
+        foreach ($doctrineEnvelopeList as $doctrineEnvelope) {
+            $doctrineEnvelopeListWithDecodedHeaders[] = $this->decodeEnvelopeHeaders($doctrineEnvelope);
+        }
+
+        return $doctrineEnvelopeListWithDecodedHeaders;
+    }
+
+    public function removeHandledFromDeliveredList(string $id): void
+    {
+        $this->lastDeliveredButNotYetHandledEnvelopesIds = array_diff($this->lastDeliveredButNotYetHandledEnvelopesIds, [$id]);
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
@@ -25,6 +25,8 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
  * @author Vincent Touzet <vincent.touzet@gmail.com>
+ * @author Herberto Graca <herberto.graca@gmail.com>
+ * @author Alexander Malyk <shu.rick.ifmo@gmail.com>
  */
 class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareInterface
 {
@@ -42,7 +44,7 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
     public function get(): iterable
     {
         try {
-            $doctrineEnvelope = $this->connection->get();
+            $doctrineEnvelopeList = $this->connection->get();
             $this->retryingSafetyCounter = 0; // reset counter
         } catch (RetryableException $exception) {
             // Do nothing when RetryableException occurs less than "MAX_RETRIES"
@@ -58,11 +60,16 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
             throw new TransportException($exception->getMessage(), 0, $exception);
         }
 
-        if (null === $doctrineEnvelope) {
+        if (null === $doctrineEnvelopeList) {
             return [];
         }
 
-        return [$this->createEnvelopeFromData($doctrineEnvelope)];
+        $envelopeList = [];
+        foreach ($doctrineEnvelopeList as $doctrineEnvelope) {
+            $envelopeList[] = $this->createEnvelopeFromData($doctrineEnvelope);
+        }
+
+        return $envelopeList;
     }
 
     public function ack(Envelope $envelope): void
@@ -81,6 +88,11 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
         } catch (DBALException $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
         }
+    }
+
+    public function undeliverNotHandled(): void
+    {
+        $this->connection->undeliverNotHandled();
     }
 
     public function getMessageCount(): int

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -19,6 +19,8 @@ use Doctrine\DBAL\Schema\Table;
  * @internal
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Herberto Graca <herberto.graca@gmail.com>
+ * @author Alexander Malyk <shu.rick.ifmo@gmail.com>
  */
 final class PostgreSqlConnection extends Connection
 {
@@ -54,7 +56,7 @@ final class PostgreSqlConnection extends Connection
         $this->unlisten();
     }
 
-    public function get(): ?array
+    public function get(): array
     {
         if (null === $this->queueEmptiedAt) {
             return parent::get();
@@ -76,7 +78,7 @@ final class PostgreSqlConnection extends Connection
         ) {
             usleep(1000);
 
-            return null;
+            return [];
         }
 
         return parent::get();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix [#47828](https://github.com/symfony/symfony/issues/47828)
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18566


Currently, the doctrine transport only delivers one message at a time,
resulting in low performance and a very high amount of hits to the DB.
(one hit per message)

With batch delivery, the transport will retrieve several messages in a single query.
