### PR TITLE
[Process] fix tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -237,4 +237,6 @@ jobs:
           tar -xjf php-8.1.2-pcntl-sigchild.tar.bz2
           cd ..
 
+          mkdir -p /opt/php/lib
+          echo memory_limit=-1 > /opt/php/lib/php.ini
           ./build/php/bin/php ./phpunit --colors=always src/Symfony/Component/Process

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -98,30 +98,11 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
+        putenv('PATH='.\dirname(\PHP_BINARY));
         $this->iniSet('open_basedir', \dirname(\PHP_BINARY).\PATH_SEPARATOR.'/');
 
         $finder = new ExecutableFinder();
         $result = $finder->find($this->getPhpBinaryName());
-
-        $this->assertSamePath(\PHP_BINARY, $result);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testFindProcessInOpenBasedir()
-    {
-        if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
-        }
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Cannot run test on windows');
-        }
-
-        $this->iniSet('open_basedir', \PHP_BINARY.\PATH_SEPARATOR.'/');
-
-        $finder = new ExecutableFinder();
-        $result = $finder->find($this->getPhpBinaryName(), false);
 
         $this->assertSamePath(\PHP_BINARY, $result);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

- `testFindProcessInOpenBasedir` is a duplicate of `testFindWithOpenBaseDir`
- `testFindWithOpenBaseDir` currently expects that we search open_basedir instead of PATH when the setting is set, but this doesn't really make sense, and #47422 removed this behavior
- `PhpSubprocessTest::testSubprocess` expects a php that defaults to memory_limit=-1, which is not the case currently for the sigchild-enabled binary
