### PR TITLE
[Console] `ChoiceQuestion` - choice to get value or key

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -174,14 +174,18 @@ class QuestionHelper extends Helper
         } elseif ($question instanceof ChoiceQuestion) {
             $choices = $question->getChoices();
 
-            if (!$question->isMultiselect()) {
-                return $choices[$default] ?? $default;
-            }
+            if ($question->isChoiceKeys()) {
+                return $question->isMultiselect() ? array_map(fn ($v) => trim($v), explode(',', $default)) : $default;
+            } else {
+                if (!$question->isMultiselect()) {
+                    return $choices[$default] ?? $default;
+                }
 
-            $default = explode(',', $default);
-            foreach ($default as $k => $v) {
-                $v = $question->isTrimmable() ? trim($v) : $v;
-                $default[$k] = $choices[$v] ?? $v;
+                $default = explode(',', $default);
+                foreach ($default as $k => $v) {
+                    $v = $question->isTrimmable() ? trim($v) : $v;
+                    $default[$k] = $choices[$v] ?? $v;
+                }
             }
         }
 

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -272,14 +272,14 @@ class SymfonyStyle extends OutputStyle
         return $this->askQuestion(new ConfirmationQuestion($question, $default));
     }
 
-    public function choice(string $question, array $choices, mixed $default = null, bool $multiSelect = false): mixed
+    public function choice(string $question, array $choices, mixed $default = null, bool $multiSelect = false, bool $choiceKeys = false): mixed
     {
         if (null !== $default) {
             $values = array_flip($choices);
             $default = $values[$default] ?? $default;
         }
 
-        $questionChoice = new ChoiceQuestion($question, $choices, $default);
+        $questionChoice = new ChoiceQuestion($question, $choices, $default, $choiceKeys);
         $questionChoice->setMultiselect($multiSelect);
 
         return $this->askQuestion($questionChoice);

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -96,6 +96,44 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         $this->assertEquals('Superman', $questionHelper->ask($this->createStreamableInputInterfaceMock($inputStream, true), $this->createOutputInterface(), $question));
     }
 
+    public function testAskChoiceDefaultWithKey()
+    {
+        $questionHelper = new QuestionHelper();
+
+        $helperSet = new HelperSet([new FormatterHelper()]);
+        $questionHelper->setHelperSet($helperSet);
+
+        $heroes = ['Superman', 'Batman', 'Spiderman'];
+
+        $inputStream = $this->getInputStream("\n");
+
+        $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, '2', true);
+        $question->setMaxAttempts(1);
+        // empty answer, we're supposed to receive the default value
+        $this->assertEquals('2', $questionHelper->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+    }
+
+    public function testAskChoiceDefaultWithAssoc()
+    {
+        $questionHelper = new QuestionHelper();
+
+        $helperSet = new HelperSet([new FormatterHelper()]);
+        $questionHelper->setHelperSet($helperSet);
+
+        $heroes = [
+            'k0' => 'Superman',
+            'k1' => 'Batman',
+            'k2' => 'Spiderman',
+        ];
+
+        $inputStream = $this->getInputStream("\n");
+
+        $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, 'Spiderman');
+        $question->setMaxAttempts(1);
+        // empty answer, we're supposed to receive the default value
+        $this->assertEquals('k2', $questionHelper->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+    }
+
     public function testAskChoiceNonInteractive()
     {
         $questionHelper = new QuestionHelper();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40439
| License       | MIT
| Doc PR        | symfony/symfony-docs#... TBD

Give the developer the Choice to get either the value(s) of a ChoiceQuestion (default behavior) or the key(s) of the selected values.

### Example
```php
$choices = ['value_0','value_1', 'value_2'];

$io = new SymfonyStyle($input, $output);

$value = $io->choice('Choose something', $choices, '1'); // $value would be 'value_1' with default choice
$key = $io->choice('Choose something', $choices, '1', true); // $key would be '1' with default choice
```
