### PR TITLE
[DependencyInjection] Allow passing an `inline_service` to a `service_locator`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -119,7 +119,7 @@ function inline_service(string $class = null): InlineServiceConfigurator
 /**
  * Creates a service locator.
  *
- * @param ReferenceConfigurator[] $values
+ * @param array<ReferenceConfigurator|InlineServiceConfigurator> $values
  */
 function service_locator(array $values): ServiceLocatorArgument
 {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -70,6 +70,7 @@ class ServiceLocatorTagPassTest extends TestCase
                 new Reference('bar'),
                 new Reference('baz'),
                 'some.service' => new Reference('bar'),
+                'inlines.service' => new Definition(CustomDefinition::class),
             ]])
             ->addTag('container.service_locator')
         ;
@@ -82,6 +83,7 @@ class ServiceLocatorTagPassTest extends TestCase
         $this->assertSame(CustomDefinition::class, $locator('bar')::class);
         $this->assertSame(CustomDefinition::class, $locator('baz')::class);
         $this->assertSame(CustomDefinition::class, $locator('some.service')::class);
+        $this->assertSame(CustomDefinition::class, \get_class($locator('inlines.service')));
     }
 
     public function testServiceWithKeyOverwritesPreviousInheritedKey()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_service_locator_argument.php
@@ -26,4 +26,10 @@ return function (ContainerConfigurator $configurator) {
             'foo' => service('foo_service'),
             service('bar_service'),
         ])]);
+
+    $services->set('locator_dependent_inline_service', \ArrayObject::class)
+        ->args([service_locator([
+            'foo' => inline_service(\stdClass::class),
+            'bar' => inline_service(\stdClass::class),
+        ])]);
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_service_locator_argument.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_service_locator_argument.xml
@@ -25,5 +25,16 @@
         <argument type="service" id="bar_service"/>
       </argument>
     </service>
+
+    <service id="locator_dependent_inline_service" class="ArrayObject">
+      <argument type="service_locator">
+        <argument key="foo" type="service">
+          <service class="stdClass"/>
+        </argument>
+        <argument key="bar" type="service">
+          <service class="stdClass"/>
+        </argument>
+      </argument>
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_service_locator_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_service_locator_argument.yml
@@ -26,3 +26,14 @@ services:
             - !service_locator
                 'foo': '@foo_service'
                 '0': '@bar_service'
+
+    locator_dependent_inline_service:
+        class: ArrayObject
+        arguments:
+            - !service_locator
+                'foo':
+                    - !service
+                        class: stdClass
+                'bar':
+                    - !service
+                        class: stdClass

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Config\Builder\ConfigBuilderGenerator;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -231,5 +232,8 @@ class PhpFileLoaderTest extends TestCase
 
         $values = ['foo' => new Reference('foo_service'), 0 => new Reference('bar_service')];
         $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_service_mixed')->getArguments());
+
+        $values = ['foo' => new Definition(\stdClass::class), 'bar' => new Definition(\stdClass::class)];
+        $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_inline_service')->getArguments());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -447,6 +447,10 @@ class XmlFileLoaderTest extends TestCase
 
         $values = ['foo' => new Reference('foo_service'), 0 => new Reference('bar_service')];
         $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_service_mixed')->getArguments());
+
+        $inlinedServiceArguments = $container->getDefinition('locator_dependent_inline_service')->getArguments();
+        $this->assertEquals((new Definition(\stdClass::class))->setPublic(false), $container->getDefinition((string) $inlinedServiceArguments[0]->getValues()['foo']));
+        $this->assertEquals((new Definition(\stdClass::class))->setPublic(false), $container->getDefinition((string) $inlinedServiceArguments[0]->getValues()['bar']));
     }
 
     public function testParseServiceClosure()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -441,6 +441,10 @@ class YamlFileLoaderTest extends TestCase
 
         $values = ['foo' => new Reference('foo_service'), 0 => new Reference('bar_service')];
         $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_service_mixed')->getArguments());
+
+        $inlinedServiceArguments = $container->getDefinition('locator_dependent_inline_service')->getArguments();
+        $this->assertEquals(new Definition(\stdClass::class), $container->getDefinition((string) $inlinedServiceArguments[0]->getValues()['foo'][0]));
+        $this->assertEquals(new Definition(\stdClass::class), $container->getDefinition((string) $inlinedServiceArguments[0]->getValues()['bar'][0]));
     }
 
     public function testParseServiceClosure()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  |no
| Deprecations? |no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

Something, you want to include an inline service to a service locator.

This works fine. Except that the PHPDoc doesn't allow it causing PHPStan to fail.

Example:
```php
 $services->set(OtherService::class)
        ->args([
            '$services' => service_locator([
                'my_service' => inline_service(SomeClass::class)->args([]),
            ])
        ]);          
```
