### PR TITLE
[Notifier] [Docs] Fix update slack messages documentation

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/README.md
@@ -200,7 +200,7 @@ $chatter->send($chatMessage);
 Updating a Slack Message
 ------------------------
 
-First, save the full message ID when sending a message:
+First, save the message ID and channel ID when sending a message:
 
 ```php
 use Symfony\Component\Notifier\Bridge\Slack\SlackSentMessage;
@@ -210,18 +210,19 @@ $sentMessage = $chatter->send(new ChatMessage('Original message'));
 
 // Make sure that Slack transport was used
 if ($sentMessage instanceOf SlackSentMessage) {
-    $fullMessageId = $sentMessage->getFullMessageId();
+    $messageId = $sentMessage->getMessageId();
+    $channelId = $sentMessage->getChannelId();
 }
 ```
 
-Then, use that full message ID to create a new
+Then, use that message ID and channel ID to create a new
 ``UpdateMessageSlackOptions`` class:
 
 ```php
 use Symfony\Component\Notifier\Bridge\Slack\UpdateMessageSlackOptions;
 use Symfony\Component\Notifier\Message\ChatMessage;
 
-$options = new UpdateMessageSlackOptions($fullMessageId);
+$options = new UpdateMessageSlackOptions($channelId, $messageId);
 $chatter->send(new ChatMessage('Updated message', $options));
 ```
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

`UpdateMessageSlackOptions` receives a channel id and message id: 

https://github.com/symfony/symfony/blob/4c1d9533355d66380e3f0fed774ebf38c601aab1/src/Symfony/Component/Notifier/Bridge/Slack/UpdateMessageSlackOptions.php#L19

The method `getFullMessageId()` does not exists, it is `getMessageId()`

https://github.com/symfony/symfony/blob/4c1d9533355d66380e3f0fed774ebf38c601aab1/src/Symfony/Component/Notifier/Message/SentMessage.php#L44