### PR TITLE
do not declare the PSR-7 bridge to be replaced by symfony/symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,6 @@
         "symfony/property-access": "self.version",
         "symfony/property-info": "self.version",
         "symfony/proxy-manager-bridge": "self.version",
-        "symfony/psr-http-message-bridge": "self.version",
         "symfony/rate-limiter": "self.version",
         "symfony/remote-event": "self.version",
         "symfony/routing": "self.version",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51192
| License       | MIT
| Doc PR        | 
