### PR TITLE
[PsrHttpMessageBridge] Support `php-http/discovery` for auto-detecting PSR-17 factories

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/CHANGELOG.md
+++ b/src/Symfony/Bridge/PsrHttpMessage/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Import the bridge into the Symfony monorepo and synchronize releases
  * Remove `ArgumentValueResolverInterface` from `PsrServerRequestResolver`
+ * Support `php-http/discovery` for auto-detecting PSR-17 factories
 
 2.3.1
 -----

--- a/src/Symfony/Bridge/PsrHttpMessage/Factory/PsrHttpFactory.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Factory/PsrHttpFactory.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\PsrHttpMessage\Factory;
 
+use Http\Discovery\Psr17Factory as DiscoveryPsr17Factory;
+use Nyholm\Psr7\Factory\Psr17Factory as NyholmPsr17Factory;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
@@ -33,12 +35,34 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class PsrHttpFactory implements HttpMessageFactoryInterface
 {
+    private readonly ServerRequestFactoryInterface $serverRequestFactory;
+    private readonly StreamFactoryInterface $streamFactory;
+    private readonly UploadedFileFactoryInterface $uploadedFileFactory;
+    private readonly ResponseFactoryInterface $responseFactory;
+
     public function __construct(
-        private readonly ServerRequestFactoryInterface $serverRequestFactory,
-        private readonly StreamFactoryInterface $streamFactory,
-        private readonly UploadedFileFactoryInterface $uploadedFileFactory,
-        private readonly ResponseFactoryInterface $responseFactory,
+        ServerRequestFactoryInterface $serverRequestFactory = null,
+        StreamFactoryInterface $streamFactory = null,
+        UploadedFileFactoryInterface $uploadedFileFactory = null,
+        ResponseFactoryInterface $responseFactory = null,
     ) {
+        if (null === $serverRequestFactory || null === $streamFactory || null === $uploadedFileFactory || null === $responseFactory) {
+            $psr17Factory = match (true) {
+                class_exists(DiscoveryPsr17Factory::class) => new DiscoveryPsr17Factory(),
+                class_exists(NyholmPsr17Factory::class) => new NyholmPsr17Factory(),
+                default => throw new \LogicException(sprintf('You cannot use the "%s" as no PSR-17 factories have been provided. Try running "composer require php-http/discovery psr/http-factory-implementation:*".', self::class)),
+            };
+
+            $serverRequestFactory ??= $psr17Factory;
+            $streamFactory ??= $psr17Factory;
+            $uploadedFileFactory ??= $psr17Factory;
+            $responseFactory ??= $psr17Factory;
+        }
+
+        $this->serverRequestFactory = $serverRequestFactory;
+        $this->streamFactory = $streamFactory;
+        $this->uploadedFileFactory = $uploadedFileFactory;
+        $this->responseFactory = $responseFactory;
     }
 
     public function createRequest(Request $symfonyRequest): ServerRequestInterface

--- a/src/Symfony/Bridge/PsrHttpMessage/composer.json
+++ b/src/Symfony/Bridge/PsrHttpMessage/composer.json
@@ -27,13 +27,17 @@
         "symfony/framework-bundle": "^6.2|^7.0",
         "symfony/http-kernel": "^6.2|^7.0",
         "nyholm/psr7": "^1.1",
+        "php-http/discovery": "^1.15",
         "psr/log": "^1.1.4|^2|^3"
     },
     "conflict": {
+        "php-http/discovery": "<1.15",
         "symfony/http-kernel": "<6.2"
     },
-    "suggest": {
-        "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\PsrHttpMessage\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

This PR follows the example of `Symfony\Component\HttpClient\Psr18Client` and makes all dependencies of `PsrHttpFactory` optional.

If `php-http/discovery` is not installed, I'm falling back to @Nyholm's implementation if it's available. This is consistent with `Psr18Client`'s behavior. However, I wonder if this is the right course of action, given that `php-http/discovery` already handles the problem of discovering an implementation well.