### PR TITLE
Use Stringable interface as much as possible

### DIFF
--- a/src/Symfony/Component/Config/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Config/Resource/ResourceInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface ResourceInterface
+interface ResourceInterface extends \Stringable
 {
     /**
      * Returns a string representation of the Resource.

--- a/src/Symfony/Component/CssSelector/Node/NodeInterface.php
+++ b/src/Symfony/Component/CssSelector/Node/NodeInterface.php
@@ -21,11 +21,9 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-interface NodeInterface
+interface NodeInterface extends \Stringable
 {
     public function getNodeName(): string;
 
     public function getSpecificity(): Specificity;
-
-    public function __toString(): string;
 }

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -35,7 +35,7 @@ use Symfony\Component\Validator\ConstraintViolation;
  * @implements \RecursiveIterator<int, T>
  * @implements \SeekableIterator<int, T>
  */
-class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \ArrayAccess, \Countable
+class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \ArrayAccess, \Countable, \Stringable
 {
     /**
      * The prefix used for indenting nested error messages.

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\HttpFoundation;
  *
  * @implements \IteratorAggregate<string, list<string|null>>
  */
-class HeaderBag implements \IteratorAggregate, \Countable
+class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
 {
     protected const UPPER = '_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     protected const LOWER = '-abcdefghijklmnopqrstuvwxyz';

--- a/src/Symfony/Component/Mailer/Transport/TransportInterface.php
+++ b/src/Symfony/Component/Mailer/Transport/TransportInterface.php
@@ -24,12 +24,10 @@ use Symfony\Component\Mime\RawMessage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface TransportInterface
+interface TransportInterface extends \Stringable
 {
     /**
      * @throws TransportExceptionInterface
      */
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage;
-
-    public function __toString(): string;
 }

--- a/src/Symfony/Component/Notifier/Transport/TransportInterface.php
+++ b/src/Symfony/Component/Notifier/Transport/TransportInterface.php
@@ -18,7 +18,7 @@ use Symfony\Component\Notifier\Message\SentMessage;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface TransportInterface
+interface TransportInterface extends \Stringable
 {
     /**
      * @throws TransportExceptionInterface
@@ -26,6 +26,4 @@ interface TransportInterface
     public function send(MessageInterface $message): ?SentMessage;
 
     public function supports(MessageInterface $message): bool;
-
-    public function __toString(): string;
 }

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\PropertyAccess;
  *
  * @extends \Traversable<int, string>
  */
-interface PropertyPathInterface extends \Traversable
+interface PropertyPathInterface extends \Traversable, \Stringable
 {
     /**
      * Returns the string representation of the property path.

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-interface TokenInterface
+interface TokenInterface extends \Stringable
 {
     /**
      * Returns a string representation of the Token.

--- a/src/Symfony/Component/Security/Core/User/InMemoryUser.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUser.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Security\Core\User;
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class InMemoryUser implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface
+final class InMemoryUser implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface, \Stringable
 {
     private string $username;
     private ?string $password;

--- a/src/Symfony/Component/Templating/TemplateReferenceInterface.php
+++ b/src/Symfony/Component/Templating/TemplateReferenceInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Templating;
  *
  * @author Victor Berchet <victor@suumit.com>
  */
-interface TemplateReferenceInterface
+interface TemplateReferenceInterface extends \Stringable
 {
     /**
      * Gets the template parameters.

--- a/src/Symfony/Component/Translation/Provider/ProviderInterface.php
+++ b/src/Symfony/Component/Translation/Provider/ProviderInterface.php
@@ -14,10 +14,8 @@ namespace Symfony\Component\Translation\Provider;
 use Symfony\Component\Translation\TranslatorBag;
 use Symfony\Component\Translation\TranslatorBagInterface;
 
-interface ProviderInterface
+interface ProviderInterface extends \Stringable
 {
-    public function __toString(): string;
-
     /**
      * Translations available in the TranslatorBag only must be created.
      * Translations available in both the TranslatorBag and on the provider

--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Uid;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-abstract class AbstractUid implements \JsonSerializable
+abstract class AbstractUid implements \JsonSerializable, \Stringable
 {
     /**
      * The identifier in its canonic representation.

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -17,7 +17,7 @@ use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class Data implements \ArrayAccess, \Countable, \IteratorAggregate
+class Data implements \ArrayAccess, \Countable, \IteratorAggregate, \Stringable
 {
     private array $data;
     private int $position = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Instead of requiring `__toString()` in interfaces, wouldn't it be better to extend `\Stringable` ?
(I kept the method when comment was added)