### PR TITLE
[Notifier] Transport possible to have null

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/NotificationAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/NotificationAssertionsTrait.php
@@ -52,12 +52,12 @@ trait NotificationAssertionsTrait
         self::assertThat($notification, new LogicalNot(new NotifierConstraint\NotificationSubjectContains($text)), $message);
     }
 
-    public static function assertNotificationTransportIsEqual(MessageInterface $notification, string $transportName, string $message = ''): void
+    public static function assertNotificationTransportIsEqual(MessageInterface $notification, string $transportName = null, string $message = ''): void
     {
         self::assertThat($notification, new NotifierConstraint\NotificationTransportIsEqual($transportName), $message);
     }
 
-    public static function assertNotificationTransportIsNotEqual(MessageInterface $notification, string $transportName, string $message = ''): void
+    public static function assertNotificationTransportIsNotEqual(MessageInterface $notification, string $transportName = null, string $message = ''): void
     {
         self::assertThat($notification, new LogicalNot(new NotifierConstraint\NotificationTransportIsEqual($transportName)), $message);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/NotificationController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/NotificationController.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Cont
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
 
 final class NotificationController
 {
@@ -21,13 +22,16 @@ final class NotificationController
     {
         $firstNotification = new Notification('Hello World!', ['chat/slack']);
         $firstNotification->content('Symfony is awesome!');
-
         $notifier->send($firstNotification);
 
         $secondNotification = (new Notification('New urgent notification'))
             ->importance(Notification::IMPORTANCE_URGENT)
         ;
         $notifier->send($secondNotification);
+
+        $thirdNotification = new Notification('Hello World!', ['sms']);
+        $thirdNotification->content('Symfony is awesome!');
+        $notifier->send($thirdNotification, new Recipient('', '112'));
 
         return new Response();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/NotificationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/NotificationTest.php
@@ -21,9 +21,10 @@ final class NotificationTest extends AbstractWebTestCase
         $client = $this->createClient(['test_case' => 'Notifier', 'root_config' => 'config.yml', 'debug' => true]);
         $client->request('GET', '/send_notification');
 
-        $this->assertNotificationCount(2);
+        $this->assertNotificationCount(3);
         $first = 0;
         $second = 1;
+        $third = 2;
         $this->assertNotificationIsNotQueued($this->getNotifierEvent($first));
         $this->assertNotificationIsNotQueued($this->getNotifierEvent($second));
 
@@ -38,5 +39,9 @@ final class NotificationTest extends AbstractWebTestCase
         $this->assertNotificationSubjectNotContains($notification, 'Hello World!');
         $this->assertNotificationTransportIsEqual($notification, 'mercure');
         $this->assertNotificationTransportIsNotEqual($notification, 'slack');
+
+        $notification = $this->getNotifierMessage($third);
+        $this->assertNotificationSubjectContains($notification, 'Hello World!');
+        $this->assertNotificationTransportIsEqual($notification, null);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Notifier/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Notifier/config.yml
@@ -13,6 +13,8 @@ framework:
             urgent: ['chat/mercure']
         admin_recipients:
             - { email: admin@example.com }
+        texter_transports:
+            smsbiuras: 'null://null'
     profiler: ~
 
 mercure:

--- a/src/Symfony/Component/Notifier/Message/NullMessage.php
+++ b/src/Symfony/Component/Notifier/Message/NullMessage.php
@@ -40,6 +40,6 @@ final class NullMessage implements MessageInterface
 
     public function getTransport(): ?string
     {
-        return $this->decoratedMessage->getTransport() ?? 'null';
+        return $this->decoratedMessage->getTransport() ?? null;
     }
 }

--- a/src/Symfony/Component/Notifier/Test/Constraint/NotificationTransportIsEqual.php
+++ b/src/Symfony/Component/Notifier/Test/Constraint/NotificationTransportIsEqual.php
@@ -19,9 +19,9 @@ use Symfony\Component\Notifier\Message\MessageInterface;
  */
 final class NotificationTransportIsEqual extends Constraint
 {
-    private string $expectedText;
+    private ?string $expectedText;
 
-    public function __construct(string $expectedText)
+    public function __construct(?string $expectedText)
     {
         $this->expectedText = $expectedText;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51236 
| License       | MIT

My test example of why I need to have properly transport null

```php
public function testSmsSending(): void
{
    $date = (new \DateTimeImmutable())->format('Y-m-d');

    $stateta = new Stateta();
    $stateta->setDate(new \DateTimeImmutable($date));
    $stateta->setA95(0);
    $stateta->setDk(0);

    $this->entityManager->persist($stateta);
    $this->entityManager->flush();

    $this->commandTester->execute([], [
        'verbosity' => OutputInterface::VERBOSITY_DEBUG
    ]);

    $this->commandTester->assertCommandIsSuccessful();

    $notifierEvent = $this->getNotifierEvent();

    self::assertEquals(null, $notifierEvent->getMessage()->getTransport());
    self::assertEquals("+37061234567", $notifierEvent->getMessage()->getRecipientId());

    self::assertNotificationIsQueued($notifierEvent);
    self::assertNotificationSubjectContains($notifierEvent->getMessage(), 'Company name');
    self::assertNotificationTransportIsEqual($notifierEvent->getMessage(), null);
}
```
