### PR TITLE
[Cache] harden LockRegistry tests, consider PHP files only

### DIFF
--- a/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
+++ b/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
@@ -23,7 +23,7 @@ class LockRegistryTest extends TestCase
         }
         $lockFiles = LockRegistry::setFiles([]);
         LockRegistry::setFiles($lockFiles);
-        $expected = array_map('realpath', glob(__DIR__.'/../Adapter/*'));
+        $expected = array_map('realpath', glob(__DIR__.'/../Adapter/*.php'));
         $this->assertSame($expected, $lockFiles);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

see https://github.com/symfony/symfony/actions/runs/5761767836/job/15641917703#step:8:2977