### PR TITLE
[Security] Fix error with lock_factory in login_throttling

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -98,9 +98,6 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface
             if (!interface_exists(LockInterface::class)) {
                 throw new LogicException(sprintf('Rate limiter "%s" requires the Lock component to be installed. Try running "composer require symfony/lock".', $name));
             }
-            if (!$container->hasDefinition('lock.factory.abstract')) {
-                throw new LogicException(sprintf('Rate limiter "%s" requires the Lock component to be configured.', $name));
-            }
 
             $limiter->replaceArgument(2, new Reference($limiterConfig['lock_factory']));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #51347
| License       | MIT
| Doc PR        | 


Remove incorrect check for Lock configuration in **Security Bundle** which leads to an exception when using lock_factory of the **login_throttling** (as explained in #51347)
