### PR TITLE
[DoctrineBridge] Bugfix - Allow to remove LazyLoaded listeners by object

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -32,6 +32,7 @@ class ContainerAwareEventManager extends EventManager
     private $subscribers;
     private $initialized = [];
     private $initializedSubscribers = false;
+    private $initializedHashMapping = [];
     private $methods = [];
     private $container;
 
@@ -138,6 +139,7 @@ class ContainerAwareEventManager extends EventManager
 
             if (\is_string($listener)) {
                 unset($this->initialized[$event]);
+                unset($this->initializedHashMapping[$event][$hash]);
             } else {
                 $this->methods[$event][$hash] = $this->getMethod($listener, $event);
             }
@@ -158,6 +160,11 @@ class ContainerAwareEventManager extends EventManager
         $hash = $this->getHash($listener);
 
         foreach ((array) $events as $event) {
+            if (isset($this->initializedHashMapping[$event][$hash])) {
+                $hash = $this->initializedHashMapping[$event][$hash];
+                unset($this->initializedHashMapping[$event][$hash]);
+            }
+
             // Check if we actually have this listener associated
             if (isset($this->listeners[$event][$hash])) {
                 unset($this->listeners[$event][$hash]);
@@ -190,13 +197,25 @@ class ContainerAwareEventManager extends EventManager
     private function initializeListeners(string $eventName)
     {
         $this->initialized[$eventName] = true;
+
+        // We'll refill the whole array in order to keep the same order
+        $listeners = [];
         foreach ($this->listeners[$eventName] as $hash => $listener) {
             if (\is_string($listener)) {
-                $this->listeners[$eventName][$hash] = $listener = $this->container->get($listener);
+                $listener = $this->container->get($listener);
+                $newHash = $this->getHash($listener);
 
-                $this->methods[$eventName][$hash] = $this->getMethod($listener, $eventName);
+                $this->initializedHashMapping[$eventName][$hash] = $newHash;
+
+                $listeners[$newHash] = $listener;
+
+                $this->methods[$eventName][$newHash] = $this->getMethod($listener, $eventName);
+            } else {
+                $listeners[$hash] = $listener;
             }
         }
+
+        $this->listeners[$eventName] = $listeners;
     }
 
     private function initializeSubscribers()

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -202,6 +202,21 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->assertSame([], $this->evm->getListeners('foo'));
     }
 
+    public function testRemoveAllEventListener()
+    {
+        $this->container->set('lazy', new MyListener());
+        $this->evm->addEventListener('foo', 'lazy');
+        $this->evm->addEventListener('foo', new MyListener());
+
+        foreach ($this->evm->getAllListeners() as $event => $listeners) {
+            foreach ($listeners as $listener) {
+                $this->evm->removeEventListener($event, $listener);
+            }
+        }
+
+        $this->assertSame([], $this->evm->getListeners('foo'));
+    }
+
     public function testRemoveEventListenerAfterDispatchEvent()
     {
         $this->container->set('lazy', $listener1 = new MyListener());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #51057
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

cc @dmaicher 