### PR TITLE
[Runtime] Add environment variable APP_RUNTIME_MODE

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+* Add the environnement variable `APP_RUNTIME_MODE`
+
 5.4
 ---
 

--- a/src/Symfony/Component/Runtime/Internal/autoload_runtime.template
+++ b/src/Symfony/Component/Runtime/Internal/autoload_runtime.template
@@ -12,6 +12,16 @@ if (!is_object($app)) {
     throw new TypeError(sprintf('Invalid return value: callable object expected, "%s" returned from "%s".', get_debug_type($app), $_SERVER['SCRIPT_FILENAME']));
 }
 
+if (null === ($_ENV['APP_RUNTIME_MODE'] ??= $_SERVER['APP_RUNTIME_MODE'] ?? null)) {
+    if ($_ENV['FRANKENPHP_WORKER'] ?? $_SERVER['FRANKENPHP_WORKER'] ?? false) {
+        $_ENV['APP_RUNTIME_MODE'] = 'worker';
+    } elseif (\PHP_SAPI === 'cli' || \PHP_SAPI === 'phpdbg') {
+        $_ENV['APP_RUNTIME_MODE'] = 'cli';
+    } else {
+        $_ENV['APP_RUNTIME_MODE'] = 'web';
+    }
+}
+
 $runtime = $_SERVER['APP_RUNTIME'] ?? $_ENV['APP_RUNTIME'] ?? %runtime_class%;
 $runtime = new $runtime(($_SERVER['APP_RUNTIME_OPTIONS'] ?? $_ENV['APP_RUNTIME_OPTIONS'] ?? []) + %runtime_options%);
 

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_default.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_default.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require __DIR__.'/autoload.php';
+
+return function (array $context): void {
+    echo 'From context ', $context['APP_RUNTIME_MODE'], ', from $_ENV ', $_ENV['APP_RUNTIME_MODE'];
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_default.php.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_default.php.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test set ENV variable APP_RUNTIME_MODE by guessing it from PHP_SAPI
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/runtime_mode_from_default.php';
+
+?>
+--EXPECTF--
+From context cli, from $_ENV cli

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$_ENV['APP_RUNTIME_MODE'] = 'env';
+
+require __DIR__.'/autoload.php';
+
+return function (array $context): void {
+    echo 'From context ', $context['APP_RUNTIME_MODE'], ', from $_ENV ', $_ENV['APP_RUNTIME_MODE'];
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env.php.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env.php.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test set ENV variable APP_RUNTIME_MODE from $_ENV
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/runtime_mode_from_env.php';
+
+?>
+--EXPECTF--
+From context env, from $_ENV env

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env_with_server_and_frankenphp_set.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env_with_server_and_frankenphp_set.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$_SERVER['APP_RUNTIME_MODE'] = 'server';
+$_ENV['APP_RUNTIME_MODE'] = 'env';
+$_ENV['FRANKENPHP_WORKER'] = '1';
+$_SERVER['FRANKENPHP_WORKER'] = '1';
+
+require __DIR__.'/autoload.php';
+
+return function (array $context): void {
+    echo 'From context ', $context['APP_RUNTIME_MODE'], ', from $_ENV ', $_ENV['APP_RUNTIME_MODE'];
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env_with_server_and_frankenphp_set.php.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env_with_server_and_frankenphp_set.php.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test set ENV variable APP_RUNTIME_MODE from $_ENV with variable also set in $_SERVER and FRANKENPHP_WORKER
+also set in $_ENV and $_SERVER
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/runtime_mode_from_env_with_server_and_frankenphp_set.php';
+
+?>
+--EXPECTF--
+From context server, from $_ENV env

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_frankenphp_env_var.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_frankenphp_env_var.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$_ENV['FRANKENPHP_WORKER'] = '1';
+
+require __DIR__.'/autoload.php';
+
+return function (array $context): void {
+    echo 'From context ', $context['APP_RUNTIME_MODE'], ', from $_ENV ', $_ENV['APP_RUNTIME_MODE'];
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_frankenphp_env_var.php.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_frankenphp_env_var.php.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test set ENV variable APP_RUNTIME_MODE with FRANKENPHP_WORKER $_ENV variable set
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/runtime_mode_from_frankenphp_env_var.php';
+
+?>
+--EXPECTF--
+From context worker, from $_ENV worker

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_frankenphp_server_var.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_frankenphp_server_var.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$_SERVER['FRANKENPHP_WORKER'] = '1';
+
+require __DIR__.'/autoload.php';
+
+return function (array $context): void {
+    echo 'From context ', $context['APP_RUNTIME_MODE'], ', from $_ENV ', $_ENV['APP_RUNTIME_MODE'];
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_frankenphp_server_var.php.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_frankenphp_server_var.php.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test set ENV variable APP_RUNTIME_MODE with FRANKENPHP_WORKER $_SERVER variable set
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/runtime_mode_from_frankenphp_server_var.php';
+
+?>
+--EXPECTF--
+From context worker, from $_ENV worker

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_server.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_server.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$_SERVER['APP_RUNTIME_MODE'] = 'server';
+
+require __DIR__.'/autoload.php';
+
+return function (array $context): void {
+    echo 'From context ', $context['APP_RUNTIME_MODE'], ', from $_ENV ', $_ENV['APP_RUNTIME_MODE'];
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_server.php.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_server.php.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test set ENV variable APP_RUNTIME_MODE from $_SERVER
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/runtime_mode_from_server.php';
+
+?>
+--EXPECTF--
+From context server, from $_ENV server


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51340
| License       | MIT
| Doc PR        | TODO

Based on https://github.com/symfony/symfony/issues/51340#issuecomment-1672895225  I added the envvar **APP_RUNTIME_MODE** in the `autoload_runtime.php`

Its purpose is to indicate in which mode the application is running (`cli` or `web`).

I had a hard time figuring out how to test this. I finally decided to only test the priority to set the value ($_ENV > $_SERVER > default guessing).

During my test, I noticed that if I define a value for `APP_RUNTIME_MODE` in `$_ENV`, and another value in `$_SERVER`, the output of `$context['APP_RUNTIME_MODE']` in my application callable will be the value defined in `$_SERVER`, and the value `$_ENV['APP_RUNTIME_MODE']` is untouched (which is normal). This is due to the way DotEnv loads and override envvars.

You can check this behavior in `src/Symfony/Component/Runtime/Tests/phpt/runtime_mode_from_env_with_server_set.php`.

For me it seems OK because I can't see a way of having `$_SERVER['APP_RUNTIME_MODE']` different from `$_ENV['APP_RUNTIME_MODE']`

I did not do the Doc PR, I first want to check if my implementation if OK for you 