### PR TITLE
[5.4] Fix symfony/deprecation-contracts require

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/config": "^4.4|^5.0|^6.0",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/twig-bridge": "^5.3|^6.0",
         "symfony/http-foundation": "^4.4|^5.0|^6.0",
         "symfony/http-kernel": "^5.0|^6.0",

--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/options-resolver": "^4.4|^5.0|^6.0",
         "symfony/polyfill-php80": "^1.15",
         "ext-ldap": "*"

--- a/src/Symfony/Component/PasswordHasher/composer.json
+++ b/src/Symfony/Component/PasswordHasher/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/polyfill-php80": "^1.16",
         "symfony/security-core": "^4.4|^5.0|^6.0"
     },

--- a/src/Symfony/Component/Security/Guard/composer.json
+++ b/src/Symfony/Component/Security/Guard/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/security-core": "^5.0",
         "symfony/security-http": "^5.3",
         "symfony/polyfill-php80": "^1.15"

--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Require `symfony/deprecation-contracts` in package that use `trigger_deprecation` without requiring the dependency :see_no_evil: .