### PR TITLE
Psalm: Ignore UnusedClass errors

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -36,6 +36,15 @@
                 <referencedClass name="UnitEnum"/>
             </errorLevel>
         </UndefinedDocblockClass>
+        <UnusedClass>
+            <errorLevel type="suppress">
+                <!--
+                    Because we don't analyze our tests or fixtures, we will
+                    get a lot of false positives regarding unused classes.
+                -->
+                <directory name="src/Symfony" />
+            </errorLevel>
+        </UnusedClass>
         <UnusedConstructor>
             <errorLevel type="suppress">
                 <!--


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`UnusedClass` errors reported by Psalm are not really helpful for us. Symfony is full of classes that are meant to be used downstream. The only usages we have are inside our tests and fixtures, but we chose to exclude those.

Let's ignore `UnusedClass` errors.