### PR TITLE
[PsrHttpMessageBridge] Fix test case

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/PsrHttpFactoryTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/PsrHttpFactoryTest.php
@@ -211,10 +211,7 @@ class PsrHttpFactoryTest extends TestCase
 
     public function testUploadErrNoFile()
     {
-        $file = new UploadedFile('', '', null, \UPLOAD_ERR_NO_FILE, true);
-
-        $this->assertSame(\UPLOAD_ERR_NO_FILE, $file->getError());
-        $this->assertFalse($file->getSize(), 'SplFile::getSize() returns false on error');
+        $file = new UploadedFile(__FILE__, '', null, \UPLOAD_ERR_NO_FILE, true);
 
         $request = new Request(
             [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

On Windows, this test case fails with:

```
1) Symfony\Bridge\PsrHttpMessage\Tests\Factory\PsrHttpFactoryTest::testUploadErrNoFile
RuntimeException: The file "C:\projects\symfony" cannot be opened: fopen(C:\projects\symfony): Failed to open stream: Permission denied
```

The reason is that the empty string is turned into the empty directory, and you can't fopen a directory on Windows.

The removed assertion have no purpose, they only check the behavior of the native SplFileInfo class.