### PR TITLE
[Mime] Add PHP mimetype "text/x-php" extension "php"

### DIFF
--- a/src/Symfony/Component/Mime/MimeTypes.php
+++ b/src/Symfony/Component/Mime/MimeTypes.php
@@ -1670,6 +1670,7 @@ final class MimeTypes implements MimeTypesInterface
         'text/x-pascal' => ['p', 'pas'],
         'text/x-patch' => ['diff', 'patch'],
         'text/x-perl' => ['pl', 'PL', 'pm', 'al', 'perl', 'pod', 't'],
+        'text/x-php' => ['php'],
         'text/x-po' => ['po'],
         'text/x-pot' => ['pot'],
         'text/x-processing' => ['pde'],

--- a/src/Symfony/Component/Mime/Tests/MimeTypesTest.php
+++ b/src/Symfony/Component/Mime/Tests/MimeTypesTest.php
@@ -49,6 +49,7 @@ class MimeTypesTest extends AbstractMimeTypeGuesserTestCase
         $this->assertSame(['ai', 'eps', 'ps'], $mt->getExtensions('application/postscript'));
         $this->assertContains('svg', $mt->getExtensions('image/svg+xml'));
         $this->assertContains('svg', $mt->getExtensions('image/svg'));
+        $this->assertContains('php', $mt->getExtensions('text/x-php'));
         $this->assertSame([], $mt->getExtensions('application/whatever-symfony'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51124
| License       | MIT

Regarding the issue https://github.com/symfony/symfony/issues/51124, Added the php extension to the MAP for the mime type.