### PR TITLE
[Workflow] Use TRANSITION_TYPE_WORKFLOW for rendering workflow in profiler

### DIFF
--- a/src/Symfony/Component/Workflow/DataCollector/WorkflowDataCollector.php
+++ b/src/Symfony/Component/Workflow/DataCollector/WorkflowDataCollector.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\Workflow\Dumper\MermaidDumper;
-use Symfony\Component\Workflow\StateMachine;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -35,8 +34,9 @@ final class WorkflowDataCollector extends DataCollector implements LateDataColle
     public function lateCollect(): void
     {
         foreach ($this->workflows as $workflow) {
-            $type = $workflow instanceof StateMachine ? MermaidDumper::TRANSITION_TYPE_STATEMACHINE : MermaidDumper::TRANSITION_TYPE_WORKFLOW;
-            $dumper = new MermaidDumper($type);
+            // We always use a workflow type because we want to mermaid to
+            // create a node for transitions
+            $dumper = new MermaidDumper(MermaidDumper::TRANSITION_TYPE_WORKFLOW);
             $this->data['workflows'][$workflow->getName()] = [
                 'dump' => $dumper->dump($workflow->getDefinition()),
             ];

--- a/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
@@ -102,7 +102,7 @@ class MermaidDumper implements DumperInterface
                     $to = $placeNameMap[$to];
 
                     if (self::TRANSITION_TYPE_STATEMACHINE === $this->transitionType) {
-                        $transitionOutput = $this->styleStatemachineTransition($from, $to, $transitionLabel, $transitionMeta);
+                        $transitionOutput = $this->styleStateMachineTransition($from, $to, $transitionLabel, $transitionMeta);
                     } else {
                         $transitionOutput = $this->styleWorkflowTransition($from, $to, $transitionId, $transitionLabel, $transitionMeta);
                     }
@@ -196,7 +196,7 @@ class MermaidDumper implements DumperInterface
         }
     }
 
-    private function styleStatemachineTransition(string $from, string $to, string $transitionLabel, array $transitionMeta): array
+    private function styleStateMachineTransition(string $from, string $to, string $transitionLabel, array $transitionMeta): array
     {
         $transitionOutput = [sprintf('%s-->|%s|%s', $from, str_replace("\n", ' ', $this->escape($transitionLabel)), $to)];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

This one is a bit special.

Usually a state machine render like this:

![image](https://github.com/symfony/symfony/assets/408368/50f45620-aa88-4fc8-97c2-1049c08b2ee7)

As you can see, **transitions** (ex: `start_process`) are not real nodes. They are arrows.

And it's not possible to attach events on arrows, only on nodes.

That's why I add this hybrid mode, where state machine are rendered like a workflow. It means transitions are renderered as node:

![image](https://github.com/symfony/symfony/assets/408368/80f6731a-2d02-4eab-be2d-77ab67495006)


Now, we can attach event on transition nodes.