### PR TITLE
Release v6.2.14

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -7,6 +7,10 @@ in 6.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.2.0...v6.2.1
 
+* 6.2.14 (2023-07-31)
+
+ * bug #51178 [Finder] Revert "Fix children condition in ExcludeDirectoryFilterIterator" (derrabus)
+
 * 6.2.13 (2023-07-30)
 
  * bug #50933 [Serializer] Fix deserializing nested arrays of objects with mixed keys (HypeMC)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -75,11 +75,11 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.2.13';
-    public const VERSION_ID = 60213;
+    public const VERSION = '6.2.14';
+    public const VERSION_ID = 60214;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 2;
-    public const RELEASE_VERSION = 13;
+    public const RELEASE_VERSION = 14;
     public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2023';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.2.13...v6.2.14)

 * bug #51178 [Finder] Revert "Fix children condition in ExcludeDirectoryFilterIterator" (@derrabus)
