### PR TITLE
[Console] fix section output when multiples section with max height

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -48,9 +48,9 @@ class ConsoleSectionOutput extends StreamOutput
     public function setMaxHeight(int $maxHeight): void
     {
         // when changing max height, clear output of current section and redraw again with the new height
-        $existingContent = $this->popStreamContentUntilCurrentSection($this->maxHeight ? min($this->maxHeight, $this->lines) : $this->lines);
-
+        $previousMaxHeight = $this->maxHeight;
         $this->maxHeight = $maxHeight;
+        $existingContent = $this->popStreamContentUntilCurrentSection($previousMaxHeight ? min($previousMaxHeight, $this->lines) : $this->lines);
 
         parent::doWrite($this->getVisibleContent(), false);
         parent::doWrite($existingContent, false);
@@ -213,7 +213,7 @@ class ConsoleSectionOutput extends StreamOutput
                 break;
             }
 
-            $numberOfLinesToClear += $section->lines;
+            $numberOfLinesToClear += $section->maxHeight ? min($section->lines, $section->maxHeight) : $section->lines;
             if ('' !== $sectionContent = $section->getVisibleContent()) {
                 if (!str_ends_with($sectionContent, \PHP_EOL)) {
                     $sectionContent .= \PHP_EOL;

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -133,6 +133,40 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals($expected, stream_get_contents($output->getStream()));
     }
 
+    public function testMaxHeightMultipleSections()
+    {
+        $expected = '';
+        $sections = [];
+
+        $firstSection = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $firstSection->setMaxHeight(3);
+
+        $secondSection = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $secondSection->setMaxHeight(3);
+
+        // fill the first section
+        $firstSection->writeln(['One', 'Two', 'Three']);
+        $expected .= 'One'.\PHP_EOL.'Two'.\PHP_EOL.'Three'.\PHP_EOL;
+
+        // fill the second section
+        $secondSection->writeln(['One', 'Two', 'Three']);
+        $expected .= 'One'.\PHP_EOL.'Two'.\PHP_EOL.'Three'.\PHP_EOL;
+
+        // cause overflow of second section (redraw whole section, without first line)
+        $secondSection->writeln('Four');
+        $expected .= "\x1b[3A\x1b[0J";
+        $expected .= 'Two'.\PHP_EOL.'Three'.\PHP_EOL.'Four'.\PHP_EOL;
+
+        // cause overflow of first section (redraw whole section, without first line)
+        $firstSection->writeln("Four\nFive\nSix");
+        $expected .= "\x1b[6A\x1b[0J";
+        $expected .= 'Four'.\PHP_EOL.'Five'.\PHP_EOL.'Six'.\PHP_EOL;
+        $expected .= 'Two'.\PHP_EOL.'Three'.\PHP_EOL.'Four'.\PHP_EOL;
+
+        rewind($this->stream);
+        $this->assertEquals(escapeshellcmd($expected), escapeshellcmd(stream_get_contents($this->stream)));
+    }
+
     public function testMaxHeightWithoutNewLine()
     {
         $expected = '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Partial fix for https://github.com/symfony/symfony/issues/35012
| License       | MIT
| Doc PR        | 

This pr does not fix https://github.com/symfony/symfony/issues/35012

However it fixes the second script wrote by @lyrixx (https://github.com/symfony/symfony/issues/35012#issuecomment-1573145508) with fiber and parallel output.

In short when there was multiple sections with max height, it was not taking into account the max height of other sections when doing a full rewrite, leading to erase more lines than intended.
