### PR TITLE
[AssetMapper] Fixing import parsing from jsdelivr

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -25,6 +25,8 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     public const URL_PATTERN_VERSION = 'https://data.jsdelivr.com/v1/packages/npm/%s/resolved?specifier=%s';
     public const URL_PATTERN_DIST = 'https://cdn.jsdelivr.net/npm/%s@%s%s/+esm';
 
+    public const IMPORT_REGEX = '{from"/npm/([^@]*@?[\S]+)@([^/]+)/\+esm"}';
+
     private HttpClientInterface $httpClient;
 
     public function __construct(
@@ -129,8 +131,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     private function parseJsDelivrImports(string $content, array &$dependencies, bool $download, bool $preload): string
     {
         // imports from jsdelivr follow a predictable format
-        $regex = '{from"/npm/([^@]*@?[^@]+)@([^/]+)/\+esm"}';
-        $content = preg_replace_callback($regex, function ($matches) use (&$dependencies, $download, $preload) {
+        $content = preg_replace_callback(self::IMPORT_REGEX, function ($matches) use (&$dependencies, $download, $preload) {
             $packageName = $matches[1];
             $version = $matches[2];
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -234,4 +234,22 @@ class JsDelivrEsmResolverTest extends TestCase
             ],
         ];
     }
+
+    public function testImportRegex()
+    {
+        $subject = 'import{Color as t}from"/npm/@kurkle/color@0.3.2/+esm";import t from"/npm/jquery@3.7.0/+esm";import e from"/npm/popper.js@1.16.1/+esm";console.log("yo");';
+        preg_match_all(JsDelivrEsmResolver::IMPORT_REGEX, $subject, $matches);
+
+        $this->assertCount(3, $matches[0]);
+        $this->assertSame([
+            '@kurkle/color',
+            'jquery',
+            'popper.js',
+        ], $matches[1]);
+        $this->assertSame([
+            '0.3.2',
+            '3.7.0',
+            '1.16.1',
+        ], $matches[2]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None - thanks to conversation with @bendavies on Slack!
| License       | MIT
| Doc PR        | n/a

Found with: https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/+esm

With the `importmap:require --download` option, we parse those `import` statements to discover which dependencies we also need to download. If a package required 2 imports and both do *not* have an `@` in their name (i.e. a namespaced package), the regex matched both package strings as a single package - so it would see the package name as `jquery@3.7.0/+esm";import e from"/npm/popper.js@1.16.1/+esm`.

Cheers!