### PR TITLE
[MonologBridge][SecurityBundle] Remove calls to `TokenInterface::isAuthenticated()`

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -47,7 +47,7 @@ abstract class AbstractTokenProcessor
 
         if (null !== $token = $this->getToken()) {
             $record['extra'][$this->getKey()] = [
-                'authenticated' => method_exists($token, 'isAuthenticated') ? $token->isAuthenticated(false) : (bool) $token->getUser(),
+                'authenticated' => (bool) $token->getUser(),
                 'roles' => $token->getRoleNames(),
             ];
 

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -114,7 +114,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
             $this->data = [
                 'enabled' => true,
-                'authenticated' => method_exists($token, 'isAuthenticated') ? $token->isAuthenticated(false) : (bool) $token->getUser(),
+                'authenticated' => (bool) $token->getUser(),
                 'impersonated' => null !== $impersonatorUser,
                 'impersonator_user' => $impersonatorUser,
                 'impersonation_exit_path' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`isAuthenticated()` has been removed from `TokenInterface` in 6.0. Both packages I've changed here (MonologBridge and SecurityBundle) announce that they're incompatible with SecurityCore 5.4. This is why I believe that the compatibility code I'm removing is obsolete.

Nevertheless, a token might still implement that method and we'd call it currently despite its removal from the interface (duck typing). I have targeted 6.4, but if we consider the removal of these calls a BC break, we could merge this PR to 7.0 instead.