### PR TITLE
[HttpKernel] Fix issue when no query parameter with mapQueryString

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -157,11 +157,13 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function mapQueryString(Request $request, string $type, MapQueryString $attribute): ?object
     {
-        if (!$data = $request->query->all()) {
-            return null;
+        $data = $request->query->all();
+
+        if (class_exists($type) || $data) {
+            return $this->serializer->denormalize($data, $type, null, self::CONTEXT_DENORMALIZE + $attribute->serializationContext);
         }
 
-        return $this->serializer->denormalize($data, $type, null, self::CONTEXT_DENORMALIZE + $attribute->serializationContext);
+        return null;
     }
 
     private function mapRequestPayload(Request $request, string $type, MapRequestPayload $attribute): ?object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

```php
#[Route('/hello', methods: ['GET'])]
public function getHello(
    #[MapQueryString] HelloGetRequest $helloGetRequest
): Response {
    var_dump($helloGetRequest);
    die;
}

final class HelloGetRequest
{
    #[Assert\NotBlank(allowNull: true)]
    #[Assert\Date]
    public ?string $dateDebut = null;

    #[Assert\NotBlank(allowNull: true)]
    #[Assert\Date]
    public ?string $dateFin = null;
}
```

If I call the URL ```http://localhost:8080/hello```, I will receive a 404 Not Found error because there is nothing in the query parameters.
The idea is to have the object ```HelloGetRequest``` initialized to access it and if I try to get ```$helloGetRequest->dateDebut```, ```null``` will be displayed.