### PR TITLE
[PsrHttpMessageBridge] Don't skip JSON tests

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/PsrHttpFactoryTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/PsrHttpFactoryTest.php
@@ -243,10 +243,6 @@ class PsrHttpFactoryTest extends TestCase
 
     public function testJsonContent()
     {
-        if (!method_exists(Request::class, 'getPayload')) {
-            $this->markTestSkipped();
-        }
-
         $headers = [
             'HTTP_HOST' => 'http_host.fr',
             'CONTENT_TYPE' => 'application/json',
@@ -259,10 +255,6 @@ class PsrHttpFactoryTest extends TestCase
 
     public function testEmptyJsonContent()
     {
-        if (!method_exists(Request::class, 'getPayload')) {
-            $this->markTestSkipped();
-        }
-
         $headers = [
             'HTTP_HOST' => 'http_host.fr',
             'CONTENT_TYPE' => 'application/json',
@@ -275,10 +267,6 @@ class PsrHttpFactoryTest extends TestCase
 
     public function testWrongJsonContent()
     {
-        if (!method_exists(Request::class, 'getPayload')) {
-            $this->markTestSkipped();
-        }
-
         $headers = [
             'HTTP_HOST' => 'http_host.fr',
             'CONTENT_TYPE' => 'application/json',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This feature does not depend on the presence of the `getPayload()` method anymore.