### PR TITLE
[HttpKernel] Adding new `#[MapRequestHeader]` attribute and resolver

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -105,6 +105,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Attribute\AsTargetedValueResolver;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestHeaderValueResolver;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
@@ -261,6 +262,9 @@ class FrameworkExtension extends Extension
         $loader->load('fragment_renderer.php');
         $loader->load('error_renderer.php');
 
+        if (!class_exists(RequestHeaderValueResolver::class)) {
+            $container->removeDefinition('argument_resolver.header_value_resolver');
+        }
         if (!class_exists(ControllerAttributesListener::class)) {
             $container->removeDefinition('kernel.controller_attributes_listener');
             $container->removeDefinition('serialize_controller_result_listener');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolv
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\QueryParameterValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestHeaderValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ServiceValueResolver;
@@ -106,6 +107,9 @@ return static function (ContainerConfigurator $container) {
 
         ->set('argument_resolver.query_parameter_value_resolver', QueryParameterValueResolver::class)
             ->tag('controller.targeted_value_resolver', ['name' => QueryParameterValueResolver::class])
+
+        ->set('argument_resolver.header_value_resolver', RequestHeaderValueResolver::class)
+            ->tag('controller.targeted_value_resolver', ['name' => RequestHeaderValueResolver::class])
 
         ->set('response_listener', ResponseListener::class)
             ->args([

--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestHeader.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestHeader.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestHeaderValueResolver;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class MapRequestHeader extends ValueResolver
+{
+    /**
+     * @param string|null  $name                       The name of the header parameter; if null, the name of the argument in the controller will be used
+     * @param class-string $resolver                   The class name of the resolver to use
+     * @param int          $validationFailedStatusCode The HTTP code to return if the validation fails
+     */
+    public function __construct(
+        public readonly ?string $name = null,
+        string $resolver = RequestHeaderValueResolver::class,
+        public readonly int $validationFailedStatusCode = Response::HTTP_BAD_REQUEST,
+    ) {
+        parent::__construct($resolver);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `#[MapRequestHeader]` to map a header from `Request` to a controller argument
  * Add `hasErrors()` method to `Profile` to track profiles with errors (exceptions or error-level logs)
  * Validate typed route parameters before calling controllers and return an HTTP error when an invalid value is provided
  * Add `ControllerAttributeEvent` et al. to dispatch events named after controller attributes

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestHeaderValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestHeaderValueResolver.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\AcceptHeader;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapRequestHeader;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class RequestHeaderValueResolver implements ValueResolverInterface
+{
+    public function resolve(Request $request, ArgumentMetadata $argument): array
+    {
+        if (!$attribute = $argument->getAttributesOfType(MapRequestHeader::class)[0] ?? null) {
+            return [];
+        }
+
+        $type = $argument->getType();
+
+        if (!\in_array($type, ['string', 'array', AcceptHeader::class])) {
+            throw new \LogicException(\sprintf('Could not resolve the argument typed "%s". Valid types are "array", "string" or "%s".', $type, AcceptHeader::class));
+        }
+
+        $name = $attribute->name ?? strtolower(preg_replace('/[a-z]\K[A-Z]/', '-$0', $argument->getName()));
+        $value = null;
+
+        if ($request->headers->has($name)) {
+            $value = match ($type) {
+                'string' => $request->headers->get($name),
+                'array' => match (strtolower($name)) {
+                    'accept' => $request->getAcceptableContentTypes(),
+                    'accept-charset' => $request->getCharsets(),
+                    'accept-language' => $request->getLanguages(),
+                    'accept-encoding' => $request->getEncodings(),
+                    default => $request->headers->all($name),
+                },
+                AcceptHeader::class => AcceptHeader::fromString($request->headers->get($name)),
+            };
+        } elseif ($argument->hasDefaultValue()) {
+            $value = $argument->getDefaultValue();
+        }
+
+        if (null === $value && 'array' === $type) {
+            $value = [];
+        }
+
+        if (null === $value && !$argument->isNullable()) {
+            throw HttpException::fromStatusCode($attribute->validationFailedStatusCode, \sprintf('Missing header "%s".', $name));
+        }
+
+        return [$value];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestHeaderValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestHeaderValueResolverTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\AcceptHeader;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapRequestHeader;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestHeaderValueResolver;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class RequestHeaderValueResolverTest extends TestCase
+{
+    public static function provideHeaderValueWithStringType(): iterable
+    {
+        yield 'with accept' => ['accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'];
+        yield 'with accept-language' => ['accept-language', 'en-us,en;q=0.5'];
+        yield 'with host' => ['host', 'localhost'];
+        yield 'with user-agent' => ['user-agent', 'Symfony'];
+    }
+
+    public static function provideHeaderValueWithArrayType(): iterable
+    {
+        yield 'with accept' => [
+            'accept',
+            'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            [
+                [
+                    'text/html',
+                    'application/xhtml+xml',
+                    'application/xml',
+                    '*/*',
+                ],
+            ],
+        ];
+        yield 'with accept-language' => [
+            'accept-language',
+            'en-us,en;q=0.5',
+            [
+                [
+                    'en_US',
+                    'en',
+                ],
+            ],
+        ];
+        yield 'with host' => [
+            'host',
+            'localhost',
+            [
+                ['localhost'],
+            ],
+        ];
+        yield 'with user-agent' => [
+            'user-agent',
+            'Symfony',
+            [
+                ['Symfony'],
+            ],
+        ];
+    }
+
+    public static function provideHeaderValueWithAcceptHeaderType(): iterable
+    {
+        yield 'with accept' => [
+            'accept',
+            'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            [AcceptHeader::fromString('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')],
+        ];
+        yield 'with accept-language' => [
+            'accept-language',
+            'en-us,en;q=0.5',
+            [AcceptHeader::fromString('en-us,en;q=0.5')],
+        ];
+        yield 'with host' => [
+            'host',
+            'localhost',
+            [AcceptHeader::fromString('localhost')],
+        ];
+        yield 'with user-agent' => [
+            'user-agent',
+            'Symfony',
+            [AcceptHeader::fromString('Symfony')],
+        ];
+    }
+
+    public static function provideHeaderValueWithDefaultAndNull(): iterable
+    {
+        yield 'with hasDefaultValue' => [true, 'foo', false, 'foo'];
+        yield 'with no isNullable' => [false, null, true, null];
+    }
+
+    public function testWrongType()
+    {
+        $this->expectException(\LogicException::class);
+
+        $metadata = new ArgumentMetadata('accept', 'int', false, false, null, false, [
+            new MapRequestHeader(),
+        ]);
+
+        $request = Request::create('/');
+
+        $resolver = new RequestHeaderValueResolver();
+        $resolver->resolve($request, $metadata);
+    }
+
+    #[DataProvider('provideHeaderValueWithStringType')]
+    public function testWithStringType(string $parameter, string $value)
+    {
+        $resolver = new RequestHeaderValueResolver();
+
+        $metadata = new ArgumentMetadata('variableName', 'string', false, false, null, false, [
+            new MapRequestHeader($parameter),
+        ]);
+
+        $request = Request::create('/');
+        $request->headers->set($parameter, $value);
+
+        $arguments = $resolver->resolve($request, $metadata);
+
+        self::assertEquals([$value], $arguments);
+    }
+
+    #[DataProvider('provideHeaderValueWithArrayType')]
+    public function testWithArrayType(string $parameter, string $value, array $expected)
+    {
+        $resolver = new RequestHeaderValueResolver();
+
+        $metadata = new ArgumentMetadata('variableName', 'array', false, false, null, false, [
+            new MapRequestHeader($parameter),
+        ]);
+
+        $request = Request::create('/');
+        $request->headers->set($parameter, $value);
+
+        $arguments = $resolver->resolve($request, $metadata);
+
+        self::assertEquals($expected, $arguments);
+    }
+
+    #[DataProvider('provideHeaderValueWithAcceptHeaderType')]
+    public function testWithAcceptHeaderType(string $parameter, string $value, array $expected)
+    {
+        $resolver = new RequestHeaderValueResolver();
+
+        $metadata = new ArgumentMetadata('variableName', AcceptHeader::class, false, false, null, false, [
+            new MapRequestHeader($parameter),
+        ]);
+
+        $request = Request::create('/');
+        $request->headers->set($parameter, $value);
+
+        $arguments = $resolver->resolve($request, $metadata);
+
+        self::assertEquals($expected, $arguments);
+    }
+
+    #[DataProvider('provideHeaderValueWithDefaultAndNull')]
+    public function testWithDefaultValueAndNull(bool $hasDefaultValue, ?string $defaultValue, bool $isNullable, ?string $expected)
+    {
+        $metadata = new ArgumentMetadata('wrong-header', 'string', false, $hasDefaultValue, $defaultValue, $isNullable, [
+            new MapRequestHeader(),
+        ]);
+
+        $request = Request::create('/');
+
+        $resolver = new RequestHeaderValueResolver();
+        $arguments = $resolver->resolve($request, $metadata);
+
+        self::assertEquals([$expected], $arguments);
+    }
+
+    public function testCamelCaseArgumentNameMapsToKebabCaseHeader()
+    {
+        $resolver = new RequestHeaderValueResolver();
+
+        $metadata = new ArgumentMetadata('acceptEncoding', 'string', false, false, null, false, [
+            new MapRequestHeader(),
+        ]);
+
+        $request = Request::create('/');
+        $request->headers->set('accept-encoding', 'gzip, deflate');
+
+        $arguments = $resolver->resolve($request, $metadata);
+
+        self::assertSame(['gzip, deflate'], $arguments);
+    }
+
+    public function testWithNoDefaultAndNotNullable()
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Missing header "variable-name".');
+
+        $metadata = new ArgumentMetadata('variableName', 'string', false, false, null, false, [
+            new MapRequestHeader(),
+        ]);
+
+        $resolver = new RequestHeaderValueResolver();
+        $resolver->resolve(Request::create('/'), $metadata);
+    }
+
+    public function testWithNoDefaultAndNotNullableArray()
+    {
+        $metadata = new ArgumentMetadata('variableName', 'array', false, false, null, false, [
+            new MapRequestHeader(),
+        ]);
+
+        $resolver = new RequestHeaderValueResolver();
+        $arguments = $resolver->resolve(Request::create('/'), $metadata);
+
+        self::assertEquals([[]], $arguments);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #51342 
| License       | MIT
| Doc PR        | #20541

This adds a `#[MapRequestHeader]` attribute to map HTTP request headers to controller arguments, similar to how `#[MapQueryParameter]` works for query parameters.

```php
#[Route('/')]
public function index(
    #[MapRequestHeader] string $accept,
    #[MapRequestHeader] array $acceptLanguage,
    #[MapRequestHeader('user-agent')] string $userAgent,
    #[MapRequestHeader] ?string $xCustom,
    #[MapRequestHeader] AcceptHeader $acceptEncoding,
): Response {
    // ...
}
```

Supported types are string, array and AcceptHeader.

When the header name is not explicitly provided, the argument name is converted from camelCase to kebab-case (e.g. `$acceptLanguage` for `accept-language`).

When typed as array, the arguments received all corresponding headers.

Missing required headers throw an HttpException with a configurable status code (defaults to 400).

