### PR TITLE
[Messenger] add handler description as array key to `HandlerFailedException::getWrappedExceptions()`

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
@@ -20,7 +20,7 @@ class HandlerFailedException extends RuntimeException implements WrappedExceptio
     private Envelope $envelope;
 
     /**
-     * @param \Throwable[] $exceptions
+     * @param \Throwable[] $exceptions The name of the handler should be given as key
      */
     public function __construct(Envelope $envelope, array $exceptions)
     {
@@ -55,7 +55,7 @@ class HandlerFailedException extends RuntimeException implements WrappedExceptio
     {
         trigger_deprecation('symfony/messenger', '6.4', 'The "%s()" method is deprecated, use "%s::getWrappedExceptions()" instead.', __METHOD__, self::class);
 
-        return $this->exceptions;
+        return array_values($this->exceptions);
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -66,7 +66,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                 if ($batchHandler && $ackStamp = $envelope->last(AckStamp::class)) {
                     $ack = new Acknowledger(get_debug_type($batchHandler), static function (\Throwable $e = null, $result = null) use ($envelope, $ackStamp, $handlerDescriptor) {
                         if (null !== $e) {
-                            $e = new HandlerFailedException($envelope, [$e]);
+                            $e = new HandlerFailedException($envelope, [$handlerDescriptor->getName() => $e]);
                         } else {
                             $envelope = $envelope->with(HandledStamp::fromDescriptor($handlerDescriptor, $result));
                         }
@@ -95,7 +95,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                 $envelope = $envelope->with($handledStamp);
                 $this->logger?->info('Message {class} handled by {handler}', $context + ['handler' => $handledStamp->getHandlerName()]);
             } catch (\Throwable $e) {
-                $exceptions[] = $e;
+                $exceptions[$handlerDescriptor->getName()] = $e;
             }
         }
 
@@ -107,7 +107,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                     $handler = $stamp->getHandlerDescriptor()->getBatchHandler();
                     $handler->flush($flushStamp->force());
                 } catch (\Throwable $e) {
-                    $exceptions[] = $e;
+                    $exceptions[$stamp->getHandlerDescriptor()->getName()] = $e;
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Currently, when looking at `HandlerFailedException` to see what exceptions were thrown for a message, you can't see what handler caused the exception.
