### PR TITLE
[Console] Customise the `SymfonyStyle` confirm regex and message

### DIFF
--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -44,7 +44,7 @@ class SymfonyQuestionHelper extends QuestionHelper
                 break;
 
             case $question instanceof ConfirmationQuestion:
-                $text = sprintf(' <info>%s (yes/no)</info> [<comment>%s</comment>]:', $text, $default ? 'yes' : 'no');
+                $text = sprintf(' <info>%s (%s/%s)</info> [<comment>%s</comment>]:', $text, $question->getTrueAnswerText(), $question->getFalseAnswerText(), $default ? $question->getTrueAnswerText() : $question->getFalseAnswerText());
 
                 break;
 

--- a/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
+++ b/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
@@ -18,19 +18,34 @@ namespace Symfony\Component\Console\Question;
  */
 class ConfirmationQuestion extends Question
 {
+    public const DEFAULT_TRUE_ANSWER_REGEX = '/^y/i';
+    public const DEFAULT_TRUE_ANSWER_TEXT = 'yes';
+    public const DEFAULT_FALSE_ANSWER_TEXT = 'no';
+
     private string $trueAnswerRegex;
 
-    /**
-     * @param string $question        The question to ask to the user
-     * @param bool   $default         The default answer to return, true or false
-     * @param string $trueAnswerRegex A regex to match the "yes" answer
-     */
-    public function __construct(string $question, bool $default = true, string $trueAnswerRegex = '/^y/i')
+    private string $trueAnswerText;
+
+    private string $falseAnswerText;
+
+    public function __construct(string $question, bool $default = true, string $trueAnswerRegex = self::DEFAULT_TRUE_ANSWER_REGEX, string $trueAnswerText = self::DEFAULT_TRUE_ANSWER_TEXT, string $falseAnswerText = self::DEFAULT_FALSE_ANSWER_TEXT)
     {
         parent::__construct($question, $default);
 
         $this->trueAnswerRegex = $trueAnswerRegex;
+        $this->trueAnswerText = $trueAnswerText;
+        $this->falseAnswerText = $falseAnswerText;
         $this->setNormalizer($this->getDefaultNormalizer());
+    }
+
+    public function getTrueAnswerText(): string
+    {
+        return $this->trueAnswerText;
+    }
+
+    public function getFalseAnswerText(): string
+    {
+        return $this->falseAnswerText;
     }
 
     /**

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -267,9 +267,9 @@ class SymfonyStyle extends OutputStyle
         return $this->askQuestion($question);
     }
 
-    public function confirm(string $question, bool $default = true): bool
+    public function confirm(string $question, bool $default = true, string $trueAnswerRegex = ConfirmationQuestion::DEFAULT_TRUE_ANSWER_REGEX, string $trueAnswerText = ConfirmationQuestion::DEFAULT_TRUE_ANSWER_TEXT, string $falseAnswerText = ConfirmationQuestion::DEFAULT_FALSE_ANSWER_TEXT): bool
     {
-        return $this->askQuestion(new ConfirmationQuestion($question, $default));
+        return $this->askQuestion(new ConfirmationQuestion($question, $default, $trueAnswerRegex, $trueAnswerText, $falseAnswerText));
     }
 
     public function choice(string $question, array $choices, mixed $default = null, bool $multiSelect = false): mixed

--- a/src/Symfony/Component/Console/Tests/Question/ConfirmationQuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/ConfirmationQuestionTest.php
@@ -59,4 +59,16 @@ class ConfirmationQuestionTest extends TestCase
             ],
         ];
     }
+
+    public function testDifferentRegex()
+    {
+        $sut = new ConfirmationQuestion('Eine Frage', true, '/^j/i');
+        $answers = ['j', 'J', 'ja', 'JA', 'jA', ''];
+
+        foreach ($answers as $answer) {
+            $normalizer = $sut->getNormalizer();
+            $actual = $normalizer($answer);
+            $this->assertTrue($actual, sprintf('When default is true, the normalizer must return true for "%s"', $answer));
+        }
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -223,4 +223,60 @@ class SymfonyStyleTest extends TestCase
             stream_get_contents($output->getStream())
         );
     }
+
+    public function testConfirm()
+    {
+        $answer = 'yes';
+        $inputStream = fopen('php://memory', 'r+');
+        fwrite($inputStream, $answer.\PHP_EOL);
+        rewind($inputStream);
+        $input = $this->createMock(Input::class);
+        $sections = [];
+        $output = new ConsoleSectionOutput(fopen('php://memory', 'r+'), $sections, StreamOutput::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $input
+            ->method('isInteractive')
+            ->willReturn(true);
+        $input
+            ->method('getStream')
+            ->willReturn($inputStream);
+
+        $io = new SymfonyStyle($input, $output);
+
+        $givenAnswer = $io->confirm('A question');
+
+        rewind($output->getStream());
+        $this->assertTrue($givenAnswer);
+        $this->assertEquals(
+            \PHP_EOL.\PHP_EOL." \033[32mA question (yes/no)\033[39m [\033[33myes\033[39m]:".\PHP_EOL.' > '.\PHP_EOL.\PHP_EOL.\PHP_EOL,
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testConfirmWithGermanLanguage()
+    {
+        $answer = 'ja';
+        $inputStream = fopen('php://memory', 'r+');
+        fwrite($inputStream, $answer.\PHP_EOL);
+        rewind($inputStream);
+        $input = $this->createMock(Input::class);
+        $sections = [];
+        $output = new ConsoleSectionOutput(fopen('php://memory', 'r+'), $sections, StreamOutput::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $input
+            ->method('isInteractive')
+            ->willReturn(true);
+        $input
+            ->method('getStream')
+            ->willReturn($inputStream);
+
+        $io = new SymfonyStyle($input, $output);
+
+        $givenAnswer = $io->confirm('Eine Frage', true, '/^j/i', 'ja', 'nein');
+
+        rewind($output->getStream());
+        $this->assertTrue($givenAnswer);
+        $this->assertEquals(
+            \PHP_EOL.\PHP_EOL." \033[32mEine Frage (ja/nein)\033[39m [\033[33mja\033[39m]:".\PHP_EOL.' > '.\PHP_EOL.\PHP_EOL.\PHP_EOL,
+            stream_get_contents($output->getStream())
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50925
| License       | MIT
| Doc PR        | symfony/symfony-docs# TBD

Make is possible to use `SymfonyStyle::confirm()` e.g. for other languages.