### PR TITLE
[Scheduler] Add `AbstractTriggerDecorator`

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow setting timezone of next run date in CronExpressionTrigger
+ * Add `AbstractTriggerDecorator`
 
 6.3
 ---

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/AbstractDecoratedTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/AbstractDecoratedTriggerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Tests\Trigger;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Scheduler\Trigger\ExcludeTimeTrigger;
+use Symfony\Component\Scheduler\Trigger\JitterTrigger;
+use Symfony\Component\Scheduler\Trigger\TriggerInterface;
+
+class AbstractDecoratedTriggerTest extends TestCase
+{
+    public function testCanGetInnerTrigger()
+    {
+        $trigger = new JitterTrigger($inner = $this->createMock(TriggerInterface::class));
+
+        $this->assertSame($inner, $trigger->inner());
+        $this->assertSame([$trigger], iterator_to_array($trigger->decorators()));
+    }
+
+    public function testCanGetNestedInnerTrigger()
+    {
+        $trigger = new ExcludeTimeTrigger(
+            $jitter = new JitterTrigger($inner = $this->createMock(TriggerInterface::class)),
+            new \DateTimeImmutable(),
+            new \DateTimeImmutable(),
+        );
+
+        $this->assertSame($inner, $trigger->inner());
+        $this->assertSame([$trigger, $jitter], iterator_to_array($trigger->decorators()));
+    }
+}

--- a/src/Symfony/Component/Scheduler/Trigger/AbstractDecoratedTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/AbstractDecoratedTrigger.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Trigger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+abstract class AbstractDecoratedTrigger implements TriggerInterface
+{
+    public function __construct(private TriggerInterface $inner)
+    {
+    }
+
+    final public function inner(): TriggerInterface
+    {
+        $inner = $this->inner;
+
+        while ($inner instanceof self) {
+            $inner = $inner->inner;
+        }
+
+        return $inner;
+    }
+
+    /**
+     * @return \Traversable<self>
+     */
+    final public function decorators(): \Traversable
+    {
+        yield $this;
+
+        $inner = $this->inner;
+
+        while ($inner instanceof self) {
+            yield $inner;
+
+            $inner = $inner->inner;
+        }
+    }
+}

--- a/src/Symfony/Component/Scheduler/Trigger/ExcludeTimeTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/ExcludeTimeTrigger.php
@@ -14,13 +14,14 @@ namespace Symfony\Component\Scheduler\Trigger;
 /**
  * @experimental
  */
-final class ExcludeTimeTrigger implements TriggerInterface
+final class ExcludeTimeTrigger extends AbstractDecoratedTrigger
 {
     public function __construct(
         private readonly TriggerInterface $inner,
         private readonly \DateTimeImmutable $from,
         private readonly \DateTimeImmutable $until,
     ) {
+        parent::__construct($inner);
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
@@ -14,13 +14,14 @@ namespace Symfony\Component\Scheduler\Trigger;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class JitterTrigger implements TriggerInterface
+final class JitterTrigger extends AbstractDecoratedTrigger
 {
     /**
      * @param positive-int $maxSeconds
      */
     public function __construct(private readonly TriggerInterface $trigger, private readonly int $maxSeconds = 60)
     {
+        parent::__construct($trigger);
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -16,7 +16,7 @@ use Symfony\Component\Scheduler\Exception\InvalidArgumentException;
 /**
  * @experimental
  */
-class PeriodicalTrigger implements TriggerInterface, \Stringable
+class PeriodicalTrigger implements TriggerInterface
 {
     private float $intervalInSeconds = 0.0;
     private \DateTimeImmutable $from;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

I have a need to know what trigger _decorators_ are used and what the _real_ trigger is.

This PR adds an `AbstractTriggerDecorator` that the current decorators (`Jitter` & `ExcludeTime`) extend. 

```php
$trigger = new ExcludeTimeTrigger(new JitterTrigger(CronExpressionTrigger::fromSpec('#midnight', new MyMessage()));

$trigger->inner(); // CronExpressionTrigger
$trigger->decorators(); // [ExcludeTimeTrigger, JitterTrigger]
```