### PR TITLE
[HttpFoundation] Serialize floats into json response

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Make `HeaderBag::getDate()`, `Response::getDate()`, `getExpires()` and `getLastModified()` return a `DateTimeImmutable`
+ * Fixed float numbers in JSON string of JsonResponse - now it serialized to float even if it has no decimal part, e.g 1.0 became 1.0 and not just a 1 as integer
 
 6.3
 ---

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -27,9 +27,9 @@ class JsonResponse extends Response
     protected $data;
     protected $callback;
 
-    // Encode <, >, ', &, and " characters in the JSON, making it also safe to be embedded into HTML.
-    // 15 === JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT
-    public const DEFAULT_ENCODING_OPTIONS = 15;
+    // Encode <, >, ', &, and " characters in the JSON, making it also safe to be embedded into HTML, represents floats.
+    // 1039 === JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_PRESERVE_ZERO_FRACTION
+    public const DEFAULT_ENCODING_OPTIONS = 1039;
 
     protected $encodingOptions = self::DEFAULT_ENCODING_OPTIONS;
 

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -190,6 +190,12 @@ class JsonResponseTest extends TestCase
 
         new JsonResponse(new \stdClass(), 200, [], true);
     }
+
+    public function testFloatNumbers()
+    {
+        $response = new JsonResponse(['data' => 1.0]);
+        $this->assertEquals('{"data":1.0}', $response->getContent());
+    }
 }
 
 class JsonSerializableObject implements \JsonSerializable

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -109,7 +109,7 @@ class JsonResponseTest extends TestCase
     {
         $response = new JsonResponse();
 
-        $this->assertEquals(\JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT, $response->getEncodingOptions());
+        $this->assertEquals(\JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_PRESERVE_ZERO_FRACTION, $response->getEncodingOptions());
     }
 
     public function testSetEncodingOptions()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

There is an unexpected behavior with float numbers in JsonResponse which is became an integer in case of decimal part is null, e.g. 1.0. So in some cases it will be int in others float, which is not ideal