### PR TITLE
More short closures + isset instead of null checks + etc.

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -1343,7 +1343,7 @@ diff --git a/src/Symfony/Component/Cache/Adapter/ChainAdapter.php b/src/Symfony/
 diff --git a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
 --- a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
 +++ b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
-@@ -71,5 +71,5 @@ class MemcachedAdapter extends AbstractAdapter
+@@ -72,5 +72,5 @@ class MemcachedAdapter extends AbstractAdapter
       * @return bool
       */
 -    public static function isSupported()
@@ -1353,7 +1353,7 @@ diff --git a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php b/src/Symf
 diff --git a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
 --- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
 +++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
-@@ -101,5 +101,5 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
+@@ -102,5 +102,5 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
       * @throws \DomainException When an unsupported PDO driver is used
       */
 -    public function createTable()
@@ -1505,7 +1505,7 @@ diff --git a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php b/src/
 +    protected function doUnlink(string $file): bool
      {
          return @unlink($file);
-@@ -175,5 +175,5 @@ trait FilesystemCommonTrait
+@@ -167,5 +167,5 @@ trait FilesystemCommonTrait
       * @return void
       */
 -    public function __wakeup()
@@ -7313,14 +7313,14 @@ diff --git a/src/Symfony/Component/HttpFoundation/Request.php b/src/Symfony/Comp
 -    public function setMethod(string $method)
 +    public function setMethod(string $method): void
      {
-         $this->method = null;
+         unset($this->method);
 @@ -1301,5 +1301,5 @@ class Request
       * @return void
       */
 -    public function setFormat(?string $format, string|array $mimeTypes)
 +    public function setFormat(?string $format, string|array $mimeTypes): void
      {
-         if (null === static::$formats) {
+         if (!isset(static::$formats)) {
 @@ -1333,5 +1333,5 @@ class Request
       * @return void
       */
@@ -7342,14 +7342,14 @@ diff --git a/src/Symfony/Component/HttpFoundation/Request.php b/src/Symfony/Comp
 +    public function setLocale(string $locale): void
      {
          $this->setPhpDefaultLocale($this->locale = $locale);
-@@ -1756,5 +1756,5 @@ class Request
+@@ -1744,5 +1744,5 @@ class Request
       * @return string
       */
 -    protected function prepareRequestUri()
 +    protected function prepareRequestUri(): string
      {
          $requestUri = '';
-@@ -1927,5 +1927,5 @@ class Request
+@@ -1915,5 +1915,5 @@ class Request
       * @return void
       */
 -    protected static function initializeFormats()
@@ -11059,14 +11059,14 @@ diff --git a/src/Symfony/Component/Security/Core/Exception/AccountStatusExceptio
 diff --git a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
 --- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
 +++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
-@@ -43,5 +43,5 @@ class AuthenticationException extends RuntimeException
+@@ -34,5 +34,5 @@ class AuthenticationException extends RuntimeException
       * @return void
       */
 -    public function setToken(TokenInterface $token)
 +    public function setToken(TokenInterface $token): void
      {
          $this->token = $token;
-@@ -94,5 +94,5 @@ class AuthenticationException extends RuntimeException
+@@ -85,5 +85,5 @@ class AuthenticationException extends RuntimeException
       * @return string
       */
 -    public function getMessageKey()
@@ -11778,7 +11778,7 @@ diff --git a/src/Symfony/Component/String/Slugger/AsciiSlugger.php b/src/Symfony
 diff --git a/src/Symfony/Component/String/UnicodeString.php b/src/Symfony/Component/String/UnicodeString.php
 --- a/src/Symfony/Component/String/UnicodeString.php
 +++ b/src/Symfony/Component/String/UnicodeString.php
-@@ -342,5 +342,5 @@ class UnicodeString extends AbstractUnicodeString
+@@ -366,5 +366,5 @@ class UnicodeString extends AbstractUnicodeString
       * @return void
       */
 -    public function __wakeup()
@@ -12075,14 +12075,14 @@ diff --git a/src/Symfony/Component/Translation/Dumper/DumperInterface.php b/src/
 diff --git a/src/Symfony/Component/Translation/Dumper/FileDumper.php b/src/Symfony/Component/Translation/Dumper/FileDumper.php
 --- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
 +++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
-@@ -40,5 +40,5 @@ abstract class FileDumper implements DumperInterface
+@@ -38,5 +38,5 @@ abstract class FileDumper implements DumperInterface
       * @return void
       */
 -    public function setRelativePathTemplate(string $relativePathTemplate)
 +    public function setRelativePathTemplate(string $relativePathTemplate): void
      {
          $this->relativePathTemplate = $relativePathTemplate;
-@@ -48,5 +48,5 @@ abstract class FileDumper implements DumperInterface
+@@ -46,5 +46,5 @@ abstract class FileDumper implements DumperInterface
       * @return void
       */
 -    public function dump(MessageCatalogue $messages, array $options = [])

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -44,7 +44,6 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
 use Symfony\Component\WebLink\GenericLinkProvider;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
-use Symfony\Component\WebLink\Link;
 use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Twig\Environment;
@@ -64,7 +63,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     #[Required]
     public function setContainer(ContainerInterface $container): ?ContainerInterface
     {
-        $previous = $this->container;
+        $previous = $this->container ?? null;
         $this->container = $container;
 
         return $previous;

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -61,7 +61,7 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
 
     public function getRouteCollection(): RouteCollection
     {
-        if (null === $this->collection) {
+        if (!isset($this->collection)) {
             $this->collection = $this->container->get('routing.loader')->load($this->resource, $this->options['resource_type']);
             $this->resolveParameters($this->collection);
             $this->collection->addResource(new ContainerParametersResource($this->collectedParameters));

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
@@ -68,19 +68,19 @@ final class AccessTokenFactory extends AbstractFactory implements StatelessAuthe
 
                 ->beforeNormalization()
                     ->ifString()
-                    ->then(static function (string $v): array { return ['id' => $v]; })
+                    ->then(static fn ($v) => ['id' => $v])
                 ->end()
 
                 ->beforeNormalization()
-                    ->ifTrue(static function ($v) { return \is_array($v) && 1 < \count($v); })
-                    ->then(static function () { throw new InvalidConfigurationException('You cannot configure multiple token handlers.'); })
+                    ->ifTrue(static fn ($v) => \is_array($v) && 1 < \count($v))
+                    ->then(static fn () => throw new InvalidConfigurationException('You cannot configure multiple token handlers.'))
                 ->end()
 
                 // "isRequired" must be set otherwise the following custom validation is not called
                 ->isRequired()
                 ->beforeNormalization()
-                    ->ifTrue(static function ($v) { return \is_array($v) && !$v; })
-                    ->then(static function () { throw new InvalidConfigurationException('You must set a token handler.'); })
+                    ->ifTrue(static fn ($v) => \is_array($v) && !$v)
+                    ->then(static fn () => throw new InvalidConfigurationException('You must set a token handler.'))
                 ->end()
 
                 ->children()

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -61,11 +61,11 @@ class Cookie
     public function __construct(string $name, ?string $value, string $expires = null, string $path = null, string $domain = '', bool $secure = false, bool $httponly = true, bool $encodedValue = false, string $samesite = null)
     {
         if ($encodedValue) {
-            $this->value = urldecode($value);
-            $this->rawValue = $value;
+            $this->rawValue = $value ?? '';
+            $this->value = urldecode($this->rawValue);
         } else {
-            $this->value = $value;
-            $this->rawValue = rawurlencode($value ?? '');
+            $this->value = $value ?? '';
+            $this->rawValue = rawurlencode($this->value);
         }
         $this->name = $name;
         $this->path = empty($path) ? '/' : $path;

--- a/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
@@ -64,7 +64,7 @@ class CouchbaseBucketAdapter extends AbstractAdapter
             throw new CacheException('Couchbase >= 2.6.0 < 3.0.0 is required.');
         }
 
-        set_error_handler(function ($type, $msg, $file, $line) { throw new \ErrorException($msg, 0, $type, $file, $line); });
+        set_error_handler(static fn ($type, $msg, $file, $line) => throw new \ErrorException($msg, 0, $type, $file, $line));
 
         $dsnPattern = '/^(?<protocol>couchbase(?:s)?)\:\/\/(?:(?<username>[^\:]+)\:(?<password>[^\@]{6,})@)?'
             .'(?<host>[^\:]+(?:\:\d+)?)(?:\/(?<bucketName>[^\?]+))(?:\?(?<options>.*))?$/i';

--- a/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
@@ -57,7 +57,7 @@ class CouchbaseCollectionAdapter extends AbstractAdapter
             throw new CacheException('Couchbase >= 3.0.0 < 4.0.0 is required.');
         }
 
-        set_error_handler(function ($type, $msg, $file, $line): bool { throw new \ErrorException($msg, 0, $type, $file, $line); });
+        set_error_handler(static fn ($type, $msg, $file, $line) => throw new \ErrorException($msg, 0, $type, $file, $line));
 
         $dsnPattern = '/^(?<protocol>couchbase(?:s)?)\:\/\/(?:(?<username>[^\:]+)\:(?<password>[^\@]{6,})@)?'
             .'(?<host>[^\:]+(?:\:\d+)?)(?:\/(?<bucketName>[^\/\?]+))(?:(?:\/(?<scopeName>[^\/]+))'

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -29,7 +29,7 @@ use Symfony\Component\Cache\PruneableInterface;
 
 class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
 {
-    protected $maxIdLength = 255;
+    private const MAX_KEY_LENGTH = 255;
 
     private MarshallerInterface $marshaller;
     private Connection $conn;
@@ -94,6 +94,7 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
             $this->conn = DriverManager::getConnection($params, $config);
         }
 
+        $this->maxIdLength = self::MAX_KEY_LENGTH;
         $this->table = $options['db_table'] ?? $this->table;
         $this->idCol = $options['db_id_col'] ?? $this->idCol;
         $this->dataCol = $options['db_data_col'] ?? $this->dataCol;

--- a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
@@ -29,8 +29,7 @@ class MemcachedAdapter extends AbstractAdapter
      */
     private const RESERVED_MEMCACHED = " \n\r\t\v\f\0";
     private const RESERVED_PSR6 = '@()\{}/';
-
-    protected $maxIdLength = 250;
+    private const MAX_KEY_LENGTH = 250;
 
     private MarshallerInterface $marshaller;
     private \Memcached $client;
@@ -51,6 +50,8 @@ class MemcachedAdapter extends AbstractAdapter
         if (!static::isSupported()) {
             throw new CacheException('Memcached > 3.1.5 is required.');
         }
+        $this->maxIdLength = self::MAX_KEY_LENGTH;
+
         if ('Memcached' === $client::class) {
             $opt = $client->getOption(\Memcached::OPT_SERIALIZER);
             if (\Memcached::SERIALIZER_PHP !== $opt && \Memcached::SERIALIZER_IGBINARY !== $opt) {
@@ -96,7 +97,7 @@ class MemcachedAdapter extends AbstractAdapter
         if (!static::isSupported()) {
             throw new CacheException('Memcached > 3.1.5 is required.');
         }
-        set_error_handler(function ($type, $msg, $file, $line) { throw new \ErrorException($msg, 0, $type, $file, $line); });
+        set_error_handler(static fn ($type, $msg, $file, $line) => throw new \ErrorException($msg, 0, $type, $file, $line));
         try {
             $client = new \Memcached($options['persistent_id'] ?? null);
             $username = $options['username'] ?? null;

--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -19,7 +19,7 @@ use Symfony\Component\Cache\PruneableInterface;
 
 class PdoAdapter extends AbstractAdapter implements PruneableInterface
 {
-    protected $maxIdLength = 255;
+    private const MAX_KEY_LENGTH = 255;
 
     private MarshallerInterface $marshaller;
     private \PDO|Connection $conn;
@@ -75,6 +75,7 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
             $this->dsn = $connOrDsn;
         }
 
+        $this->maxIdLength = self::MAX_KEY_LENGTH;
         $this->table = $options['db_table'] ?? $this->table;
         $this->idCol = $options['db_id_col'] ?? $this->idCol;
         $this->dataCol = $options['db_data_col'] ?? $this->dataCol;

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -97,7 +97,7 @@ final class LockRegistry
         }
 
         self::$signalingException ??= unserialize("O:9:\"Exception\":1:{s:16:\"\0Exception\0trace\";a:0:{}}");
-        self::$signalingCallback ??= function () { throw self::$signalingException; };
+        self::$signalingCallback ??= fn () => throw self::$signalingException;
 
         while (true) {
             try {

--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -87,7 +87,7 @@ trait FilesystemCommonTrait
 
     private function write(string $file, string $data, int $expiresAt = null): bool
     {
-        set_error_handler(self::throwError(...));
+        set_error_handler(static fn ($type, $message, $file, $line) => throw new \ErrorException($message, 0, $type, $file, $line));
         try {
             $tmp = $this->directory.$this->tmpSuffix ??= str_replace('/', '-', base64_encode(random_bytes(6)));
             try {
@@ -156,14 +156,6 @@ trait FilesystemCommonTrait
                 }
             }
         }
-    }
-
-    /**
-     * @internal
-     */
-    public static function throwError(int $type, string $message, string $file, int $line): never
-    {
-        throw new \ErrorException($message, 0, $type, $file, $line);
     }
 
     public function __sleep(): array

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -348,7 +348,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
 
     protected function createNode(): NodeInterface
     {
-        if (null === $this->prototype) {
+        if (!isset($this->prototype)) {
             $node = new ArrayNode($this->name, $this->parent, $this->pathSeparator);
 
             $this->validateConcreteNode($node);
@@ -382,7 +382,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
 
             if (false !== $this->addDefaultChildren) {
                 $node->setAddChildrenIfNoneSet($this->addDefaultChildren);
-                if ($this->prototype instanceof static && null === $this->prototype->prototype) {
+                if ($this->prototype instanceof static && !isset($this->prototype->prototype)) {
                     $this->prototype->addDefaultsIfNotSet();
                 }
             }
@@ -404,18 +404,18 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
             $node->setDeprecated($this->deprecation['package'], $this->deprecation['version'], $this->deprecation['message']);
         }
 
-        if (null !== $this->normalization) {
+        if (isset($this->normalization)) {
             $node->setNormalizationClosures($this->normalization->before);
             $node->setNormalizedTypes($this->normalization->declaredTypes);
             $node->setXmlRemappings($this->normalization->remappings);
         }
 
-        if (null !== $this->merge) {
+        if (isset($this->merge)) {
             $node->setAllowOverwrite($this->merge->allowOverwrite);
             $node->setAllowFalse($this->merge->allowFalse);
         }
 
-        if (null !== $this->validation) {
+        if (isset($this->validation)) {
             $node->setFinalValidationClosures($this->validation->rules);
         }
 

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -105,7 +105,7 @@ abstract class NodeDefinition implements NodeParentInterface
             $this->parent = null;
         }
 
-        if (null !== $this->normalization) {
+        if (isset($this->normalization)) {
             $allowedTypes = [];
             foreach ($this->normalization->before as $expr) {
                 $allowedTypes[] = $expr->allowedTypes;
@@ -115,7 +115,7 @@ abstract class NodeDefinition implements NodeParentInterface
             $this->normalization->declaredTypes = $allowedTypes;
         }
 
-        if (null !== $this->validation) {
+        if (isset($this->validation)) {
             $this->validation->rules = ExprBuilder::buildExpressions($this->validation->rules);
         }
 

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -53,7 +53,7 @@ class TreeBuilder implements NodeParentInterface
     public function setPathSeparator(string $separator)
     {
         // unset last built as changing path separator changes all nodes
-        $this->tree = null;
+        unset($this->tree);
 
         $this->root->setPathSeparator($separator);
     }

--- a/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
@@ -33,11 +33,11 @@ class VariableNodeDefinition extends NodeDefinition
     {
         $node = $this->instantiateNode();
 
-        if (null !== $this->normalization) {
+        if (isset($this->normalization)) {
             $node->setNormalizationClosures($this->normalization->before);
         }
 
-        if (null !== $this->merge) {
+        if (isset($this->merge)) {
             $node->setAllowOverwrite($this->merge->allowOverwrite);
         }
 
@@ -55,7 +55,7 @@ class VariableNodeDefinition extends NodeDefinition
             $node->setDeprecated($this->deprecation['package'], $this->deprecation['version'], $this->deprecation['message']);
         }
 
-        if (null !== $this->validation) {
+        if (isset($this->validation)) {
             $node->setFinalValidationClosures($this->validation->rules);
         }
 

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -198,7 +198,7 @@ class ExprBuilderTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('You must specify a then part.');
         $builder = $this->getTestBuilder();
-        $builder->ifPart = 'test';
+        $builder->ifPart = static fn () => false;
         $builder->end();
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -561,7 +561,7 @@ class AutowirePass extends AbstractRecursivePass
 
     private function createTypeNotFoundMessageCallback(TypedReference $reference, string $label): \Closure
     {
-        if (null === $this->typesClone->container) {
+        if (!isset($this->typesClone->container)) {
             $this->typesClone->container = new ContainerBuilder($this->container->getParameterBag());
             $this->typesClone->container->setAliases($this->container->getAliases());
             $this->typesClone->container->setDefinitions($this->container->getDefinitions());

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1639,7 +1639,7 @@ EOF;
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -27,7 +27,7 @@ abstract class AbstractConfigurator
     public const FACTORY = 'unknown';
 
     /**
-     * @var callable(mixed, bool)|null
+     * @var \Closure(mixed, bool):mixed|null
      */
     public static $valuePreProcessor;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -72,7 +72,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -72,7 +72,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -87,7 +87,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -83,7 +83,7 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -59,7 +59,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -678,7 +678,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -462,7 +462,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -521,7 +521,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -114,7 +114,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -76,7 +76,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
@@ -59,7 +59,7 @@ class Symfony_DI_PhpDumper_Test_Base64Parameters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
@@ -59,7 +59,7 @@ class Symfony_DI_PhpDumper_Test_CsvParameters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
@@ -59,7 +59,7 @@ class Symfony_DI_PhpDumper_Test_DefaultParameters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters.php
@@ -80,7 +80,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters_as_files.txt
@@ -124,7 +124,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
@@ -91,7 +91,7 @@ class ProjectServiceContainer extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -462,7 +462,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
@@ -59,7 +59,7 @@ class Symfony_DI_PhpDumper_Test_JsonParameters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
@@ -59,7 +59,7 @@ class Symfony_DI_PhpDumper_Test_QueryStringParameters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -95,7 +95,7 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
@@ -94,7 +94,7 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
@@ -59,7 +59,7 @@ class Symfony_DI_PhpDumper_Test_UrlParameters extends Container
 
     public function getParameterBag(): ParameterBagInterface
     {
-        if (null === $this->parameterBag) {
+        if (!isset($this->parameterBag)) {
             $parameters = $this->parameters;
             foreach ($this->loadedDynamicParameters as $name => $loaded) {
                 $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1110,7 +1110,7 @@ class Crawler implements \Countable, \IteratorAggregate
      */
     private function convertToHtmlEntities(string $htmlContent, string $charset = 'UTF-8'): string
     {
-        set_error_handler(function () { throw new \Exception(); });
+        set_error_handler(static fn () => throw new \Exception());
 
         try {
             return mb_encode_numericentity($htmlContent, [0x80, 0x10FFFF, 0, 0x1FFFFF], $charset);

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -359,7 +359,7 @@ class ErrorHandler
     private function reRegister(int $prev): void
     {
         if ($prev !== ($this->thrownErrors | $this->loggedErrors)) {
-            $handler = set_error_handler('is_int');
+            $handler = set_error_handler(static fn () => null);
             $handler = \is_array($handler) ? $handler[0] : null;
             restore_error_handler();
             if ($handler === $this) {

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
@@ -56,7 +56,7 @@ class WrappedListenerTest extends TestCase
 
         $dispatcher = $this->createStub(EventDispatcherInterface::class);
 
-        $wrappedListener = new WrappedListener(function () { throw new \Exception(); }, null, $stopwatch, $dispatcher);
+        $wrappedListener = new WrappedListener(static fn () => throw new \Exception(), null, $stopwatch, $dispatcher);
 
         try {
             $wrappedListener(new \stdClass(), 'foo', $dispatcher);

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -55,7 +55,7 @@ class BinaryNode extends Node
             }
 
             $compiler
-                ->raw('(static function ($regexp, $str) { set_error_handler(function ($t, $m) use ($regexp, $str) { throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr($m, 12)); }); try { return preg_match($regexp, (string) $str); } finally { restore_error_handler(); } })(')
+                ->raw('(static function ($regexp, $str) { set_error_handler(static fn ($t, $m) => throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr($m, 12))); try { return preg_match($regexp, (string) $str); } finally { restore_error_handler(); } })(')
                 ->compile($this->nodes['right'])
                 ->raw(', ')
                 ->compile($this->nodes['left'])
@@ -194,9 +194,7 @@ class BinaryNode extends Node
 
     private function evaluateMatches(string $regexp, ?string $str): int
     {
-        set_error_handler(function ($t, $m) use ($regexp) {
-            throw new SyntaxError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12));
-        });
+        set_error_handler(static fn ($t, $m) => throw new SyntaxError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12)));
         try {
             return preg_match($regexp, (string) $str);
         } finally {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -123,7 +123,7 @@ class BinaryNodeTest extends AbstractNodeTestCase
 
             ['range(1, 3)', new BinaryNode('..', new ConstantNode(1), new ConstantNode(3))],
 
-            ['(static function ($regexp, $str) { set_error_handler(function ($t, $m) use ($regexp, $str) { throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr($m, 12)); }); try { return preg_match($regexp, (string) $str); } finally { restore_error_handler(); } })("/^[a-z]+\$/", "abc")', new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('/^[a-z]+$/'))],
+            ['(static function ($regexp, $str) { set_error_handler(static fn ($t, $m) => throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr($m, 12))); try { return preg_match($regexp, (string) $str); } finally { restore_error_handler(); } })("/^[a-z]+\$/", "abc")', new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('/^[a-z]+$/'))],
 
             ['str_starts_with("abc", "a")', new BinaryNode('starts with', new ConstantNode('abc'), new ConstantNode('a'))],
             ['str_ends_with("abc", "a")', new BinaryNode('ends with', new ConstantNode('abc'), new ConstantNode('a'))],

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -69,7 +69,7 @@ class ArrayChoiceList implements ChoiceListInterface
 
         if (null !== $value) {
             // If a deterministic value generator was passed, use it later
-            $this->valueCallback = $value;
+            $this->valueCallback = $value(...);
         } else {
             // Otherwise generate incrementing integers as values
             $value = static function () {

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -35,13 +35,6 @@ abstract class TypeTestCase extends FormIntegrationTestCase
         $this->builder = new FormBuilder('', null, $this->dispatcher, $this->factory);
     }
 
-    protected function tearDown(): void
-    {
-        if (\in_array(ValidatorExtensionTrait::class, class_uses($this))) {
-            $this->validator = null;
-        }
-    }
-
     protected function getExtensions()
     {
         $extensions = [];

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -264,8 +264,8 @@ class FormValidatorTest extends ConstraintValidatorTestCase
             ])
             ->setData($object)
             ->addViewTransformer(new CallbackTransformer(
-                fn ($data) => $data,
-                function () { throw new TransformationFailedException(); }
+                static fn ($data) => $data,
+                static fn () => throw new TransformationFailedException()
             ))
             ->getForm();
 
@@ -301,8 +301,8 @@ class FormValidatorTest extends ConstraintValidatorTestCase
             ])
             ->setData($object)
             ->addViewTransformer(new CallbackTransformer(
-                fn ($data) => $data,
-                function () { throw new TransformationFailedException(); }
+                static fn ($data) => $data,
+                static fn () => throw new TransformationFailedException()
             ))
             ->getForm();
 
@@ -336,8 +336,8 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $form = $this->getBuilder('name', '\stdClass', $options)
             ->setData($object)
             ->addViewTransformer(new CallbackTransformer(
-                fn ($data) => $data,
-                function () { throw new TransformationFailedException(); }
+                static fn ($data) => $data,
+                static fn () => throw new TransformationFailedException()
             ))
             ->getForm();
 
@@ -367,8 +367,8 @@ class FormValidatorTest extends ConstraintValidatorTestCase
             ])
             ->setData($object)
             ->addViewTransformer(new CallbackTransformer(
-                fn ($data) => $data,
-                function () {
+                static fn ($data) => $data,
+                static function () {
                     $failure = new TransformationFailedException();
                     $failure->setInvalidMessage('safe message to be used', ['{{ bar }}' => 'bar']);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -72,8 +72,8 @@ class ViolationMapperTest extends TestCase
 
         if (!$synchronized) {
             $config->addViewTransformer(new CallbackTransformer(
-                fn ($normData) => $normData,
-                function () { throw new TransformationFailedException(); }
+                static fn ($normData) => $normData,
+                static fn () => throw new TransformationFailedException()
             ));
         }
 

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -293,7 +293,7 @@ class BinaryFileResponse extends Response
     {
         try {
             if (!$this->isSuccessful()) {
-                return parent::sendContent();
+                return $this;
             }
 
             if (0 === $this->maxlen) {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -279,16 +279,16 @@ class Request
         $this->headers = new HeaderBag($this->server->getHeaders());
 
         $this->content = $content;
-        $this->languages = null;
-        $this->charsets = null;
-        $this->encodings = null;
-        $this->acceptableContentTypes = null;
-        $this->pathInfo = null;
-        $this->requestUri = null;
-        $this->baseUrl = null;
-        $this->basePath = null;
-        $this->method = null;
-        $this->format = null;
+        unset($this->languages);
+        unset($this->charsets);
+        unset($this->encodings);
+        unset($this->acceptableContentTypes);
+        unset($this->pathInfo);
+        unset($this->requestUri);
+        unset($this->baseUrl);
+        unset($this->basePath);
+        unset($this->method);
+        unset($this->format);
     }
 
     /**
@@ -465,16 +465,16 @@ class Request
             $dup->server = new ServerBag($server);
             $dup->headers = new HeaderBag($dup->server->getHeaders());
         }
-        $dup->languages = null;
-        $dup->charsets = null;
-        $dup->encodings = null;
-        $dup->acceptableContentTypes = null;
-        $dup->pathInfo = null;
-        $dup->requestUri = null;
-        $dup->baseUrl = null;
-        $dup->basePath = null;
-        $dup->method = null;
-        $dup->format = null;
+        unset($dup->languages);
+        unset($dup->charsets);
+        unset($dup->encodings);
+        unset($dup->acceptableContentTypes);
+        unset($dup->pathInfo);
+        unset($dup->requestUri);
+        unset($dup->baseUrl);
+        unset($dup->basePath);
+        unset($dup->method);
+        unset($dup->format);
 
         if (!$dup->get('_format') && $this->get('_format')) {
             $dup->attributes->set('_format', $this->get('_format'));
@@ -1179,7 +1179,7 @@ class Request
      */
     public function setMethod(string $method)
     {
-        $this->method = null;
+        unset($this->method);
         $this->server->set('REQUEST_METHOD', $method);
     }
 
@@ -1198,7 +1198,7 @@ class Request
      */
     public function getMethod(): string
     {
-        if (null !== $this->method) {
+        if (isset($this->method)) {
             return $this->method;
         }
 
@@ -1246,7 +1246,7 @@ class Request
      */
     public function getMimeType(string $format): ?string
     {
-        if (null === static::$formats) {
+        if (!isset(static::$formats)) {
             static::initializeFormats();
         }
 
@@ -1260,7 +1260,7 @@ class Request
      */
     public static function getMimeTypes(string $format): array
     {
-        if (null === static::$formats) {
+        if (!isset(static::$formats)) {
             static::initializeFormats();
         }
 
@@ -1277,7 +1277,7 @@ class Request
             $canonicalMimeType = trim(substr($mimeType, 0, $pos));
         }
 
-        if (null === static::$formats) {
+        if (!isset(static::$formats)) {
             static::initializeFormats();
         }
 
@@ -1302,7 +1302,7 @@ class Request
      */
     public function setFormat(?string $format, string|array $mimeTypes)
     {
-        if (null === static::$formats) {
+        if (!isset(static::$formats)) {
             static::initializeFormats();
         }
 
@@ -1583,13 +1583,13 @@ class Request
      */
     public function getPreferredFormat(?string $default = 'html'): ?string
     {
-        if (null !== $this->preferredFormat || null !== $this->preferredFormat = $this->getRequestFormat(null)) {
-            return $this->preferredFormat;
+        if (isset($this->preferredFormat) || null !== $preferredFormat = $this->getRequestFormat(null)) {
+            return $this->preferredFormat ??= $preferredFormat;
         }
 
         foreach ($this->getAcceptableContentTypes() as $mimeType) {
-            if ($this->preferredFormat = $this->getFormat($mimeType)) {
-                return $this->preferredFormat;
+            if ($preferredFormat = $this->getFormat($mimeType)) {
+                return $this->preferredFormat = $preferredFormat;
             }
         }
 
@@ -1636,7 +1636,7 @@ class Request
      */
     public function getLanguages(): array
     {
-        if (null !== $this->languages) {
+        if (isset($this->languages)) {
             return $this->languages;
         }
 
@@ -1677,11 +1677,7 @@ class Request
      */
     public function getCharsets(): array
     {
-        if (null !== $this->charsets) {
-            return $this->charsets;
-        }
-
-        return $this->charsets = array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept-Charset'))->all()));
+        return $this->charsets ??= array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept-Charset'))->all()));
     }
 
     /**
@@ -1691,11 +1687,7 @@ class Request
      */
     public function getEncodings(): array
     {
-        if (null !== $this->encodings) {
-            return $this->encodings;
-        }
-
-        return $this->encodings = array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept-Encoding'))->all()));
+        return $this->encodings ??= array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept-Encoding'))->all()));
     }
 
     /**
@@ -1705,11 +1697,7 @@ class Request
      */
     public function getAcceptableContentTypes(): array
     {
-        if (null !== $this->acceptableContentTypes) {
-            return $this->acceptableContentTypes;
-        }
-
-        return $this->acceptableContentTypes = array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept'))->all()));
+        return $this->acceptableContentTypes ??= array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept'))->all()));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -51,7 +51,7 @@ class StreamedResponse extends Response
      */
     public function setCallback(callable $callback): static
     {
-        $this->callback = $callback;
+        $this->callback = $callback(...);
 
         return $this;
     }
@@ -90,8 +90,8 @@ class StreamedResponse extends Response
 
         $this->streamed = true;
 
-        if (null === $this->callback) {
-            throw new \LogicException('The Response callback must not be null.');
+        if (!isset($this->callback)) {
+            throw new \LogicException('The Response callback must be set.');
         }
 
         ($this->callback)();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -40,7 +40,7 @@ class HttpKernelTest extends TestCase
     public function testHandleWhenControllerThrowsAnExceptionAndCatchIsTrue()
     {
         $this->expectException(\RuntimeException::class);
-        $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \RuntimeException(); });
+        $kernel = $this->getHttpKernel(new EventDispatcher(), static fn () => throw new \RuntimeException());
 
         $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, true);
     }
@@ -48,7 +48,7 @@ class HttpKernelTest extends TestCase
     public function testRequestStackIsNotBrokenWhenControllerThrowsAnExceptionAndCatchIsTrue()
     {
         $requestStack = new RequestStack();
-        $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \RuntimeException(); }, $requestStack);
+        $kernel = $this->getHttpKernel(new EventDispatcher(), static fn () => throw new \RuntimeException(), $requestStack);
 
         try {
             $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
@@ -61,7 +61,7 @@ class HttpKernelTest extends TestCase
     public function testRequestStackIsNotBrokenWhenControllerThrowsAnExceptionAndCatchIsFalse()
     {
         $requestStack = new RequestStack();
-        $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \RuntimeException(); }, $requestStack);
+        $kernel = $this->getHttpKernel(new EventDispatcher(), static fn () => throw new \RuntimeException(), $requestStack);
 
         try {
             $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, false);
@@ -74,7 +74,7 @@ class HttpKernelTest extends TestCase
     public function testRequestStackIsNotBrokenWhenControllerThrowsAnThrowable()
     {
         $requestStack = new RequestStack();
-        $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \Error(); }, $requestStack);
+        $kernel = $this->getHttpKernel(new EventDispatcher(), static fn () => throw new \Error(), $requestStack);
 
         try {
             $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
@@ -92,7 +92,7 @@ class HttpKernelTest extends TestCase
     public function testHandleWhenControllerThrowsAnExceptionAndCatchIsFalseAndNoListenerIsRegistered()
     {
         $this->expectException(\RuntimeException::class);
-        $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \RuntimeException(); });
+        $kernel = $this->getHttpKernel(new EventDispatcher(), static fn () => throw new \RuntimeException());
 
         $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, false);
     }
@@ -109,7 +109,7 @@ class HttpKernelTest extends TestCase
             $event->setResponse(new Response($event->getThrowable()->getMessage()));
         });
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { throw new \RuntimeException('foo'); });
+        $kernel = $this->getHttpKernel($dispatcher, static fn () => throw new \RuntimeException('foo'));
         $response = $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, true);
 
         $this->assertEquals('500', $response->getStatusCode());
@@ -128,7 +128,7 @@ class HttpKernelTest extends TestCase
             $event->setResponse(new Response($event->getThrowable()->getMessage()));
         });
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { throw new \TypeError('foo'); }, handleAllThrowables: true);
+        $kernel = $this->getHttpKernel($dispatcher, static fn () => throw new \TypeError('foo'), handleAllThrowables: true);
         $response = $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, true);
 
         $this->assertEquals('500', $response->getStatusCode());
@@ -147,7 +147,7 @@ class HttpKernelTest extends TestCase
             $event->setResponse(new Response($event->getThrowable()->getMessage()));
         });
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { throw new \TypeError('foo'); }, handleAllThrowables: true);
+        $kernel = $this->getHttpKernel($dispatcher, static fn () => throw new \TypeError('foo'), handleAllThrowables: true);
         $this->expectException(\TypeError::class);
         $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, false);
     }
@@ -168,7 +168,7 @@ class HttpKernelTest extends TestCase
         $controllerResolver
             ->expects($this->any())
             ->method('getController')
-            ->willReturn(function () { throw new \TypeError('foo'); });
+            ->willReturn(static fn () => throw new \TypeError('foo'));
 
         $argumentResolver = $this->createMock(ArgumentResolverInterface::class);
         $argumentResolver
@@ -196,7 +196,7 @@ class HttpKernelTest extends TestCase
             // should set a response, but does not
         });
 
-        $kernel = $this->getHttpKernel($dispatcher, function () use ($exception) { throw $exception; });
+        $kernel = $this->getHttpKernel($dispatcher, static fn () => throw $exception);
 
         try {
             $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, true);
@@ -213,7 +213,7 @@ class HttpKernelTest extends TestCase
             $event->setResponse(new RedirectResponse('/login', 301));
         });
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { throw new AccessDeniedHttpException(); });
+        $kernel = $this->getHttpKernel($dispatcher, static fn () => throw new AccessDeniedHttpException());
         $response = $kernel->handle(new Request());
 
         $this->assertEquals('301', $response->getStatusCode());
@@ -227,7 +227,7 @@ class HttpKernelTest extends TestCase
             $event->setResponse(new Response($event->getThrowable()->getMessage()));
         });
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { throw new MethodNotAllowedHttpException(['POST']); });
+        $kernel = $this->getHttpKernel($dispatcher, static fn () => throw new MethodNotAllowedHttpException(['POST']));
         $response = $kernel->handle(new Request());
 
         $this->assertEquals('405', $response->getStatusCode());
@@ -255,7 +255,7 @@ class HttpKernelTest extends TestCase
             $event->setResponse(new Response('', $expectedStatusCode));
         });
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { throw new \RuntimeException(); });
+        $kernel = $this->getHttpKernel($dispatcher, static fn () => throw new \RuntimeException());
         $response = $kernel->handle(new Request());
 
         $this->assertEquals($expectedStatusCode, $response->getStatusCode());
@@ -335,7 +335,7 @@ class HttpKernelTest extends TestCase
     public function testHandleWhenTheControllerDoesNotReturnAResponse()
     {
         $dispatcher = new EventDispatcher();
-        $kernel = $this->getHttpKernel($dispatcher, function () {});
+        $kernel = $this->getHttpKernel($dispatcher, static fn () => null);
 
         try {
             $kernel->handle(new Request());

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -46,7 +46,6 @@ class Query extends AbstractQuery
     public function __destruct()
     {
         $con = $this->connection->getResource();
-        $this->connection = null;
 
         if (!isset($this->results)) {
             return;
@@ -60,7 +59,6 @@ class Query extends AbstractQuery
                 throw new LdapException('Could not free results: '.ldap_error($con));
             }
         }
-        unset($this->results);
     }
 
     public function execute(): CollectionInterface

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
@@ -349,7 +349,7 @@ EOF;
             $state->markTail = 0;
 
             // if the regex is too large, throw a signaling exception to recompute with smaller chunk size
-            set_error_handler(function ($type, $message) { throw str_contains($message, $this->signalingException->getMessage()) ? $this->signalingException : new \ErrorException($message); });
+            set_error_handler(fn ($type, $message) => throw str_contains($message, $this->signalingException->getMessage()) ? $this->signalingException : new \ErrorException($message));
             try {
                 preg_match($state->regex, '');
             } finally {

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -193,10 +193,10 @@ class Router implements RouterInterface, RequestMatcherInterface
     {
         $this->context = $context;
 
-        if (null !== $this->matcher) {
+        if (isset($this->matcher)) {
             $this->getMatcher()->setContext($context);
         }
-        if (null !== $this->generator) {
+        if (isset($this->generator)) {
             $this->getGenerator()->setContext($context);
         }
     }
@@ -242,7 +242,7 @@ class Router implements RouterInterface, RequestMatcherInterface
      */
     public function getMatcher(): UrlMatcherInterface|RequestMatcherInterface
     {
-        if (null !== $this->matcher) {
+        if (isset($this->matcher)) {
             return $this->matcher;
         }
 
@@ -283,7 +283,7 @@ class Router implements RouterInterface, RequestMatcherInterface
      */
     public function getGenerator(): UrlGeneratorInterface
     {
-        if (null !== $this->generator) {
+        if (isset($this->generator)) {
             return $this->generator;
         }
 

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -23,16 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 #[WithHttpStatus(401)]
 class AuthenticationException extends RuntimeException
 {
-    /** @internal */
-    protected $serialized;
-
     private ?TokenInterface $token = null;
-
-    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
-    {
-        unset($this->serialized);
-        parent::__construct($message, $code, $previous);
-    }
 
     public function getToken(): ?TokenInterface
     {
@@ -104,24 +95,5 @@ class AuthenticationException extends RuntimeException
     public function getMessageData(): array
     {
         return [];
-    }
-
-    /**
-     * @internal
-     */
-    public function __sleep(): array
-    {
-        $this->serialized = $this->__serialize();
-
-        return ['serialized'];
-    }
-
-    /**
-     * @internal
-     */
-    public function __wakeup(): void
-    {
-        $this->__unserialize($this->serialized);
-        unset($this->serialized);
     }
 }

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -20,6 +20,9 @@ use Symfony\Component\Serializer\Exception\NotEncodableValueException;
  */
 class JsonDecode implements DecoderInterface
 {
+    /**
+     * @deprecated since Symfony 6.4, to be removed in 7.0
+     */
     protected $serializer;
 
     /**

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -448,7 +448,7 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
             $delimiter .= 'i';
         }
 
-        set_error_handler(static function ($t, $m) { throw new InvalidArgumentException($m); });
+        set_error_handler(static fn ($t, $m) => throw new InvalidArgumentException($m));
 
         try {
             if (false === $chunks = preg_split($delimiter, $this->string, $limit, $flags)) {
@@ -507,7 +507,7 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
             return $b;
         }
 
-        set_error_handler(static function ($t, $m) { throw new InvalidArgumentException($m); });
+        set_error_handler(static fn ($t, $m) => throw new InvalidArgumentException($m));
 
         try {
             try {

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -228,7 +228,7 @@ abstract class AbstractUnicodeString extends AbstractString
             $regexp .= 'i';
         }
 
-        set_error_handler(static function ($t, $m) { throw new InvalidArgumentException($m); });
+        set_error_handler(static fn ($t, $m) => throw new InvalidArgumentException($m));
 
         try {
             if (false === $match($regexp.'u', $this->string, $matches, $flags | \PREG_UNMATCHED_AS_NULL, $offset)) {
@@ -312,7 +312,7 @@ abstract class AbstractUnicodeString extends AbstractString
             $replace = 'preg_replace';
         }
 
-        set_error_handler(static function ($t, $m) { throw new InvalidArgumentException($m); });
+        set_error_handler(static fn ($t, $m) => throw new InvalidArgumentException($m));
 
         try {
             if (null === $string = $replace($fromRegexp.'u', $to, $this->string)) {

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -236,7 +236,7 @@ class ByteString extends AbstractString
             $regexp .= 'i';
         }
 
-        set_error_handler(static function ($t, $m) { throw new InvalidArgumentException($m); });
+        set_error_handler(static fn ($t, $m) => throw new InvalidArgumentException($m));
 
         try {
             if (false === $match($regexp, $this->string, $matches, $flags | \PREG_UNMATCHED_AS_NULL, $offset)) {
@@ -300,7 +300,7 @@ class ByteString extends AbstractString
 
         $replace = \is_array($to) || $to instanceof \Closure ? 'preg_replace_callback' : 'preg_replace';
 
-        set_error_handler(static function ($t, $m) { throw new InvalidArgumentException($m); });
+        set_error_handler(static fn ($t, $m) => throw new InvalidArgumentException($m));
 
         try {
             if (null === $string = $replace($fromRegexp, $to, $this->string)) {
@@ -417,7 +417,7 @@ class ByteString extends AbstractString
             return $u;
         }
 
-        set_error_handler(static function ($t, $m) { throw new InvalidArgumentException($m); });
+        set_error_handler(static fn ($t, $m) => throw new InvalidArgumentException($m));
 
         try {
             try {

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -34,22 +34,31 @@ class UnicodeString extends AbstractUnicodeString
 {
     public function __construct(string $string = '')
     {
-        $this->string = normalizer_is_normalized($string) ? $string : normalizer_normalize($string);
+        if ('' === $string || normalizer_is_normalized($this->string = $string)) {
+            return;
+        }
 
-        if (false === $this->string) {
+        if (false === $string = normalizer_normalize($string)) {
             throw new InvalidArgumentException('Invalid UTF-8 string.');
         }
+
+        $this->string = $string;
     }
 
     public function append(string ...$suffix): static
     {
         $str = clone $this;
         $str->string = $this->string.(1 >= \count($suffix) ? ($suffix[0] ?? '') : implode('', $suffix));
-        normalizer_is_normalized($str->string) ?: $str->string = normalizer_normalize($str->string);
 
-        if (false === $str->string) {
+        if (normalizer_is_normalized($str->string)) {
+            return $str;
+        }
+
+        if (false === $string = normalizer_normalize($str->string)) {
             throw new InvalidArgumentException('Invalid UTF-8 string.');
         }
+
+        $str->string = $string;
 
         return $str;
     }
@@ -209,11 +218,16 @@ class UnicodeString extends AbstractUnicodeString
     {
         $str = clone $this;
         $str->string = (1 >= \count($prefix) ? ($prefix[0] ?? '') : implode('', $prefix)).$this->string;
-        normalizer_is_normalized($str->string) ?: $str->string = normalizer_normalize($str->string);
 
-        if (false === $str->string) {
+        if (normalizer_is_normalized($str->string)) {
+            return $str;
+        }
+
+        if (false === $string = normalizer_normalize($str->string)) {
             throw new InvalidArgumentException('Invalid UTF-8 string.');
         }
+
+        $str->string = $string;
 
         return $str;
     }
@@ -235,11 +249,16 @@ class UnicodeString extends AbstractUnicodeString
             }
 
             $str->string = $result.$tail;
-            normalizer_is_normalized($str->string) ?: $str->string = normalizer_normalize($str->string);
 
-            if (false === $str->string) {
+            if (normalizer_is_normalized($str->string)) {
+                return $str;
+            }
+
+            if (false === $string = normalizer_normalize($str->string)) {
                 throw new InvalidArgumentException('Invalid UTF-8 string.');
             }
+
+            $str->string = $string;
         }
 
         return $str;
@@ -269,11 +288,16 @@ class UnicodeString extends AbstractUnicodeString
         $start = $start ? \strlen(grapheme_substr($this->string, 0, $start)) : 0;
         $length = $length ? \strlen(grapheme_substr($this->string, $start, $length ?? 2147483647)) : $length;
         $str->string = substr_replace($this->string, $replacement, $start, $length ?? 2147483647);
-        normalizer_is_normalized($str->string) ?: $str->string = normalizer_normalize($str->string);
 
-        if (false === $str->string) {
+        if (normalizer_is_normalized($str->string)) {
+            return $str;
+        }
+
+        if (false === $string = normalizer_normalize($str->string)) {
             throw new InvalidArgumentException('Invalid UTF-8 string.');
         }
+
+        $str->string = $string;
 
         return $str;
     }

--- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
@@ -35,8 +35,6 @@ abstract class FileDumper implements DumperInterface
     /**
      * Sets the template for the relative paths to files.
      *
-     * @param string $relativePathTemplate A template for the relative paths to files
-     *
      * @return void
      */
     public function setRelativePathTemplate(string $relativePathTemplate)

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -59,7 +59,7 @@ class Length extends Constraint
     public $min;
     public $charset = 'UTF-8';
     public $normalizer;
-    /* @var self::COUNT_* */
+    /** @var self::COUNT_* */
     public string $countUnit = self::COUNT_CODEPOINTS;
 
     /**

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -43,7 +43,7 @@ class YamlFileLoader extends FileLoader
 
     public function loadClassMetadata(ClassMetadata $metadata): bool
     {
-        if (null === $this->classes) {
+        if (!isset($this->classes)) {
             $this->loadClassesFromYaml();
         }
 
@@ -65,7 +65,7 @@ class YamlFileLoader extends FileLoader
      */
     public function getMappedClasses(): array
     {
-        if (null === $this->classes) {
+        if (!isset($this->classes)) {
             $this->loadClassesFromYaml();
         }
 

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -146,7 +146,7 @@ class ParentTestService2
 
     public function setContainer(ContainerInterface $container)
     {
-        $previous = $this->container;
+        $previous = $this->container ?? null;
         $this->container = $container;
 
         return $previous;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Some of the isset() checks are needed to make #51069 green on high-deps job.