### PR TITLE
[HttpKernel] Revert #45476 to fix missing `Request` in `RequestStack` for `StreamedResponse`

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -27,11 +27,6 @@ FrameworkBundle
    To prevent services resetting after each message the "--no-reset" option in "messenger:consume" command can be set
  * Deprecate not setting the `http_method_override` config option. The default value will change to `false` in 7.0.
 
-HttpKernel
-----------
-
- * Deprecate StreamedResponseListener, it's not needed anymore
-
 Routing
 -------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpKernel\EventListener\DisallowRobotsIndexingListener;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
+use Symfony\Component\HttpKernel\EventListener\StreamedResponseListener;
 use Symfony\Component\HttpKernel\EventListener\ValidateRequestListener;
 
 return static function (ContainerConfigurator $container) {
@@ -102,6 +103,9 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.charset'),
                 abstract_arg('The "set_content_language_from_locale" config value'),
             ])
+            ->tag('kernel.event_subscriber')
+
+        ->set('streamed_response_listener', StreamedResponseListener::class)
             ->tag('kernel.event_subscriber')
 
         ->set('locale_listener', LocaleListener::class)

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -32,7 +32,6 @@ CHANGELOG
 
  * Add `BackedEnumValueResolver` to resolve backed enum cases from request attributes in controller arguments
  * Add `DateTimeValueResolver` to resolve request attributes into DateTime objects in controller arguments
- * Deprecate StreamedResponseListener, it's not needed anymore
  * Add `Profiler::isEnabled()` so collaborating collector services may elect to omit themselves
  * Add the `UidValueResolver` argument value resolver
  * Add `AbstractBundle` class for DI configuration/definition on a single file

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -257,7 +257,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest', 128],
-            // low priority to come after regular response listeners
+            // low priority to come after regular response listeners, but higher than StreamedResponseListener
             KernelEvents::RESPONSE => ['onKernelResponse', -1000],
         ];
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/StreamedResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/StreamedResponseListener.php
@@ -16,8 +16,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-trigger_deprecation('symfony/http-kernel', '6.1', 'The "%s" class is deprecated.', StreamedResponseListener::class);
-
 /**
  * StreamedResponseListener is responsible for sending the Response
  * to the client.
@@ -25,8 +23,6 @@ trigger_deprecation('symfony/http-kernel', '6.1', 'The "%s" class is deprecated.
  * @author Fabien Potencier <fabien@symfony.com>
  *
  * @final
- *
- * @deprecated since Symfony 6.1
  */
 class StreamedResponseListener implements EventSubscriberInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 6.3
| Bug fix      | yes
| New feature  | no
| Deprecations | no
| Tickets       | Fix #46743
| License       | MIT

Revert #45476 and add test to ensure `Request` availability while using `StreamedResponse` callback.