### PR TITLE
[Scheduler] Display friendly dates in debug:schedule

### DIFF
--- a/src/Symfony/Component/Scheduler/Command/DebugCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/DebugCommand.php
@@ -77,7 +77,7 @@ final class DebugCommand extends Command
 
         $date = new \DateTimeImmutable($input->getOption('date'));
         if ('now' !== $input->getOption('date')) {
-            $io->comment(sprintf('All next run dates computed from %s.', $date->format(\DateTimeInterface::ATOM)));
+            $io->comment(sprintf('All next run dates computed from %s.', $date->format('r')));
         }
 
         foreach ($names as $name) {
@@ -114,7 +114,7 @@ final class DebugCommand extends Command
         return [
             $message instanceof \Stringable ? (string) $message : (new \ReflectionClass($message))->getShortName(),
             (string) $trigger,
-            $trigger->getNextRunDate($date)?->format(\DateTimeInterface::ATOM) ?? '-',
+            $trigger->getNextRunDate($date)?->format('r') ?? '-',
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Atom dates are difficult to read for a human, let's make it easier for us :)
