### PR TITLE
Remove me from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,10 +38,10 @@
 # Serializer
 /src/Symfony/Component/Serializer/ @dunglas
 # Security
-/src/Symfony/Bridge/Doctrine/Security/ @wouterj @chalasr
-/src/Symfony/Bundle/SecurityBundle/ @wouterj @chalasr
-/src/Symfony/Component/Security/ @wouterj @chalasr
-/src/Symfony/Component/Ldap/Security/ @wouterj @chalasr
+/src/Symfony/Bridge/Doctrine/Security/ @chalasr
+/src/Symfony/Bundle/SecurityBundle/ @chalasr
+/src/Symfony/Component/Security/ @chalasr
+/src/Symfony/Component/Ldap/Security/ @chalasr
 # TwigBundle
 /src/Symfony/Bundle/TwigBundle/ @yceruto
 # WebLink


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Extremely minor PR.

The automatic CODEOWNER pings from GitHub have been more noisy than useful in my opinion, due to being triggered for each rebased PR. I'm checking GitHub notifications often enough to spot security PRs that need my attention, so I want to remove the noisy extra pings.