### PR TITLE
[FrameworkBundle][Validator] Allow implementing validation groups provider outside DTOs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -101,6 +101,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'twig.runtime',
         'validator.auto_mapper',
         'validator.constraint_validator',
+        'validator.group_provider',
         'validator.initializer',
         'workflow',
     ];

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -177,6 +177,7 @@ use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Validator\Constraints\ExpressionLanguageProvider;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\GroupProviderInterface;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Validator\ObjectInitializerInterface;
 use Symfony\Component\Validator\Validation;
@@ -657,6 +658,8 @@ class FrameworkExtension extends Extension
             ->addTag('serializer.normalizer');
         $container->registerForAutoconfiguration(ConstraintValidatorInterface::class)
             ->addTag('validator.constraint_validator');
+        $container->registerForAutoconfiguration(GroupProviderInterface::class)
+            ->addTag('validator.group_provider');
         $container->registerForAutoconfiguration(ObjectInitializerInterface::class)
             ->addTag('validator.initializer');
         $container->registerForAutoconfiguration(MessageHandlerInterface::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -42,6 +42,9 @@ return static function (ContainerConfigurator $container) {
             ->call('setConstraintValidatorFactory', [
                 service('validator.validator_factory'),
             ])
+            ->call('setGroupProviderLocator', [
+                tagged_locator('validator.group_provider'),
+            ])
             ->call('setTranslator', [
                 service('translator')->ignoreOnInvalid(),
             ])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1230,16 +1230,18 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $annotations = !class_exists(FullStack::class);
 
-        $this->assertCount($annotations ? 7 : 6, $calls);
+        $this->assertCount($annotations ? 8 : 7, $calls);
         $this->assertSame('setConstraintValidatorFactory', $calls[0][0]);
         $this->assertEquals([new Reference('validator.validator_factory')], $calls[0][1]);
-        $this->assertSame('setTranslator', $calls[1][0]);
-        $this->assertEquals([new Reference('translator', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)], $calls[1][1]);
-        $this->assertSame('setTranslationDomain', $calls[2][0]);
-        $this->assertSame(['%validator.translation_domain%'], $calls[2][1]);
-        $this->assertSame('addXmlMappings', $calls[3][0]);
-        $this->assertSame([$xmlMappings], $calls[3][1]);
-        $i = 3;
+        $this->assertSame('setGroupProviderLocator', $calls[1][0]);
+        $this->assertInstanceOf(ServiceLocatorArgument::class, $calls[1][1][0]);
+        $this->assertSame('setTranslator', $calls[2][0]);
+        $this->assertEquals([new Reference('translator', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)], $calls[2][1]);
+        $this->assertSame('setTranslationDomain', $calls[3][0]);
+        $this->assertSame(['%validator.translation_domain%'], $calls[3][1]);
+        $this->assertSame('addXmlMappings', $calls[4][0]);
+        $this->assertSame([$xmlMappings], $calls[4][1]);
+        $i = 4;
         if ($annotations) {
             $this->assertSame('enableAttributeMapping', $calls[++$i][0]);
         }
@@ -1288,12 +1290,12 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
-        $this->assertCount(7, $calls);
-        $this->assertSame('enableAttributeMapping', $calls[4][0]);
-        $this->assertSame('addMethodMapping', $calls[5][0]);
-        $this->assertSame(['loadValidatorMetadata'], $calls[5][1]);
-        $this->assertSame('setMappingCache', $calls[6][0]);
-        $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[6][1]);
+        $this->assertCount(8, $calls);
+        $this->assertSame('enableAttributeMapping', $calls[5][0]);
+        $this->assertSame('addMethodMapping', $calls[6][0]);
+        $this->assertSame(['loadValidatorMetadata'], $calls[6][1]);
+        $this->assertSame('setMappingCache', $calls[7][0]);
+        $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[7][1]);
         // no cache this time
     }
 
@@ -1308,14 +1310,14 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
-        $this->assertCount(8, $calls);
-        $this->assertSame('enableAttributeMapping', $calls[4][0]);
+        $this->assertCount(9, $calls);
+        $this->assertSame('enableAttributeMapping', $calls[5][0]);
         if (method_exists(ValidatorBuilder::class, 'setDoctrineAnnotationReader')) {
-            $this->assertSame('setDoctrineAnnotationReader', $calls[5][0]);
-            $this->assertEquals([new Reference('annotation_reader')], $calls[5][1]);
-            $i = 6;
+            $this->assertSame('setDoctrineAnnotationReader', $calls[6][0]);
+            $this->assertEquals([new Reference('annotation_reader')], $calls[6][1]);
+            $i = 7;
         } else {
-            $i = 5;
+            $i = 6;
         }
         $this->assertSame('addMethodMapping', $calls[$i][0]);
         $this->assertSame(['loadValidatorMetadata'], $calls[$i][1]);
@@ -1335,16 +1337,16 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
-        $this->assertCount(8, $calls);
-        $this->assertSame('addXmlMappings', $calls[3][0]);
-        $this->assertSame('addYamlMappings', $calls[4][0]);
-        $this->assertSame('enableAttributeMapping', $calls[5][0]);
-        $this->assertSame('addMethodMapping', $calls[6][0]);
-        $this->assertSame(['loadValidatorMetadata'], $calls[6][1]);
-        $this->assertSame('setMappingCache', $calls[7][0]);
-        $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[7][1]);
+        $this->assertCount(9, $calls);
+        $this->assertSame('addXmlMappings', $calls[4][0]);
+        $this->assertSame('addYamlMappings', $calls[5][0]);
+        $this->assertSame('enableAttributeMapping', $calls[6][0]);
+        $this->assertSame('addMethodMapping', $calls[7][0]);
+        $this->assertSame(['loadValidatorMetadata'], $calls[7][1]);
+        $this->assertSame('setMappingCache', $calls[8][0]);
+        $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[8][1]);
 
-        $xmlMappings = $calls[3][1][0];
+        $xmlMappings = $calls[4][1][0];
         $this->assertCount(3, $xmlMappings);
         try {
             // Testing symfony/symfony
@@ -1355,7 +1357,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         }
         $this->assertStringEndsWith('TestBundle/Resources/config/validation.xml', $xmlMappings[1]);
 
-        $yamlMappings = $calls[4][1][0];
+        $yamlMappings = $calls[5][1][0];
         $this->assertCount(1, $yamlMappings);
         $this->assertStringEndsWith('TestBundle/Resources/config/validation.yml', $yamlMappings[0]);
     }
@@ -1370,7 +1372,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         ]);
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
-        $xmlMappings = $calls[3][1][0];
+        $xmlMappings = $calls[4][1][0];
         $this->assertCount(3, $xmlMappings);
 
         try {
@@ -1382,7 +1384,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         }
         $this->assertStringEndsWith('CustomPathBundle/Resources/config/validation.xml', $xmlMappings[1]);
 
-        $yamlMappings = $calls[4][1][0];
+        $yamlMappings = $calls[5][1][0];
         $this->assertCount(1, $yamlMappings);
         $this->assertStringEndsWith('CustomPathBundle/Resources/config/validation.yml', $yamlMappings[0]);
     }
@@ -1395,9 +1397,9 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $annotations = !class_exists(FullStack::class);
 
-        $this->assertCount($annotations ? 6 : 5, $calls);
-        $this->assertSame('addXmlMappings', $calls[3][0]);
-        $i = 3;
+        $this->assertCount($annotations ? 7 : 6, $calls);
+        $this->assertSame('addXmlMappings', $calls[4][0]);
+        $i = 4;
         if ($annotations) {
             $this->assertSame('enableAttributeMapping', $calls[++$i][0]);
         }
@@ -1426,14 +1428,14 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
-        $this->assertSame('addXmlMappings', $calls[3][0]);
-        $this->assertCount(3, $calls[3][1][0]);
-
-        $this->assertSame('addYamlMappings', $calls[4][0]);
+        $this->assertSame('addXmlMappings', $calls[4][0]);
         $this->assertCount(3, $calls[4][1][0]);
-        $this->assertStringContainsString('foo.yml', $calls[4][1][0][0]);
-        $this->assertStringContainsString('validation.yml', $calls[4][1][0][1]);
-        $this->assertStringContainsString('validation.yaml', $calls[4][1][0][2]);
+
+        $this->assertSame('addYamlMappings', $calls[5][0]);
+        $this->assertCount(3, $calls[5][1][0]);
+        $this->assertStringContainsString('foo.yml', $calls[5][1][0][0]);
+        $this->assertStringContainsString('validation.yml', $calls[5][1][0][1]);
+        $this->assertStringContainsString('validation.yaml', $calls[5][1][0][2]);
     }
 
     public function testValidationAutoMapping()

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead
  * Deprecate `ValidatorBuilder::disableAnnotationMapping()`, use `ValidatorBuilder::disableAttributeMapping()` instead
  * Deprecate `AnnotationLoader`, use `AttributeLoader` instead
+ * Add `GroupProviderInterface` to implement validation group providers outside the underlying class
 
 6.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/GroupSequenceProvider.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequenceProvider.php
@@ -11,10 +11,15 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
+
 /**
  * Attribute to define a group sequence provider.
  *
  * @Annotation
+ *
+ * @NamedArgumentConstructor
  *
  * @Target({"CLASS", "ANNOTATION"})
  *
@@ -23,4 +28,8 @@ namespace Symfony\Component\Validator\Constraints;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class GroupSequenceProvider
 {
+    #[HasNamedArguments]
+    public function __construct(public ?string $provider = null)
+    {
+    }
 }

--- a/src/Symfony/Component/Validator/GroupProviderInterface.php
+++ b/src/Symfony/Component/Validator/GroupProviderInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator;
+
+use Symfony\Component\Validator\Constraints\GroupSequence;
+
+/**
+ * Defines the interface for a validation group provider.
+ *
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+interface GroupProviderInterface
+{
+    /**
+     * Returns which validation groups should be used for a certain state
+     * of the object.
+     *
+     * @return string[]|string[][]|GroupSequence
+     */
+    public function getGroups(object $object): array|GroupSequence;
+}

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -87,6 +87,13 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     public bool $groupSequenceProvider = false;
 
     /**
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getGroupProvider()} instead.
+     */
+    public ?string $groupProvider = null;
+
+    /**
      * The strategy for traversing traversable objects.
      *
      * By default, only instances of {@link \Traversable} are traversed.
@@ -123,6 +130,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             'getters',
             'groupSequence',
             'groupSequenceProvider',
+            'groupProvider',
             'members',
             'name',
             'properties',
@@ -319,6 +327,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     public function mergeConstraints(self $source)
     {
         if ($source->isGroupSequenceProvider()) {
+            $this->setGroupProvider($source->getGroupProvider());
             $this->setGroupSequenceProvider(true);
         }
 
@@ -432,7 +441,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             throw new GroupDefinitionException('Defining a group sequence provider is not allowed with a static group sequence.');
         }
 
-        if (!$this->getReflectionClass()->implementsInterface(GroupSequenceProviderInterface::class)) {
+        if (null === $this->groupProvider && !$this->getReflectionClass()->implementsInterface(GroupSequenceProviderInterface::class)) {
             throw new GroupDefinitionException(sprintf('Class "%s" must implement GroupSequenceProviderInterface.', $this->name));
         }
 
@@ -442,6 +451,16 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     public function isGroupSequenceProvider(): bool
     {
         return $this->groupSequenceProvider;
+    }
+
+    public function setGroupProvider(?string $provider): void
+    {
+        $this->groupProvider = $provider;
+    }
+
+    public function getGroupProvider(): ?string
+    {
+        return $this->groupProvider;
     }
 
     public function getCascadingStrategy(): int

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadataInterface.php
@@ -30,6 +30,8 @@ use Symfony\Component\Validator\GroupSequenceProviderInterface;
  * @see GroupSequence
  * @see GroupSequenceProviderInterface
  * @see TraversalStrategy
+ *
+ * @method string|null getGroupProvider()
  */
 interface ClassMetadataInterface extends MetadataInterface
 {

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -51,6 +51,7 @@ class AnnotationLoader implements LoaderInterface
             if ($constraint instanceof GroupSequence) {
                 $metadata->setGroupSequence($constraint->groups);
             } elseif ($constraint instanceof GroupSequenceProvider) {
+                $metadata->setGroupProvider($constraint->provider);
                 $metadata->setGroupSequenceProvider(true);
             } elseif ($constraint instanceof Constraint) {
                 $metadata->addConstraint($constraint);

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -201,6 +201,7 @@ class XmlFileLoader extends FileLoader
     private function loadClassMetadataFromXml(ClassMetadata $metadata, \SimpleXMLElement $classDescription): void
     {
         if (\count($classDescription->{'group-sequence-provider'}) > 0) {
+            $metadata->setGroupProvider($classDescription->{'group-sequence-provider'}[0]->value ?: null);
             $metadata->setGroupSequenceProvider(true);
         }
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -150,6 +150,9 @@ class YamlFileLoader extends FileLoader
     private function loadClassMetadataFromYaml(ClassMetadata $metadata, array $classDescription): void
     {
         if (isset($classDescription['group_sequence_provider'])) {
+            if (\is_string($classDescription['group_sequence_provider'])) {
+                $metadata->setGroupProvider($classDescription['group_sequence_provider']);
+            }
             $metadata->setGroupSequenceProvider(
                 (bool) $classDescription['group_sequence_provider']
             );

--- a/src/Symfony/Component/Validator/Mapping/Loader/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd
+++ b/src/Symfony/Component/Validator/Mapping/Loader/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd
@@ -14,9 +14,9 @@
       validation constraints.
     ]]></xsd:documentation>
   </xsd:annotation>
-  
+
   <xsd:element name="constraint-mapping" type="constraint-mapping" />
-  
+
   <xsd:complexType name="constraint-mapping">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
@@ -28,7 +28,7 @@
       <xsd:element name="class" type="class" maxOccurs="unbounded" />
     </xsd:sequence>
   </xsd:complexType>
-  
+
   <xsd:complexType name="namespace">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
@@ -41,13 +41,13 @@
       </xsd:extension>
     </xsd:simpleContent>
   </xsd:complexType>
-  
+
   <xsd:complexType name="class">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
         Contains constraints for a single class.
-        
-        Nested elements may be class constraints, property and/or getter 
+
+        Nested elements may be class constraints, property and/or getter
         definitions.
       ]]></xsd:documentation>
     </xsd:annotation>
@@ -72,15 +72,18 @@
       <xsd:element name="value" type="value" minOccurs="1" maxOccurs="unbounded" />
     </xsd:sequence>
   </xsd:complexType>
-  
+
   <xsd:complexType name="group-sequence-provider">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
         Defines the name of the group sequence provider for a class.
       ]]></xsd:documentation>
     </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="value" type="value" minOccurs="0" maxOccurs="unbounded" />
+    </xsd:sequence>
   </xsd:complexType>
-  
+
   <xsd:complexType name="property">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
@@ -93,7 +96,7 @@
     </xsd:sequence>
     <xsd:attribute name="name" type="xsd:string" use="required" />
   </xsd:complexType>
-  
+
   <xsd:complexType name="getter">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
@@ -106,14 +109,14 @@
     </xsd:sequence>
     <xsd:attribute name="property" type="xsd:string" use="required" />
   </xsd:complexType>
-  
+
   <xsd:complexType name="constraint" mixed="true">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
         Contains a constraint definition. The name of the constraint should be
         given in the "name" option.
-        
-        May contain a single value, multiple "constraint" elements, 
+
+        May contain a single value, multiple "constraint" elements,
         multiple "value" elements or multiple "option" elements.
       ]]></xsd:documentation>
     </xsd:annotation>
@@ -122,15 +125,15 @@
       <xsd:element name="option" type="option" minOccurs="1" maxOccurs="unbounded" />
       <xsd:element name="value" type="value" minOccurs="1" maxOccurs="unbounded" />
     </xsd:choice>
-    <xsd:attribute name="name" type="xsd:string" use="required" />    
+    <xsd:attribute name="name" type="xsd:string" use="required" />
   </xsd:complexType>
-  
+
   <xsd:complexType name="option" mixed="true">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
         Contains a constraint option definition. The name of the option
         should be given in the "name" option.
-        
+
         May contain a single value, multiple "value" elements or multiple
         "constraint" elements.
       ]]></xsd:documentation>
@@ -139,14 +142,14 @@
       <xsd:element name="constraint" type="constraint" minOccurs="1" maxOccurs="unbounded" />
       <xsd:element name="value" type="value" minOccurs="1" maxOccurs="unbounded" />
     </xsd:choice>
-    <xsd:attribute name="name" type="xsd:string" use="required" />  
+    <xsd:attribute name="name" type="xsd:string" use="required" />
   </xsd:complexType>
-  
+
   <xsd:complexType name="value" mixed="true">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
         A value of an element.
-        
+
         May contain a single value, multiple "value" elements or multiple
         "constraint" elements.
       ]]></xsd:documentation>
@@ -155,6 +158,6 @@
       <xsd:element name="constraint" type="constraint" minOccurs="1" maxOccurs="unbounded" />
       <xsd:element name="value" type="value" minOccurs="1" maxOccurs="unbounded" />
     </xsd:choice>
-    <xsd:attribute name="key" type="xsd:string" use="optional" /> 
+    <xsd:attribute name="key" type="xsd:string" use="optional" />
   </xsd:complexType>
 </xsd:schema>

--- a/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceProviderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\GroupSequenceProvider;
+use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
+
+class GroupSequenceProviderTest extends TestCase
+{
+    public function testCreateAttributeStyle()
+    {
+        $sequence = new GroupSequenceProvider(provider: DummyGroupProvider::class);
+
+        $this->assertSame(DummyGroupProvider::class, $sequence->provider);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Dummy/DummyGroupProvider.php
+++ b/src/Symfony/Component/Validator/Tests/Dummy/DummyGroupProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Dummy;
+
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\GroupProviderInterface;
+
+class DummyGroupProvider implements GroupProviderInterface
+{
+    public function getGroups(object $object): array|GroupSequence
+    {
+        return ['foo', 'bar'];
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/GroupProviderDto.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/GroupProviderDto.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures\Attribute;
+
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
+
+#[Assert\GroupSequenceProvider(provider: DummyGroupProvider::class)]
+class GroupProviderDto
+{
+    public string $firstName = '';
+    public string $lastName = '';
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -24,6 +24,8 @@ use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\XmlFileLoader;
+use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
+use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
@@ -121,6 +123,20 @@ class XmlFileLoaderTest extends TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected = new ClassMetadata(GroupSequenceProviderEntity::class);
+        $expected->setGroupSequenceProvider(true);
+
+        $this->assertEquals($expected, $metadata);
+    }
+
+    public function testLoadGroupProvider()
+    {
+        $loader = new XmlFileLoader(__DIR__.'/constraint-mapping.xml');
+        $metadata = new ClassMetadata(GroupProviderDto::class);
+
+        $loader->loadClassMetadata($metadata);
+
+        $expected = new ClassMetadata(GroupProviderDto::class);
+        $expected->setGroupProvider(DummyGroupProvider::class);
         $expected->setGroupSequenceProvider(true);
 
         $this->assertEquals($expected, $metadata);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\YamlFileLoader;
+use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
+use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
@@ -161,6 +163,20 @@ class YamlFileLoaderTest extends TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected = new ClassMetadata(GroupSequenceProviderEntity::class);
+        $expected->setGroupSequenceProvider(true);
+
+        $this->assertEquals($expected, $metadata);
+    }
+
+    public function testLoadGroupProvider()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/constraint-mapping.yml');
+        $metadata = new ClassMetadata(GroupProviderDto::class);
+
+        $loader->loadClassMetadata($metadata);
+
+        $expected = new ClassMetadata(GroupProviderDto::class);
+        $expected->setGroupProvider(DummyGroupProvider::class);
         $expected->setGroupSequenceProvider(true);
 
         $this->assertEquals($expected, $metadata);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
@@ -121,4 +121,10 @@
     <group-sequence-provider />
 
   </class>
+
+  <class name="Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto">
+    <group-sequence-provider>
+      <value>Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider</value>
+    </group-sequence-provider>
+  </class>
 </constraint-mapping>

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
@@ -60,3 +60,6 @@ Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
 
 Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\GroupSequenceProviderEntity:
   group_sequence_provider: true
+
+Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto:
+  group_sequence_provider: Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider

--- a/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Validator;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
@@ -32,18 +33,20 @@ class RecursiveValidator implements ValidatorInterface
     protected $metadataFactory;
     protected $validatorFactory;
     protected $objectInitializers;
+    protected ?ContainerInterface $groupProviderLocator;
 
     /**
      * Creates a new validator.
      *
      * @param ObjectInitializerInterface[] $objectInitializers The object initializers
      */
-    public function __construct(ExecutionContextFactoryInterface $contextFactory, MetadataFactoryInterface $metadataFactory, ConstraintValidatorFactoryInterface $validatorFactory, array $objectInitializers = [])
+    public function __construct(ExecutionContextFactoryInterface $contextFactory, MetadataFactoryInterface $metadataFactory, ConstraintValidatorFactoryInterface $validatorFactory, array $objectInitializers = [], ContainerInterface $groupProviderLocator = null)
     {
         $this->contextFactory = $contextFactory;
         $this->metadataFactory = $metadataFactory;
         $this->validatorFactory = $validatorFactory;
         $this->objectInitializers = $objectInitializers;
+        $this->groupProviderLocator = $groupProviderLocator;
     }
 
     public function startContext(mixed $root = null): ContextualValidatorInterface
@@ -52,7 +55,8 @@ class RecursiveValidator implements ValidatorInterface
             $this->contextFactory->createContext($this, $root),
             $this->metadataFactory,
             $this->validatorFactory,
-            $this->objectInitializers
+            $this->objectInitializers,
+            $this->groupProviderLocator,
         );
     }
 
@@ -62,7 +66,8 @@ class RecursiveValidator implements ValidatorInterface
             $context,
             $this->metadataFactory,
             $this->validatorFactory,
-            $this->objectInitializers
+            $this->objectInitializers,
+            $this->groupProviderLocator,
         );
     }
 

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
 use Symfony\Component\Validator\Exception\LogicException;
@@ -53,6 +54,7 @@ class ValidatorBuilder
     private bool $enableAttributeMapping = false;
     private ?MetadataFactoryInterface $metadataFactory = null;
     private ConstraintValidatorFactoryInterface $validatorFactory;
+    private ?ContainerInterface $groupProviderLocator = null;
     private ?CacheItemPoolInterface $mappingCache = null;
     private ?TranslatorInterface $translator = null;
     private ?string $translationDomain = null;
@@ -313,6 +315,16 @@ class ValidatorBuilder
     }
 
     /**
+     * @return $this
+     */
+    public function setGroupProviderLocator(ContainerInterface $groupProviderLocator): static
+    {
+        $this->groupProviderLocator = $groupProviderLocator;
+
+        return $this;
+    }
+
+    /**
      * Sets the translator used for translating violation messages.
      *
      * @return $this
@@ -414,7 +426,7 @@ class ValidatorBuilder
 
         $contextFactory = new ExecutionContextFactory($translator, $this->translationDomain);
 
-        return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers);
+        return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers, $this->groupProviderLocator);
     }
 
     private function createAnnotationReader(): Reader


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18744

Alternative to https://github.com/symfony/symfony/pull/51233
Inspiration: https://github.com/symfony/symfony/discussions/51012

Currently, you can determine the sequence of groups to apply dynamically based on the state of your DTO by implementing the `GroupSequenceProviderInterface` in your DTO class. https://symfony.com/doc/current/validation/sequence_provider.html#group-sequence-providers
```php
use Symfony\Component\Validator\GroupSequenceProviderInterface;

#[Assert\GroupSequenceProvider]
class UserDto implements GroupSequenceProviderInterface
{
    // ...

    public function getGroupSequence(): array|GroupSequence
    {
        if ($this->isCompanyType()) {
            return ['User', 'Company'];
        }

        return ['User'];
    }
}
```
It covers most of the common scenarios, but for more advanced ones, it may not be sufficient. Suppose now you need to provide the sequence of groups from an external configuration (or service) which can change its value dynamically:
```php
#[Assert\GroupSequenceProvider]
class UserDto implements GroupSequenceProviderInterface
{
    // ...

    public __constructor(private readonly ConfigService $config) 
    {
    }

    public function getGroupSequence(): array|GroupSequence
    {
        if ($this->config->isEnabled()) {
            return ['User', $this->config->getGroup()];
        }

        return ['User'];
    }
}
```
This issue cannot be resolved at present without managing the DTO initialization and manually setting its dependencies. On the other hand, since the state of the DTO is not used at all, the implementation of the `GroupSequenceProviderInterface` becomes less fitting to the DTO responsibility. Further, stricter programming may raise a complaint about a violation of SOLID principles here.

So, the proposal of this PR is to allow configuring the validation groups provider outside of the DTO, while simultaneously enabling the registration of this provider as a service if necessary.

To achieve this, you'll need to implement a new `GroupProviderInterface` in a separate class, and configure it using the new `provider` option within the `GroupSequenceProvider` attribute:
```php
#[Assert\GroupSequenceProvider(provider: UserGroupProvider::class)]
class UserDto
{
    // ...
}

class UserGroupProvider implements GroupProviderInterface
{
    public __constructor(private readonly ConfigService $config) 
    {
    }

    public function getGroups(object $object): array|GroupSequence
    {
        if ($this->config->isEnabled()) {
            return ['User', $this->config->getGroup()];
        }

        return ['User'];
    }
}
```
That's all you'll need to do if autowiring is enabled under your custom provider. Otherwise, you can manually tag your service with `validator.group_provider` to collect it and utilize it as a provider service during the validation process.

In conclusion, no more messing with the DTO structure, just use the new `class` option for more advanced use cases.

---

TODO:

- [x] Add tests
- [x] Create doc PR