### PR TITLE
[Messenger] BatchHandlerTrait - fix phpdoc typo

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -66,7 +66,7 @@ trait BatchHandlerTrait
     /**
      * Completes the jobs in the list.
      *
-     * @list<array{0: object, 1: Acknowledger}> $jobs A list of pairs of messages and their corresponding acknowledgers
+     * @param list<array{0: object, 1: Acknowledger}> $jobs A list of pairs of messages and their corresponding acknowledgers
      */
     private function process(array $jobs): void
     {


### PR DESCRIPTION
Just a fix for phpdoc typo that I found