### PR TITLE
[Scheduler] Postpone schedule creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^2.13.1|^3.0",
         "doctrine/orm": "^2.12",
-        "dragonmantank/cron-expression": "^3",
+        "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^2.1.10|^3.1|^4",
         "guzzlehttp/promises": "^1.4",
         "league/html-to-markdown": "^5.0",

--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -15,37 +15,39 @@ use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
 
 /**
  * @experimental
  */
 final class MessageGenerator implements MessageGeneratorInterface
 {
+    private Schedule $schedule;
     private TriggerHeap $triggerHeap;
     private ?\DateTimeImmutable $waitUntil;
-    private CheckpointInterface $checkpoint;
 
     public function __construct(
-        private readonly Schedule $schedule,
+        private readonly ScheduleProviderInterface $scheduleProvider,
         private readonly string $name,
         private readonly ClockInterface $clock = new Clock(),
-        CheckpointInterface $checkpoint = null,
+        private ?CheckpointInterface $checkpoint = null,
     ) {
         $this->waitUntil = new \DateTimeImmutable('@0');
-        $this->checkpoint = $checkpoint ?? new Checkpoint('scheduler_checkpoint_'.$this->name, $this->schedule->getLock(), $this->schedule->getState());
     }
 
     public function getMessages(): \Generator
     {
+        $checkpoint = $this->checkpoint();
+
         if (!$this->waitUntil
             || $this->waitUntil > ($now = $this->clock->now())
-            || !$this->checkpoint->acquire($now)
+            || !$checkpoint->acquire($now)
         ) {
             return;
         }
 
-        $lastTime = $this->checkpoint->time();
-        $lastIndex = $this->checkpoint->index();
+        $lastTime = $checkpoint->time();
+        $lastIndex = $checkpoint->index();
         $heap = $this->heap($lastTime);
 
         while (!$heap->isEmpty() && $heap->top()[0] <= $now) {
@@ -71,13 +73,13 @@ final class MessageGenerator implements MessageGeneratorInterface
 
             if ($yield) {
                 yield (new MessageContext($this->name, $id, $trigger, $time, $nextTime)) => $message;
-                $this->checkpoint->save($time, $index);
+                $checkpoint->save($time, $index);
             }
         }
 
         $this->waitUntil = $heap->isEmpty() ? null : $heap->top()[0];
 
-        $this->checkpoint->release($now, $this->waitUntil);
+        $checkpoint->release($now, $this->waitUntil);
     }
 
     private function heap(\DateTimeImmutable $time): TriggerHeap
@@ -88,7 +90,7 @@ final class MessageGenerator implements MessageGeneratorInterface
 
         $heap = new TriggerHeap($time);
 
-        foreach ($this->schedule->getRecurringMessages() as $index => $recurringMessage) {
+        foreach ($this->schedule()->getRecurringMessages() as $index => $recurringMessage) {
             if (!$nextTime = $recurringMessage->getTrigger()->getNextRunDate($time)) {
                 continue;
             }
@@ -97,5 +99,15 @@ final class MessageGenerator implements MessageGeneratorInterface
         }
 
         return $this->triggerHeap = $heap;
+    }
+
+    private function schedule(): Schedule
+    {
+        return $this->schedule ??= $this->scheduleProvider->getSchedule();
+    }
+
+    private function checkpoint(): Checkpoint
+    {
+        return $this->checkpoint ??= new Checkpoint('scheduler_checkpoint_'.$this->name, $this->schedule()->getLock(), $this->schedule()->getState());
     }
 }

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransportFactory.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransportFactory.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Scheduler\Exception\InvalidArgumentException;
 use Symfony\Component\Scheduler\Generator\MessageGenerator;
-use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
 
 /**
  * @experimental
@@ -43,10 +43,10 @@ class SchedulerTransportFactory implements TransportFactoryInterface
             throw new InvalidArgumentException(sprintf('The schedule "%s" is not found.', $scheduleName));
         }
 
-        /** @var Schedule $schedule */
-        $schedule = $this->scheduleProviders->get($scheduleName)->getSchedule();
+        /** @var ScheduleProviderInterface $scheduleProvider */
+        $scheduleProvider = $this->scheduleProviders->get($scheduleName);
 
-        return new SchedulerTransport(new MessageGenerator($schedule, $scheduleName, $this->clock));
+        return new SchedulerTransport(new MessageGenerator($scheduleProvider, $scheduleName, $this->clock));
     }
 
     public function supports(string $dsn, array $options): bool

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportFactoryTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportFactoryTest.php
@@ -36,13 +36,13 @@ class SchedulerTransportFactoryTest extends TestCase
         $defaultRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'default']);
         $customRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'custom']);
 
-        $default = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$defaultRecurringMessage]))->getSchedule(), 'default', $clock));
-        $custom = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$customRecurringMessage]))->getSchedule(), 'custom', $clock));
+        $default = new SchedulerTransport(new MessageGenerator(new SomeScheduleProvider([$defaultRecurringMessage]), 'default', $clock));
+        $custom = new SchedulerTransport(new MessageGenerator(new SomeScheduleProvider([$customRecurringMessage]), 'custom', $clock));
 
         $factory = new SchedulerTransportFactory(
             new Container([
-                'default' => fn () => (new SomeScheduleProvider([$defaultRecurringMessage]))->getSchedule(),
-                'custom' => fn () => (new SomeScheduleProvider([$customRecurringMessage]))->getSchedule(),
+                'default' => fn () => new SomeScheduleProvider([$defaultRecurringMessage]),
+                'custom' => fn () => new SomeScheduleProvider([$customRecurringMessage]),
             ]),
             $clock,
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51112
| License       | MIT
| Doc PR        | -

The issue is caused by the `MessengerTransportDoctrineSchemaListener` which is triggered when `doctrine:schema:create` is run. It [instantiates all transports](https://github.com/symfony/symfony/blob/4c1d9533355d66380e3f0fed774ebf38c601aab1/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php#L37) which causes the `ScheduleProviderInterface::getSchedule()` method to be called, but since the schema is not yet created, everything breaks.

This PR changes the `MessageGenerator` class to accept the `ScheduleProviderInterface` instead of only `Schedule`. That way the call to `getSchedule()` can be postponed to when it's really needed, and since the `Shedule` class implements the `ScheduleProviderInterface`, there's no breaking change.