### PR TITLE
[Form] Remove an obsolete phpdoc comment

### DIFF
--- a/src/Symfony/Component/Form/FormTypeGuesserInterface.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserInterface.php
@@ -40,13 +40,6 @@ interface FormTypeGuesserInterface
     /**
      * Returns a guess about the field's pattern.
      *
-     * - When you have a min value, you guess a min length of this min (LOW_CONFIDENCE)
-     * - Then line below, if this value is a float type, this is wrong so you guess null with MEDIUM_CONFIDENCE to override the previous guess.
-     * Example:
-     *  You want a float greater than 5, 4.512313 is not valid but length(4.512314) > length(5)
-     *
-     * @see https://github.com/symfony/symfony/pull/3927
-     *
      * @return Guess\ValueGuess|null
      */
     public function guessPattern(string $class, string $property);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

It seems that the comment was introduced when renaming `guessMinLength` to `guessPattern` 11 years ago (https://github.com/symfony/symfony/commit/f7200e479c12767282cbdf1613532903ebbb936e#diff-c8f9f12ae6d4b48f0f41c30c0cd9716c41e92563a7ded52264a0eb3540ad04e5).
However the comment seems to be about a min length, as is it brings to value when guessing a pattern IMHO, so let's drop it.