### PR TITLE
[Runtime] Fix property must not be accessed before initialization on SymfonyRuntime

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -106,7 +106,7 @@ class SymfonyRuntime extends GenericRuntime
                 ->usePutenv($options['use_putenv'] ?? false)
                 ->bootEnv($options['project_dir'].'/'.($options['dotenv_path'] ?? '.env'), 'dev', (array) ($options['test_envs'] ?? ['test']), $options['dotenv_overload'] ?? false);
 
-            if ($this->input && ($options['dotenv_overload'] ?? false)) {
+            if (isset($this->input) && ($options['dotenv_overload'] ?? false)) {
                 if ($this->input->getParameterOption(['--env', '-e'], $_SERVER[$envKey], true) !== $_SERVER[$envKey]) {
                     throw new \LogicException(sprintf('Cannot use "--env" or "-e" when the "%s" file defines "%s" and the "dotenv_overload" runtime option is true.', $options['dotenv_path'] ?? '.env', $envKey));
                 }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Introduced by https://github.com/symfony/symfony/pull/51068, see https://github.com/symfony/symfony/pull/51068#issuecomment-1650330435
