### PR TITLE
[Cache] Fix compat with ext-redis v6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,8 @@ install:
     - cd ext
     - appveyor DownloadFile https://github.com/symfony/binary-utils/releases/download/v0.1/php_apcu-5.1.22-8.2-ts-vs16-x86.zip
     - 7z x php_apcu-5.1.22-8.2-ts-vs16-x86.zip -y >nul
-    - appveyor DownloadFile https://github.com/symfony/binary-utils/releases/download/v0.1/php_redis-5.3.7-8.2-ts-vs16-x86.zip
-    - 7z x php_redis-5.3.7-8.2-ts-vs16-x86.zip -y >nul
+    - appveyor DownloadFile https://github.com/symfony/binary-utils/releases/download/v0.1/php_redis-6.0.0-dev-8.2-ts-vs16-x86.zip
+    - 7z x php_redis-6.0.0-dev-8.2-ts-vs16-x86.zip -y >nul
     - cd ..
     - copy /Y php.ini-development php.ini-min
     - echo memory_limit=-1 >> php.ini-min

--- a/src/Symfony/Component/Cache/Tests/Traits/RedisProxiesTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisProxiesTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\VarExporter\ProxyHelper;
 class RedisProxiesTest extends TestCase
 {
     /**
-     * @requires extension redis
+     * @requires extension redis < 6
      *
      * @testWith ["Redis"]
      *           ["RedisCluster"]
@@ -85,19 +85,24 @@ class RedisProxiesTest extends TestCase
      */
     public function testRedis6Proxy($class, $stub)
     {
-        $this->markTestIncomplete('To be re-enabled when phpredis v6 becomes stable');
+        if (version_compare(phpversion('redis'), '6.0.0', '<')) {
+            $this->markTestIncomplete('To be re-enabled when phpredis v6 becomes stable');
 
-        $stub = file_get_contents("https://raw.githubusercontent.com/phpredis/phpredis/develop/{$stub}.stub.php");
-        $stub = preg_replace('/^class /m', 'return; \0', $stub);
-        $stub = preg_replace('/^return; class ([a-zA-Z]++)/m', 'interface \1StubInterface', $stub, 1);
-        $stub = preg_replace('/^    public const .*/m', '', $stub);
-        eval(substr($stub, 5));
+            $stub = file_get_contents("https://raw.githubusercontent.com/phpredis/phpredis/develop/{$stub}.stub.php");
+            $stub = preg_replace('/^class /m', 'return; \0', $stub);
+            $stub = preg_replace('/^return; class ([a-zA-Z]++)/m', 'interface \1StubInterface', $stub, 1);
+            $stub = preg_replace('/^    public const .*/m', '', $stub);
+            eval(substr($stub, 5));
+            $r = new \ReflectionClass($class.'StubInterface');
+        } else {
+            $r = new \ReflectionClass($class);
+        }
 
         $proxy = file_get_contents(\dirname(__DIR__, 2)."/Traits/{$class}6Proxy.php");
         $proxy = substr($proxy, 0, 4 + strpos($proxy, '[];'));
         $methods = [];
 
-        foreach ((new \ReflectionClass($class.'StubInterface'))->getMethods() as $method) {
+        foreach ($r->getMethods() as $method) {
             if ('reset' === $method->name || method_exists(LazyProxyTrait::class, $method->name)) {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

WIP, looking to fix the failures on appveyor.

Redis::scan() deprecations need https://github.com/phpredis/phpredis/pull/2363