### PR TITLE
[OptionsResolver] Improve invalid type message on nested option

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+* Improve message with full path on invalid type in nested option
+
 6.3
 ---
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1064,7 +1064,7 @@ class OptionsResolver implements Options
             if (!$success) {
                 $message = sprintf(
                     'The option "%s" with value %s is invalid.',
-                    $option,
+                    $this->formatOptions([$option]),
                     $this->formatValue($value)
                 );
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -1009,6 +1009,32 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
+    public function testResolveFailsIfInvalidValueFromNestedOption()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "foo[bar]" with value "invalid value" is invalid. Accepted values are: "valid value".');
+        $this->resolver->setDefault('foo', function (OptionsResolver $resolver) {
+            $resolver
+                ->setDefined('bar')
+                ->setAllowedValues('bar', 'valid value');
+        });
+
+        $this->resolver->resolve(['foo' => ['bar' => 'invalid value']]);
+    }
+
+    public function testResolveFailsIfInvalidTypeFromNestedOption()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "foo[bar]" with value 1 is expected to be of type "string", but is of type "int".');
+        $this->resolver->setDefault('foo', function (OptionsResolver $resolver) {
+            $resolver
+                ->setDefined('bar')
+                ->setAllowedTypes('bar', 'string');
+        });
+
+        $this->resolver->resolve(['foo' => ['bar' => 1]]);
+    }
+
     public function testResolveFailsIfInvalidValue()
     {
         $this->expectException(InvalidOptionsException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | not required I think

OptionsResolver exception message is very explicit on which option has an invalid value with the full path of the option on lazy option. But the message only showed the latest option name when the type is not valid. This PR fixes it and display the full option path of the lazy option's invalid type.
