### PR TITLE
Psalm: Suppress UnusedConstructor errors

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -36,5 +36,14 @@
                 <referencedClass name="UnitEnum"/>
             </errorLevel>
         </UndefinedDocblockClass>
+        <UnusedConstructor>
+            <errorLevel type="suppress">
+                <!--
+                    We use private constructors to avoid instantiation.
+                    This kind of error is bogus in most cases.
+                -->
+                <directory name="src/Symfony" />
+            </errorLevel>
+        </UnusedConstructor>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The CI on our pull requests keeps failing because of `UnusedConstructor` Psalm errors. I believe that this class of errors is not relevant for this codebase.