### PR TITLE
[Serializer] Remove obsolete annotation from fixture

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ChildOfGroupsAnnotationDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ChildOfGroupsAnnotationDummy.php
@@ -4,10 +4,6 @@ namespace Symfony\Component\Serializer\Tests\Fixtures;
 
 use Symfony\Component\Serializer\Annotation\Groups;
 
-/**
- * @Annotation
- * @Target({"PROPERTY", "METHOD"})
- */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 final class ChildOfGroupsAnnotationDummy extends Groups
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Follows #51080
| License       | MIT
| Doc PR        | not needed

I missed a spot while working on #51080.