### PR TITLE
[Form] Use `form.post_set_data` in `ResizeFormListener`

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Deprecate the `VersionAwareTest` trait, use feature detection instead
  * Add support for the `calendar` option in `DateType`
  * Add `LazyChoiceLoader` and `choice_lazy` option in `ChoiceType` for loading and rendering choices on demand
+ * Use `form.post_set_data` instead of `form.pre_set_data` in `ResizeFormListener`
+ * Change the priority of `DataCollectorListener` from 255 to -255
 
 7.1
 ---

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Event\PostSetDataEvent;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -27,6 +28,9 @@ class ResizeFormListener implements EventSubscriberInterface
     protected array $prototypeOptions;
 
     private \Closure|bool $deleteEmpty;
+    // BC, to be removed in 8.0
+    private bool $overridden = true;
+    private bool $usePreSetData = false;
 
     public function __construct(
         private string $type,
@@ -44,15 +48,57 @@ class ResizeFormListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::PRE_SET_DATA => 'preSetData',
+            FormEvents::PRE_SET_DATA => 'preSetData', // deprecated
+            FormEvents::POST_SET_DATA => ['postSetData', 255], // as early as possible
             FormEvents::PRE_SUBMIT => 'preSubmit',
             // (MergeCollectionListener, MergeDoctrineCollectionListener)
             FormEvents::SUBMIT => ['onSubmit', 50],
         ];
     }
 
+    /**
+     * @deprecated Since Symfony 7.2, use {@see postSetData()} instead.
+     */
     public function preSetData(FormEvent $event): void
     {
+        if (__CLASS__ === static::class
+            || __CLASS__ === (new \ReflectionClass($this))->getMethod('preSetData')->getDeclaringClass()->name
+        ) {
+            // not a child class, or child class does not overload PRE_SET_DATA
+            return;
+        }
+
+        trigger_deprecation('symfony/form', '7.2', 'Calling "%s()" is deprecated, use "%s::postSetData()" instead.', __METHOD__, __CLASS__);
+        // parent::preSetData() has been called
+        $this->overridden = false;
+        try {
+            $this->postSetData($event);
+        } finally {
+            $this->usePreSetData = true;
+        }
+    }
+
+    /**
+     * Remove FormEvent type hint in 8.0.
+     *
+     * @final since Symfony 7.2
+     */
+    public function postSetData(FormEvent|PostSetDataEvent $event): void
+    {
+        if (__CLASS__ !== static::class) {
+            if ($this->overridden) {
+                trigger_deprecation('symfony/form', '7.2', 'Calling "%s::preSetData()" is deprecated, use "%s::postSetData()" instead.', static::class, __CLASS__);
+                // parent::preSetData() has not been called, noop
+
+                return;
+            }
+
+            if ($this->usePreSetData) {
+                // nothing else to do
+                return;
+            }
+        }
+
         $form = $event->getForm();
         $data = $event->getData() ?? [];
 

--- a/src/Symfony/Component/Form/Extension/DataCollector/EventListener/DataCollectorListener.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/EventListener/DataCollectorListener.php
@@ -32,8 +32,8 @@ class DataCollectorListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            // High priority in order to be called as soon as possible
-            FormEvents::POST_SET_DATA => ['postSetData', 255],
+            // Low priority in order to be called as late as possible
+            FormEvents::POST_SET_DATA => ['postSetData', -255],
             // Low priority in order to be called as late as possible
             FormEvents::POST_SUBMIT => ['postSubmit', -255],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

The `form.pre_set_data` event allows to change the initial data, modifying the form based on it should be done early during `form.post_set_data` instead.

Ref https://github.com/symfony/symfony-docs/pull/18587.

Also, the collect of form config should be done as late as possible to account for modification from other listeners.