### PR TITLE
[Workflow] Add a `TraceableWorkflow`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -70,6 +70,7 @@ use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 use Symfony\Component\Validator\DependencyInjection\AddValidatorInitializersPass;
 use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\Registry;
+use Symfony\Component\Workflow\DependencyInjection\WorkflowDebugPass;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowGuardListenerPass;
 
 // Help opcache.preload discover always-needed symbols
@@ -189,6 +190,7 @@ class FrameworkBundle extends Bundle
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);
             $container->addCompilerPass(new CacheCollectorPass(), PassConfig::TYPE_BEFORE_REMOVING);
+            $this->addCompilerPassIfExists($container, WorkflowDebugPass::class);
         }
     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
@@ -1,5 +1,22 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
+{% block toolbar %}
+    {% if collector.callsCount > 0 %}
+        {% set icon %}
+            {{ source('@WebProfiler/Icon/workflow.svg') }}
+            <span class="sf-toolbar-value">{{ collector.callsCount }}</span>
+        {% endset %}
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                <b>Workflow Calls</b>
+                <span>{{ collector.callsCount }}</span>
+            </div>
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}
+    {% endif %}
+{% endblock %}
+
 {% block menu %}
     <span class="label {{ collector.workflows|length == 0 ? 'disabled' }}">
         <span class="icon">
@@ -45,15 +62,67 @@
             });
         </script>
 
-        <h2>Definitions</h2>
         <div class="sf-tabs js-tabs">
             {% for name, data in collector.workflows %}
                 <div class="tab">
-                    <h3 class="tab-title">{{ name }}</h3>
+                    <h2 class="tab-title">{{ name }}{% if data.calls|length %} ({{ data.calls|length }}){% endif %}</h2>
+
                     <div class="tab-content">
+                        <h3>Definition</h3>
                         <pre class="sf-mermaid">
                             {{ data.dump|raw }}
                         </pre>
+
+                        <h3>Calls</h3>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Call</th>
+                                    <th>Args</th>
+                                    <th>Return</th>
+                                    <th>Exception</th>
+                                    <th>Duration</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for call in data.calls %}
+                                    <tr>
+                                        <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
+                                        <td>
+                                            <code>{{ call.method }}()</code>
+                                            {% if call.previousMarking ?? null %}
+                                                <hr />
+                                                Previous marking:
+                                                {{ profiler_dump(call.previousMarking) }}
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {{ profiler_dump(call.args) }}
+                                        </td>
+                                        <td>
+                                            {% if call.return is defined %}
+                                                {% if call.return is same as true %}
+                                                    <code>true</code>
+                                                {% elseif call.return is same as false %}
+                                                    <code>false</code>
+                                                {% else %}
+                                                    {{ profiler_dump(call.return) }}
+                                                {% endif %}
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {% if call.exception is defined %}
+                                                {{ profiler_dump(call.exception) }}
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {{ call.duration }}ms
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     </div>
                 </div>
             {% endfor %}

--- a/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
+++ b/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Debug;
+
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
+use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
+use Symfony\Component\Workflow\TransitionBlockerList;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class TraceableWorkflow implements WorkflowInterface
+{
+    private array $calls = [];
+
+    public function __construct(
+        private readonly WorkflowInterface $workflow,
+        private readonly Stopwatch $stopwatch,
+    ) {
+    }
+
+    public function getMarking(object $subject, array $context = []): Marking
+    {
+        return $this->callInner(__FUNCTION__, \func_get_args());
+    }
+
+    public function can(object $subject, string $transitionName): bool
+    {
+        return $this->callInner(__FUNCTION__, \func_get_args());
+    }
+
+    public function buildTransitionBlockerList(object $subject, string $transitionName): TransitionBlockerList
+    {
+        return $this->callInner(__FUNCTION__, \func_get_args());
+    }
+
+    public function apply(object $subject, string $transitionName, array $context = []): Marking
+    {
+        return $this->callInner(__FUNCTION__, \func_get_args());
+    }
+
+    public function getEnabledTransitions(object $subject): array
+    {
+        return $this->callInner(__FUNCTION__, \func_get_args());
+    }
+
+    public function getName(): string
+    {
+        return $this->workflow->getName();
+    }
+
+    public function getDefinition(): Definition
+    {
+        return $this->workflow->getDefinition();
+    }
+
+    public function getMarkingStore(): MarkingStoreInterface
+    {
+        return $this->workflow->getMarkingStore();
+    }
+
+    public function getMetadataStore(): MetadataStoreInterface
+    {
+        return $this->workflow->getMetadataStore();
+    }
+
+    public function getCalls(): array
+    {
+        return $this->calls;
+    }
+
+    private function callInner(string $method, array $args): mixed
+    {
+        $sMethod = $this->workflow::class.'::'.$method;
+        $this->stopwatch->start($sMethod, 'workflow');
+
+        $previousMarking = null;
+        if ('apply' === $method) {
+            try {
+                $previousMarking = $this->workflow->getMarking($args[0]);
+            } catch (\Throwable) {
+            }
+        }
+
+        try {
+            $return = $this->workflow->{$method}(...$args);
+
+            $this->calls[] = [
+                'method' => $method,
+                'duration' => $this->stopwatch->stop($sMethod)->getDuration(),
+                'args' => $args,
+                'previousMarking' => $previousMarking ?? null,
+                'return' => $return,
+            ];
+
+            return $return;
+        } catch (\Throwable $exception) {
+            $this->calls[] = [
+                'method' => $method,
+                'duration' => $this->stopwatch->stop($sMethod)->getDuration(),
+                'args' => $args,
+                'previousMarking' => $previousMarking ?? null,
+                'exception' => $exception,
+            ];
+
+            throw $exception;
+        }
+    }
+}

--- a/src/Symfony/Component/Workflow/DependencyInjection/WorkflowDebugPass.php
+++ b/src/Symfony/Component/Workflow/DependencyInjection/WorkflowDebugPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Workflow\Debug\TraceableWorkflow;
+
+/**
+ * Adds all configured security voters to the access decision manager.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class WorkflowDebugPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('workflow') as $id => $attributes) {
+            $container->register("debug.{$id}", TraceableWorkflow::class)
+                ->setDecoratedService($id)
+                ->setArguments([
+                    new Reference("debug.{$id}.inner"),
+                    new Reference('debug.stopwatch'),
+                ]);
+        }
+    }
+}

--- a/src/Symfony/Component/Workflow/Registry.php
+++ b/src/Symfony/Component/Workflow/Registry.php
@@ -41,7 +41,7 @@ class Registry
         return false;
     }
 
-    public function get(object $subject, string $workflowName = null): Workflow
+    public function get(object $subject, string $workflowName = null): WorkflowInterface
     {
         $matched = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

![image](https://github.com/symfony/symfony/assets/408368/fd6baf45-7b70-452d-beac-d673a8eeef8c)


![image](https://github.com/symfony/symfony/assets/408368/c58d8e00-abf2-4967-a22a-71bde33e3fe2)

---

Initially, I wanted to display the current marking on the graph, but it's not possible. "current" does not mean anything. What if I use the workflow for 2 entities? What if I call twice `apply()`. Which marking should I choose? => this is not possible.

But, DoctrineBundle use ajax, like for explaining SQL request. It would be nice to be able to click on a marking, and it'll re-render the graph with this marking. WDYT?