### PR TITLE
[Finder] Revert "Fix children condition in ExcludeDirectoryFilterIterator"

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -59,7 +59,7 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator implements \Recursi
     #[\ReturnTypeWillChange]
     public function accept()
     {
-        if (isset($this->excludedDirs[$this->getFilename()]) && $this->hasChildren()) {
+        if ($this->isRecursive && isset($this->excludedDirs[$this->getFilename()]) && $this->isDir()) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51162, revert #50885
| License       | MIT
| Doc PR        | not needed

This PR reverts #50885 because it did not fix a bug and instead introduced a regression described in #51162.