### PR TITLE
[Console] avoid multiple new line when message already ends with a new line in section output

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -119,8 +119,7 @@ class ConsoleSectionOutput extends StreamOutput
             // re-add the line break (that has been removed in the above `explode()` for
             // - every line that is not the last line
             // - if $newline is required, also add it to the last line
-            // - if it's not new line, but input ending with `\PHP_EOL`
-            if ($i < $count || $newline || str_ends_with($input, \PHP_EOL)) {
+            if ($i < $count || $newline) {
                 $lineContent .= \PHP_EOL;
             }
 
@@ -168,6 +167,12 @@ class ConsoleSectionOutput extends StreamOutput
      */
     protected function doWrite(string $message, bool $newline)
     {
+        // Simulate newline behavior for consistent output formatting, avoiding extra logic
+        if (!$newline && str_ends_with($message, \PHP_EOL)) {
+            $message = substr($message, 0, -\strlen(\PHP_EOL));
+            $newline = true;
+        }
+
         if (!$this->isDecorated()) {
             parent::doWrite($message, $newline);
 

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -158,7 +158,7 @@ class ConsoleSectionOutputTest extends TestCase
         $expected .= 'Two'.\PHP_EOL.'Three'.\PHP_EOL.'Four'.\PHP_EOL;
 
         // cause overflow of first section (redraw whole section, without first line)
-        $firstSection->writeln("Four\nFive\nSix");
+        $firstSection->writeln('Four'.\PHP_EOL.'Five'.\PHP_EOL.'Six');
         $expected .= "\x1b[6A\x1b[0J";
         $expected .= 'Four'.\PHP_EOL.'Five'.\PHP_EOL.'Six'.\PHP_EOL;
         $expected .= 'Two'.\PHP_EOL.'Three'.\PHP_EOL.'Four'.\PHP_EOL;
@@ -289,5 +289,17 @@ class ConsoleSectionOutputTest extends TestCase
 
         rewind($output->getStream());
         $this->assertSame('What\'s your favorite super hero?'.\PHP_EOL."\x1b[2A\x1b[0J", stream_get_contents($output->getStream()));
+    }
+
+    public function testWriteWithoutNewLine()
+    {
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->write('Foo'.\PHP_EOL);
+        $output->write('Bar');
+
+        rewind($output->getStream());
+        $this->assertEquals(escapeshellcmd('Foo'.\PHP_EOL.'Bar'.\PHP_EOL), escapeshellcmd(stream_get_contents($output->getStream())));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -212,15 +212,15 @@ class SymfonyStyleTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals($answer, $givenAnswer);
-        $this->assertEquals(
+        $this->assertEquals(escapeshellcmd(
             'start'.\PHP_EOL. // write start
             'foo'.\PHP_EOL. // write foo
             "\x1b[1A\x1b[0Jfoo and bar".\PHP_EOL. // complete line
-            \PHP_EOL.\PHP_EOL." \033[32mDummy question?\033[39m:".\PHP_EOL.' > '.\PHP_EOL.\PHP_EOL.\PHP_EOL. // question
-            'foo2'.\PHP_EOL.\PHP_EOL. // write foo2
+            \PHP_EOL." \033[32mDummy question?\033[39m:".\PHP_EOL.' > '.\PHP_EOL.\PHP_EOL. // question
+            'foo2'.\PHP_EOL. // write foo2
             'bar2'.\PHP_EOL. // write bar
-            "\033[12A\033[0J", // clear 12 lines (11 output lines and one from the answer input return)
-            stream_get_contents($output->getStream())
+            "\033[9A\033[0J"), // clear 9 lines (8 output lines and one from the answer input return)
+            escapeshellcmd(stream_get_contents($output->getStream()))
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | https://github.com/symfony/symfony/issues/50382
| License       | MIT
| Doc PR        | 

When we write to the section with a new line in the message it ends up adding a double new line, it can be easily seen when we set a section as a console handler for the logs, each line of log will have a double new line ending adding a lot of noise.

I began to fix the implementation to correctly handle this case, but with all the logic of the max height and other stuff it appears to be way more complicated. 

Simulating this case by removing the new line at the end of the message and recalling the write function with the newline parameter to true was way easier and avoid too many headcache when looking at the code.

Should fix https://github.com/symfony/symfony/issues/50382

