### PR TITLE
Fix requiring symfony/deprecation-contracts in symfony/routing

### DIFF
--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -24,6 +24,7 @@
         "symfony/yaml": "^6.4|^7.0",
         "symfony/expression-language": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "psr/log": "^1|^2|^3"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Last PR for this issue. `symfony/routing` always need this dep for deprecated routes.