### PR TITLE
[Scheduler] Only use toString if defined for message

### DIFF
--- a/src/Symfony/Component/Scheduler/Command/DebugCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/DebugCommand.php
@@ -113,21 +113,10 @@ final class DebugCommand extends Command
             $message = $message->getMessage();
         }
 
-        $messageName = (new \ReflectionClass($message))->getShortName();
-        $triggerName = (new \ReflectionClass($trigger))->getShortName();
-
-        if ($message instanceof \Stringable) {
-            $messageName .= ": {$message}";
-        }
-
-        if ($trigger instanceof \Stringable) {
-            $triggerName .= ": {$trigger}";
-        }
-
         return [
-            $messageName,
-            $triggerName,
-            $recurringMessage->getTrigger()->getNextRunDate($date)?->format(\DateTimeInterface::ATOM) ?? '-',
+            $message instanceof \Stringable ? (string) $message : (new \ReflectionClass($message))->getShortName(),
+            (string) $trigger,
+            $trigger->getNextRunDate($date)?->format(\DateTimeInterface::ATOM) ?? '-',
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

If the message is stringable, let's only use that instead of having the class name and the message as string (more flexible).
For the trigger, it's always stringable anyway.
