### PR TITLE
[VarExporter] Fix calling scope detection inside magic accessors

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
@@ -141,7 +141,7 @@ class LazyObjectRegistry
         if (\ReflectionProperty::class === $scope = $frame['class'] ?? \Closure::class) {
             $scope = $frame['object']->class;
         }
-        if (null === $readonlyScope && '*' === $k[1] && ($class === $scope || is_subclass_of($class, $scope))) {
+        if (null === $readonlyScope && '*' === $k[1] && ($class === $scope || (is_subclass_of($class, $scope) && !isset($propertyScopes["\0$scope\0$property"])))) {
             return null;
         }
 

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/TestOverwritePropClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/TestOverwritePropClass.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
+
+class TestOverwritePropClass extends FinalPublicClass
+{
+    public function __construct(
+        protected string $dep,
+        protected int $count,
+    ) {
+    }
+
+    public function getDep(): string
+    {
+        return $this->dep;
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\FinalPublicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\ReadOnlyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\StringMagicGetClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestOverwritePropClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestUnserializeClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestWakeupClass;
 
@@ -192,6 +193,14 @@ class LazyProxyTraitTest extends TestCase
         $this->assertSame(1, $proxy->increment());
         $this->assertSame(2, $proxy->increment());
         $this->assertSame(1, $proxy->decrement());
+    }
+
+    public function testOverwritePropClass()
+    {
+        $proxy = $this->createLazyProxy(TestOverwritePropClass::class, fn () => new TestOverwritePropClass('123', 5));
+
+        $this->assertSame('123', $proxy->getDep());
+        $this->assertSame(1, $proxy->increment());
     }
 
     public function testWither()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes 
| New feature?  | no
| Deprecations? |  -
| Tickets       | Fix #51048
| License       | MIT
| Doc PR        | -

This PR provides fixes related to detection of class scope for which the magic method was called.
this fixes are related to the issue described in this RFC https://wiki.php.net/rfc/access_scope_from_magic_accessors

more accurate STR for the bug:

```php
class A1Class {
    private $prop1;
    public function __construct($prop1)
    {
        $this->prop1 = $prop1;
    }

    public function getProp1()
    {
        return $this->prop1;
    }
}

class B1Class extends A1Class
{
    protected $prop1;
    protected $prop2;

    public function __construct($prop1)
    {
        parent::__construct($prop1);
        $this->prop1 = $prop1;
    }

    public function test()
    {
        return $this->prop1;
    }

    public function test2()
    {
        return $this->prop2;
    }

    public function setProp2($prop2)
    {
        $this->prop2 = $prop2;
    }
}
```

```yml
    App\B1Class:
        arguments: [ 'test1' ]
        calls:
            - [ setProp2, [ 'test2' ] ]
        lazy: true
```

Call `$this->b1Class->test2();`

Actual result:
![Selection_1645](https://github.com/symfony/symfony/assets/21358010/db71f9c3-cfec-4f1e-b638-e10b9384fef9)

