### PR TITLE
[RateLimiter] Use RateLimiterFactory with custom limit

### DIFF
--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -41,15 +41,19 @@ final class RateLimiterFactory
         $this->config = $options->resolve($config);
     }
 
-    public function create(string $key = null): LimiterInterface
+    /**
+     * Parsing a custom limit to this function will overwrite the limit in your configuration for this request.
+     */
+    public function create(string $key = null, ?int $limit = null): LimiterInterface
     {
         $id = $this->config['id'].'-'.$key;
         $lock = $this->lockFactory?->createLock($id);
+        $limit = $limit ?? $this->config['limit'];
 
         return match ($this->config['policy']) {
-            'token_bucket' => new TokenBucketLimiter($id, $this->config['limit'], $this->config['rate'], $this->storage, $lock),
-            'fixed_window' => new FixedWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock),
-            'sliding_window' => new SlidingWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock),
+            'token_bucket' => new TokenBucketLimiter($id, $limit, $this->config['rate'], $this->storage, $lock),
+            'fixed_window' => new FixedWindowLimiter($id, $limit, $this->config['interval'], $this->storage, $lock),
+            'sliding_window' => new SlidingWindowLimiter($id, $limit, $this->config['interval'], $this->storage, $lock),
             'no_limit' => new NoLimiter(),
             default => throw new \LogicException(sprintf('Limiter policy "%s" does not exists, it must be either "token_bucket", "sliding_window", "fixed_window" or "no_limit".', $this->config['policy'])),
         };

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -43,6 +43,7 @@ final class RateLimiterFactory
 
     /**
      * Parsing a custom limit to this function will overwrite the limit in your configuration for this request.
+     * When using a NoLimiter the limit will be ignored.
      */
     public function create(string $key = null, int $limit = null): LimiterInterface
     {

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -44,7 +44,7 @@ final class RateLimiterFactory
     /**
      * Parsing a custom limit to this function will overwrite the limit in your configuration for this request.
      */
-    public function create(string $key = null, ?int $limit = null): LimiterInterface
+    public function create(string $key = null, int $limit = null): LimiterInterface
     {
         $id = $this->config['id'].'-'.$key;
         $lock = $this->lockFactory?->createLock($id);

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -48,12 +48,11 @@ final class RateLimiterFactory
     {
         $id = $this->config['id'].'-'.$key;
         $lock = $this->lockFactory?->createLock($id);
-        $limit = $limit ?? $this->config['limit'];
 
         return match ($this->config['policy']) {
-            'token_bucket' => new TokenBucketLimiter($id, $limit, $this->config['rate'], $this->storage, $lock),
-            'fixed_window' => new FixedWindowLimiter($id, $limit, $this->config['interval'], $this->storage, $lock),
-            'sliding_window' => new SlidingWindowLimiter($id, $limit, $this->config['interval'], $this->storage, $lock),
+            'token_bucket' => new TokenBucketLimiter($id, $limit ?? $this->config['limit'], $this->config['rate'], $this->storage, $lock),
+            'fixed_window' => new FixedWindowLimiter($id, $limit ?? $this->config['limit'], $this->config['interval'], $this->storage, $lock),
+            'sliding_window' => new SlidingWindowLimiter($id, $limit ?? $this->config['limit'], $this->config['interval'], $this->storage, $lock),
             'no_limit' => new NoLimiter(),
             default => throw new \LogicException(sprintf('Limiter policy "%s" does not exists, it must be either "token_bucket", "sliding_window", "fixed_window" or "no_limit".', $this->config['policy'])),
         };

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
@@ -70,6 +70,23 @@ class RateLimiterFactoryTest extends TestCase
         $factory->create('key');
     }
 
+    public function testCustomLimit()
+    {
+        $factory = new RateLimiterFactory(
+            [
+                'policy' => 'sliding_window',
+                'id' => 'test',
+                'limit' => 5,
+                'interval' => '5 seconds',
+            ],
+            new InMemoryStorage()
+        );
+
+        $rateLimiter = $factory->create('key', 10);
+        $rateLimit = $rateLimiter->consume(0);
+        $this->assertSame(10, $rateLimit->getRemainingTokens());
+    }
+
     public static function invalidConfigProvider()
     {
         yield [MissingOptionsException::class, [


### PR DESCRIPTION
Add an optional custom limit to the RateLimiterFactory to overwrite configured values.

| Q             | A
| ------------- | ---
| Branch?       | 6.4  <!-- see below -->
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #51401 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The RateLimiterFactory by default uses the limit set in Config. However in certain situations you might want to change this limit per user. This allows for for that option. When no limit is passed to the Factory, the default configured value will be used.
<!--
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
