### PR TITLE
[FrameworkBundle] Add `--exclude` option to the `cache:pool:clear` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -29,6 +29,7 @@ CHANGELOG
  * Add support for relative URLs in BrowserKit's redirect assertion
  * Change BrowserKitAssertionsTrait::getClient() to be protected
  * Deprecate the `framework.asset_mapper.provider` config option
+ * Add `--exclude` option to the `cache:pool:clear` command
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -53,6 +53,7 @@ final class CachePoolClearCommand extends Command
                 new InputArgument('pools', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'A list of cache pools or cache pool clearers'),
             ])
             ->addOption('all', null, InputOption::VALUE_NONE, 'Clear all cache pools')
+            ->addOption('exclude', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'A list of cache pools or cache pool clearers to exclude')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command clears the given cache pools or cache pool clearers.
 
@@ -70,16 +71,22 @@ EOF
         $clearers = [];
 
         $poolNames = $input->getArgument('pools');
+        $excludedPoolNames = $input->getOption('exclude');
         if ($input->getOption('all')) {
             if (!$this->poolNames) {
                 throw new InvalidArgumentException('Could not clear all cache pools, try specifying a specific pool or cache clearer.');
             }
 
-            $io->comment('Clearing all cache pools...');
+            if (!$excludedPoolNames) {
+                $io->comment('Clearing all cache pools...');
+            }
+
             $poolNames = $this->poolNames;
         } elseif (!$poolNames) {
             throw new InvalidArgumentException('Either specify at least one pool name, or provide the --all option to clear all pools.');
         }
+
+        $poolNames = array_diff($poolNames, $excludedPoolNames);
 
         foreach ($poolNames as $id) {
             if ($this->poolClearer->hasPool($id)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -132,6 +132,17 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString('[WARNING] Cache pool "cache.public_pool" could not be cleared.', $tester->getDisplay());
     }
 
+    public function testExcludedPool()
+    {
+        $tester = $this->createCommandTester(['cache.app_clearer']);
+        $tester->execute(['--all' => true, '--exclude' => ['cache.app_clearer']], ['decorated' => false]);
+
+        $tester->assertCommandIsSuccessful('cache:pool:clear exits with 0 in case of success');
+        $this->assertStringNotContainsString('Clearing all cache pools...', $tester->getDisplay());
+        $this->assertStringNotContainsString('Calling cache clearer: cache.app_clearer', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
+    }
+
     private function createCommandTester(array $poolNames = null)
     {
         $application = new Application(static::$kernel);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51023
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18595

For now this PR just ignores excluded pools/clearers when they don’t exist or wouldn’t be cleared/run anyways. Not sure what the best DX would be :thinking: 