### PR TITLE
CI: Disable Psalm's `findUnusedBaselineEntry` feature

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     cacheDirectory="./.github/psalm/cache/"
     errorBaseline=".github/psalm/psalm.baseline.xml"
+    findUnusedBaselineEntry="false"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Psalm has introduced a feature for detecting unused entries in the error baseline. This is useful for a baseline that is maintained along with the code because it tells the developer when the baseline starts to smell and needs to be regenerated.

However, we use the baseline differently: We generate the baseline on the fly in order to check if a PR introduces new errors. Failing on baseline entries that can be purged is not what we want in that case because a contributor cannot fix those errors.

Example for a Psalm run that failed because of unused baseline entries: https://github.com/symfony/symfony/actions/runs/5706412328/job/15462071408