### PR TITLE
[FrameworkBundle] Deprecate not setting some options

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -85,6 +85,11 @@ FrameworkBundle
  * [BC break] Add native return type to `Translator` and to `Application::reset()`
  * Deprecate the integration of Doctrine annotations, either uninstall the `doctrine/annotations` package or disable
    the integration by setting `framework.annotations` to `false`
+ * Deprecate not setting the `framework.handle_all_throwables` config option; it will default to `true` in 7.0
+ * Deprecate not setting the `framework.php_errors.log` config option; it will default to `true` in 7.0
+ * Deprecate not setting the `framework.session.cookie_secure` config option; it will default to `auto` in 7.0
+ * Deprecate not setting the `framework.session.cookie_samesite` config option; it will default to `lax` in 7.0
+ * Deprecate not setting the `framework.session.handler_id` config option; it will default to `session.handler.native_file` when `framework.session.save_path` is set or `null` otherwise in 7.0
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Fixtures/App/Kernel.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Fixtures/App/Kernel.php
@@ -52,6 +52,8 @@ class Kernel extends SymfonyKernel
             'test' => true,
             'annotations' => false,
             'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
         ]);
 
         $container->services()

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,11 @@ CHANGELOG
  * Add `DomCrawlerAssertionsTrait::assertAnySelectorTextNotContains(string $selector, string $text)`
  * Deprecate `EnableLoggerDebugModePass`, use argument `$debug` of HttpKernel's `Logger` instead
  * Deprecate `AddDebugLogProcessorPass::configureLogger()`, use HttpKernel's `DebugLoggerConfigurator` instead
+ * Deprecate not setting the `framework.handle_all_throwables` config option; it will default to `true` in 7.0
+ * Deprecate not setting the `framework.php_errors.log` config option; it will default to `true` in 7.0
+ * Deprecate not setting the `framework.session.cookie_secure` config option; it will default to `auto` in 7.0
+ * Deprecate not setting the `framework.session.cookie_samesite` config option; it will default to `lax` in 7.0
+ * Deprecate not setting the `framework.session.handler_id` config option; it will default to `session.handler.native_file` when `framework.session.save_path` is set or `null` otherwise in 7.0
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/Fixture/TestAppKernel.php
@@ -36,6 +36,8 @@ class TestAppKernel extends Kernel
             $container->loadFromExtension('framework', [
                 'annotations' => false,
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
             ]);
         });
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/config.yml
@@ -1,4 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     secret: test

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -35,7 +35,13 @@ class ConfigurationTest extends TestCase
     public function testDefaultConfig()
     {
         $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(true), [['http_method_override' => false, 'secret' => 's3cr3t', 'serializer' => ['default_context' => ['foo' => 'bar']]]]);
+        $config = $processor->processConfiguration(new Configuration(true), [[
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
+            'secret' => 's3cr3t',
+            'serializer' => ['default_context' => ['foo' => 'bar']],
+        ]]);
 
         $this->assertEquals(self::getBundleDefaultConfig(), $config);
     }
@@ -59,7 +65,12 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
         $processor->processConfiguration(
             new Configuration(true),
-            [['http_method_override' => false, 'session' => ['name' => $sessionName]]]
+            [[
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'session' => ['name' => $sessionName, 'cookie_secure' => 'auto', 'cookie_samesite' => 'lax'],
+            ]]
         );
     }
 
@@ -79,7 +90,12 @@ class ConfigurationTest extends TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(true);
-        $config = $processor->processConfiguration($configuration, [['http_method_override' => false, 'assets' => null]]);
+        $config = $processor->processConfiguration($configuration, [[
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
+            'assets' => null,
+        ]]);
 
         $defaultConfig = [
             'enabled' => true,
@@ -100,7 +116,12 @@ class ConfigurationTest extends TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(true);
-        $config = $processor->processConfiguration($configuration, [['http_method_override' => false, 'asset_mapper' => null]]);
+        $config = $processor->processConfiguration($configuration, [[
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
+            'asset_mapper' => null,
+        ]]);
 
         $defaultConfig = [
             'enabled' => true,
@@ -130,6 +151,8 @@ class ConfigurationTest extends TestCase
         $config = $processor->processConfiguration($configuration, [
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'assets' => [
                     'packages' => [
                         $packageName => [],
@@ -163,6 +186,8 @@ class ConfigurationTest extends TestCase
         $processor->processConfiguration($configuration, [
                 [
                     'http_method_override' => false,
+                    'handle_all_throwables' => true,
+                    'php_errors' => ['log' => true],
                     'assets' => $assetConfig,
                 ],
             ]);
@@ -211,6 +236,8 @@ class ConfigurationTest extends TestCase
         $config = $processor->processConfiguration($configuration, [
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'lock' => $lockConfig,
             ],
         ]);
@@ -272,12 +299,16 @@ class ConfigurationTest extends TestCase
         $config = $processor->processConfiguration($configuration, [
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'lock' => [
                     'payload' => 'flock',
                 ],
             ],
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'lock' => [
                     'payload' => 'semaphore',
                 ],
@@ -305,6 +336,8 @@ class ConfigurationTest extends TestCase
         $config = $processor->processConfiguration($configuration, [
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'semaphore' => $semaphoreConfig,
             ],
         ]);
@@ -358,6 +391,8 @@ class ConfigurationTest extends TestCase
         $processor->processConfiguration($configuration, [
             'framework' => [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'messenger' => [
                     'default_bus' => null,
                     'buses' => [
@@ -376,6 +411,8 @@ class ConfigurationTest extends TestCase
         $config = $processor->processConfiguration($configuration, [
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'messenger' => [
                     'default_bus' => 'existing_bus',
                     'buses' => [
@@ -391,6 +428,8 @@ class ConfigurationTest extends TestCase
             ],
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'messenger' => [
                     'buses' => [
                         'common_bus' => [
@@ -440,6 +479,8 @@ class ConfigurationTest extends TestCase
         $processor->processConfiguration($configuration, [
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'messenger' => [
                     'default_bus' => 'foo',
                     'buses' => [
@@ -459,6 +500,8 @@ class ConfigurationTest extends TestCase
         $config = $processor->processConfiguration($configuration, [
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'lock' => ['enabled' => false],
             ],
         ]);
@@ -477,6 +520,8 @@ class ConfigurationTest extends TestCase
         $processor->processConfiguration($configuration, [
             [
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'lock' => ['enabled' => true],
             ],
         ]);
@@ -486,6 +531,7 @@ class ConfigurationTest extends TestCase
     {
         return [
             'http_method_override' => false,
+            'handle_all_throwables' => true,
             'trust_x_sendfile_type_header' => false,
             'ide' => '%env(default::SYMFONY_IDE)%',
             'default_locale' => 'en',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'assets' => [
         'version' => 'SomeVersionScheme',
         'base_urls' => 'http://cdn.example.com',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_disabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'assets' => [
         'enabled' => false,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_version_strategy_as_service.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_version_strategy_as_service.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'assets' => [
         'version_strategy' => 'assets.custom_version_strategy',
         'base_urls' => 'http://cdn.example.com',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'cache' => [
         'pools' => [
             'cache.foo' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'cache' => [
         'app' => 'cache.adapter.redis_tag_aware',
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware_pool.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware_pool.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'cache' => [
         'app' => 'cache.redis_tag_aware.foo',
         'pools' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf.php
@@ -3,9 +3,13 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'csrf_protection' => true,
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,
+        'cookie_secure' => 'auto',
+        'cookie_samesite' => 'lax',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf_needs_session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf_needs_session.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'csrf_protection' => [
         'enabled' => true,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/default_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/default_config.php
@@ -3,4 +3,6 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/esi_and_ssi_without_fragments.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/esi_and_ssi_without_fragments.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'fragments' => [
         'enabled' => false,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/esi_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/esi_disabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'esi' => [
         'enabled' => false,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/exceptions.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/exceptions.php
@@ -8,6 +8,8 @@ use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'exceptions' => [
         BadRequestHttpException::class => [
             'log_level' => 'info',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_csrf_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_csrf_disabled.php
@@ -7,4 +7,6 @@ $container->loadFromExtension('framework', [
         'csrf_protection' => true,
     ],
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_default_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_default_csrf.php
@@ -3,8 +3,12 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,
+        'cookie_secure' => 'auto',
+        'cookie_samesite' => 'lax',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_no_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_no_csrf.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'form' => [
         'csrf_protection' => [
             'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/fragments_and_hinclude.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/fragments_and_hinclude.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'fragments' => [
         'enabled' => true,
         'hinclude_default_template' => 'global_hinclude_template',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -11,6 +11,8 @@ $container->loadFromExtension('framework', [
         ],
     ],
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'trust_x_sendfile_type_header' => true,
     'esi' => [
         'enabled' => true,
@@ -35,6 +37,7 @@ $container->loadFromExtension('framework', [
         'cookie_path' => '/',
         'cookie_domain' => 'example.com',
         'cookie_secure' => true,
+        'cookie_samesite' => 'lax',
         'cookie_httponly' => false,
         'use_cookies' => true,
         'gc_maxlifetime' => 90000,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'html_sanitizer' => [
         'sanitizers' => [
             'custom' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_allowed_link_and_media_hosts.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_allowed_link_and_media_hosts.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'html_sanitizer' => [
         'sanitizers' => [
             'custom_default' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_config.php
@@ -3,4 +3,6 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'html_sanitizer' => null]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_default_options.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'http_client' => [
         'max_host_connections' => 4,
         'default_options' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_full_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_full_default_options.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'http_client' => [
         'default_options' => [
             'headers' => ['X-powered' => 'PHP'],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_mock_response_factory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_mock_response_factory.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'http_client' => [
         'default_options' => null,
         'mock_response_factory' => 'my_response_factory',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_override_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_override_default_options.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'http_client' => [
         'max_host_connections' => 4,
         'default_options' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'http_client' => [
         'default_options' => [
             'retry_failed' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_scoped_without_query_option.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_scoped_without_query_option.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'http_client' => [
         'scoped_clients' => [
             'foo' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_xml_key.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_xml_key.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'http_client' => [
         'default_options' => [
             'resolve' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/legacy_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/legacy_annotations.php
@@ -7,4 +7,6 @@ $container->loadFromExtension('framework', [
         'file_cache_dir' => '%kernel.cache_dir%/annotations',
     ],
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'mailer' => [
         'dsn' => 'smtp://example.com',
         'envelope' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_disabled_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_disabled_message_bus.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'mailer' => [
         'dsn' => 'smtp://example.com',
         'message_bus' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_dsn.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_dsn.php
@@ -6,6 +6,8 @@ return static function (ContainerConfigurator $container) {
     $container->extension('framework', [
         'annotations' => false,
         'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
         'mailer' => [
             'dsn' => 'smtp://example.com',
             'envelope' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_specific_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_specific_message_bus.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'mailer' => [
         'dsn' => 'smtp://example.com',
         'message_bus' => 'app.another_bus',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_transports.php
@@ -6,6 +6,8 @@ return static function (ContainerConfigurator $container) {
     $container->extension('framework', [
         'annotations' => false,
         'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
         'mailer' => [
             'transports' => [
                 'transport1' => 'smtp://example1.com',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'scheduler' => true,
     'messenger' => [
         'routing' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_disabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => false,
     'scheduler' => false,
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_middleware_factory_erroneous_format.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_middleware_factory_erroneous_format.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'buses' => [
             'command_bus' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'default_bus' => 'messenger.bus.commands',
         'buses' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_failure_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_failure_transports.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'transports' => [
             'transport_1' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_failure_transports_global.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_failure_transports_global.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'failure_transport' => 'failure_transport_global',
         'transports' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'serializer' => true,
     'messenger' => [
         'serializer' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_transport.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_transport.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'serializer' => true,
     'messenger' => [
         'serializer' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_wildcard.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_wildcard.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'serializer' => true,
     'messenger' => [
         'serializer' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_single.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_single.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'routing' => [
             DummyMessage::class => ['amqp'],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'serializer' => true,
     'messenger' => [
         'serializer' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'serializer' => true,
     'messenger' => [
         'failure_transport' => 'failed',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_with_disabled_reset_on_message.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_with_disabled_reset_on_message.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'reset_on_message' =>  false,
         'routing' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_with_explict_reset_on_message_legacy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_with_explict_reset_on_message_legacy.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'reset_on_message' =>  true,
         'routing' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'enabled' => true
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_with_disabled_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_with_disabled_message_bus.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'enabled' => true,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_with_specific_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_with_specific_message_bus.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'messenger' => [
         'enabled' => true,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_mailer.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'mailer' => [
         'enabled' => false,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_messenger.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'mailer' => [
         'dsn' => 'smtp://example.com',
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_transports.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'notifier' => [
         'enabled' => true,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_disabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'php_errors' => [
         'log' => false,
         'throw' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_enabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'php_errors' => [
         'log' => true,
         'throw' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_level.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_level.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'php_errors' => [
         'log' => 8,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_levels.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_levels.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'php_errors' => [
         'log' => [
             \E_NOTICE => \Psr\Log\LogLevel::ERROR,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'profiler' => [
         'enabled' => true,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler_collect_serializer_data.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler_collect_serializer_data.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'profiler' => [
         'enabled' => true,
         'collect_serializer_data' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'property_access' => [
         'magic_call' => true,
         'magic_get' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_info.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'property_info' => [
         'enabled' => true,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/request.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/request.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'request' => [
         'formats' => [],
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_disabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'serializer' => [
         'enabled' => false,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_enabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'serializer' => [
         'enabled' => true,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping.php
@@ -2,6 +2,8 @@
 
 $container->loadFromExtension('framework', [
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'annotations' => false,
     'serializer' => [
         'enable_annotations' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping_without_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping_without_annotations.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'serializer' => [
         'enable_annotations' => false,
         'mapping' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session.php
@@ -3,8 +3,12 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,
+        'cookie_secure' => false,
+        'cookie_samesite' => 'lax',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_cookie_secure_auto.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_cookie_secure_auto.php
@@ -3,9 +3,12 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,
         'cookie_secure' => 'auto',
+        'cookie_samesite' => 'lax',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/ssi_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/ssi_disabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'ssi' => [
         'enabled' => false,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/translator_cache_dir_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/translator_cache_dir_disabled.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'translator' => [
         'cache_dir' => null,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/translator_fallbacks.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/translator_fallbacks.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'translator' => [
         'fallbacks' => ['en', 'fr'],
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_annotations.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'secret' => 's3cr3t',
     'validation' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_auto_mapping.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_auto_mapping.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'property_info' => ['enabled' => true],
     'validation' => [
         'auto_mapping' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_email_validation_mode.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_email_validation_mode.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'validation' => [
         'email_validation_mode' => 'html5',
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_legacy_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_legacy_annotations.php
@@ -5,6 +5,8 @@ $container->loadFromExtension('framework', [
         'enabled' => true,
     ],
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'secret' => 's3cr3t',
     'validation' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_mapping.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_mapping.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'validation' => [
         'mapping' => [
             'paths' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_multiple_static_methods.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_multiple_static_methods.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'secret' => 's3cr3t',
     'validation' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_no_static_method.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_no_static_method.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'secret' => 's3cr3t',
     'validation' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_translation_domain.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_translation_domain.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'validation' => [
         'translation_domain' => 'messages',
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/web_link.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/web_link.php
@@ -3,5 +3,7 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'web_link' => ['enabled' => true],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/webhook.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'webhook' => ['enabled' => true],
     'http_client' => ['enabled' => true],
     'serializer' => ['enabled' => true],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/webhook_without_serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/webhook_without_serializer.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'webhook' => ['enabled' => true],
     'http_client' => ['enabled' => true],
     'serializer' => ['enabled' => false],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_not_valid.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_not_valid.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'my_workflow' => [
             'type' => 'state_machine',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'article' => [
             'type' => 'workflow',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_multiple_transitions_with_same_name.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_multiple_transitions_with_same_name.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'article' => [
             'type' => 'workflow',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_no_events_to_dispatch.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_no_events_to_dispatch.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'my_workflow' => [
             'type' => 'state_machine',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_events_to_dispatch.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_events_to_dispatch.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'my_workflow' => [
             'type' => 'state_machine',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_support_and_support_strategy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_support_and_support_strategy.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'my_workflow' => [
             'type' => 'workflow',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_without_support_and_support_strategy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_without_support_and_support_strategy.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'my_workflow' => [
             'type' => 'workflow',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'article' => [
             'type' => 'workflow',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_enabled.php
@@ -3,5 +3,7 @@
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => null,
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'enabled' => true,
         'foo' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled_named_workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled_named_workflows.php
@@ -5,6 +5,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionT
 $container->loadFromExtension('framework', [
     'annotations' => false,
     'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
     'workflows' => [
         'enabled' => true,
         'workflows' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/asset_mapper.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/asset_mapper.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:asset-mapper
             enabled="true"
             server="true"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:assets version="SomeVersionScheme" version-format="%%s?version=%%s">
             <framework:base-url>http://cdn.example.com</framework:base-url>
             <framework:package name="images_path" base-path="/foo" version-format="%%s-%%s" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_disabled.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:assets enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_version_strategy_as_service.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_version_strategy_as_service.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:assets version-strategy="assets.custom_version_strategy">
             <framework:base-url>http://cdn.example.com</framework:base-url>
         </framework:assets>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:cache>
             <framework:pool name="cache.foo" adapter="cache.adapter.apcu" default-lifetime="30" />
             <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:cache>
             <framework:app>cache.adapter.redis_tag_aware</framework:app>
         </framework:cache>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware_pool.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware_pool.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:cache>
             <framework:app>cache.redis_tag_aware.foo</framework:app>
             <framework:pool name="cache.redis_tag_aware.foo" adapter="cache.adapter.redis_tag_aware" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
@@ -6,9 +6,10 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:csrf-protection />
-        <framework:session storage-factory-id="session.storage.factory.native" />
+        <framework:session storage-factory-id="session.storage.factory.native" handler-id="null" cookie-secure="auto" cookie-samesite="lax" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf_disabled.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:csrf-protection enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf_needs_session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf_needs_session.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:csrf-protection />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/default_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/default_config.xml
@@ -5,7 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/esi_and_ssi_without_fragments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/esi_and_ssi_without_fragments.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:fragments enabled="false" />
         <framework:esi enabled="true" />
         <framework:ssi enabled="true" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/esi_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/esi_disabled.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:esi enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/exceptions.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/exceptions.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
 
         <framework:exception
             class="Symfony\Component\HttpKernel\Exception\BadRequestHttpException"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/exceptions_legacy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/exceptions_legacy.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:exceptions>
             <framework:exception name="Symfony\Component\HttpKernel\Exception\BadRequestHttpException" log-level="info" status-code="422" />
             <framework:exception name="Symfony\Component\HttpKernel\Exception\NotFoundHttpException" log-level="info" status-code="0" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_disabled.xml
@@ -8,8 +8,9 @@
             http://symfony.com/schema/dic/symfony
             https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
 >
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false"/>
+        <framework:php-errors log="true" />
         <framework:csrf-protection enabled="false"/>
         <framework:form enabled="true">
             <framework:csrf-protection enabled="true"/>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:csrf-protection field-name="_custom" />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:csrf-protection field-name="_custom_form" />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_default_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_default_csrf.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:form enabled="true" />
         <framework:session storage-factory-id="session.storage.factory.native" handler-id="null"/>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:form enabled="true">
             <framework:csrf-protection enabled="false" />
         </framework:form>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/fragments_and_hinclude.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/fragments_and_hinclude.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:fragments enabled="true" hinclude-default-template="global_hinclude_template"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config secret="s3cr3t" ide="file%%link%%format" default-locale="fr" http-method-override="false" trust-x-sendfile-type-header="true">
+    <framework:config secret="s3cr3t" ide="file%%link%%format" default-locale="fr" http-method-override="false" handle-all-throwables="true" trust-x-sendfile-type-header="true">
         <framework:enabled-locale>fr</framework:enabled-locale>
         <framework:enabled-locale>en</framework:enabled-locale>
         <framework:csrf-protection />
@@ -17,7 +17,7 @@
         <framework:ssi enabled="true" />
         <framework:profiler only-exceptions="true" enabled="false" />
         <framework:router resource="%kernel.project_dir%/config/routing.xml" type="xml" utf8="true" />
-        <framework:session gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-factory-id="session.storage.factory.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="false" use-cookies="true" save-path="/path/to/sessions" sid-length="22" sid-bits-per-character="4" />
+        <framework:session gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-factory-id="session.storage.factory.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-samesite="lax" cookie-httponly="false" use-cookies="true" save-path="/path/to/sessions" sid-length="22" sid-bits-per-character="4" />
         <framework:request>
             <framework:format name="csv">
                 <framework:mime-type>text/csv</framework:mime-type>
@@ -33,6 +33,7 @@
         </framework:translator>
         <framework:validation enabled="true" />
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" circular-reference-handler="my.circular.reference.handler" max-depth-handler="my.max.depth.handler">
             <framework:default-context>
                 <framework:enable_max_depth>true</framework:enable_max_depth>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false">
+    <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false" handle-all-throwables="true">
         <annotations enabled="false" />
+        <php-errors log="true" />
         <html-sanitizer>
             <sanitizer name="custom"
                 allow-safe-elements="true"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_allowed_link_and_media_hosts.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_allowed_link_and_media_hosts.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false">
+    <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false" handle-all-throwables="true">
         <annotations enabled="false" />
+        <php-errors log="true" />
         <html-sanitizer>
             <sanitizer name="custom_default"/>
         </html-sanitizer>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_config.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false">
+    <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false" handle-all-throwables="true">
         <annotations enabled="false" />
+        <php-errors log="true" />
         <html-sanitizer />
     </config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_default_options.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:http-client max-host-connections="4">
             <framework:default-options />
             <framework:scoped-client

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_full_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_full_default_options.xml
@@ -5,8 +5,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:http-client>
             <framework:default-options
                     proxy="proxy.org"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_mock_response_factory.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_mock_response_factory.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:http-client mock-response-factory="my_response_factory">
             <framework:default-options />
         </framework:http-client>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_override_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_override_default_options.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:http-client max-host-connections="4">
             <framework:default-options>
                 <framework:header name="foo">bar</framework:header>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
@@ -5,8 +5,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:http-client>
             <framework:default-options>
                 <framework:retry-failed

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_scoped_without_query_option.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_scoped_without_query_option.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:http-client>
             <framework:scoped-client
                 name="foo"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_xml_key.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_xml_key.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:http-client>
             <framework:default-options>
                 <framework:resolve host="host">127.0.0.1</framework:resolve>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/legacy_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/legacy_annotations.xml
@@ -6,7 +6,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="true"
                                cache="file"
                                debug="true"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:lock/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock_named.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock_named.xml
@@ -10,8 +10,9 @@
         <parameter key="env(REDIS_URL)">redis://paas.com</parameter>
     </parameters>
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:lock>
             <framework:resource name="foo">semaphore</framework:resource>
             <framework:resource name="bar">flock</framework:resource>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_disabled_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_disabled_message_bus.xml
@@ -6,8 +6,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:mailer dsn="smtp://example.com" message-bus="false">
         </framework:mailer>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
@@ -6,8 +6,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:mailer dsn="smtp://example.com">
             <framework:envelope>
                 <framework:sender>sender@example.org</framework:sender>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_specific_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_specific_message_bus.xml
@@ -6,8 +6,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:mailer dsn="smtp://example.com" message-bus="app.another_bus">
         </framework:mailer>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_transports.xml
@@ -6,8 +6,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:mailer>
             <framework:transport name="transport1">smtp://example1.com</framework:transport>
             <framework:transport name="transport2">smtp://example2.com</framework:transport>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:scheduler enabled="true" />
         <framework:messenger>
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_disabled.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger enabled="false" />
         <framework:scheduler enabled="false" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger default-bus="messenger.bus.commands">
             <framework:bus name="messenger.bus.commands" />
             <framework:bus name="messenger.bus.events">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_failure_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_failure_transports.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger>
             <framework:transport name="transport_1" dsn="null://" failure-transport="failure_transport_1" />
             <framework:transport name="transport_2" dsn="null://" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_failure_transports_global.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_failure_transports_global.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger failure-transport="failure_transport_global">
             <framework:transport name="transport_1" dsn="null://" failure-transport="failure_transport_1" />
             <framework:transport name="transport_2" dsn="null://" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_transport.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_transport.xml
@@ -5,8 +5,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_wildcard.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_wildcard.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_single.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_single.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger>
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage">
                 <framework:sender service="amqp" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_schedule.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_schedule.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger>
             <framework:transport name="schedule" dsn="schedule://default" />
         </framework:messenger>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enabled="true" />
         <framework:messenger failure-transport="failed">
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_with_disabled_reset_on_message.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_with_disabled_reset_on_message.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger reset-on-message="false">
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage">
                 <framework:sender service="sender.bar" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_with_explict_reset_on_message_legacy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_with_explict_reset_on_message_legacy.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger reset-on-message="true">
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage">
                 <framework:sender service="sender.bar" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger enabled="true" />
         <framework:mailer dsn="smtp://example.com" />
         <framework:notifier enabled="true" notification-on-failed-messages="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_with_disabled_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_with_disabled_message_bus.xml
@@ -6,8 +6,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger enabled="true" />
         <framework:mailer dsn="smtp://example.com" />
         <framework:notifier enabled="true" message-bus="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_with_specific_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_with_specific_message_bus.xml
@@ -6,8 +6,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:messenger enabled="true" />
         <framework:mailer dsn="smtp://example.com" />
         <framework:notifier enabled="true" message-bus="app.another_bus">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_mailer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_mailer.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:mailer enabled="false" />
         <framework:messenger enabled="true" />
         <framework:notifier enabled="true" notification-on-failed-messages="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_messenger.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:mailer dsn="smtp://example.com" />
         <framework:messenger enabled="false" />
         <framework:notifier enabled="true" notification-on-failed-messages="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_transports.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:notifier enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_disabled.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="false" throw="false" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_enabled.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" throw="true" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_level.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_level.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="8" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_levels.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_levels.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors>
             <framework:log type="8" logLevel="error" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:profiler enabled="true" />
         <framework:serializer enabled="true" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler_collect_serializer_data.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler_collect_serializer_data.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:profiler enabled="true" collect-serializer-data="true" />
         <framework:serializer enabled="true" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_accessor.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_accessor.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false"/>
+        <framework:php-errors log="true" />
         <framework:property-access magic-call="true" magic-get="true" magic-set="false" throw-exception-on-invalid-index="true" throw-exception-on-invalid-property-path="false"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_info.xml
@@ -5,8 +5,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:property-info enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/rate_limiter.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/rate_limiter.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:rate-limiter>
             <framework:limiter
                 name="sliding_window"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/request.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/request.xml
@@ -5,8 +5,9 @@
     xmlns:framework="http://symfony.com/schema/dic/symfony"
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:request />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/semaphore.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/semaphore.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:semaphore/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_disabled.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_enabled.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping.xml
@@ -4,8 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:framework="http://symfony.com/schema/dic/symfony">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enable-annotations="true">
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping_without_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping_without_annotations.xml
@@ -4,8 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:framework="http://symfony.com/schema/dic/symfony">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:serializer enable-annotations="false">
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
-        <framework:session storage-factory-id="session.storage.factory.native" handler-id="null"/>
+        <framework:php-errors log="true" />
+        <framework:session storage-factory-id="session.storage.factory.native" handler-id="null" cookie-secure="false" cookie-samesite="lax" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_cookie_secure_auto.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_cookie_secure_auto.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
-        <framework:session storage-factory-id="session.storage.factory.native" handler-id="null" cookie-secure="auto" />
+        <framework:php-errors log="true" />
+        <framework:session storage-factory-id="session.storage.factory.native" handler-id="null" cookie-secure="auto" cookie-samesite="lax" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/ssi_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/ssi_disabled.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:ssi enabled="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/translator_cache_dir_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/translator_cache_dir_disabled.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config secret="s3cr3t" http-method-override="false">
+    <framework:config secret="s3cr3t" http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:translator enabled="true" fallback="fr" logging="true" cache-dir="null" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/translator_fallbacks.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/translator_fallbacks.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config secret="s3cr3t" http-method-override="false">
+    <framework:config secret="s3cr3t" http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:translator enabled="true">
             <framework:fallback>en</framework:fallback>
             <framework:fallback>fr</framework:fallback>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_annotations.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config secret="s3cr3t" http-method-override="false">
+    <framework:config secret="s3cr3t" http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:validation enabled="true" enable-annotations="true" />
     </framework:config>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_auto_mapping.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_auto_mapping.xml
@@ -3,8 +3,9 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:framework="http://symfony.com/schema/dic/symfony">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:property-info enabled="true" />
         <framework:validation>
             <framework:auto-mapping namespace="App\">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_email_validation_mode.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_email_validation_mode.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:validation email-validation-mode="html5" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_legacy_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_legacy_annotations.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config secret="s3cr3t" http-method-override="false">
+    <framework:config secret="s3cr3t" http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="true" />
+        <framework:php-errors log="true" />
         <framework:validation enabled="true" enable-annotations="true" />
     </framework:config>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_mapping.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_mapping.xml
@@ -4,8 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:framework="http://symfony.com/schema/dic/symfony">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:validation>
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/validation_mapping/files</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_multiple_static_methods.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_multiple_static_methods.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config secret="s3cr3t" http-method-override="false">
+    <framework:config secret="s3cr3t" http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:validation enabled="true">
             <framework:static-method>loadFoo</framework:static-method>
             <framework:static-method>loadBar</framework:static-method>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_no_static_method.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_no_static_method.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config secret="s3cr3t" http-method-override="false">
+    <framework:config secret="s3cr3t" http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:validation enabled="true" static-method="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_translation_domain.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_translation_domain.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:validation translation-domain="messages" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/web_link.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/web_link.xml
@@ -6,8 +6,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:web-link enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/webhook.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/webhook.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:webhook enabled="true" />
         <framework:http-client enabled="true" />
         <framework:serializer enabled="true" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/webhook_without_serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/webhook_without_serializer.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:webhook enabled="true" />
         <framework:http-client enabled="true" />
         <framework:serializer enabled="false" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_not_valid.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_not_valid.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow name="my_workflow" type="state_machine">
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
             <framework:place name="first" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
@@ -6,8 +6,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow name="article" type="workflow">
             <framework:initial-marking>draft</framework:initial-marking>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_multiple_transitions_with_same_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_multiple_transitions_with_same_name.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow name="article" type="workflow">
             <framework:initial-marking>draft</framework:initial-marking>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_no_events_to_dispatch.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_no_events_to_dispatch.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow name="my_workflow" type="state_machine">
             <framework:initial-marking>one</framework:initial-marking>
             <framework:marking-store type="method" property="state" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_specified_events_to_dispatch.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_specified_events_to_dispatch.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow name="my_workflow" type="state_machine">
             <framework:initial-marking>one</framework:initial-marking>
             <framework:marking-store property="state" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_support_and_support_strategy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_support_and_support_strategy.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow name="my_workflow" support-strategy="foobar" type="workflow">
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
             <framework:place name="first" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_without_support_and_support_strategy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_without_support_and_support_strategy.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow name="my_workflow" type="workflow">
             <framework:place name="first" />
             <framework:place name="last" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
@@ -6,8 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow name="article" type="workflow">
             <framework:audit-trail enabled="true"/>
             <framework:initial-marking>draft</framework:initial-marking>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_enabled.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_explicitly_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_explicitly_enabled.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow enabled="true" name="foo" type="workflow" initial-marking="bar">
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
             <framework:place>bar</framework:place>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_explicitly_enabled_named_workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_explicitly_enabled_named_workflows.xml
@@ -5,8 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config http-method-override="false">
+    <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
         <framework:workflow enabled="true" name="workflows" type="workflow">
             <framework:initial-marking>bar</framework:initial-marking>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     assets:
         version: SomeVersionScheme
         version_format: '%%s?version=%%s'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_disabled.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     assets:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_version_strategy_as_service.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_version_strategy_as_service.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     assets:
         version_strategy: assets.custom_version_strategy
         base_urls: http://cdn.example.com

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     cache:
         pools:
             cache.foo:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     cache:
         app: cache.adapter.redis_tag_aware

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware_pool.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware_pool.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     cache:
         app: cache.redis_tag_aware.foo
         pools:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf.yml
@@ -1,7 +1,13 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     secret: s3cr3t
     csrf_protection: ~
     session:
+        handler_id: null
         storage_factory_id: session.storage.factory.native
+        cookie_secure: auto
+        cookie_samesite: lax

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf_needs_session.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf_needs_session.yml
@@ -1,4 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     csrf_protection: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/default_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/default_config.yml
@@ -1,3 +1,6 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/esi_and_ssi_without_fragments.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/esi_and_ssi_without_fragments.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     fragments:
         enabled: false
     esi:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/esi_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/esi_disabled.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     esi:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/exceptions.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/exceptions.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     exceptions:
         Symfony\Component\HttpKernel\Exception\BadRequestHttpException:
             log_level: info

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_csrf_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_csrf_disabled.yml
@@ -4,3 +4,6 @@ framework:
     form:
         csrf_protection: true
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_default_csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_default_csrf.yml
@@ -1,6 +1,11 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     session:
         storage_factory_id: session.storage.factory.native
         handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_no_csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_no_csrf.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     form:
         csrf_protection:
             enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/fragments_and_hinclude.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/fragments_and_hinclude.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     fragments:
         enabled: true
         hinclude_default_template: global_hinclude_template

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -7,6 +7,9 @@ framework:
         csrf_protection:
             field_name: _csrf
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     trust_x_sendfile_type_header: true
     esi:
         enabled: true
@@ -27,6 +30,7 @@ framework:
         cookie_path:      /
         cookie_domain:    example.com
         cookie_secure:    true
+        cookie_samesite:  lax
         cookie_httponly:  false
         use_cookies:      true
         gc_probability:  1

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     html_sanitizer:
         sanitizers:
             custom:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_allowed_link_and_media_hosts.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_allowed_link_and_media_hosts.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     html_sanitizer:
         sanitizers:
             custom_default: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_config.yml
@@ -1,4 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     html_sanitizer: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_default_options.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     http_client:
         max_host_connections: 4
         default_options: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_full_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_full_default_options.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     http_client:
         default_options:
             headers:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_mock_response_factory.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_mock_response_factory.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     http_client:
         default_options: ~
         mock_response_factory: my_response_factory

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_override_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_override_default_options.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     http_client:
         max_host_connections: 4
         default_options:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     http_client:
         default_options:
             retry_failed:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_scoped_without_query_option.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_scoped_without_query_option.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     http_client:
         scoped_clients:
             foo:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_xml_key.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_xml_key.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     http_client:
         default_options:
             resolve:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/legacy_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/legacy_annotations.yml
@@ -5,3 +5,6 @@ framework:
         debug: true
         file_cache_dir: '%kernel.cache_dir%/annotations'
     http_method_override: true
+    handle_all_throwables: true
+    php_errors:
+        log: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock.yml
@@ -1,4 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     lock: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_named.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_named.yml
@@ -4,6 +4,9 @@ parameters:
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     lock:
         foo: semaphore
         bar: flock

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_disabled_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_disabled_message_bus.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     mailer:
         dsn: 'smtp://example.com'
         message_bus: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_dsn.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_dsn.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     mailer:
         dsn: 'smtp://example.com'
         envelope:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_specific_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_specific_message_bus.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     mailer:
         dsn: 'smtp://example.com'
         message_bus: app.another_bus

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_transports.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     mailer:
         transports:
             transport1: 'smtp://example1.com'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     scheduler: true
     messenger:
         routing:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_disabled.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger: false
     scheduler: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_middleware_factory_erroneous_format.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_middleware_factory_erroneous_format.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         buses:
             command_bus:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         default_bus: messenger.bus.commands
         buses:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_failure_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_failure_transports.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         transports:
             transport_1:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_failure_transports_global.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_failure_transports_global.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         failure_transport: failure_transport_global
         transports:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer: true
     messenger:
         serializer:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_transport.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_transport.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer: true
     messenger:
         serializer:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_wildcard.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_wildcard.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer: true
     messenger:
         serializer:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_single.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_single.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         routing:
             'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage': [amqp]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_schedule.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_schedule.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         transports:
             schedule: 'schedule://default'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer: true
     messenger:
         serializer:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer: true
     messenger:
         failure_transport: failed

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_with_disabled_reset_on_message.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_with_disabled_reset_on_message.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         reset_on_message: false
         routing:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_with_explict_reset_on_message_legacy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_with_explict_reset_on_message_legacy.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         reset_on_message: true
         routing:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         enabled: true
     mailer:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_with_disabled_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_with_disabled_message_bus.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         enabled: true
     mailer:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_with_specific_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_with_specific_message_bus.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     messenger:
         enabled: true
     mailer:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_mailer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_mailer.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     mailer:
         enabled: false
     messenger:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_messenger.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_messenger.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     mailer:
         dsn: 'smtp://example.com'
     messenger:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_transports.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     notifier:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_disabled.yml
@@ -1,5 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
     php_errors:
+        log: false
         throw: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_enabled.yml
@@ -1,6 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
     php_errors:
         log: true
         throw: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_level.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_level.yml
@@ -1,5 +1,6 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
     php_errors:
         log: 8

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_levels.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_levels.yml
@@ -1,6 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
     php_errors:
         log:
             !php/const \E_NOTICE: !php/const Psr\Log\LogLevel::ERROR

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     profiler:
         enabled: true
     serializer:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler_collect_serializer_data.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler_collect_serializer_data.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer:
         enabled: true
     profiler:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     property_access:
         magic_call: true
         magic_get: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_info.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_info.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     property_info:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/request.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/request.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     request:
         formats: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore.yml
@@ -1,4 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     semaphore: redis://localhost

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore_named.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore_named.yml
@@ -4,6 +4,9 @@ parameters:
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     semaphore:
         foo: redis://paas.com
         qux: "%env(REDIS_DSN)%"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_disabled.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_enabled.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping.yml
@@ -1,5 +1,8 @@
 framework:
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     annotations: false
     serializer:
         enable_annotations: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping_without_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping_without_annotations.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     serializer:
         enable_annotations: false
         mapping:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session.yml
@@ -1,6 +1,11 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     session:
         storage_factory_id: session.storage.factory.native
         handler_id: null
+        cookie_secure: false
+        cookie_samesite: lax

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_cookie_secure_auto.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_cookie_secure_auto.yml
@@ -1,7 +1,11 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     session:
         storage_factory_id: session.storage.factory.native
         handler_id: ~
-        cookie_secure: auto
+        cookie_secure: false
+        cookie_samesite: lax

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/ssi_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/ssi_disabled.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     ssi:
         enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/translator_cache_dir_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/translator_cache_dir_disabled.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     translator:
         cache_dir: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/translator_fallbacks.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/translator_fallbacks.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     translator:
         fallbacks: [en, fr]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_annotations.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     secret: s3cr3t
     validation:
         enabled:     true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_auto_mapping.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_auto_mapping.yml
@@ -1,6 +1,9 @@
 framework:
   annotations: false
   http_method_override: false
+  handle_all_throwables: true
+  php_errors:
+    log: true
   property_info: { enabled: true }
   validation:
     auto_mapping:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_email_validation_mode.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_email_validation_mode.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     validation:
         email_validation_mode: html5

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_legacy_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_legacy_annotations.yml
@@ -2,6 +2,9 @@ framework:
     annotations:
         enabled: true
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     secret: s3cr3t
     validation:
         enabled:     true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_mapping.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_mapping.yml
@@ -1,6 +1,9 @@
 framework:
   annotations: false
   http_method_override: false
+  handle_all_throwables: true
+  php_errors:
+    log: true
   validation:
     mapping:
       paths:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_multiple_static_methods.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_multiple_static_methods.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     secret: s3cr3t
     validation:
         enabled:       true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_no_static_method.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_no_static_method.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     secret: s3cr3t
     validation:
         enabled:       true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_translation_domain.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_translation_domain.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     validation:
         translation_domain: messages

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/web_link.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/web_link.yml
@@ -1,5 +1,8 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     web_link:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/webhook.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/webhook.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     webhook:
         enabled: true
     http_client:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/webhook_without_serializer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/webhook_without_serializer.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     webhook:
         enabled: true
     http_client:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_not_valid.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_not_valid.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         my_workflow:
             type: state_machine

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_guard_expression.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_guard_expression.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         article:
             type: workflow

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_multiple_transitions_with_same_name.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_multiple_transitions_with_same_name.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         article:
             type: workflow

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_no_events_to_dispatch.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_no_events_to_dispatch.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         my_workflow:
             type: state_machine

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_specified_events_to_dispatch.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_specified_events_to_dispatch.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         my_workflow:
             type: state_machine

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_support_and_support_strategy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_support_and_support_strategy.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         my_workflow:
             type: workflow

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_without_support_and_support_strategy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_without_support_and_support_strategy.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         my_workflow:
             type: workflow

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         article:
             type: workflow

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_enabled.yml
@@ -1,4 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_explicitly_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_explicitly_enabled.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         enabled: true
         workflows:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_explicitly_enabled_named_workflows.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_explicitly_enabled_named_workflows.yml
@@ -1,6 +1,9 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
     workflows:
         enabled: true
         workflows:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -637,7 +637,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->expectException(InvalidConfigurationException::class);
         $container = $this->createContainer();
         $loader = new FrameworkExtension();
-        $loader->load([['http_method_override' => false, 'router' => true]], $container);
+        $loader->load([['http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true], 'router' => true]], $container);
     }
 
     public function testSession()
@@ -1878,11 +1878,11 @@ abstract class FrameworkExtensionTestCase extends TestCase
     public function testRemovesResourceCheckerConfigCacheFactoryArgumentOnlyIfNoDebug()
     {
         $container = $this->createContainer(['kernel.debug' => true]);
-        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true]]], $container);
         $this->assertCount(1, $container->getDefinition('config_cache_factory')->getArguments());
 
         $container = $this->createContainer(['kernel.debug' => false]);
-        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true]]], $container);
         $this->assertEmpty($container->getDefinition('config_cache_factory')->getArguments());
     }
 
@@ -1913,21 +1913,21 @@ abstract class FrameworkExtensionTestCase extends TestCase
     public function testRobotsTagListenerIsRegisteredInDebugMode()
     {
         $container = $this->createContainer(['kernel.debug' => true]);
-        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true]]], $container);
         $this->assertTrue($container->has('disallow_search_engine_index_response_listener'), 'DisallowRobotsIndexingListener should be registered');
 
         $definition = $container->getDefinition('disallow_search_engine_index_response_listener');
         $this->assertTrue($definition->hasTag('kernel.event_subscriber'), 'DisallowRobotsIndexingListener should have the correct tag');
 
         $container = $this->createContainer(['kernel.debug' => true]);
-        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false, 'disallow_search_engine_index' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true], 'disallow_search_engine_index' => false]], $container);
         $this->assertFalse(
             $container->has('disallow_search_engine_index_response_listener'),
             'DisallowRobotsIndexingListener should not be registered when explicitly disabled'
         );
 
         $container = $this->createContainer(['kernel.debug' => false]);
-        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false]], $container);
+        (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true]]], $container);
         $this->assertFalse($container->has('disallow_search_engine_index_response_listener'), 'DisallowRobotsIndexingListener should NOT be registered');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -34,6 +34,8 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             $container->loadFromExtension('framework', [
                 'annotations' => false,
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'assets' => [
                     'base_urls' => 'http://cdn.example.com',
                     'base_path' => '/foo',
@@ -49,6 +51,8 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             $container->loadFromExtension('framework', [
                 'annotations' => false,
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'assets' => [
                     'packages' => [
                         'impossible' => [
@@ -99,6 +103,8 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             $container->loadFromExtension('framework', [
                 'annotations' => false,
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'workflows' => [
                     'article' => [
                         'type' => 'state_machine',
@@ -128,6 +134,8 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             $container->loadFromExtension('framework', [
                 'annotations' => false,
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'workflows' => [
                     'workflow_a' => [
                         'type' => 'state_machine',
@@ -187,6 +195,8 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
                 $container->loadFromExtension('framework', [
                     'annotations' => false,
                     'http_method_override' => false,
+                    'handle_all_throwables' => true,
+                    'php_errors' => ['log' => true],
                     'lock' => false,
                     'rate_limiter' => [
                         'with_lock' => ['policy' => 'fixed_window', 'limit' => 10, 'interval' => '1 hour'],
@@ -203,6 +213,8 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             $container->loadFromExtension('framework', [
                 'annotations' => false,
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'lock' => true,
                 'rate_limiter' => [
                     'with_lock' => ['policy' => 'fixed_window', 'limit' => 10, 'interval' => '1 hour'],
@@ -220,6 +232,8 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             $container->loadFromExtension('framework', [
                 'annotations' => false,
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'rate_limiter' => [
                     'without_lock' => ['policy' => 'fixed_window', 'limit' => 10, 'interval' => '1 hour', 'lock_factory' => null],
                 ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -1,6 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
     secret:        test
     router:        { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation:    { enabled: true, enable_annotations: true }
@@ -11,7 +12,12 @@ framework:
     default_locale: en
     enabled_locales: ['en', 'fr']
     session:
+        handler_id: null
         storage_factory_id: session.storage.factory.mock_file
+        cookie_secure: auto
+        cookie_samesite: lax
+    php_errors:
+        log: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -85,6 +85,8 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
         $c->loadFromExtension('framework', [
             'annotations' => false,
             'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
             'secret' => '$ecret',
             'router' => ['utf8' => true],
         ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -122,6 +122,8 @@ class MicroKernelTraitTest extends TestCase
                 $c->extension('framework', [
                     'annotations' => false,
                     'http_method_override' => false,
+                    'handle_all_throwables' => true,
+                    'php_errors' => ['log' => true],
                     'router' => ['utf8' => true],
                 ]);
                 $c->services()->set('logger', NullLogger::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
@@ -103,6 +103,8 @@ class FlexStyleMicroKernel extends Kernel
         $c->extension('framework', [
             'annotations' => false,
             'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
             'router' => ['utf8' => true],
         ]);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -26,7 +26,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
 {
     public function testSessionCookie()
     {
-        $container = $this->createContainer(['cookie_domain' => '.symfony.com.', 'cookie_secure' => true]);
+        $container = $this->createContainer(['cookie_domain' => '.symfony.com.', 'cookie_secure' => true, 'cookie_samesite' => 'lax']);
 
         $utils = $container->get('security.http_utils');
         $request = Request::create('/', 'get');
@@ -41,7 +41,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
 
     public function testSessionNoDomain()
     {
-        $container = $this->createContainer(['cookie_secure' => true]);
+        $container = $this->createContainer(['cookie_secure' => true, 'cookie_samesite' => 'lax']);
 
         $utils = $container->get('security.http_utils');
         $request = Request::create('/', 'get');
@@ -56,7 +56,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
 
     public function testSessionNoSecure()
     {
-        $container = $this->createContainer(['cookie_domain' => '.symfony.com.']);
+        $container = $this->createContainer(['cookie_domain' => '.symfony.com.', 'cookie_samesite' => 'lax']);
 
         $utils = $container->get('security.http_utils');
         $request = Request::create('/', 'get');
@@ -102,7 +102,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
 
     public function testSessionAutoSecure()
     {
-        $container = $this->createContainer(['cookie_domain' => '.symfony.com.', 'cookie_secure' => 'auto']);
+        $container = $this->createContainer(['cookie_domain' => '.symfony.com.', 'cookie_secure' => 'auto', 'cookie_samesite' => 'lax']);
 
         $utils = $container->get('security.http_utils');
         $request = Request::create('/', 'get');
@@ -145,7 +145,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
         ];
 
         $ext = new FrameworkExtension();
-        $ext->load(['framework' => ['annotations' => false, 'http_method_override' => false, 'csrf_protection' => false, 'router' => ['resource' => 'dummy', 'utf8' => true]]], $container);
+        $ext->load(['framework' => ['annotations' => false, 'http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true], 'csrf_protection' => false, 'router' => ['resource' => 'dummy', 'utf8' => true]]], $container);
 
         $ext = new SecurityExtension();
         $ext->load($config, $container);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
@@ -1,13 +1,19 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
     secret: test
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     test: ~
     default_locale: en
     profiler: false
     session:
+        handler_id: null
         storage_factory_id: session.storage.factory.mock_file
+        cookie_secure: auto
+        cookie_samesite: lax
+    php_errors:
+        log: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -1,6 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
     secret: test
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation: { enabled: true, enable_annotations: true }
@@ -10,7 +11,12 @@ framework:
     test: ~
     default_locale: en
     session:
+        handler_id: null
         storage_factory_id: session.storage.factory.mock_file
+        cookie_secure: auto
+        cookie_samesite: lax
+    php_errors:
+        log: true
     profiler: { only_exceptions: false }
 
 services:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -1,6 +1,7 @@
 framework:
     annotations: false
     http_method_override: false
+    handle_all_throwables: true
     secret: test
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation: { enabled: true, enable_annotations: true }
@@ -11,7 +12,12 @@ framework:
     test: ~
     default_locale: en
     session:
+        handler_id: null
         storage_factory_id: session.storage.factory.mock_file
+        cookie_secure: auto
+        cookie_samesite: lax
+    php_errors:
+        log: true
     profiler: { only_exceptions: false }
 
 services:

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -62,13 +62,20 @@ class NoTemplatingEntryKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(function (ContainerBuilder $container) {
+            $config = [
+                'annotations' => false,
+                'http_method_override' => false,
+                'php_errors' => ['log' => true],
+                'secret' => '$ecret',
+                'form' => ['enabled' => false],
+            ];
+
+            if (Kernel::VERSION_ID >= 60400) {
+                $config['handle_all_throwables'] = true;
+            }
+
             $container
-                ->loadFromExtension('framework', [
-                    'annotations' => false,
-                    'http_method_override' => false,
-                    'secret' => '$ecret',
-                    'form' => ['enabled' => false],
-                ])
+                ->loadFromExtension('framework', $config)
                 ->loadFromExtension('twig', [
                     'default_path' => __DIR__.'/templates',
                 ])

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -53,11 +53,16 @@ class WebProfilerBundleKernel extends Kernel
         $config = [
             'annotations' => false,
             'http_method_override' => false,
+            'php_errors' => ['log' => true],
             'secret' => 'foo-secret',
             'profiler' => ['only_exceptions' => false],
-            'session' => ['storage_factory_id' => 'session.storage.factory.mock_file'],
+            'session' => ['handler_id' => null, 'storage_factory_id' => 'session.storage.factory.mock_file', 'cookie-secure' => 'auto', 'cookie-samesite' => 'lax'],
             'router' => ['utf8' => true],
         ];
+
+        if (Kernel::VERSION_ID >= 60400) {
+            $config['handle_all_throwables'] = true;
+        }
 
         $container->loadFromExtension('framework', $config);
 

--- a/src/Symfony/Component/AssetMapper/Tests/fixtures/AssetMapperTestAppKernel.php
+++ b/src/Symfony/Component/AssetMapper/Tests/fixtures/AssetMapperTestAppKernel.php
@@ -38,6 +38,8 @@ class AssetMapperTestAppKernel extends Kernel
             $container->loadFromExtension('framework', [
                 'annotations' => false,
                 'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
                 'http_client' => true,
                 'assets' => null,
                 'asset_mapper' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes 
| Tickets       | Fix #51097
| License       | MIT
| Doc PR        | 

This PR deprecates not setting 5 options in framework configuration to match the v7.0 recipe:
* `handle_all_throwables` which is `false` by default and is set to `true` by recipe
* `php_errors.log` which use `$debug` value by default and is set to `true` by recipe
* `session.cookie_secure` (if session is enabled) which is `null` by default and is set to `auto` by recipe
* `session.cookie_samesite` (if session is enabled) which is `null` by default and is set to `lax` by recipe
* `session.handler_id` (if session is enabled) which is `session.handler.native_file` by default and is set to `null` by recipe (could be `session.handler.native_file` if `framework.session.save_path` is set)

See #51097.