### PR TITLE
[Serializer] Add support for seld/jsonlint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,7 @@
         "predis/predis": "^1.1|^2.0",
         "psr/http-client": "^1.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
+        "seld/jsonlint": "^1.10",
         "symfony/mercure-bundle": "^0.3",
         "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
         "symfony/runtime": "self.version",

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate Doctrine annotations support in favor of native attributes
  * Deprecate passing an annotation reader to the constructor of `AnnotationLoader`
  * Allow the `Groups` attribute/annotation on classes
+ * JsonDecode: Add `json_decode_detailed_errors` option
 
 6.3
 ---

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Serializer\Encoder;
 
+use Seld\JsonLint\JsonParser;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+use Symfony\Component\Serializer\Exception\UnsupportedException;
 
 /**
  * Decodes JSON data.
@@ -30,6 +32,11 @@ class JsonDecode implements DecoderInterface
      */
     public const ASSOCIATIVE = 'json_decode_associative';
 
+    /**
+     * True to enable seld/jsonlint as a source for more specific error messages when json_decode fails.
+     */
+    public const DETAILED_ERROR_MESSAGES = 'json_decode_detailed_errors';
+
     public const OPTIONS = 'json_decode_options';
 
     /**
@@ -39,6 +46,7 @@ class JsonDecode implements DecoderInterface
 
     private array $defaultContext = [
         self::ASSOCIATIVE => false,
+        self::DETAILED_ERROR_MESSAGES => false,
         self::OPTIONS => 0,
         self::RECURSION_DEPTH => 512,
     ];
@@ -69,6 +77,10 @@ class JsonDecode implements DecoderInterface
      * json_decode_options: integer
      *      Specifies additional options as per documentation for json_decode
      *
+     * json_decode_detailed_errors: bool
+     *      If true, enables seld/jsonlint as a source for more specific error messages when json_decode fails.
+     *      If false or not specified, this method will use default error messages from PHP's json_decode
+     *
      * @throws NotEncodableValueException
      *
      * @see https://php.net/json_decode
@@ -89,11 +101,20 @@ class JsonDecode implements DecoderInterface
             return $decodedData;
         }
 
-        if (\JSON_ERROR_NONE !== json_last_error()) {
-            throw new NotEncodableValueException(json_last_error_msg());
+        if (\JSON_ERROR_NONE === json_last_error()) {
+            return $decodedData;
+        }
+        $errorMessage = json_last_error_msg();
+
+        if (!($context[self::DETAILED_ERROR_MESSAGES] ?? $this->defaultContext[self::DETAILED_ERROR_MESSAGES])) {
+            throw new NotEncodableValueException($errorMessage);
         }
 
-        return $decodedData;
+        if (!class_exists(JsonParser::class)) {
+            throw new UnsupportedException(sprintf('Enabling "%s" serializer option requires seld/jsonlint. Try running "composer require seld/jsonlint".', self::DETAILED_ERROR_MESSAGES));
+        }
+
+        throw new NotEncodableValueException((new JsonParser())->lint($data)?->getMessage() ?: $errorMessage);
     }
 
     public function supportsDecoding(string $format): bool

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
@@ -58,17 +58,20 @@ class JsonDecodeTest extends TestCase
     /**
      * @dataProvider decodeProviderException
      */
-    public function testDecodeWithException($value)
+    public function testDecodeWithException(string $value, string $expectedExceptionMessage, array $context)
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->decode->decode($value, JsonEncoder::FORMAT);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        $this->decode->decode($value, JsonEncoder::FORMAT, $context);
     }
 
     public static function decodeProviderException()
     {
         return [
-            ["{'foo': 'bar'}"],
-            ['kaboom!'],
+            ["{'foo': 'bar'}", 'Syntax error', []],
+            ["{'foo': 'bar'}", 'single quotes instead of double quotes', ['json_decode_detailed_errors' => true]],
+            ['kaboom!', 'Syntax error', ['json_decode_detailed_errors' => false]],
+            ['kaboom!', "Expected one of: 'STRING', 'NUMBER', 'NULL',", ['json_decode_detailed_errors' => true]],
         ];
     }
 }

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.12|^2",
+        "seld/jsonlint": "^1.10",
         "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
         "symfony/cache": "^5.4|^6.0|^7.0",
         "symfony/config": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

This is kinda RFC proposal for improving JSON parsing errors in API context. At the moment, pretty much any time there is something wrong with input payload, framework will return something like so
```json
{
	"title": "Deserialization Failed",
	"detail": "Syntax error"
}
```
This provides very minimal info to go on. Also, "Syntax error" is quite confusing for majority of PHP devs I know (and _especially_ frontend developers, to whom these errors display), as they don't realize this is how PHP's json_decode reports these issues. Wouldn't it be better if we got something like
```json
{
	"title": "Deserialization Failed",
	"detail": "Parse error on line 1:\n{'foo': 'bar'}\n^\nInvalid string, it appears you used single quotes instead of double quotes"
}
```
or
```json
{
	"title": "Deserialization Failed",
	"detail": "Parse error on line 1:\nkaboom!\n^\nExpected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '['"
}
```
^ scenarios above are from https://github.com/symfony/symfony/blob/fe3094630f59739a506b34471b86cc2d1a271179/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php#L70-L71

? This is what my patch will do. All you need to do is install @Seldaek's [seld/jsonlint](https://packagist.org/packages/seld/jsonlint).

Now, initially I've just implemented support for this only in case jsonlint is installed, because I know how much Symfony tries to avoid adding dependencies. But if you are up for it, we could also make this required dependency, or embed its parser in Symfony. Or not do anything about it, saying PHP itself should improve this, but not sure how likely is that going to happen any time soon.