### PR TITLE
[Routing] Fix `testMissingPrefixLocale` and `testMissingRouteLocale`

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/LocalizedPrefixMissingLocaleActionController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/LocalizedPrefixMissingLocaleActionController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: ['nl' => '/nl'])]
+class LocalizedPrefixMissingLocaleActionController
+{
+    #[Route(path: ['nl' => '/actie', 'en' => '/action'], name: 'action')]
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/LocalizedPrefixMissingRouteLocaleActionController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/LocalizedPrefixMissingRouteLocaleActionController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: ['nl' => '/nl', 'en' => '/en'])]
+class LocalizedPrefixMissingRouteLocaleActionController
+{
+    #[Route(path: ['nl' => '/actie'], name: 'action')]
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTestCase.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTestCase.php
@@ -197,12 +197,14 @@ abstract class AnnotationClassLoaderTestCase extends TestCase
     public function testMissingPrefixLocale()
     {
         $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf('Route to "action" with locale "en" is missing a corresponding prefix in class "%s\LocalizedPrefixMissingLocaleActionController".', $this->getNamespace()));
         $this->loader->load($this->getNamespace().'\LocalizedPrefixMissingLocaleActionController');
     }
 
     public function testMissingRouteLocale()
     {
         $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf('Route to "%s\LocalizedPrefixMissingRouteLocaleActionController::action" is missing paths for locale(s) "en".', $this->getNamespace()));
         $this->loader->load($this->getNamespace().'\LocalizedPrefixMissingRouteLocaleActionController');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/51082#discussion_r1272195743
| License       | MIT
| Doc PR        | not needed

Those two fixtures only exist as annotation versions. Their attribute counterparts were missing.

The corresponding tests only expected a `LogicException` which is what `AnnotationClassLoader` would raise for undefined classes as well.

This PR adds new assertions for the exception messages which would have discovered the missing fixtures. Finally, the two missing fixtures are added.