### PR TITLE
[HttpKernel] Fix missing `Request` in `RequestStack` for `StreamedResponse`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -57,6 +57,14 @@ class StreamedResponse extends Response
     }
 
     /**
+     * Decorates the PHP callback associated with this Response.
+     */
+    public function getCallback(): callable
+    {
+        return $this->callback;
+    }
+
+    /**
      * This method only sends the headers once.
      *
      * @param null|positive-int $statusCode The status code to use, override the statusCode property if set and not null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 6.3
| Bug fix      | yes
| New feature  | no
| Deprecations | no
| Tickets       | Fix #46743
| License       | MIT

Fix removing the `\Symfony\Component\HttpFoundation\Request` from `\Symfony\Component\HttpFoundation\RequestStack` when using `\Symfony\Component\HttpFoundation\StreamedResponse`.