### PR TITLE
[Notifier] Fix invalid method call + improve exception message

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverTransport.php
@@ -77,7 +77,7 @@ final class PushoverTransport extends AbstractTransport
         $result = $response->toArray(false);
 
         if (!isset($result['request'])) {
-            throw new TransportException(sprintf('Unable to send the Pushover push notification: "%s".', $result->getContent(false)), $response);
+            throw new TransportException(sprintf('Unable to find the message id within the Pushover response: "%s".', $response->getContent(false)), $response);
         }
 
         $sentMessage = new SentMessage($message, (string) $this);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |


Current code is calling `getContent()` method on an array instead of the real response object
