### PR TITLE
[SecurityBundle] remove the deprecated require_previous_session option

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -63,12 +63,7 @@ abstract class AbstractFactory implements AuthenticatorFactoryInterface
         ;
 
         foreach (array_merge($this->options, $this->defaultSuccessHandlerOptions, $this->defaultFailureHandlerOptions) as $name => $default) {
-            if ('require_previous_session' === $name) {
-                $builder
-                    ->booleanNode($name)
-                    ->setDeprecated('symfony/security-bundle', '6.4', 'Option "%node%" at "%path%" is deprecated, it will be removed in version 7.0. Setting it has no effect anymore.')
-                    ->defaultValue($default);
-            } elseif (\is_bool($default)) {
+            if (\is_bool($default)) {
                 $builder->booleanNode($name)->defaultValue($default);
             } else {
                 $builder->scalarNode($name)->defaultValue($default);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Facto
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -109,27 +108,6 @@ class AbstractFactoryTest extends TestCase
             $this->assertEquals($expectedSuccessHandlerOptions, $successHandlerArguments['index_1']);
             $this->assertEquals($expectedFirewallName, $successHandlerArguments['index_2']);
         }
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testRequirePreviousSessionOptionLegacy()
-    {
-        $this->expectDeprecation('Since symfony/security-bundle 6.4: Option "require_previous_session" at "root" is deprecated, it will be removed in version 7.0. Setting it has no effect anymore.');
-
-        $options = [
-            'require_previous_session' => true,
-        ];
-
-        $factory = new StubFactory();
-        $nodeDefinition = new ArrayNodeDefinition('root');
-        $factory->addConfiguration($nodeDefinition);
-
-        $node = $nodeDefinition->getNode();
-        $normalizedConfig = $node->normalize($options);
-
-        $node->finalize($normalizedConfig);
     }
 
     public static function getSuccessHandlers()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 