### PR TITLE
[Translation] Add `--as-tree` option  to `translation:pull` command

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Give current locale to `LocaleSwitcher::runWithLocale()`'s callback
+ * Add `--as-tree` option to `translation:pull` command to write YAML messages as a tree-like structure
 
 6.3
 ---

--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -95,6 +95,7 @@ final class TranslationPullCommand extends Command
                 new InputOption('domains', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Specify the domains to pull.'),
                 new InputOption('locales', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Specify the locales to pull.'),
                 new InputOption('format', null, InputOption::VALUE_OPTIONAL, 'Override the default output format.', 'xlf12'),
+                new InputOption('as-tree', null, InputOption::VALUE_OPTIONAL, 'Write messages as a tree-like structure. Needs --format=yaml. The given value defines the level where to switch to inline YAML'),
             ])
             ->setHelp(<<<'EOF'
 The <info>%command.name%</> command pulls translations from the given provider. Only
@@ -126,6 +127,7 @@ EOF
         $locales = $input->getOption('locales') ?: $this->enabledLocales;
         $domains = $input->getOption('domains');
         $format = $input->getOption('format');
+        $asTree = (int) $input->getOption('as-tree');
         $xliffVersion = '1.2';
 
         if ($intlIcu && !$force) {
@@ -142,6 +144,8 @@ EOF
             'path' => end($this->transPaths),
             'xliff_version' => $xliffVersion,
             'default_locale' => $this->defaultLocale,
+            'as_tree' => (bool) $asTree,
+            'inline' => $asTree,
         ];
 
         if (!$domains) {

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationProviderTestCase.php
@@ -55,6 +55,22 @@ abstract class TranslationProviderTestCase extends TestCase
         return new TranslationProviderCollection($collection);
     }
 
+    protected function createYamlFile(array $messages = ['node' => 'NOTE'], $targetLanguage = 'en', $fileNamePattern = 'messages.%locale%.yml'): string
+    {
+        $yamlContent = '';
+        foreach ($messages as $key => $value) {
+            $yamlContent .= "$key: $value\n";
+        }
+        $yamlContent .= "\n";
+
+        $filename = sprintf('%s/%s', $this->translationAppDir.'/translations', str_replace('%locale%', $targetLanguage, $fileNamePattern));
+        file_put_contents($filename, $yamlContent);
+
+        $this->files[] = $filename;
+
+        return $filename;
+    }
+
     protected function createFile(array $messages = ['note' => 'NOTE'], $targetLanguage = 'en', $fileNamePattern = 'messages.%locale%.xlf', string $xlfVersion = 'xlf12'): string
     {
         if ('xlf12' === $xlfVersion) {

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -16,8 +16,10 @@ use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Translation\Command\TranslationPullCommand;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Dumper\YamlFileDumper;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\Loader\YamlFileLoader;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\Reader\TranslationReader;
 use Symfony\Component\Translation\TranslatorBag;
@@ -233,6 +235,96 @@ XLIFF
 </xliff>
 XLIFF
             , file_get_contents($filenameFr));
+    }
+
+    public function testPullNewYamlMessagesAsInlined()
+    {
+        $arrayLoader = new ArrayLoader();
+        $filenameEn = $this->createYamlFile(['note' => 'NOTE'], 'en', 'messages.%locale%.yml');
+        $filenameFr = $this->createYamlFile(['note' => 'NOTE'], 'fr', 'messages.%locale%.yml');
+        $locales = ['en', 'fr'];
+        $domains = ['messages'];
+
+        $providerReadTranslatorBag = new TranslatorBag();
+        $providerReadTranslatorBag->addCatalogue($arrayLoader->load([
+            'note' => 'NOTE',
+            'new.foo' => 'newFoo',
+        ], 'en'));
+        $providerReadTranslatorBag->addCatalogue($arrayLoader->load([
+            'note' => 'NOTE',
+            'new.foo' => 'nouveauFoo',
+        ], 'fr'));
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('read')
+            ->with($domains, $locales)
+            ->willReturn($providerReadTranslatorBag);
+
+        $provider->expects($this->once())
+            ->method('__toString')
+            ->willReturn('null://default');
+
+        $tester = $this->createCommandTester($provider, $locales, $domains);
+        $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--format' => 'yml']);
+
+        $this->assertStringContainsString('[OK] New translations from "null" has been written locally (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertEquals(<<<YAML
+new.foo: newFoo
+note: NOTE
+
+YAML, file_get_contents($filenameEn));
+        $this->assertEquals(<<<YAML
+new.foo: nouveauFoo
+note: NOTE
+
+YAML, file_get_contents($filenameFr));
+    }
+
+    public function testPullNewYamlMessagesAsTree()
+    {
+        $arrayLoader = new ArrayLoader();
+        $filenameEn = $this->createYamlFile(['note' => 'NOTE'], 'en', 'messages.%locale%.yml');
+        $filenameFr = $this->createYamlFile(['note' => 'NOTE'], 'fr', 'messages.%locale%.yml');
+        $locales = ['en', 'fr'];
+        $domains = ['messages'];
+
+        $providerReadTranslatorBag = new TranslatorBag();
+        $providerReadTranslatorBag->addCatalogue($arrayLoader->load([
+            'note' => 'NOTE',
+            'new.foo' => 'newFoo',
+        ], 'en'));
+        $providerReadTranslatorBag->addCatalogue($arrayLoader->load([
+            'note' => 'NOTE',
+            'new.foo' => 'nouveauFoo',
+        ], 'fr'));
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('read')
+            ->with($domains, $locales)
+            ->willReturn($providerReadTranslatorBag);
+
+        $provider->expects($this->once())
+            ->method('__toString')
+            ->willReturn('null://default');
+
+        $tester = $this->createCommandTester($provider, $locales, $domains);
+        $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--format' => 'yml', '--as-tree' => 10]);
+
+        $this->assertStringContainsString('[OK] New translations from "null" has been written locally (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertEquals(<<<YAML
+new:
+    foo: newFoo
+note: NOTE
+
+YAML, file_get_contents($filenameEn));
+        $this->assertEquals(<<<YAML
+new:
+    foo: nouveauFoo
+note: NOTE
+
+YAML, file_get_contents($filenameFr));
     }
 
     public function testPullForceMessages()
@@ -641,9 +733,11 @@ XLIFF
     {
         $writer = new TranslationWriter();
         $writer->addDumper('xlf', new XliffFileDumper());
+        $writer->addDumper('yml', new YamlFileDumper());
 
         $reader = new TranslationReader();
         $reader->addLoader('xlf', new XliffFileLoader());
+        $reader->addLoader('yml', new YamlFileLoader());
 
         return new TranslationPullCommand(
             $this->getProviderCollection($provider, $providerNames, $locales, $domains),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | yes/no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This PR adds an option `--as-tree` to the command `translation:pull`, like the PR #38393 did it for the command `translation:extract`.

This option would ease the use of the command `translation:pull` when the yaml translations are stored as a tree. Without it, the yaml translations are inlined after a `translation:pull`, regardless of whether it was stored as inline or as a tree. To bypass this, you would either have to 
- re-indent the yaml file yourself after a `translation:pull`
- replace one service (e.g. `translation.dumper.yaml`) to forcefully add the option `as_tree` for the yaml file dumper 