### PR TITLE
[Serializer] Fix tests for extended Context attributes

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
@@ -121,12 +121,12 @@ class ContextChildMetadataDummy
      * @var \DateTime
      */
     #[Groups(['extended', 'simple'])]
-    #[Context([DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::RFC3339])]
-    #[Context(
+    #[DummyContextChild([DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::RFC3339])]
+    #[DummyContextChild(
         normalizationContext: [DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::RFC3339_EXTENDED],
         groups: ['extended'],
     )]
-    #[Context(
+    #[DummyContextChild(
         denormalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'd/m/Y'],
         groups: ['simple'],
     )]

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/DummyContextChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/DummyContextChild.php
@@ -13,14 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 
 use Symfony\Component\Serializer\Annotation\Context;
 
-/**
- * Annotation class for @DummyContextChild().
- *
- * @Annotation
- * @NamedArgumentConstructor
- * @Target({"PROPERTY", "METHOD"})
- */
-#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class DummyContextChild extends Context
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Follows #50983
| License       | MIT
| Doc PR        | not needed

In #50983, I broke one test scenario where we test that extending the `Context` class works. This PR corrects that mistake.