### PR TITLE
[DependencyInjection] Fix autocasting `null` env values to empty string with `container.env_var_processors_locator`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -391,13 +391,9 @@ class Container implements ContainerInterface, ResetInterface
             $localName = $name;
         }
 
-        if ($processors->has($prefix)) {
-            $processor = $processors->get($prefix);
-        } else {
-            $processor = new EnvVarProcessor($this);
-            if (false === $i) {
-                $prefix = '';
-            }
+        $processor = $processors->has($prefix) ? $processors->get($prefix) : new EnvVarProcessor($this);
+        if (false === $i) {
+            $prefix = '';
         }
 
         $this->resolving[$envName] = true;

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessorInterface.php
@@ -23,7 +23,7 @@ interface EnvVarProcessorInterface
     /**
      * Returns the value of the given variable as managed by the current instance.
      *
-     * @param string   $prefix The namespace of the variable
+     * @param string   $prefix The namespace of the variable; when the empty string is passed, null values should be kept as is
      * @param string   $name   The name of the variable within the namespace
      * @param \Closure $getEnv A closure that allows fetching more env vars
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/50837#discussion_r1279230875
| License       | MIT
| Doc PR        | no

The previous fix doesn't work when `$processors` comes from `container.env_var_processors_locator`.