### PR TITLE
[Console] Fix linewraps in `OutputFormatter`

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Console\Formatter;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 
+use function Symfony\Component\String\b;
+
 /**
  * Formatter class for console output.
  *
@@ -258,7 +260,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
         }
 
         preg_match('~(\\n)$~', $text, $matches);
-        $text = $prefix.preg_replace('~([^\\n]{'.$width.'})\\ *~', "\$1\n", $text);
+        $text = $prefix.$this->addLineBreaks($text, $width);
         $text = rtrim($text, "\n").($matches[1] ?? '');
 
         if (!$currentLineLength && '' !== $current && "\n" !== substr($current, -1)) {
@@ -281,5 +283,12 @@ class OutputFormatter implements WrappableOutputFormatterInterface
         }
 
         return implode("\n", $lines);
+    }
+
+    private function addLineBreaks(string $text, int $width): string
+    {
+        $encoding = mb_detect_encoding($text, null, true) ?: 'UTF-8';
+
+        return b($text)->toCodePointString($encoding)->wordwrap($width, "\n", true)->toByteString($encoding);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -367,10 +367,10 @@ EOF
         $formatter = new OutputFormatter(true);
 
         $this->assertSame("fo\no\e[37;41mb\e[39;49m\n\e[37;41mar\e[39;49m\nba\nz", $formatter->formatAndWrap('foo<error>bar</error> baz', 2));
-        $this->assertSame("pr\ne \e[37;41m\e[39;49m\n\e[37;41mfo\e[39;49m\n\e[37;41mo \e[39;49m\n\e[37;41mba\e[39;49m\n\e[37;41mr \e[39;49m\n\e[37;41mba\e[39;49m\n\e[37;41mz\e[39;49m \npo\nst", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 2));
+        $this->assertSame("pr\ne \e[37;41m\e[39;49m\n\e[37;41mfo\e[39;49m\n\e[37;41mo\e[39;49m\n\e[37;41mba\e[39;49m\n\e[37;41mr\e[39;49m\n\e[37;41mba\e[39;49m\n\e[37;41mz\e[39;49m \npo\nst", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 2));
         $this->assertSame("pre\e[37;41m\e[39;49m\n\e[37;41mfoo\e[39;49m\n\e[37;41mbar\e[39;49m\n\e[37;41mbaz\e[39;49m\npos\nt", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 3));
-        $this->assertSame("pre \e[37;41m\e[39;49m\n\e[37;41mfoo \e[39;49m\n\e[37;41mbar \e[39;49m\n\e[37;41mbaz\e[39;49m \npost", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 4));
-        $this->assertSame("pre \e[37;41mf\e[39;49m\n\e[37;41moo ba\e[39;49m\n\e[37;41mr baz\e[39;49m\npost", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 5));
+        $this->assertSame("pre \e[37;41m\e[39;49m\n\e[37;41mfoo\e[39;49m\n\e[37;41mbar\e[39;49m\n\e[37;41mbaz\e[39;49m \npost", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 4));
+        $this->assertSame("pre \e[37;41mf\e[39;49m\n\e[37;41moo\e[39;49m\n\e[37;41mbar\e[39;49m\n\e[37;41mbaz\e[39;49m p\nost", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 5));
         $this->assertSame("Lore\nm \e[37;41mip\e[39;49m\n\e[37;41msum\e[39;49m \ndolo\nr \e[32msi\e[39m\n\e[32mt\e[39m am\net", $formatter->formatAndWrap('Lorem <error>ipsum</error> dolor <info>sit</info> amet', 4));
         $this->assertSame("Lorem \e[37;41mip\e[39;49m\n\e[37;41msum\e[39;49m dolo\nr \e[32msit\e[39m am\net", $formatter->formatAndWrap('Lorem <error>ipsum</error> dolor <info>sit</info> amet', 8));
         $this->assertSame("Lorem \e[37;41mipsum\e[39;49m dolor \e[32m\e[39m\n\e[32msit\e[39m, \e[37;41mamet\e[39;49m et \e[32mlauda\e[39m\n\e[32mntium\e[39m architecto", $formatter->formatAndWrap('Lorem <error>ipsum</error> dolor <info>sit</info>, <error>amet</error> et <info>laudantium</info> architecto', 18));
@@ -378,10 +378,12 @@ EOF
         $formatter = new OutputFormatter();
 
         $this->assertSame("fo\nob\nar\nba\nz", $formatter->formatAndWrap('foo<error>bar</error> baz', 2));
-        $this->assertSame("pr\ne \nfo\no \nba\nr \nba\nz \npo\nst", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 2));
+        $this->assertSame("pr\ne \nfo\no\nba\nr\nba\nz \npo\nst", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 2));
         $this->assertSame("pre\nfoo\nbar\nbaz\npos\nt", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 3));
-        $this->assertSame("pre \nfoo \nbar \nbaz \npost", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 4));
-        $this->assertSame("pre f\noo ba\nr baz\npost", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 5));
+        $this->assertSame("pre \nfoo\nbar\nbaz \npost", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 4));
+        $this->assertSame("pre f\noo\nbar\nbaz p\nost", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 5));
+        $this->assertSame("Â rèälly\nlöng tîtlè\nthät cöüld\nnèêd\nmúltîplê\nlínès", $formatter->formatAndWrap('Â rèälly löng tîtlè thät cöüld nèêd múltîplê línès', 10));
+        $this->assertSame("Â rèälly\nlöng tîtlè\nthät cöüld\nnèêd\nmúltîplê\n línès", $formatter->formatAndWrap("Â rèälly löng tîtlè thät cöüld nèêd múltîplê\n línès", 10));
         $this->assertSame('', $formatter->formatAndWrap(null, 5));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -118,30 +118,30 @@ TABLE
                 ['ISBN', 'Title', 'Author'],
                 $books,
                 'compact',
-<<<'TABLE'
-ISBN          Title                    Author           
-99921-58-10-7 Divine Comedy            Dante Alighieri  
-9971-5-0210-0 A Tale of Two Cities     Charles Dickens  
-960-425-059-0 The Lord of the Rings    J. R. R. Tolkien 
-80-902734-1-6 And Then There Were None Agatha Christie  
-
-TABLE
+                implode("\n", [
+                    'ISBN          Title                    Author           ',
+                    '99921-58-10-7 Divine Comedy            Dante Alighieri  ',
+                    '9971-5-0210-0 A Tale of Two Cities     Charles Dickens  ',
+                    '960-425-059-0 The Lord of the Rings    J. R. R. Tolkien ',
+                    '80-902734-1-6 And Then There Were None Agatha Christie  ',
+                    '',
+                ]),
             ],
             [
                 ['ISBN', 'Title', 'Author'],
                 $books,
                 'borderless',
-<<<'TABLE'
- =============== ========================== ================== 
-  ISBN            Title                      Author            
- =============== ========================== ================== 
-  99921-58-10-7   Divine Comedy              Dante Alighieri   
-  9971-5-0210-0   A Tale of Two Cities       Charles Dickens   
-  960-425-059-0   The Lord of the Rings      J. R. R. Tolkien  
-  80-902734-1-6   And Then There Were None   Agatha Christie   
- =============== ========================== ================== 
-
-TABLE
+                implode("\n", [
+                    ' =============== ========================== ================== ',
+                    '  ISBN            Title                      Author            ',
+                    ' =============== ========================== ================== ',
+                    '  99921-58-10-7   Divine Comedy              Dante Alighieri   ',
+                    '  9971-5-0210-0   A Tale of Two Cities       Charles Dickens   ',
+                    '  960-425-059-0   The Lord of the Rings      J. R. R. Tolkien  ',
+                    '  80-902734-1-6   And Then There Were None   Agatha Christie   ',
+                    ' =============== ========================== ================== ',
+                    '',
+                ]),
             ],
             [
                 ['ISBN', 'Title', 'Author'],
@@ -1378,12 +1378,14 @@ TABLE;
 
         $expected =
             <<<TABLE
-+---------------+-------+------------+-----------------+
-| Divine Comedy | A Tal | The Lord o | And Then There  |
-|               | e of  | f the Ring | Were None       |
-|               | Two C | s          |                 |
-|               | ities |            |                 |
-+---------------+-------+------------+-----------------+
++---------------+-------+----------+----------------+
+| Divine Comedy | A     | The Lord | And Then There |
+|               | Tale  | of the   | Were None      |
+|               | of    | Rings    |                |
+|               | Two   |          |                |
+|               | Citie |          |                |
+|               | s     |          |                |
++---------------+-------+----------+----------------+
 
 TABLE;
 
@@ -1416,8 +1418,8 @@ TABLE;
 | Publication | Very long header with a lot of |
 |             | information                    |
 +-------------+--------------------------------+
-| 1954        | The Lord of the Rings, by J.R. |
-|             | R. Tolkien                     |
+| 1954        | The Lord of the Rings, by      |
+|             | J.R.R. Tolkien                 |
 +-------------+--------------------------------+
 
 TABLE;
@@ -1577,8 +1579,8 @@ EOTXT;
 | Lorem ipsum dolor sit amet, consectetur adipi       |
 | scing elit, sed do eiusmod tempor                   |
 +-----------------+-----------------+-----------------+
-| Lorem ipsum dolor sit amet, consectetur adipi       |
-| scing elit, sed do eiusmod tempor                   |
+| Lorem ipsum dolor sit amet, consectetur             |
+| adipiscing elit, sed do eiusmod tempor              |
 +-----------------+-----------------+-----------------+
 | Lorem ipsum dolor sit amet, co    | hello world     |
 | nsectetur                         |                 |
@@ -1586,13 +1588,13 @@ EOTXT;
 | hello world     | Lorem ipsum dolor sit amet, co    |
 |                 | nsectetur adipiscing elit         |
 +-----------------+-----------------+-----------------+
-| hello           | world           | Lorem ipsum dol |
-|                 |                 | or sit amet, co |
-|                 |                 | nsectetur       |
+| hello           | world           | Lorem ipsum     |
+|                 |                 | dolor sit amet, |
+|                 |                 | consectetur     |
 +-----------------+-----------------+-----------------+
 | Symfony         | Test            | Lorem ipsum dol |
-|                 |                 | or sit amet, co |
-|                 |                 | nsectetur       |
+|                 |                 | or sit amet,    |
+|                 |                 | consectetur     |
 +-----------------+-----------------+-----------------+
 
 TABLE;
@@ -1614,8 +1616,9 @@ TABLE;
         $expected =
             <<<TABLE
 +----------------------+
-| \033]8;;Lorem\033\\Lorem ipsum dolor si\033]8;;\033\\ |
-| \033]8;;Lorem\033\\t amet, consectetur \033]8;;\033\\ |
+| \033]8;;Lorem\033\\Lorem ipsum dolor\033]8;;\033\\    |
+| \033]8;;Lorem\033\\sit amet,\033]8;;\033\\            |
+| \033]8;;Lorem\033\\consectetur\033]8;;\033\\          |
 | \033]8;;Lorem\033\\adipiscing elit, sed\033]8;;\033\\ |
 | \033]8;;Lorem\033\\do eiusmod tempor\033]8;;\033\\    |
 +----------------------+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42034
| License       | MIT
| Doc PR        | n/a

Fix output for tables with linebreaks and special chars;
```php
$table = new \Symfony\Component\Console\Helper\Table($output);
$table
    ->setColumnMaxWidth(1, 10)
    ->setHeaders(['ISBN', 'Title'])
    ->setRows([
        ['99921-58-10-7', 'A really long title that could need multiple lines'],
        new \Symfony\Component\Console\Helper\TableSeparator(),
        ['99921-58-10-7', 'Â rèälly löng tîtlè thät cöüld nèêd múltîplê línès']
    ])
;
$table->render();
```

**Before**
```
+---------------+------------+
| ISBN          | Title      |
+---------------+------------+
| 99921-58-10-7 | A really l |
|               | ong title  |
|               | that could |
|               | need multi |
|               | ple lines  |
+---------------+------------+
| 99921-58-10-7 | Â rèäll    |
|               | y löng t |
|               | tlè thä |
|               | t cöüld    |
|               | nèêd mú    |
|               | ltîplê l   |
|               | ínès       |
+---------------+------------+
```

**After**
```
+---------------+------------+
| ISBN          | Title      |
+---------------+------------+
| 99921-58-10-7 | A really   |
|               | long title |
|               | that could |
|               | need       |
|               | multiple   |
|               | lines      |
+---------------+------------+
| 99921-58-10-7 | Â rèälly   |
|               | löng tîtlè |
|               | thät cöüld |
|               | nèêd       |
|               | múltîplê   |
|               | línès      |
+---------------+------------+

```
