### PR TITLE
[AssetMapper] Fixing bug where a circular exception could be thrown while making error message

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\AssetMapper\AssetDependency;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\Exception\CircularAssetsException;
 use Symfony\Component\AssetMapper\Exception\RuntimeException;
 use Symfony\Component\AssetMapper\MappedAsset;
 
@@ -57,8 +58,12 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
             if (!$dependentAsset) {
                 $message = sprintf('Unable to find asset "%s" imported from "%s".', $matches[1], $asset->sourcePath);
 
-                if (null !== $assetMapper->getAsset(sprintf('%s.js', $resolvedPath))) {
-                    $message .= sprintf(' Try adding ".js" to the end of the import - i.e. "%s.js".', $matches[1]);
+                try {
+                    if (null !== $assetMapper->getAsset(sprintf('%s.js', $resolvedPath))) {
+                        $message .= sprintf(' Try adding ".js" to the end of the import - i.e. "%s.js".', $matches[1]);
+                    }
+                } catch (CircularAssetsException $e) {
+                    // avoid circular error if there is self-referencing import comments
                 }
 
                 $this->handleMissingImport($message);

--- a/src/Symfony/Component/AssetMapper/Exception/CircularAssetsException.php
+++ b/src/Symfony/Component/AssetMapper/Exception/CircularAssetsException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Exception;
+
+/**
+ * Thrown when a circular reference is detected while creating an asset.
+ */
+class CircularAssetsException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\AssetMapper\Factory;
 
 use Symfony\Component\AssetMapper\AssetMapperCompiler;
+use Symfony\Component\AssetMapper\Exception\CircularAssetsException;
 use Symfony\Component\AssetMapper\Exception\RuntimeException;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface;
@@ -36,7 +37,7 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
     public function createMappedAsset(string $logicalPath, string $sourcePath): ?MappedAsset
     {
         if (\in_array($logicalPath, $this->assetsBeingCreated, true)) {
-            throw new RuntimeException(sprintf('Circular reference detected while creating asset for "%s": "%s".', $logicalPath, implode(' -> ', $this->assetsBeingCreated).' -> '.$logicalPath));
+            throw new CircularAssetsException(sprintf('Circular reference detected while creating asset for "%s": "%s".', $logicalPath, implode(' -> ', $this->assetsBeingCreated).' -> '.$logicalPath));
         }
 
         if (!isset($this->assetsCache[$logicalPath])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | none
| Tickets       | Fix #51291
| License       | MIT
| Doc PR        | Not needed

AssetMapper's `JavaScriptImportPathCompiler` parses import statements. That process is imperfect and will over-match in some cases (e.g. matching `import()` that is commented-out). but that's not a huge issue: any matches are simply added to the importmap and matches for not-found-files are ignored.

However, in #51291, we hit a spot where, while trying to improve the log message (`Try adding ".js" to the end of the import - i.e. "%s.js"`), we triggered a circular exception. This PR suppresses that.

We may need to improve the parsing logic later to handle more edge-cases, but we'll handle those if/when they come up.

Cheers!