### PR TITLE
[VarDumper] Dump uninitialized properties

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Dump uninitialized properties
+
 6.3
 ---
 

--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -32,12 +32,15 @@ class Caster
     public const EXCLUDE_EMPTY = 128;
     public const EXCLUDE_NOT_IMPORTANT = 256;
     public const EXCLUDE_STRICT = 512;
+    public const EXCLUDE_UNINITIALIZED = 1024;
 
     public const PREFIX_VIRTUAL = "\0~\0";
     public const PREFIX_DYNAMIC = "\0+\0";
     public const PREFIX_PROTECTED = "\0*\0";
     // usage: sprintf(Caster::PATTERN_PRIVATE, $class, $property)
     public const PATTERN_PRIVATE = "\0%s\0%s";
+
+    private static array $classProperties = [];
 
     /**
      * Casts objects to arrays and adds the dynamic property prefix.
@@ -61,20 +64,17 @@ class Caster
             return $a;
         }
 
+        $classProperties = self::$classProperties[$class] ??= self::getClassProperties(new \ReflectionClass($class));
+        $a = array_replace($classProperties, $a);
+
         if ($a) {
-            static $publicProperties = [];
             $debugClass ??= get_debug_type($obj);
 
             $i = 0;
             $prefixedKeys = [];
             foreach ($a as $k => $v) {
                 if ("\0" !== ($k[0] ?? '')) {
-                    if (!isset($publicProperties[$class])) {
-                        foreach ((new \ReflectionClass($class))->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
-                            $publicProperties[$class][$prop->name] = true;
-                        }
-                    }
-                    if (!isset($publicProperties[$class][$k])) {
+                    if (!isset($classProperties[$k])) {
                         $prefixedKeys[$i] = self::PREFIX_DYNAMIC.$k;
                     }
                 } elseif ($debugClass !== $class && 1 === strpos($k, $class)) {
@@ -131,6 +131,8 @@ class Caster
                 $type |= self::EXCLUDE_EMPTY & $filter;
             } elseif (false === $v || '' === $v || '0' === $v || 0 === $v || 0.0 === $v || [] === $v) {
                 $type |= self::EXCLUDE_EMPTY & $filter;
+            } elseif ($v instanceof UninitializedStub) {
+                $type |= self::EXCLUDE_UNINITIALIZED & $filter;
             }
             if ((self::EXCLUDE_NOT_IMPORTANT & $filter) && !\in_array($k, $listedProperties, true)) {
                 $type |= self::EXCLUDE_NOT_IMPORTANT;
@@ -168,5 +170,29 @@ class Caster
         }
 
         return $a;
+    }
+
+    private static function getClassProperties(\ReflectionClass $class): array
+    {
+        $classProperties = [];
+        $className = $class->name;
+
+        foreach ($class->getProperties() as $p) {
+            if ($p->isStatic()) {
+                continue;
+            }
+
+            $classProperties[match (true) {
+                $p->isPublic() => $p->name,
+                $p->isProtected() => self::PREFIX_PROTECTED.$p->name,
+                default => "\0".$className."\0".$p->name,
+            }] = new UninitializedStub($p);
+        }
+
+        if ($parent = $class->getParentClass()) {
+            $classProperties += self::$classProperties[$parent->name] ??= self::getClassProperties($parent);
+        }
+
+        return $classProperties;
     }
 }

--- a/src/Symfony/Component/VarDumper/Caster/UninitializedStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/UninitializedStub.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+/**
+ * Represents an uninitialized property.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class UninitializedStub extends ConstStub
+{
+    public function __construct(\ReflectionProperty $property)
+    {
+        parent::__construct('?'.($property->hasType() ? ' '.$property->getType() : ''), 'Uninitialized property');
+    }
+}

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -85,6 +85,7 @@ class XmlReaderCaster
             $info[$props]->cut = $count;
         }
 
+        $a = Caster::filter($a, Caster::EXCLUDE_UNINITIALIZED, [], $count);
         $info = Caster::filter($info, Caster::EXCLUDE_EMPTY, [], $count);
         // +2 because hasValue and hasAttributes are always filtered
         $stub->cut += $count + 2;

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -378,6 +378,7 @@ array:1 [
     -file: "%sExceptionCasterTest.php"
     -line: %d
     -asString: null
+    -dataRepresentation: ? Symfony\Component\VarDumper\Cloner\Data
   }
 ]
 EODUMP;

--- a/src/Symfony/Component/VarDumper/Tests/Caster/MysqliCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/MysqliCasterTest.php
@@ -30,7 +30,6 @@ class MysqliCasterTest extends TestCase
 
         $xCast = <<<EODUMP
 mysqli_driver {%A
-  +reconnect: false
   +report_mode: 3
 }
 EODUMP;

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "ext-iconv": "*",
         "symfony/console": "^5.4|^6.0|^7.0",
+        "symfony/error-handler": "^6.3|^7.0",
         "symfony/http-kernel": "^5.4|^6.0|^7.0",
         "symfony/process": "^5.4|^6.0|^7.0",
         "symfony/uid": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50054
| License       | MIT
| Doc PR        | -

Replaces #50076

Given this:

```php
class Foo {
    private int|float $foo;
    public $baz;
}

$f = new Foo;
unset($f->baz);

dump($f);
```

This displays:

![image](https://github.com/symfony/symfony/assets/243674/00af5f8a-22ea-45ca-9ece-fec201517096)
