### PR TITLE
[Mailer] update Brevo SMTP host

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueSmtpTransport.php
@@ -22,7 +22,7 @@ final class SendinblueSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, #[\SensitiveParameter] string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp-relay.sendinblue.com', 465, true, $dispatcher, $logger);
+        parent::__construct('smtp-relay.brevo.com', 465, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51118
| License       | MIT

Backporting https://github.com/symfony/symfony/pull/51119 into 6.3.

See https://developers.brevo.com/docs/changes-in-smtp-relay-address
We don't know the termination date for the legacy sendinblue SMTP, it's safer to update it.