### PR TITLE
[FrameworkBundle][HttpKernel][MonologBridge] Revisit wiring of debug loggers

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -357,7 +357,7 @@ diff --git a/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php b/src/Symfony/
 diff --git a/src/Symfony/Bridge/Monolog/Logger.php b/src/Symfony/Bridge/Monolog/Logger.php
 --- a/src/Symfony/Bridge/Monolog/Logger.php
 +++ b/src/Symfony/Bridge/Monolog/Logger.php
-@@ -60,5 +60,5 @@ class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
+@@ -62,5 +62,5 @@ class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
       * @return void
       */
 -    public function removeDebugLogger()
@@ -567,13 +567,13 @@ diff --git a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/Add
 +    public function process(ContainerBuilder $container): void
      {
          if (!$container->hasDefinition('profiler')) {
-@@ -41,5 +41,5 @@ class AddDebugLogProcessorPass implements CompilerPassInterface
+@@ -42,5 +42,5 @@ class AddDebugLogProcessorPass implements CompilerPassInterface
       * @return void
       */
 -    public static function configureLogger(mixed $logger)
 +    public static function configureLogger(mixed $logger): void
      {
-         if (\is_object($logger) && method_exists($logger, 'removeDebugLogger') && \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
+         trigger_deprecation('symfony/framework-bundle', '6.4', 'The "%s()" method is deprecated, use HttpKernel\'s DebugLoggerConfigurator instead.', __METHOD__);
 diff --git a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
 --- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
 +++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -687,14 +687,14 @@ diff --git a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/Wor
 diff --git a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
 --- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
 +++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
-@@ -218,5 +218,5 @@ class FrameworkExtension extends Extension
+@@ -219,5 +219,5 @@ class FrameworkExtension extends Extension
       * @throws LogicException
       */
 -    public function load(array $configs, ContainerBuilder $container)
 +    public function load(array $configs, ContainerBuilder $container): void
      {
          $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
-@@ -2974,5 +2974,5 @@ class FrameworkExtension extends Extension
+@@ -2979,5 +2979,5 @@ class FrameworkExtension extends Extension
       * @return void
       */
 -    public static function registerRateLimiter(ContainerBuilder $container, string $name, array $limiterConfig)
@@ -704,14 +704,14 @@ diff --git a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExt
 diff --git a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
 --- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
 +++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
-@@ -94,5 +94,5 @@ class FrameworkBundle extends Bundle
+@@ -93,5 +93,5 @@ class FrameworkBundle extends Bundle
       * @return void
       */
 -    public function boot()
 +    public function boot(): void
      {
          $_ENV['DOCTRINE_DEPRECATIONS'] = $_SERVER['DOCTRINE_DEPRECATIONS'] ??= 'trigger';
-@@ -119,5 +119,5 @@ class FrameworkBundle extends Bundle
+@@ -118,5 +118,5 @@ class FrameworkBundle extends Bundle
       * @return void
       */
 -    public function build(ContainerBuilder $container)
@@ -8310,7 +8310,7 @@ diff --git a/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRender
 diff --git a/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php b/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
 --- a/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
 +++ b/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
-@@ -29,5 +29,5 @@ class LoggerPass implements CompilerPassInterface
+@@ -30,5 +30,5 @@ class LoggerPass implements CompilerPassInterface
       * @return void
       */
 -    public function process(ContainerBuilder $container)

--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add native return type to `Logger::clear()` and to `DebugProcessor::clear()`
+ * Deprecate class `Logger`, use HttpKernel's `DebugLoggerConfigurator` instead
 
 6.1
 ---

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\Monolog;
 
+trigger_deprecation('symfony/monolog-bridge', '6.4', 'The "%s" class is deprecated, use HttpKernel\'s DebugLoggerConfigurator instead.', Logger::class);
+
 use Monolog\Logger as BaseLogger;
 use Monolog\ResettableInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,7 +20,7 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
- * @author Fabien Potencier <fabien@symfony.com>
+ * @deprecated since Symfony 6.4, use HttpKernel's DebugLoggerConfigurator instead
  */
 class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
 {

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Bridge\Monolog\Tests\Handler;
 
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\FirePHPHandler;
-use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
@@ -13,11 +13,11 @@ namespace Symfony\Bridge\Monolog\Tests\Handler;
 
 use Monolog\Formatter\HtmlFormatter;
 use Monolog\Formatter\LineFormatter;
+use Monolog\Logger;
 use Monolog\LogRecord;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\MailerHandler;
-use Symfony\Bridge\Monolog\Logger;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -18,6 +18,9 @@ use Symfony\Bridge\Monolog\Logger;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @group legacy
+ */
 class LoggerTest extends TestCase
 {
     public function testGetLogsWithoutDebugProcessor()

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
  * Add `DomCrawlerAssertionsTrait::assertAnySelectorTextContains(string $selector, string $text)`
  * Add `DomCrawlerAssertionsTrait::assertAnySelectorTextSame(string $selector, string $text)`
  * Add `DomCrawlerAssertionsTrait::assertAnySelectorTextNotContains(string $selector, string $text)`
+ * Deprecate `EnableLoggerDebugModePass`, use argument `$debug` of HttpKernel's `Logger` instead
+ * Deprecate `AddDebugLogProcessorPass::configureLogger()`, use HttpKernel's `DebugLoggerConfigurator` instead
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
@@ -32,16 +32,19 @@ class AddDebugLogProcessorPass implements CompilerPassInterface
             return;
         }
 
-        $definition = $container->getDefinition('monolog.logger_prototype');
-        $definition->setConfigurator([__CLASS__, 'configureLogger']);
-        $definition->addMethodCall('pushProcessor', [new Reference('debug.log_processor')]);
+        $container->getDefinition('monolog.logger_prototype')
+            ->setConfigurator([new Reference('debug.debug_logger_configurator'), 'pushDebugLogger']);
     }
 
     /**
+     * @deprecated since Symfony 6.4, use HttpKernel's DebugLoggerConfigurator instead
+     *
      * @return void
      */
     public static function configureLogger(mixed $logger)
     {
+        trigger_deprecation('symfony/framework-bundle', '6.4', 'The "%s()" method is deprecated, use HttpKernel\'s DebugLoggerConfigurator instead.', __METHOD__);
+
         if (\is_object($logger) && method_exists($logger, 'removeDebugLogger') && \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
             $logger->removeDebugLogger();
         }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/EnableLoggerDebugModePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/EnableLoggerDebugModePass.php
@@ -11,10 +11,15 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+trigger_deprecation('symfony/framework-bundle', '6.4', 'The "%s" class is deprecated, use argument $debug of HttpKernel\'s Logger instead.', EnableLoggerDebugModePass::class);
+
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Log\Logger;
 
+/**
+ * @deprecated since Symfony 6.4, use argument $debug of HttpKernel's Logger instead
+ */
 final class EnableLoggerDebugModePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
@@ -32,7 +37,7 @@ final class EnableLoggerDebugModePass implements CompilerPassInterface
 
     public static function configureLogger(Logger $logger): void
     {
-        if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && method_exists($logger, 'enableDebug')) {
+        if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
             $logger->enableDebug();
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -101,6 +101,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\PersistingStoreInterface;
@@ -1171,7 +1172,11 @@ class FrameworkExtension extends Extension
             $definition = new Definition(DebugProcessor::class);
             $definition->setPublic(false);
             $definition->addArgument(new Reference('request_stack'));
+            $definition->addTag('kernel.reset', ['method' => 'reset']);
             $container->setDefinition('debug.log_processor', $definition);
+
+            $container->register('debug.debug_logger_configurator', DebugLoggerConfigurator::class)
+                ->setArguments([new Reference('debug.log_processor')]);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -17,7 +17,6 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddExpressionLan
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
-use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\EnableLoggerDebugModePass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggingTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
@@ -183,7 +182,6 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RemoveUnusedSessionMarshallingHandlerPass());
 
         if ($container->getParameter('kernel.debug')) {
-            $container->addCompilerPass(new EnableLoggerDebugModePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -33);
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -16,7 +16,7 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
-use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
@@ -144,7 +144,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
             'exceptionMessage' => $exceptionMessage,
             'statusText' => $statusText,
             'statusCode' => $statusCode,
-            'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
+            'logger' => DebugLoggerConfigurator::getDebugLogger($this->logger),
             'currentContent' => \is_string($this->outputBuffer) ? $this->outputBuffer : ($this->outputBuffer)(),
         ]);
     }

--- a/src/Symfony/Component/ErrorHandler/composer.json
+++ b/src/Symfony/Component/ErrorHandler/composer.json
@@ -21,12 +21,13 @@
         "symfony/var-dumper": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
-        "symfony/http-kernel": "^5.4|^6.0|^7.0",
+        "symfony/http-kernel": "^6.4|^7.0",
         "symfony/serializer": "^5.4|^6.0|^7.0",
         "symfony/deprecation-contracts": "^2.5|^3"
     },
     "conflict": {
-        "symfony/deprecation-contracts": "<2.5"
+        "symfony/deprecation-contracts": "<2.5",
+        "symfony/http-kernel": "<6.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\ErrorHandler\\": "" },

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
  * Add optional `$className` parameter to `ControllerEvent::getAttributes()`
  * Add native return types to `TraceableEventDispatcher` and to `MergeExtensionConfigurationPass`
  * Add argument `$validationFailedStatusCode` to `#[MapQueryString]` and `#[MapRequestPayload]`
+ * Add argument `$debug` to `Logger`
+ * Add class `DebugLoggerConfigurator`
 
 6.3
 ---

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -15,6 +15,7 @@ use Symfony\Component\ErrorHandler\Exception\SilencedErrorContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\VarDumper\Cloner\Data;
 
@@ -25,7 +26,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
  */
 class LoggerDataCollector extends DataCollector implements LateDataCollectorInterface
 {
-    private DebugLoggerInterface $logger;
+    private ?DebugLoggerInterface $logger;
     private ?string $containerPathPrefix;
     private ?Request $currentRequest = null;
     private ?RequestStack $requestStack;
@@ -33,10 +34,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
 
     public function __construct(object $logger = null, string $containerPathPrefix = null, RequestStack $requestStack = null)
     {
-        if ($logger instanceof DebugLoggerInterface) {
-            $this->logger = $logger;
-        }
-
+        $this->logger = DebugLoggerConfigurator::getDebugLogger($logger);
         $this->containerPathPrefix = $containerPathPrefix;
         $this->requestStack = $requestStack;
     }
@@ -46,17 +44,9 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         $this->currentRequest = $this->requestStack && $this->requestStack->getMainRequest() !== $request ? $request : null;
     }
 
-    public function reset(): void
-    {
-        if (isset($this->logger)) {
-            $this->logger->clear();
-        }
-        parent::reset();
-    }
-
     public function lateCollect(): void
     {
-        if (isset($this->logger)) {
+        if ($this->logger) {
             $containerDeprecationLogs = $this->getContainerDeprecationLogs();
             $this->data = $this->computeErrorsCount($containerDeprecationLogs);
             // get compiler logs later (only when they are needed) to improve performance

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\DependencyInjection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Log\Logger;
@@ -37,8 +38,21 @@ class LoggerPass implements CompilerPassInterface
             return;
         }
 
+        if ($debug = $container->getParameter('kernel.debug')) {
+            // Build an expression that will be equivalent to `!in_array(PHP_SAPI, ['cli', 'phpdbg'])`
+            $debug = (new Definition('bool'))
+                ->setFactory('in_array')
+                ->setArguments([
+                    (new Definition('string'))->setFactory('constant')->setArguments(['PHP_SAPI']),
+                    ['cli', 'phpdbg'],
+                ]);
+            $debug = (new Definition('bool'))
+                ->setFactory('in_array')
+                ->setArguments([$debug, [false]]);
+        }
+
         $container->register('logger', Logger::class)
-            ->setArguments([null, null, null, new Reference(RequestStack::class)])
+            ->setArguments([null, null, null, new Reference(RequestStack::class), $debug])
             ->setPublic(false);
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -231,7 +231,7 @@ class ErrorListener implements EventSubscriberInterface
         $attributes = [
             '_controller' => $this->controller,
             'exception' => $exception,
-            'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
+            'logger' => DebugLoggerConfigurator::getDebugLogger($this->logger),
         ];
         $request = $request->duplicate(null, null, $attributes);
         $request->setMethod('GET');

--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Log;
+
+use Monolog\Logger;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class DebugLoggerConfigurator
+{
+    private ?DebugLoggerInterface $processor = null;
+
+    public function __construct(DebugLoggerInterface $processor, bool $enable = null)
+    {
+        if ($enable ?? \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
+            $this->processor = $processor;
+        }
+    }
+
+    public function pushDebugLogger(Logger $logger): void
+    {
+        if ($this->processor) {
+            $logger->pushProcessor($this->processor);
+        }
+    }
+
+    public static function getDebugLogger(mixed $logger): ?DebugLoggerInterface
+    {
+        if ($logger instanceof DebugLoggerInterface) {
+            return $logger;
+        }
+
+        if (!$logger instanceof Logger) {
+            return null;
+        }
+
+        foreach ($logger->getProcessors() as $processor) {
+            if ($processor instanceof DebugLoggerInterface) {
+                return $processor;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Log/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Log/Logger.php
@@ -57,7 +57,7 @@ class Logger extends AbstractLogger implements DebugLoggerInterface
     /**
      * @param string|resource|null $output
      */
-    public function __construct(string $minLevel = null, $output = null, callable $formatter = null, private readonly ?RequestStack $requestStack = null)
+    public function __construct(string $minLevel = null, $output = null, callable $formatter = null, private readonly ?RequestStack $requestStack = null, bool $debug = false)
     {
         if (null === $minLevel) {
             $minLevel = null === $output || 'php://stdout' === $output || 'php://stderr' === $output ? LogLevel::ERROR : LogLevel::WARNING;
@@ -82,6 +82,7 @@ class Logger extends AbstractLogger implements DebugLoggerInterface
         if ($output && false === $this->handle = \is_resource($output) ? $output : @fopen($output, 'a')) {
             throw new InvalidArgumentException(sprintf('Unable to open "%s".', $output));
         }
+        $this->debug = $debug;
     }
 
     public function enableDebug(): void

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -167,18 +167,6 @@ class LoggerDataCollectorTest extends TestCase
         }
     }
 
-    public function testReset()
-    {
-        $logger = $this
-            ->getMockBuilder(DebugLoggerInterface::class)
-            ->onlyMethods(['countErrors', 'getLogs', 'clear'])
-            ->getMock();
-        $logger->expects($this->once())->method('clear');
-
-        $c = new LoggerDataCollector($logger);
-        $c->reset();
-    }
-
     public static function getCollectTestData()
     {
         yield 'simple log' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Replaces #51229

Implements the suggestions from @stof and @Seldaek in https://github.com/symfony/symfony/pull/51229#discussion_r1282056615

It turns our we had almost everything available. This is mostly a matter of wiring.

* Deprecate class `Symfony\Bridge\Monolog\Logger`
* Deprecate `AddDebugLogProcessorPass::configureLogger()`
* Add `DebugLoggerConfigurator` to HttpKernel, which wires `DebugProcessor` when desired

Bonus:
* Add argument `$debug` to HttpKernel's `Logger`
* Deprecate `EnableLoggerDebugModePass` in favor of the previous