### PR TITLE
[DomCrawler] Added argument `$default` to method `Crawler::attr()`

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -61,6 +61,11 @@ DoctrineBridge
  * Deprecate `DoctrineDataCollector::addLogger()`, use a `DebugDataHolder` instead
  * Deprecate `ContainerAwareLoader`, use dependency injection in your fixtures instead
 
+DomCrawler
+----------
+
+ * Add argument `$default` to `Crawler::attr()`
+
 ErrorHandler
 ------------
 

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,8 +4,9 @@ CHANGELOG
 6.4
 ---
 
-* Add `CrawlerAnySelectorTextContains` test constraint
-* Add `CrawlerAnySelectorTextSame` test constraint
+ * Add `CrawlerAnySelectorTextContains` test constraint
+ * Add `CrawlerAnySelectorTextSame` test constraint
+ * Add argument `$default` to `Crawler::attr()`
 
 6.3
 ---

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -58,7 +58,6 @@ class Crawler implements \Countable, \IteratorAggregate
      */
     private bool $isHtml = true;
 
-
     private ?HTML5 $html5Parser = null;
 
     /**
@@ -522,17 +521,24 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the attribute value of the first node of the list.
      *
+     * @param string|null $default When not null: the value to return when the node or attribute is empty
+     *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function attr(string $attribute): ?string
+    public function attr(string $attribute/* , string $default = null */): ?string
     {
+        $default = \func_num_args() > 1 ? func_get_arg(1) : null;
         if (!$this->nodes) {
+            if (null !== $default) {
+                return $default;
+            }
+
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
         $node = $this->getNode(0);
 
-        return $node->hasAttribute($attribute) ? $node->getAttribute($attribute) : null;
+        return $node->hasAttribute($attribute) ? $node->getAttribute($attribute) : $default;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
@@ -305,6 +305,9 @@ abstract class AbstractCrawlerTestCase extends TestCase
         } catch (\InvalidArgumentException $e) {
             $this->assertTrue(true, '->attr() throws an \InvalidArgumentException if the node list is empty');
         }
+
+        $this->assertSame('my value', $this->createTestCrawler()->filterXPath('//notexists')->attr('class', 'my value'));
+        $this->assertSame('my value', $this->createTestCrawler()->filterXPath('//li')->attr('attr-not-exists', 'my value'));
     }
 
     public function testMissingAttrValueIsNull()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

Added argument `$default` to method `->attr()` like `->text()` and `->html()` have.