### PR TITLE
[FrameworkBundle] Add `AbstractController::renderBlock()` and `renderBlockView()`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * Add `AbstractController::renderBlock()` and `renderBlockView()`
  * Add native return type to `Translator` and to `Application::reset()`
  * Deprecate the integration of Doctrine annotations, either uninstall the `doctrine/annotations` package or disable the integration by setting `framework.annotations` to `false`
  * Enable `json_decode_detailed_errors` context for Serializer by default if `kernel.debug` is true and the `seld/jsonlint` package is installed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This would be especially useful when generating turbo-stream responses.
Right now, [the doc](https://symfony.com/bundles/ux-turbo/current/index.html#coming-alive-with-turbo-streams) recommends creating new partial templates, but this increases the complexity and scatters HTML fragments. Instead, we could encourage using twig blocks.

Adding this could help remove some boilerplate.

before (using blocks):
```php
return new Response($this->container->get('twig')->load('foo.html.twig')->renderBlock('the_block', $context));
```

after:
```php
return $this->renderBlock('foo.html.twig', 'the_block', $context);
```

