### PR TITLE
[FrameworkBundle] Remove redundant `interface_exists()` check

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -217,12 +217,8 @@ return static function (ContainerConfigurator $container) {
                     ->factory([HtmlErrorRenderer::class, 'isDebug'])
                     ->args([service('request_stack'), param('kernel.debug')]),
             ])
-    ;
 
-    if (interface_exists(\BackedEnum::class)) {
-        $container->services()
-            ->set('serializer.normalizer.backed_enum', BackedEnumNormalizer::class)
+        ->set('serializer.normalizer.backed_enum', BackedEnumNormalizer::class)
             ->tag('serializer.normalizer', ['priority' => -915])
-        ;
-    }
+    ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is no longer needed since the min required PHP version is 8.1.