### PR TITLE
[FrameworkBundle] add missing default-doctrine-dbal-provider cache pool attribute to XSD

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -290,6 +290,7 @@
             <xsd:element name="default-psr6-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="default-redis-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="default-memcached-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="default-doctrine-dbal-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="default-pdo-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="pool" type="cache_pool" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
