### PR TITLE
[FrameworkBundle][Workflow] Throw exception is workflow.xxx.transitions is not an array

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -446,6 +446,10 @@ class Configuration implements ConfigurationInterface
                                         ->beforeNormalization()
                                             ->always()
                                             ->then(function ($places) {
+                                                if (!\is_array($places)) {
+                                                    throw new InvalidConfigurationException('The "places" option must be an array in workflow configuration.');
+                                                }
+
                                                 // It's an indexed array of shape  ['place1', 'place2']
                                                 if (isset($places[0]) && \is_string($places[0])) {
                                                     return array_map(function (string $place) {
@@ -491,6 +495,10 @@ class Configuration implements ConfigurationInterface
                                         ->beforeNormalization()
                                             ->always()
                                             ->then(function ($transitions) {
+                                                if (!\is_array($transitions)) {
+                                                    throw new InvalidConfigurationException('The "transitions" option must be an array in workflow configuration.');
+                                                }
+
                                                 // It's an indexed array, we let the validation occur
                                                 if (isset($transitions[0]) && \is_array($transitions[0])) {
                                                     return $transitions;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -50,6 +51,36 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
                             'base_urls' => 'http://cdn.example.com',
                             'base_path' => '/foo',
                         ],
+                    ],
+                ],
+            ]);
+        });
+    }
+
+    public function testWorkflowValidationPlacesIsArray()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "places" option must be an array in workflow configuration.');
+        $this->createContainerFromClosure(function ($container) {
+            $container->loadFromExtension('framework', [
+                'workflows' => [
+                    'article' => [
+                        'places' => null,
+                    ],
+                ],
+            ]);
+        });
+    }
+
+    public function testWorkflowValidationTransitonsIsArray()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "transitions" option must be an array in workflow configuration.');
+        $this->createContainerFromClosure(function ($container) {
+            $container->loadFromExtension('framework', [
+                'workflows' => [
+                    'article' => [
+                        'transitions' => null,
                     ],
                 ],
             ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

The following code raises a fatal error:
```yaml
framework:
    workflows:
        articles:
            transitions:
```

<details>

```
ErrorException:
Warning: foreach() argument must be of type array|object, null given

  at /home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/framework-bundle/DependencyInjection/Configuration.php:522
  at Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration->Symfony\Bundle\FrameworkBundle\DependencyInjection\{closure}()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/Builder/ExprBuilder.php:246)
  at Symfony\Component\Config\Definition\Builder\ExprBuilder::Symfony\Component\Config\Definition\Builder\{closure}()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/BaseNode.php:357)
  at Symfony\Component\Config\Definition\BaseNode->normalize()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/ArrayNode.php:292)
  at Symfony\Component\Config\Definition\ArrayNode->normalizeValue()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/BaseNode.php:385)
  at Symfony\Component\Config\Definition\BaseNode->normalize()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/PrototypedArrayNode.php:251)
  at Symfony\Component\Config\Definition\PrototypedArrayNode->normalizeValue()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/BaseNode.php:385)
  at Symfony\Component\Config\Definition\BaseNode->normalize()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/ArrayNode.php:292)
  at Symfony\Component\Config\Definition\ArrayNode->normalizeValue()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/BaseNode.php:385)
  at Symfony\Component\Config\Definition\BaseNode->normalize()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/ArrayNode.php:292)
  at Symfony\Component\Config\Definition\ArrayNode->normalizeValue()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/BaseNode.php:385)
  at Symfony\Component\Config\Definition\BaseNode->normalize()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/Processor.php:32)
  at Symfony\Component\Config\Definition\Processor->process()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/config/Definition/Processor.php:46)
  at Symfony\Component\Config\Definition\Processor->processConfiguration()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/dependency-injection/Extension/Extension.php:109)
  at Symfony\Component\DependencyInjection\Extension\Extension->processConfiguration()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/framework-bundle/DependencyInjection/FrameworkExtension.php:259)
  at Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension->load()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php:76)
  at Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass->process()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/http-kernel/DependencyInjection/MergeExtensionConfigurationPass.php:45)
  at Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass->process()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/dependency-injection/Compiler/Compiler.php:80)
  at Symfony\Component\DependencyInjection\Compiler\Compiler->compile()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/dependency-injection/ContainerBuilder.php:767)
  at Symfony\Component\DependencyInjection\ContainerBuilder->compile()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/http-kernel/Kernel.php:506)
  at Symfony\Component\HttpKernel\Kernel->initializeContainer()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/http-kernel/Kernel.php:757)
  at Symfony\Component\HttpKernel\Kernel->preBoot()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/http-kernel/Kernel.php:185)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35)
  at Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/autoload_runtime.php:29)
  at require_once('/home/gregoire/dev/github.com/Faume-co/modules-shopify/vendor/autoload_runtime.php')
     (/home/gregoire/dev/github.com/Faume-co/modules-shopify/public/index.php:5)          
```

</details>
