### PR TITLE
[SecurityBundle] Allow an array of `pattern` in firewall configuration

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `Security::ACCESS_DENIED_ERROR`, `AUTHENTICATION_ERROR` and `LAST_USERNAME` constants, use the ones on `SecurityRequestAttributes` instead
+ * Allow an array of `pattern` in firewall configuration
 
 6.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -191,7 +191,12 @@ class MainConfiguration implements ConfigurationInterface
         ;
 
         $firewallNodeBuilder
-            ->scalarNode('pattern')->end()
+            ->scalarNode('pattern')
+                ->beforeNormalization()
+                    ->ifArray()
+                    ->then(fn ($v) => sprintf('(?:%s)', implode('|', $v)))
+                ->end()
+            ->end()
             ->scalarNode('host')->end()
             ->arrayNode('methods')
                 ->beforeNormalization()->ifString()->then(function ($v) { return preg_split('/\s*,\s*/', $v); })->end()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
@@ -716,6 +716,15 @@ abstract class CompleteConfigurationTestCase extends TestCase
         $this->assertSame(['cookies', 'executionContexts'], $ClearSiteDataConfig);
     }
 
+    public function testFirewallPatterns()
+    {
+        $container = $this->getContainer('firewall_patterns');
+        $chainRequestMatcherId = (string) $container->getDefinition('security.firewall.map')->getArgument(1)->getValues()['security.firewall.map.context.no_security'];
+        $requestMatcherId = (string) $container->getDefinition($chainRequestMatcherId)->getArgument(0)[0];
+
+        $this->assertSame('(?:^/register$|^/documentation$)', $container->getDefinition($requestMatcherId)->getArgument(0));
+    }
+
     protected function getContainer($file)
     {
         $file .= '.'.$this->getFileExtension();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_patterns.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_patterns.php
@@ -1,0 +1,12 @@
+<?php
+
+$container->loadFromExtension('security', [
+    'firewalls' => [
+        'no_security' => [
+            'pattern' => [
+                '^/register$',
+                '^/documentation$',
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_patterns.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_patterns.yml
@@ -1,0 +1,6 @@
+security:
+    firewalls:
+        no_security:
+            pattern:
+                - "^/register$"
+                - "^/documentation$"

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCompleteConfigurationTest.php
@@ -17,6 +17,11 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlCompleteConfigurationTest extends CompleteConfigurationTestCase
 {
+    public function testFirewallPatterns()
+    {
+        $this->markTestSkipped('This features is not supported in XML.');
+    }
+
     protected function getLoader(ContainerBuilder $container)
     {
         return new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18617


allow this : 
```diff
 security:
     firewalls:
         no_security:
-            pattern: "^/(register|documentation)$"
+            pattern:
+                - "^/register$"
+                - "^/documentation$"
```

---


```php
/**
 * @Revs(100)
 * @Iterations(100)
 */
class RegexBench
{
    public function benchOneBigString()
    {
        preg_match("{^/(register|documentation)$}", "/register");
        preg_match("{^/(register|documentation)$}", "/foo");
    }

    public function benchArrayConcat()
    {
        preg_match("{(?:^/register$|^/documentation$)}", "/register");
        preg_match("{(?:^/register$|^/documentation$)}", "/foo");
    }
}
```

=> 

```
PHPBench (dev-master) running benchmarks... #standwithukraine                                                                                                                                
with configuration file: /home/gregoire/dev/github.com/lyrixx/php-bench/phpbench.json                                                                                                        
with PHP version 8.2.8, xdebug ❌, opcache ✔                                                                                                                                                 
                                                                                                                                                                                             
\RegexBench                                                                                                                                                                                  
                                                                                                                                                                                             
    benchOneBigString.......................I99 - Mo0.670μs (±17.85%)                                                                                                                        
    benchArrayConcat........................I99 - Mo0.664μs (±12.49%)                                                                                                                        
                                                                                                                                                                                             
Subjects: 2, Assertions: 0, Failures: 0, Errors: 0                                                                                                                                           
+-------------------+---------+-----------+                                                                                                                                                  
| subject           | mean    | mem_peak  |                                                                                                                                                  
+-------------------+---------+-----------+                                                                                                                                                  
| benchOneBigString | 0.716μs | 995.920kb |                                                                                                                                                  
| benchArrayConcat  | 0.707μs | 995.920kb |                                                                                                                                                  
+-------------------+---------+-----------+  
```