### PR TITLE
[Mailer] Precise AbstractApiTransport::getRecipients signature

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
@@ -37,6 +37,9 @@ abstract class AbstractApiTransport extends AbstractHttpTransport
         return $this->doSendApi($message, $email, $message->getEnvelope());
     }
 
+    /**
+     * @return Address[]
+     */
     protected function getRecipients(Email $email, Envelope $envelope): array
     {
         return array_filter($envelope->getRecipients(), fn (Address $address) => false === \in_array($address, array_merge($email->getCc(), $email->getBcc()), true));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Not sure about the branch I should target for this PHPdoc.
I started with 6.4 cause I assume the PR is not finished...

`AbstractApiTransport::getRecipients` is filtering the `Address[]` so return an array of Address too,
adding the `@return` phpdoc will help with autocompletion from PHPStorm and for static analysis.

Currently I have a some issue with adding the phpdoc, 
`MandrillApiTransport` is overriding the getRecipients without keeping the same structure ; 
I don't think it's a good practice since we can't be sure about the array elements then...

Maybe `MandrillApiTransport` should have his own `getPayloadRecipients` instead of overriding `getRecipients` ?