### PR TITLE
[Messenger] Transport possible to have null

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/NotificationAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/NotificationAssertionsTrait.php
@@ -52,12 +52,12 @@ trait NotificationAssertionsTrait
         self::assertThat($notification, new LogicalNot(new NotifierConstraint\NotificationSubjectContains($text)), $message);
     }
 
-    public static function assertNotificationTransportIsEqual(MessageInterface $notification, string $transportName, string $message = ''): void
+    public static function assertNotificationTransportIsEqual(MessageInterface $notification, ?string $transportName = null, string $message = ''): void
     {
         self::assertThat($notification, new NotifierConstraint\NotificationTransportIsEqual($transportName), $message);
     }
 
-    public static function assertNotificationTransportIsNotEqual(MessageInterface $notification, string $transportName, string $message = ''): void
+    public static function assertNotificationTransportIsNotEqual(MessageInterface $notification, ?string $transportName = null, string $message = ''): void
     {
         self::assertThat($notification, new LogicalNot(new NotifierConstraint\NotificationTransportIsEqual($transportName)), $message);
     }

--- a/src/Symfony/Component/Notifier/Test/Constraint/NotificationTransportIsEqual.php
+++ b/src/Symfony/Component/Notifier/Test/Constraint/NotificationTransportIsEqual.php
@@ -19,9 +19,9 @@ use Symfony\Component\Notifier\Message\MessageInterface;
  */
 final class NotificationTransportIsEqual extends Constraint
 {
-    private $expectedText;
+    private ?string $expectedText;
 
-    public function __construct(string $expectedText)
+    public function __construct(?string $expectedText)
     {
         $this->expectedText = $expectedText;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Technically we can have for our own testing purposes the tests

```
SMSBIURAS_DSN="null://null"
```