### PR TITLE
Added argument `$default` to `Crawler::attr()` like to `Crawler::text()` and `html()` do.

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Add `CrawlerAnySelectorTextContains` test constraint
 * Add `CrawlerAnySelectorTextSame` test constraint
+* Added argument `$default` to `Crawler::attr()`
 
 6.3
 ---

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -522,11 +522,17 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the attribute value of the first node of the list.
      *
+     * @param string|null $default When not null: the value to return when the attribute is empty
+     *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function attr(string $attribute): ?string
+    public function attr(string $attribute, string $default = null): ?string
     {
         if (!$this->nodes) {
+            if (null !== $default) {
+                return $default;
+            }
+
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
@@ -305,6 +305,8 @@ abstract class AbstractCrawlerTestCase extends TestCase
         } catch (\InvalidArgumentException $e) {
             $this->assertTrue(true, '->attr() throws an \InvalidArgumentException if the node list is empty');
         }
+
+        $this->assertSame('my value', $this->createTestCrawler()->filterXPath('//li')->attr('attr-not-exists','my value'));
     }
 
     public function testMissingAttrValueIsNull()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Added argument `$default` to `Crawler::attr()` like to `Crawler::text()` and `html()` do.
