### PR TITLE
[HttpKernel] Add validation groups resolver option to `RequestPayloadValueResolver`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -47,6 +47,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'container.service_subscriber',
         'container.stack',
         'controller.argument_value_resolver',
+        'controller.request_payload.validation_groups_resolver',
         'controller.service_arguments',
         'controller.targeted_value_resolver',
         'data_collector',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -68,6 +68,7 @@ return static function (ContainerConfigurator $container) {
                 service('serializer'),
                 service('validator')->nullOnInvalid(),
                 service('translator')->nullOnInvalid(),
+                tagged_locator('controller.request_payload.validation_groups_resolver'),
             ])
             ->tag('controller.targeted_value_resolver', ['name' => RequestPayloadValueResolver::class])
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
@@ -25,13 +25,17 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
 class MapQueryString extends ValueResolver
 {
     public ArgumentMetadata $metadata;
+    public readonly string|\Closure|null $validationGroupsResolver;
 
     public function __construct(
         public readonly array $serializationContext = [],
         public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
         public readonly int $validationFailedStatusCode = Response::HTTP_NOT_FOUND,
+        string|callable $validationGroupsResolver = null,
     ) {
         parent::__construct($resolver);
+
+        $this->validationGroupsResolver = \is_callable($validationGroupsResolver) ? $validationGroupsResolver(...) : $validationGroupsResolver;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
@@ -25,6 +25,7 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
 class MapRequestPayload extends ValueResolver
 {
     public ArgumentMetadata $metadata;
+    public readonly string|\Closure|null $validationGroupsResolver;
 
     public function __construct(
         public readonly array|string|null $acceptFormat = null,
@@ -32,7 +33,10 @@ class MapRequestPayload extends ValueResolver
         public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
         public readonly int $validationFailedStatusCode = Response::HTTP_UNPROCESSABLE_ENTITY,
+        string|callable $validationGroupsResolver = null,
     ) {
         parent::__construct($resolver);
+
+        $this->validationGroupsResolver = \is_callable($validationGroupsResolver) ? $validationGroupsResolver(...) : $validationGroupsResolver;
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add optional `$className` parameter to `ControllerEvent::getAttributes()`
  * Add native return types to `TraceableEventDispatcher` and to `MergeExtensionConfigurationPass`
  * Add argument `$validationFailedStatusCode` to `#[MapQueryString]` and `#[MapRequestPayload]`
+ * Add argument `$validationGroupsResolver` to `#[MapQueryString]` and `#[MapRequestPayload]`
 
 6.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51012
| License       | MIT
| Doc PR        | -

This PR introduces a way to configure validation groups for the `RequestPayloadValueResolver` dynamically, similar to how it can be done in the [form component](https://symfony.com/doc/current/form/validation_group_service_resolver.html):

```php
class ValidationGroupsResolver
{
    public function __invoke(mixed $payload, Request $request)
    {
        // ...
        return $groups;
    }
}

public function index(
    #[MapRequestPayload(validationGroupsResolver: new ValidationGroupsResolver())] DTO $dto,
): Response {
    // ...
}
```

The resolver can also be a service, it just needs to be tagged with `controller.request_payload.validation_groups_resolver`:

```php
#[AutoconfigureTag('controller.request_payload.validation_groups_resolver')]
class ValidationGroupsResolver
{
    public function __construct(SomeDep $someDep)
    {
    }

    public function __invoke(mixed $payload, Request $request)
    {
        // ...
        return $groups;
    }
}

public function index(
    #[MapRequestPayload(validationGroupsResolver: ValidationGroupsResolver::class)] DTO $dto,
): Response {
    // ...
}
```