### PR TITLE
[AssetMapper] Improve the error message when a downloaded file is missing

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -382,6 +382,10 @@ class ImportMapManager
 
             if (null !== $entryOptions->path) {
                 if (!$asset = $this->assetMapper->getAsset($entryOptions->path)) {
+                    if ($entryOptions->isDownloaded) {
+                        throw new \InvalidArgumentException(sprintf('The "%s" downloaded asset is missing. Run "php bin/console importmap:require "%s" --download".', $entryOptions->path, $entryOptions->importName));
+                    }
+
                     throw new \InvalidArgumentException(sprintf('The asset "%s" mentioned in "%s" cannot be found in any asset map paths.', $entryOptions->path, basename($this->importMapConfigPath)));
                 }
                 $path = $asset->publicPath;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When a file downloaded using the `importmap:require [packageName] --download` command is missing, the error message is this one:

> The asset "vendor/@hotwired/stimulus.js" mentioned in "importmap.php" cannot be found in any asset map paths.

This PR slightly improves the error message to explain how it can be fixed:

> The "vendor/@hotwired/stimulus.js" downloaded asset is missing. Run "php bin/console importmap:require @hotwired/stimulus --download".