### PR TITLE
[Scheduler] add `ScheduledStamp` to `RedispatchMessage`

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allow setting timezone of next run date in CronExpressionTrigger
  * Add `AbstractTriggerDecorator`
  * Make `ScheduledStamp` "send-able"
+ * Add `ScheduledStamp` to `RedispatchMessage`
 
 6.3
 ---

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Scheduler\Messenger;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Message\RedispatchMessage;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\Generator\MessageGeneratorInterface;
@@ -29,7 +30,16 @@ class SchedulerTransport implements TransportInterface
     public function get(): iterable
     {
         foreach ($this->messageGenerator->getMessages() as $context => $message) {
-            yield Envelope::wrap($message, [new ScheduledStamp($context)]);
+            $stamp = new ScheduledStamp($context);
+
+            if ($message instanceof RedispatchMessage) {
+                $message = new RedispatchMessage(
+                    Envelope::wrap($message->envelope, [$stamp]),
+                    $message->transportNames,
+                );
+            }
+
+            yield Envelope::wrap($message, [$stamp]);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51205
| License       | MIT
| Doc PR        | n/a

This solves my specific issue in #51205. Now, we can track messages that were generated by the scheduler even if they are _re-dispatched_.
