### PR TITLE
[RemoteEvent][Webhook] Add Sendgrid support

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+* Add support for `RemoteEvent` and `Webhook`
+
 5.4
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/RemoteEvent/SendgridPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/RemoteEvent/SendgridPayloadConverter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent;
+
+use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\RemoteEvent\PayloadConverterInterface;
+
+final class SendgridPayloadConverter implements PayloadConverterInterface
+{
+    public function convert(array $payload): AbstractMailerEvent
+    {
+        if (\in_array($payload['event'], ['bounce', 'deferred', 'delivered', 'dropped', 'processed'], true)) {
+            $name = match ($payload['event']) {
+                'bounce' => MailerDeliveryEvent::BOUNCE,
+                'deferred' => MailerDeliveryEvent::DEFERRED,
+                'delivered' => MailerDeliveryEvent::DELIVERED,
+                'dropped' => MailerDeliveryEvent::DROPPED,
+                'processed' => MailerDeliveryEvent::RECEIVED,
+            };
+            $event = new MailerDeliveryEvent($name, $payload['sg_event_id'], $payload);
+            if (isset($payload['reason'])) {
+                $event->setReason($payload['reason']);
+            }
+        } else {
+            $name = match ($payload['event']) {
+                'click' => MailerEngagementEvent::CLICK,
+                'group_unsubscribe' => MailerEngagementEvent::UNSUBSCRIBE,
+                'open' => MailerEngagementEvent::OPEN,
+                'spamreport' => MailerEngagementEvent::SPAM,
+                'unsubscribe' => MailerEngagementEvent::UNSUBSCRIBE,
+                default => throw new ParseException(sprintf('Unsupported event "%s".', $payload['event'])),
+            };
+            $event = new MailerEngagementEvent($name, $payload['sg_event_id'], $payload);
+        }
+
+        if (!$date = \DateTimeImmutable::createFromFormat('U', $payload['timestamp'])) {
+            throw new ParseException(sprintf('Invalid date "%s".', $payload['timestamp']));
+        }
+        $event->setDate($date);
+
+        $event->setRecipientEmail($payload['email']);
+
+        if (isset($payload['category'])) {
+            $event->setTags((array) $payload['category']);
+        }
+
+        return $event;
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/bounce.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/bounce.json
@@ -1,0 +1,15 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "bounce_classification": "invalid",
+    "event": "bounce",
+    "ip": "168.1.1.1",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "reason": "500 unknown recipient",
+    "status": "5.0.0"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/bounce.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/bounce.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setRecipientEmail('example@test.com');
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setReason('500 unknown recipient');
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/click.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/click.json
@@ -1,0 +1,14 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "click",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+    "ip": "255.255.255.255",
+    "url": "http://www.sendgrid.com/"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/click.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/click.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::CLICK, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setRecipientEmail('example@test.com');
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/deferred.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/deferred.json
@@ -1,0 +1,14 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "deferred",
+    "ip": "168.1.1.1",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "response": "400 try again later",
+    "attempt": "5"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/deferred.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/deferred.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DEFERRED, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setRecipientEmail('example@test.com');
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/delivered.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/delivered.json
@@ -1,0 +1,13 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "delivered",
+    "ip": "168.1.1.1",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "response": "250 OK"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/delivered.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/delivered.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setRecipientEmail('example@test.com');
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/dropped.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/dropped.json
@@ -1,0 +1,13 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "dropped",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "reason": "Bounced Address",
+    "status": "5.0.0"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/dropped.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/dropped.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DROPPED, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setReason('Bounced Address');
+$wh->setRecipientEmail('example@test.com');
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/group_unsubscribe.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/group_unsubscribe.json
@@ -1,0 +1,15 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "group_unsubscribe",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+    "ip": "255.255.255.255",
+    "url": "http://www.sendgrid.com/",
+    "asm_group_id": 10
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/group_unsubscribe.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/group_unsubscribe.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::UNSUBSCRIBE, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setRecipientEmail('example@test.com');
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/open.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/open.json
@@ -1,0 +1,14 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "open",
+    "sg_machine_open": false,
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+    "ip": "255.255.255.255"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/open.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/open.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::OPEN, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setRecipientEmail('example@test.com');
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/processed.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/processed.json
@@ -1,0 +1,11 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "processed",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/processed.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/processed.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::RECEIVED, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setRecipientEmail('example@test.com');
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/spamreport.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/spamreport.json
@@ -1,0 +1,10 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "spamreport",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/spamreport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/spamreport.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::SPAM, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setRecipientEmail('example@test.com');
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/unsubscribe.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/unsubscribe.json
@@ -1,0 +1,11 @@
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "unsubscribe",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/unsubscribe.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/Fixtures/unsubscribe.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::UNSUBSCRIBE, 'sg_event_id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR)[0]);
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1513299569));
+$wh->setRecipientEmail('example@test.com');
+$wh->setTags(['cat facts']);
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridRequestParserTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Webhook;
+
+use Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent\SendgridPayloadConverter;
+use Symfony\Component\Mailer\Bridge\Sendgrid\Webhook\SendgridRequestParser;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
+
+class SendgridRequestParserTest extends AbstractRequestParserTestCase
+{
+    protected function createRequestParser(): RequestParserInterface
+    {
+        return new SendgridRequestParser(new SendgridPayloadConverter());
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sendgrid\Webhook;
+
+use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent\SendgridPayloadConverter;
+use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\Webhook\Client\AbstractRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+final class SendgridRequestParser extends AbstractRequestParser
+{
+    public function __construct(
+        private readonly SendgridPayloadConverter $converter,
+    ) {
+    }
+
+    protected function getRequestMatcher(): RequestMatcherInterface
+    {
+        return new ChainRequestMatcher([
+            new MethodRequestMatcher('POST'),
+            new IsJsonRequestMatcher(),
+        ]);
+    }
+
+    protected function doParse(Request $request, string $secret): ?AbstractMailerEvent
+    {
+        $payload = $request->toArray();
+        if (
+            !\is_array($content = $payload[0] ?? null)
+            || !isset($content['event'])
+            || !isset($content['email'])
+            || !isset($content['sg_event_id'])
+            || !isset($content['timestamp'])
+        ) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        if ('group_resubscribe' === $content['event']) {
+            return null;
+        }
+
+        try {
+            return $this->converter->convert($content);
+        } catch (ParseException $e) {
+            throw new RejectWebhookException(406, $e->getMessage(), $e);
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -20,7 +20,8 @@
         "symfony/mailer": "^5.4.21|^6.2.7|^7.0"
     },
     "require-dev": {
-        "symfony/http-client": "^5.4|^6.0|^7.0"
+        "symfony/http-client": "^5.4|^6.0|^7.0",
+        "symfony/webhook": "^6.4|^7.0"
     },
     "conflict": {
         "symfony/mime": "<6.2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | - 

Add support for Sendgrid [webhook events](https://docs.sendgrid.com/for-developers/tracking-events/event) 

Test fixtures come from the [documentation](https://docs.sendgrid.com/for-developers/tracking-events/event#events)


