### PR TITLE
[Scheduler] make `ScheduledStamp` "send-able"

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Allow setting timezone of next run date in CronExpressionTrigger
  * Add `AbstractTriggerDecorator`
+ * Make `ScheduledStamp` "send-able"
 
 6.3
 ---

--- a/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
+++ b/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\Scheduler\Messenger;
 
-use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Scheduler\Generator\MessageContext;
 
 /**
  * @experimental
  */
-final class ScheduledStamp implements NonSendableStampInterface
+final class ScheduledStamp implements StampInterface
 {
     public function __construct(public readonly MessageContext $messageContext)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

It's important the `ScheduledStamp` stay on the envelope when using `RedispatchMessage` (https://speakerdeck.com/fabpot/s?slide=46).

This may still need some work as at least one of the triggers (`CallbackTrigger`) cannot be serialized. Any ideas about this?