### PR TITLE
[Serializer] Fix denormalizing abstract part headers in MimeMessageNormalizer

### DIFF
--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -168,6 +168,7 @@ EOF;
             ),
             new DataPart('text data', 'text.txt')
         );
+        $body->getHeaders()->addHeader('foo', 'bar');
         $e = new Message((new Headers())->addMailboxListHeader('To', ['you@example.com']), $body);
         $expected = clone $e;
 
@@ -232,7 +233,17 @@ EOF;
                 "class": "Symfony\\\\Component\\\\Mime\\\\Part\\\\DataPart"
             }
         ],
-        "headers": [],
+        "headers": {
+            "foo": [
+                {
+                    "value": "bar",
+                    "name": "foo",
+                    "lineLength": 76,
+                    "lang": null,
+                    "charset": "utf-8"
+                }
+            ]
+        },
         "class": "Symfony\\\\Component\\\\Mime\\\\Part\\\\Multipart\\\\MixedPart"
     },
     "message": null
@@ -252,7 +263,7 @@ EOF;
         $this->assertSame($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n = $serializer->deserialize($serialized, Message::class, 'json');
-        $this->assertEquals($expected->getHeaders(), $n->getHeaders());
+        $this->assertEquals($expected, $n);
 
         $serialized = $serializer->serialize($e, 'json');
         $this->assertSame($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));

--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -28,14 +28,14 @@
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "symfony/property-access": "^4.4|^5.1|^6.0",
         "symfony/property-info": "^4.4|^5.1|^6.0",
-        "symfony/serializer": "^5.4.14|~6.0.14|^6.1.6"
+        "symfony/serializer": "^5.4.26|^6.2.13"
     },
     "conflict": {
         "egulias/email-validator": "~3.0.0",
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",
         "symfony/mailer": "<4.4",
-        "symfony/serializer": "<5.4.14|>=6.0,<6.0.14|>=6.1,<6.1.6"
+        "symfony/serializer": "<5.4.26|>=6.2,<6.2.13"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mime\\": "" },

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -93,6 +93,7 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         if (AbstractPart::class === $type) {
             $type = $data['class'];
             unset($data['class']);
+            $data['headers'] = $this->serializer->denormalize($data['headers'], Headers::class, $format, $context);
         }
 
         return $this->normalizer->denormalize($data, $type, $format, $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`AbstractPart::$headers` property is not denormalized to the `Headers` object but remains an array. 