### PR TITLE
[FrameworkBundle] Simplify marking store configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -406,7 +406,7 @@ class Configuration implements ConfigurationInterface
                                                 ->values(['method'])
                                             ->end()
                                             ->scalarNode('property')
-                                                ->defaultValue('marking')
+                                                ->cannotBeEmpty()
                                             ->end()
                                             ->scalarNode('service')
                                                 ->cannotBeEmpty()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -998,11 +998,11 @@ class FrameworkExtension extends Extension
 
             // Create MarkingStore
             $markingStoreDefinition = null;
-            if (isset($workflow['marking_store']['type'])) {
+            if (isset($workflow['marking_store']['type']) || isset($workflow['marking_store']['property'])) {
                 $markingStoreDefinition = new ChildDefinition('workflow.marking_store.method');
                 $markingStoreDefinition->setArguments([
                     'state_machine' === $type, // single state
-                    $workflow['marking_store']['property'],
+                    $workflow['marking_store']['property'] ?? 'marking',
                 ]);
             } elseif (isset($workflow['marking_store']['service'])) {
                 $markingStoreDefinition = new Reference($workflow['marking_store']['service']);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_events_to_dispatch.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_events_to_dispatch.php
@@ -9,7 +9,6 @@ $container->loadFromExtension('framework', [
         'my_workflow' => [
             'type' => 'state_machine',
             'marking_store' => [
-                'type' => 'method',
                 'property' => 'state',
             ],
             'supports' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_specified_events_to_dispatch.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_specified_events_to_dispatch.xml
@@ -10,7 +10,7 @@
         <framework:annotations enabled="false" />
         <framework:workflow name="my_workflow" type="state_machine">
             <framework:initial-marking>one</framework:initial-marking>
-            <framework:marking-store type="method" property="state" />
+            <framework:marking-store property="state" />
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
             <framework:event-to-dispatch>workflow.leave</framework:event-to-dispatch>
             <framework:event-to-dispatch>workflow.completed</framework:event-to-dispatch>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_specified_events_to_dispatch.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_specified_events_to_dispatch.yml
@@ -7,7 +7,6 @@ framework:
             initial_marking: one
             events_to_dispatch: ['workflow.leave', 'workflow.completed']
             marking_store:
-                type: method
                 property: state
             supports:
                 - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

```yaml
framework:
    workflows:
        my_workflow:
            marking_store:
                #type: method <= not needed anymore if property is explicitly set
                property: state
```