### PR TITLE
[Webhook] Allow slash in webhook type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/webhook.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/webhook.xml
@@ -6,5 +6,6 @@
 
     <route id="_webhook_controller" path="/{type}">
         <default key="_controller">webhook.controller::handle</default>
+        <requirement key="type">.+</requirement>
     </route>
 </routes>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #50973 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allow `/` in webhook type.

This allow to have route like`/webhook/foo/bar`

