### PR TITLE
[Form] Deprecate `FormEvent::setData()` for events that do not allow it

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -29,6 +29,8 @@ Form
 
  * Deprecate using `DateTime` or `DateTimeImmutable` model data with a different timezone than configured with the
    `model_timezone` option in `DateType`, `DateTimeType`, and `TimeType`
+ * Deprecate `PostSetDataEvent::setData()`, use `PreSetDataEvent::setData()` instead
+ * Deprecate `PostSubmitEvent::setData()`, use `PreSubmitDataEvent::setData()` or `SubmitDataEvent::setData()` instead
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Deprecate using `DateTime` or `DateTimeImmutable` model data with a different timezone than configured with the
    `model_timezone` option in `DateType`, `DateTimeType`, and `TimeType`
+ * Deprecate `PostSetDataEvent::setData()`, use `PreSetDataEvent::setData()` instead
+ * Deprecate `PostSubmitEvent::setData()`, use `PreSubmitDataEvent::setData()` or `SubmitDataEvent::setData()` instead
 
 6.3
 ---

--- a/src/Symfony/Component/Form/Event/PostSetDataEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSetDataEvent.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Event;
 
+use Symfony\Component\Form\Exception\BadMethodCallException;
 use Symfony\Component\Form\FormEvent;
 
 /**
@@ -20,4 +21,12 @@ use Symfony\Component\Form\FormEvent;
  */
 final class PostSetDataEvent extends FormEvent
 {
+    /**
+     * @deprecated since Symfony 6.4, it will throw an exception in 7.0.
+     */
+    public function setData(mixed $data): void
+    {
+        trigger_deprecation('symfony/form', '6.4', 'Calling "%s()" will throw an exception as of 7.0, listen to "form.pre_set_data" instead.', __METHOD__);
+        // throw new BadMethodCallException('Form data cannot be changed during "form.post_set_data", you should use "form.pre_set_data" instead.');
+    }
 }

--- a/src/Symfony/Component/Form/Event/PostSubmitEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSubmitEvent.php
@@ -21,4 +21,12 @@ use Symfony\Component\Form\FormEvent;
  */
 final class PostSubmitEvent extends FormEvent
 {
+    /**
+     * @deprecated since Symfony 6.4, it will throw an exception in 7.0.
+     */
+    public function setData(mixed $data): void
+    {
+        trigger_deprecation('symfony/form', '6.4', 'Calling "%s()" will throw an exception as of 7.0, listen to "form.pre_submit" or "form.submit" instead.', __METHOD__);
+        // throw new BadMethodCallException('Form data cannot be changed during "form.post_submit", you should use "form.pre_submit" or "form.submit" instead.');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

Now that specific classes exist for each event, we can improve DX by forbidding to call `FormEvent::setData()` where it does not make sense.