### PR TITLE
[SecurityBundle] Remove the `require_previous_session` config option

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -297,6 +297,7 @@ SecurityBundle
 --------------
 
  * Enabling SecurityBundle and not configuring it is not allowed, either remove the bundle or configure at least one firewall
+ * Remove the `require_previous_session` config option
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Enabling SecurityBundle and not configuring it is not allowed
- * Remove configuration options `enable_authenticator_manager` and `csrf_token_generator`
+ * Remove configuration options `enable_authenticator_manager`, `csrf_token_generator` and `require_previous_session`
 
 6.4
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -28,7 +28,6 @@ abstract class AbstractFactory implements AuthenticatorFactoryInterface
     protected array $options = [
         'check_path' => '/login_check',
         'use_forward' => false,
-        'require_previous_session' => false,
         'login_path' => '/login',
     ];
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
@@ -20,7 +20,6 @@ security:
       form_login:
         check_path: login
         remember_me: true
-        require_previous_session: false
       logout: ~
       stateless: false
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/legacy_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/legacy_config.yml
@@ -20,7 +20,6 @@ security:
       form_login:
         check_path: login
         remember_me: true
-        require_previous_session: false
       logout: ~
       stateless: false
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
@@ -29,7 +29,6 @@ security:
             stateless: true
             json_login_ldap:
                 check_path: /login
-                require_previous_session: false
                 service: Symfony\Component\Ldap\Ldap
                 dn_string: ''
                 username_path: user.login

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
@@ -16,7 +16,6 @@ security:
             form_login:
                 check_path: login
                 remember_me: true
-                require_previous_session: false
             logout: ~
             stateless: true
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
@@ -16,7 +16,6 @@ security:
             form_login:
                 check_path: login
                 remember_me: true
-                require_previous_session: false
             logout:
                 delete_cookies:
                     flavor: { path: null, domain: somedomain }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_enabled.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_enabled.yml
@@ -16,7 +16,6 @@ security:
             form_login:
                 check_path: login
                 remember_me: true
-                require_previous_session: false
             logout:
                 enable_csrf: true
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -16,7 +16,6 @@ security:
             form_login:
                 check_path: login
                 remember_me: true
-                require_previous_session: false
             remember_me:
                 always_remember_me: true
                 secret: secret

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
@@ -16,7 +16,6 @@ security:
             form_login:
                 check_path: login
                 remember_me: true
-                require_previous_session: false
             remember_me:
                 always_remember_me: true
                 secret: key


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

To merge after #51332 is merged on 6.4 which deprecate config option. This PR remove last usage of option

