### PR TITLE
[MonologBridge] Deprecate `Logger` class in favor of `Symfony\Bridge\Monolog\Monolog`

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -64,6 +64,7 @@ MonologBridge
 -------------
 
  * Add native return type to `Logger::clear()` and to `DebugProcessor::clear()`
+ * Deprecate `Logger` class in favor of `Symfony\Bridge\Monolog\Monolog`
 
 PsrHttpMessageBridge
 --------------------

--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add native return type to `Logger::clear()` and to `DebugProcessor::clear()`
+ * Deprecate `Logger` class in favor of `Symfony\Bridge\Monolog\Monolog`
 
 6.1
 ---

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -17,8 +17,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
+trigger_deprecation('symfony/monolog-bridge', '6.4', 'The "%s" class is deprecated, use "%s" instead.', Logger::class, Monolog::class);
+
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 6.4, use Symfony\Bridge\Monolog\Monolog instead
  */
 class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
 {

--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -1,0 +1,403 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog;
+
+use Monolog\DateTimeImmutable;
+use Monolog\Handler\HandlerInterface;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Monolog\Logger as BaseLogger;
+use Monolog\Logger;
+use Monolog\Processor\ProcessorInterface;
+use Monolog\ResettableInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Logger implements a PSR-3 logger with psr/log and forwards logs to a Monolog
+ * instance.
+ *
+ * I has the same features a Monolog, and can be used as a drop in replacement.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+final class Monolog implements LoggerInterface, DebugLoggerInterface, ResettableInterface, ResetInterface
+{
+    use LoggerTrait;
+
+    /**
+     * Mapping between levels numbers defined in RFC 5424 and Monolog ones.
+     *
+     * @phpstan-var array<int, Level> $rfc_5424_levels
+     */
+    private const RFC_5424_LEVELS = [
+        7 => Level::Debug,
+        6 => Level::Info,
+        5 => Level::Notice,
+        4 => Level::Warning,
+        3 => Level::Error,
+        2 => Level::Critical,
+        1 => Level::Alert,
+        0 => Level::Emergency,
+    ];
+
+    private BaseLogger $monolog;
+
+    /**
+     * @param string             $name       The logging channel, a simple descriptive name that is attached to all log records
+     * @param HandlerInterface[] $handlers   optional stack of handlers, the first one in the array is called first, etc
+     * @param callable[]         $processors Optional array of processors
+     * @param \DateTimeZone|null $timezone   Optional timezone, if not provided date_default_timezone_get() will be used
+     *
+     * @phpstan-param array<(callable(LogRecord): LogRecord)|ProcessorInterface> $processors
+     */
+    public function __construct(string $name, array $handlers = [], array $processors = [], \DateTimeZone $timezone = null)
+    {
+        if (BaseLogger::API < 3) {
+            throw new \LogicException(sprintf('Monolog "%s" is not supported. Please upgrade to Monolog 3.x or higher.', BaseLogger::API));
+        }
+
+        $this->monolog = new BaseLogger($name, $handlers, $processors, $timezone);
+    }
+
+    public function getLogs(Request $request = null): array
+    {
+        if ($logger = $this->getDebugLogger()) {
+            return $logger->getLogs($request);
+        }
+
+        return [];
+    }
+
+    public function countErrors(Request $request = null): int
+    {
+        if ($logger = $this->getDebugLogger()) {
+            return $logger->countErrors($request);
+        }
+
+        return 0;
+    }
+
+    public function clear(): void
+    {
+        if ($logger = $this->getDebugLogger()) {
+            $logger->clear();
+        }
+    }
+
+    public function reset(): void
+    {
+        $this->clear();
+
+        if ($this->monolog instanceof ResettableInterface) {
+            $this->monolog->reset();
+        }
+    }
+
+    public function removeDebugLogger(): void
+    {
+        $processors = $this->monolog->getProcessors();
+        foreach ($processors as $k => $processor) {
+            if ($processor instanceof DebugLoggerInterface) {
+                unset($processors[$k]);
+            }
+        }
+
+        $handlers = $this->monolog->getHandlers();
+        foreach ($handlers as $k => $handler) {
+            if ($handler instanceof DebugLoggerInterface) {
+                unset($handlers[$k]);
+            }
+        }
+
+        $this->monolog->__construct($this->monolog->getName(), $handlers, $processors, $this->monolog->getTimezone());
+    }
+
+    /**
+     * Returns a DebugLoggerInterface instance if one is registered with this logger.
+     */
+    private function getDebugLogger(): ?DebugLoggerInterface
+    {
+        foreach ($this->monolog->getProcessors() as $processor) {
+            if ($processor instanceof DebugLoggerInterface) {
+                return $processor;
+            }
+        }
+
+        foreach ($this->monolog->getHandlers() as $handler) {
+            if ($handler instanceof DebugLoggerInterface) {
+                return $handler;
+            }
+        }
+
+        return null;
+    }
+
+    public function getName(): string
+    {
+        return $this->monolog->getName();
+    }
+
+    /**
+     * Return a new cloned instance with the name changed.
+     */
+    public function withName(string $name): static
+    {
+        $new = clone $this;
+        $new->monolog = $this->monolog->withName($name);
+
+        return $new;
+    }
+
+    /**
+     * Pushes a handler on to the stack.
+     *
+     * @return $this
+     */
+    public function pushHandler(HandlerInterface $handler): self
+    {
+        $this->monolog->pushHandler($handler);
+
+        return $this;
+    }
+
+    /**
+     * Pops a handler from the stack.
+     *
+     * @throws \LogicException If empty handler stack
+     */
+    public function popHandler(): HandlerInterface
+    {
+        return $this->monolog->popHandler();
+    }
+
+    /**
+     * Set handlers, replacing all existing ones.
+     *
+     * If a map is passed, keys will be ignored.
+     *
+     * @param list<HandlerInterface> $handlers
+     *
+     * @return $this
+     */
+    public function setHandlers(array $handlers): static
+    {
+        $this->monolog->setHandlers($handlers);
+
+        return $this;
+    }
+
+    /**
+     * @return list<HandlerInterface>
+     */
+    public function getHandlers(): array
+    {
+        return $this->monolog->getHandlers();
+    }
+
+    /**
+     * Adds a processor on to the stack.
+     *
+     * @phpstan-param ProcessorInterface|(callable(LogRecord): LogRecord) $callback
+     *
+     * @return $this
+     */
+    public function pushProcessor(ProcessorInterface|callable $callback): static
+    {
+        $this->monolog->pushProcessor($callback);
+
+        return $this;
+    }
+
+    /**
+     * Removes the processor on top of the stack and returns it.
+     *
+     * @phpstan-return ProcessorInterface|(callable(LogRecord): LogRecord)
+     *
+     * @throws \LogicException If empty processor stack
+     */
+    public function popProcessor(): callable
+    {
+        return $this->monolog->popProcessor();
+    }
+
+    /**
+     * @return callable[]
+     *
+     * @phpstan-return array<ProcessorInterface|(callable(LogRecord): LogRecord)>
+     */
+    public function getProcessors(): array
+    {
+        return $this->monolog->getProcessors();
+    }
+
+    /**
+     * Control the use of microsecond resolution timestamps in the 'datetime'
+     * member of new records.
+     *
+     * As of PHP7.1 microseconds are always included by the engine, so
+     * there is no performance penalty and Monolog 2 enabled microseconds
+     * by default. This function lets you disable them though in case you want
+     * to suppress microseconds from the output.
+     *
+     * @param bool $micro True to use microtime() to create timestamps
+     *
+     * @return $this
+     */
+    public function useMicrosecondTimestamps(bool $micro): static
+    {
+        $this->monolog->useMicrosecondTimestamps($micro);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useLoggingLoopDetection(bool $detectCycles): static
+    {
+        $this->monolog->useLoggingLoopDetection($detectCycles);
+
+        return $this;
+    }
+
+    /**
+     * Adds a log record.
+     *
+     * @param int               $level    The logging level (a Monolog or RFC 5424 level)
+     * @param string            $message  The log message
+     * @param mixed[]           $context  The log context
+     * @param DateTimeImmutable $datetime Optional log date to log into the past or future
+     *
+     * @return bool Whether the record has been processed
+     *
+     * @phpstan-param value-of<Level::VALUES>|Level $level
+     */
+    public function addRecord(int|Level $level, string $message, array $context = [], DateTimeImmutable $datetime = null): bool
+    {
+        return $this->monolog->addRecord($level, $message, $context, $datetime);
+    }
+
+    /**
+     * Ends a log cycle and frees all resources used by handlers.
+     *
+     * Closing a Handler means flushing all buffers and freeing any open resources/handles.
+     * Handlers that have been closed should be able to accept log records again and re-open
+     * themselves on demand, but this may not always be possible depending on implementation.
+     *
+     * This is useful at the end of a request and will be called automatically on every handler
+     * when they get destructed.
+     */
+    public function close(): void
+    {
+        $this->monolog->close();
+    }
+
+    /**
+     * Checks whether the Logger has a handler that listens on the given level.
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function isHandling(int|string|Level $level): bool
+    {
+        return $this->monolog->isHandling($level);
+    }
+
+    /**
+     * Set a custom exception handler that will be called if adding a new record fails.
+     *
+     * The Closure will receive an exception object and the record that failed to be logged
+     *
+     * @return $this
+     */
+    public function setExceptionHandler(\Closure|null $callback): static
+    {
+        $this->monolog->setExceptionHandler($callback);
+
+        return $this;
+    }
+
+    public function getExceptionHandler(): \Closure|null
+    {
+        return $this->monolog->getExceptionHandler();
+    }
+
+    /**
+     * Adds a log record at an arbitrary level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param mixed              $level   The log level (a Monolog, PSR-3 or RFC 5424 level)
+     * @param string|\Stringable $message The log message
+     * @param mixed[]            $context The log context
+     *
+     * @phpstan-param Level|LogLevel::* $level
+     */
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        if (!$level instanceof Level) {
+            if (!\is_string($level) && !\is_int($level)) {
+                throw new \InvalidArgumentException('$level is expected to be a string, int or '.Level::class.' instance');
+            }
+
+            if (isset(self::RFC_5424_LEVELS[$level])) {
+                $level = self::RFC_5424_LEVELS[$level];
+            }
+
+            $level = BaseLogger::toMonologLevel($level);
+        }
+
+        $this->addRecord($level, (string) $message, $context);
+    }
+
+    /**
+     * Sets the timezone to be used for the timestamp of log records.
+     *
+     * @return $this
+     */
+    public function setTimezone(\DateTimeZone $tz): static
+    {
+        $this->monolog->setTimezone($tz);
+
+        return $this;
+    }
+
+    /**
+     * Returns the timezone to be used for the timestamp of log records.
+     */
+    public function getTimezone(): \DateTimeZone
+    {
+        return $this->monolog->getTimezone();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
+    {
+        return $this->monolog->__serialize();
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->monolog = new BaseLogger('');
+        $this->monolog->__unserialize($data);
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Bridge\Monolog\Tests\Handler;
 
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\FirePHPHandler;
-use Symfony\Bridge\Monolog\Logger;
+use Symfony\Bridge\Monolog\Monolog;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +27,11 @@ class FirePHPHandlerTest extends TestCase
     public function testLogHandling()
     {
         $handler = $this->createHandler();
-        $logger = new Logger('my_logger', [$handler]);
+        if (Logger::API >= 3) {
+            $logger = new Monolog('my_logger', [$handler]);
+        } else {
+            $logger = new Logger('my_logger', [$handler]);
+        }
 
         $logger->warning('This does not look right.');
 
@@ -75,7 +80,11 @@ class FirePHPHandlerTest extends TestCase
     public function testNoFirePhpClient()
     {
         $handler = $this->createHandler();
-        $logger = new Logger('my_logger', [$handler]);
+        if (Logger::API >= 3) {
+            $logger = new Monolog('my_logger', [$handler]);
+        } else {
+            $logger = new Logger('my_logger', [$handler]);
+        }
 
         $logger->warning('This does not look right.');
 

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
@@ -13,11 +13,11 @@ namespace Symfony\Bridge\Monolog\Tests\Handler;
 
 use Monolog\Formatter\HtmlFormatter;
 use Monolog\Formatter\LineFormatter;
+use Monolog\Logger;
 use Monolog\LogRecord;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\MailerHandler;
-use Symfony\Bridge\Monolog\Logger;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -11,118 +11,18 @@
 
 namespace Symfony\Bridge\Monolog\Tests;
 
-use Monolog\Handler\TestHandler;
-use Monolog\ResettableInterface;
-use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Logger;
-use Symfony\Bridge\Monolog\Processor\DebugProcessor;
-use Symfony\Component\HttpFoundation\Request;
 
-class LoggerTest extends TestCase
+/**
+ * @group legacy
+ */
+class LoggerTest extends MonologTest
 {
-    public function testGetLogsWithoutDebugProcessor()
+    public function testPublicApi()
     {
-        $handler = new TestHandler();
-        $logger = new Logger(__METHOD__, [$handler]);
-
-        $logger->error('error message');
-        $this->assertSame([], $logger->getLogs());
-    }
-
-    public function testCountErrorsWithoutDebugProcessor()
-    {
-        $handler = new TestHandler();
-        $logger = new Logger(__METHOD__, [$handler]);
-
-        $logger->error('error message');
-        $this->assertSame(0, $logger->countErrors());
-    }
-
-    public function testGetLogsWithDebugProcessor()
-    {
-        $handler = new TestHandler();
-        $processor = new DebugProcessor();
-        $logger = new Logger(__METHOD__, [$handler], [$processor]);
-
-        $logger->error('error message');
-        $this->assertCount(1, $logger->getLogs());
-    }
-
-    public function testCountErrorsWithDebugProcessor()
-    {
-        $handler = new TestHandler();
-        $processor = new DebugProcessor();
-        $logger = new Logger(__METHOD__, [$handler], [$processor]);
-
-        $logger->debug('test message');
-        $logger->info('test message');
-        $logger->notice('test message');
-        $logger->warning('test message');
-
-        $logger->error('test message');
-        $logger->critical('test message');
-        $logger->alert('test message');
-        $logger->emergency('test message');
-
-        $this->assertSame(4, $logger->countErrors());
-    }
-
-    public function testGetLogsWithDebugProcessor2()
-    {
-        $handler = new TestHandler();
-        $logger = new Logger('test', [$handler]);
-        $logger->pushProcessor(new DebugProcessor());
-
-        $logger->info('test');
-        $this->assertCount(1, $logger->getLogs());
-        [$record] = $logger->getLogs();
-
-        $this->assertEquals('test', $record['message']);
-        $this->assertEquals(Logger::INFO, $record['priority']);
-    }
-
-    public function testGetLogsWithDebugProcessor3()
-    {
-        $request = new Request();
-        $processor = $this->createMock(DebugProcessor::class);
-        $processor->expects($this->once())->method('getLogs')->with($request);
-        $processor->expects($this->once())->method('countErrors')->with($request);
-
-        $handler = new TestHandler();
-        $logger = new Logger('test', [$handler]);
-        $logger->pushProcessor($processor);
-
-        $logger->getLogs($request);
-        $logger->countErrors($request);
-    }
-
-    public function testClear()
-    {
-        $handler = new TestHandler();
-        $logger = new Logger('test', [$handler]);
-        $logger->pushProcessor(new DebugProcessor());
-
-        $logger->info('test');
-        $logger->clear();
-
-        $this->assertEmpty($logger->getLogs());
-        $this->assertSame(0, $logger->countErrors());
-    }
-
-    public function testReset()
-    {
-        $handler = new TestHandler();
-        $logger = new Logger('test', [$handler]);
-        $logger->pushProcessor(new DebugProcessor());
-
-        $logger->info('test');
-        $logger->reset();
-
-        $this->assertEmpty($logger->getLogs());
-        $this->assertSame(0, $logger->countErrors());
-        if (class_exists(ResettableInterface::class)) {
-            $this->assertEmpty($handler->getRecords());
-        }
+        // We override the parent test because it's not relevant for legacy
+        // tests
+        $this->assertTrue(true);
     }
 
     public function testInheritedClassCallGetLogsWithoutArgument()
@@ -135,5 +35,10 @@ class LoggerTest extends TestCase
     {
         $loggerChild = new ClassThatInheritLogger('test');
         $this->assertEquals(0, $loggerChild->countErrors());
+    }
+
+    protected function createLogger($name, array $handlers = [], array $processors = [])
+    {
+        return new Logger($name, $handlers, $processors);
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/MonologTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/MonologTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests;
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Monolog\ResettableInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Monolog;
+use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\VarDumper\Caster\EnumStub;
+use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+class MonologTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    protected function setUp(): void
+    {
+        $this->setUpVarDumper([
+            \ReflectionMethod::class => function (\ReflectionMethod $method, array $a, Stub $stub, bool $isNested) {
+                // Obviously, the class is different
+                unset($a['class']);
+
+                $extra = $a[Caster::PREFIX_VIRTUAL.'extra']->value;
+                // We have to remove comments, because we have some diff like
+                // `\DateTimeZone` vs `DateTimeZone`
+                unset($extra['line'], $extra['file'], $extra['docComment']);
+                $a[Caster::PREFIX_VIRTUAL.'extra'] = new EnumStub($extra, false);
+
+                // Also, return type may vary between self, static, and Logger
+                if (\array_key_exists(Caster::PREFIX_VIRTUAL.'returnType', $a)) {
+                    $v = $a[Caster::PREFIX_VIRTUAL.'returnType']->value;
+                    if (
+                        'self' === $v
+                        || 'static' === $v
+                        || Logger::class === $v
+                    ) {
+                        unset($a[Caster::PREFIX_VIRTUAL.'returnType']);
+                    }
+                }
+
+                return $a;
+            },
+        ]);
+    }
+
+    public function testPublicApi()
+    {
+        $base = new \ReflectionClass(Logger::class);
+        foreach ($base->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            // We do not support deprecated methods
+            if (in_array($method->getName(), ['getLevelName', 'toMonologLevel'])) {
+                continue;
+            }
+            $symfonyMethod = new \ReflectionMethod(Monolog::class, $method->getName());
+            $this->assertDumpEquals($method, $symfonyMethod);
+        }
+
+        foreach ($base->getConstants(\ReflectionClassConstant::IS_PUBLIC) as $name => $value) {
+            // We do not support deprecated methods
+            if (in_array($name, ['DEBUG', 'INFO', 'NOTICE', 'WARNING', 'ERROR', 'CRITICAL', 'ALERT', 'EMERGENCY', 'API'])) {
+                continue;
+            }
+            $symfonyConstant = new \ReflectionClassConstant(Monolog::class, $name);
+            $this->assertDumpEquals($value, $symfonyConstant->getValue());
+        }
+    }
+
+    public function testGetLogsWithoutDebugProcessor()
+    {
+        $handler = new TestHandler();
+        $logger = $this->createLogger(__METHOD__, [$handler]);
+
+        $logger->error('error message');
+        $this->assertSame([], $logger->getLogs());
+    }
+
+    public function testCountErrorsWithoutDebugProcessor()
+    {
+        $handler = new TestHandler();
+        $logger = $this->createLogger(__METHOD__, [$handler]);
+
+        $logger->error('error message');
+        $this->assertSame(0, $logger->countErrors());
+    }
+
+    public function testGetLogsWithDebugProcessor()
+    {
+        $handler = new TestHandler();
+        $processor = new DebugProcessor();
+        $logger = $this->createLogger(__METHOD__, [$handler], [$processor]);
+
+        $logger->error('error message');
+        $this->assertCount(1, $logger->getLogs());
+    }
+
+    public function testCountErrorsWithDebugProcessor()
+    {
+        $handler = new TestHandler();
+        $processor = new DebugProcessor();
+        $logger = $this->createLogger(__METHOD__, [$handler], [$processor]);
+
+        $logger->debug('test message');
+        $logger->info('test message');
+        $logger->notice('test message');
+        $logger->warning('test message');
+
+        $logger->error('test message');
+        $logger->critical('test message');
+        $logger->alert('test message');
+        $logger->emergency('test message');
+
+        $this->assertSame(4, $logger->countErrors());
+    }
+
+    public function testGetLogsWithDebugProcessor2()
+    {
+        $handler = new TestHandler();
+        $logger = $this->createLogger('test', [$handler]);
+        $logger->pushProcessor(new DebugProcessor());
+
+        $logger->info('test');
+        $this->assertCount(1, $logger->getLogs());
+        [$record] = $logger->getLogs();
+
+        $this->assertEquals('test', $record['message']);
+        $this->assertEquals(200, $record['priority']);
+    }
+
+    public function testGetLogsWithDebugProcessor3()
+    {
+        $request = new Request();
+        $processor = $this->createMock(DebugProcessor::class);
+        $processor->expects($this->once())->method('getLogs')->with($request);
+        $processor->expects($this->once())->method('countErrors')->with($request);
+
+        $handler = new TestHandler();
+        $logger = $this->createLogger('test', [$handler]);
+        $logger->pushProcessor($processor);
+
+        $logger->getLogs($request);
+        $logger->countErrors($request);
+    }
+
+    public function testClear()
+    {
+        $handler = new TestHandler();
+        $logger = $this->createLogger('test', [$handler]);
+        $logger->pushProcessor(new DebugProcessor());
+
+        $logger->info('test');
+        $logger->clear();
+
+        $this->assertEmpty($logger->getLogs());
+        $this->assertSame(0, $logger->countErrors());
+    }
+
+    public function testReset()
+    {
+        $handler = new TestHandler();
+        $logger = $this->createLogger('test', [$handler]);
+        $logger->pushProcessor(new DebugProcessor());
+
+        $logger->info('test');
+        $logger->reset();
+
+        $this->assertEmpty($logger->getLogs());
+        $this->assertSame(0, $logger->countErrors());
+        if (class_exists(ResettableInterface::class)) {
+            $this->assertEmpty($handler->getRecords());
+        }
+    }
+
+    protected function createLogger($name, array $handlers = [], array $processors = [])
+    {
+        if (Logger::API <= 2) {
+            $this->markTestSkipped('Monolog 3.x is required.');
+        }
+
+        return new Monolog($name, $handlers, $processors);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | kind of
| Deprecations? | yes
| Tickets       |
| License       | MIT
| Doc PR        |

---

For the record, I imported the new Monolog class in Monolog, and I ran the test suite and it was okay 👍🏼 all green except one failure, but it's a [monolog issue](https://github.com/Seldaek/monolog/pull/1825) I guess
