### PR TITLE
[Security] Do not make PasswordUpgraderInterface a generic

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -125,7 +125,7 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
         }
 
         $repository = $this->getRepository();
-        if ($repository instanceof PasswordUpgraderInterface) {
+        if ($user instanceof PasswordAuthenticatedUserInterface && $repository instanceof PasswordUpgraderInterface) {
             $repository->upgradePassword($user, $newHashedPassword);
         }
     }

--- a/src/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Security\Core\User;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
- *
- * @template TUser of PasswordAuthenticatedUserInterface
  */
 interface PasswordUpgraderInterface
 {
@@ -24,8 +22,6 @@ interface PasswordUpgraderInterface
      * This method should persist the new password in the user storage and update the $user object accordingly.
      * Because you don't want your users not being able to log in, this method should be opportunistic:
      * it's fine if it does nothing or if it fails without throwing any exception.
-     *
-     * @param TUser $user
      */
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Ref https://github.com/symfony/symfony/pull/50399#discussion_r1281652268
| License       | MIT
| Doc PR        | -

Making `PasswordUpgraderInterface` a generic in 6.3 (#48750) was a mistake. Nothing guarantees that the calling side will only pass `TUser` into the `upgradePassword()` method, as there is no way to check which users are supported. Passing a potentially unsupported user is expected behavior and we document in the PHPdoc that the method should silently fail in such cases. The referenced GitHub discussion contains some more details.

Removing the generic from the interface creates a static analysis failure in both [Psalm](https://psalm.dev/r/c86a59ab67) and [PHPstan](https://phpstan.org/r/3c85447a-533c-4196-b0c8-730687c497cc). For this reason, I selected the 6.4 branch although this is a bug fix for 6.3. I'm fine with merging this in 6.3 as well, if this feels better.