### PR TITLE
[Clock] load function only if not loaded before

### DIFF
--- a/src/Symfony/Component/Clock/Resources/now.php
+++ b/src/Symfony/Component/Clock/Resources/now.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Component\Clock;
 
-/**
- * Returns the current time as a DateTimeImmutable.
- *
- * Note that you should prefer injecting a ClockInterface or using
- * ClockAwareTrait when possible instead of using this function.
- */
-function now(): \DateTimeImmutable
-{
-    return Clock::get()->now();
+if (!\function_exists(now::class)) {
+    /**
+     * Returns the current time as a DateTimeImmutable.
+     *
+     * Note that you should prefer injecting a ClockInterface or using
+     * ClockAwareTrait when possible instead of using this function.
+     */
+    function now(): \DateTimeImmutable
+    {
+        return Clock::get()->now();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51180
| License       | MIT
| Doc PR        | 

We do the same for functions defined in the String, Translation and VarDumper components.