### PR TITLE
[Messenger] helpful exception when requesting an AMQP queue that is not configured

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -509,6 +509,9 @@ class Connection
     public function queue(string $queueName): \AMQPQueue
     {
         if (!isset($this->amqpQueues[$queueName])) {
+            if (!\array_key_exists($queueName, $this->queuesOptions)) {
+                throw new InvalidArgumentException(sprintf('Exchange "%s" does not have a queue named "%s", known queues are "%s"', $this->exchangeOptions['name'], $queueName, implode('", "', array_keys($this->queuesOptions))));
+            }
             $queueConfig = $this->queuesOptions[$queueName];
 
             $amqpQueue = $this->amqpFactory->createQueue($this->channel());


### PR DESCRIPTION
without this check, running `messenger:consume --queue=notexisting` gives an "undefined array key" PHP error with no helpful context at all.

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

just struggled a bit to figure out what the problem was, until i realized my typo in the queue name on the cli...

this could also be added to older versions of symfony as its not a new feature but a sanity check that replaces a PHP error with a meaningful exception. happy to adjust my pull request if you want me to.