### PR TITLE
[SecurityBundle] Auto-hash `PasswordAuthenticatedUserInterface` instances

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow an array of `pattern` in firewall configuration
  * Add `$badges` argument to `Security::login`
  * Deprecate the `require_previous_session` config option. Setting it has no effect anymore
+ * Auto-hash `PasswordAuthenticatedUserInterface` instances
 
 6.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -56,6 +56,7 @@ use Symfony\Component\Security\Core\Authorization\Strategy\UnanimousStrategy;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\User\ChainUserChecker;
 use Symfony\Component\Security\Core\User\ChainUserProvider;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
@@ -172,10 +173,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $this->createFirewalls($config, $container);
         $this->createAuthorization($config, $container);
         $this->createRoleHierarchy($config, $container);
-
-        if ($config['password_hashers']) {
-            $this->createHashers($config['password_hashers'], $container);
-        }
+        $this->createHashers($config['password_hashers'] += [PasswordAuthenticatedUserInterface::class => ['algorithm' => 'auto']], $container);
 
         if (class_exists(Application::class)) {
             $loader->load('console.php');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
@@ -30,6 +30,7 @@ use Symfony\Component\PasswordHasher\Hasher\PlaintextPasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Strategy\AffirmativeStrategy;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
@@ -404,6 +405,9 @@ abstract class CompleteConfigurationTestCase extends TestCase
                 'time_cost' => null,
                 'migrate_from' => [],
             ],
+            PasswordAuthenticatedUserInterface::class => [
+                'algorithm' => 'auto',
+            ],
         ]], $container->getDefinition('security.password_hasher_factory')->getArguments());
     }
 
@@ -457,6 +461,9 @@ abstract class CompleteConfigurationTestCase extends TestCase
                 'class' => SodiumPasswordHasher::class,
                 'arguments' => [8, 128 * 1024 * 1024],
             ],
+            PasswordAuthenticatedUserInterface::class => [
+                'algorithm' => 'auto',
+            ],
         ]], $container->getDefinition('security.password_hasher_factory')->getArguments());
     }
 
@@ -509,6 +516,9 @@ abstract class CompleteConfigurationTestCase extends TestCase
             'JMS\FooBundle\Entity\User7' => [
                 'class' => $sodium ? SodiumPasswordHasher::class : NativePasswordHasher::class,
                 'arguments' => $sodium ? [256, 1] : [1, 262144, null, \PASSWORD_ARGON2I],
+            ],
+            PasswordAuthenticatedUserInterface::class => [
+                'algorithm' => 'auto',
             ],
         ]], $container->getDefinition('security.password_hasher_factory')->getArguments());
     }
@@ -571,6 +581,9 @@ abstract class CompleteConfigurationTestCase extends TestCase
                 'time_cost' => 1,
                 'migrate_from' => ['bcrypt'],
             ],
+            PasswordAuthenticatedUserInterface::class => [
+                'algorithm' => 'auto',
+            ],
         ]], $container->getDefinition('security.password_hasher_factory')->getArguments());
     }
 
@@ -619,6 +632,9 @@ abstract class CompleteConfigurationTestCase extends TestCase
             'JMS\FooBundle\Entity\User7' => [
                 'class' => NativePasswordHasher::class,
                 'arguments' => [null, null, 15, \PASSWORD_BCRYPT],
+            ],
+            PasswordAuthenticatedUserInterface::class => [
+                'algorithm' => 'auto',
             ],
         ]], $container->getDefinition('security.password_hasher_factory')->getArguments());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Will allow removing these lines from the default recipe:
```yaml
    password_hashers:
        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
```

`auto` is the best option anyway so there is little need to configure this map nowadays.