### PR TITLE
[FrameworkBundle][Serializer] Wire the `CustomNormalizer`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Move the Router `cache_dir` to `kernel.build_dir`
  * Deprecate the `router.cache_dir` config option
  * Add `rate_limiter` tags to rate limiter services
+ * Wire the `CustomNormalizer` with the highest priority
 
 7.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -34,6 +34,7 @@ use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
+use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -210,6 +211,9 @@ return static function (ContainerConfigurator $container) {
                     ->factory([HtmlErrorRenderer::class, 'isDebug'])
                     ->args([service('request_stack'), param('kernel.debug')]),
             ])
+
+        ->set('serializer.normalizer.custom', CustomNormalizer::class)
+            ->tag('serializer.normalizer', ['priority' => 1100])
 
         ->set('serializer.normalizer.backed_enum', BackedEnumNormalizer::class)
             ->tag('serializer.normalizer', ['priority' => -915])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the `CustomNormalizer` is not wired out of the box. I'm not sure what the reason for that is but I suggest wiring it as it only applies to objects implementing the `NormalizableInterface` or `DenormalizableInterface`. I also think it'd make sense for it to have the highest priority:

```
Symfony Container Services Tagged with "serializer.normalizer" Tag
==================================================================

 ------------------------------------------------- ---------- ------------------------------------------------------------------------------------------- 
  Service ID                                        priority   Class name                                                                                 
 ------------------------------------------------- ---------- ------------------------------------------------------------------------------------------- 
  serializer.normalizer.custom                      1100       Symfony\Component\Serializer\Normalizer\CustomNormalizer                                   
  serializer.denormalizer.unwrapping                1000       Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer                             
  serializer.normalizer.flatten_exception           -880       Symfony\Component\Messenger\Transport\Serialization\Normalizer\FlattenExceptionNormalizer  
  serializer.normalizer.problem                     -890       Symfony\Component\Serializer\Normalizer\ProblemNormalizer                                  
  serializer.normalizer.uid                         -890       Symfony\Component\Serializer\Normalizer\UidNormalizer                                      
  serializer.normalizer.translatable                -890       Symfony\Component\Serializer\Normalizer\TranslatableNormalizer                             
  serializer.normalizer.datetime                    -910       Symfony\Component\Serializer\Normalizer\DateTimeNormalizer                                 
  serializer.normalizer.constraint_violation_list   -915       Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer                  
  serializer.normalizer.mime_message                -915       Symfony\Component\Serializer\Normalizer\MimeMessageNormalizer                              
  serializer.normalizer.datetimezone                -915       Symfony\Component\Serializer\Normalizer\DateTimeZoneNormalizer                             
  serializer.normalizer.dateinterval                -915       Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer                             
  serializer.normalizer.form_error                  -915       Symfony\Component\Serializer\Normalizer\FormErrorNormalizer                                
  serializer.normalizer.backed_enum                 -915       Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer                               
  serializer.normalizer.data_uri                    -920       Symfony\Component\Serializer\Normalizer\DataUriNormalizer                                  
  serializer.normalizer.json_serializable           -950       Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer                         
  serializer.denormalizer.array                     -990       Symfony\Component\Serializer\Normalizer\ArrayDenormalizer                                  
  serializer.normalizer.object                      -1000      Symfony\Component\Serializer\Normalizer\ObjectNormalizer                                   
 ------------------------------------------------- ---------- ------------------------------------------------------------------------------------------- 
```