### PR TITLE
Fix bug MapQueryString when request has only optional parameters

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -135,11 +135,16 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             }
 
             if (null === $payload) {
-                $payload = match (true) {
-                    $argument->metadata->hasDefaultValue() => $argument->metadata->getDefaultValue(),
-                    $argument->metadata->isNullable() => null,
-                    default => throw new HttpException($validationFailedCode)
-                };
+                try {
+                    $payload = match (true) {
+                        $argument->metadata->hasDefaultValue() => $argument->metadata->getDefaultValue(),
+                        !$argument->metadata->hasDefaultValue() && $argument->metadata->getType() !== null => new ($argument->metadata->getType())(),
+                        $argument->metadata->isNullable() => null,
+                        default => throw new HttpException($validationFailedCode),
+                    };
+                } catch (\Throwable) {
+                    throw new HttpException($validationFailedCode);
+                }
             }
 
             $arguments[$i] = $payload;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50690
| License       | MIT
| Doc PR        | 

Based on the discussion here https://github.com/symfony/symfony/issues/50690 I propose my solution
