### PR TITLE
[Clock] Throw `DateMalformedStringException`/`DateInvalidTimeZoneException` when appropriate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "symfony/polyfill-intl-idn": "^1.10",
         "symfony/polyfill-intl-normalizer": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/polyfill-php83": "^1.27",
+        "symfony/polyfill-php83": "^1.28",
         "symfony/polyfill-uuid": "^1.15"
     },
     "replace": {

--- a/src/Symfony/Component/Clock/CHANGELOG.md
+++ b/src/Symfony/Component/Clock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Throw `DateMalformedStringException`/`DateInvalidTimeZoneException` when appropriate
+
 6.3
 ---
 

--- a/src/Symfony/Component/Clock/Clock.php
+++ b/src/Symfony/Component/Clock/Clock.php
@@ -62,10 +62,23 @@ final class Clock implements ClockInterface
         }
     }
 
+    /**
+     * @throws \DateInvalidTimeZoneException When $timezone is invalid
+     */
     public function withTimeZone(\DateTimeZone|string $timezone): static
     {
+        if (\PHP_VERSION_ID >= 80300 && \is_string($timezone)) {
+            $timezone = new \DateTimeZone($timezone);
+        } elseif (\is_string($timezone)) {
+            try {
+                $timezone = new \DateTimeZone($timezone);
+            } catch (\Exception $e) {
+                throw new \DateInvalidTimeZoneException($e->getMessage(), $e->getCode(), $e);
+            }
+        }
+
         $clone = clone $this;
-        $clone->timezone = \is_string($timezone) ? new \DateTimeZone($timezone) : $timezone;
+        $clone->timezone = $timezone;
 
         return $clone;
     }

--- a/src/Symfony/Component/Clock/MonotonicClock.php
+++ b/src/Symfony/Component/Clock/MonotonicClock.php
@@ -22,6 +22,9 @@ final class MonotonicClock implements ClockInterface
     private int $usOffset;
     private \DateTimeZone $timezone;
 
+    /**
+     * @throws \DateInvalidTimeZoneException When $timezone is invalid
+     */
     public function __construct(\DateTimeZone|string $timezone = null)
     {
         if (false === $offset = hrtime()) {
@@ -32,11 +35,7 @@ final class MonotonicClock implements ClockInterface
         $this->sOffset = $time[1] - $offset[0];
         $this->usOffset = (int) ($time[0] * 1000000) - (int) ($offset[1] / 1000);
 
-        if (\is_string($timezone ??= date_default_timezone_get())) {
-            $this->timezone = new \DateTimeZone($timezone);
-        } else {
-            $this->timezone = $timezone;
-        }
+        $this->timezone = \is_string($timezone ??= date_default_timezone_get()) ? $this->withTimeZone($timezone)->timezone : $timezone;
     }
 
     public function now(): \DateTimeImmutable
@@ -71,10 +70,23 @@ final class MonotonicClock implements ClockInterface
         }
     }
 
+    /**
+     * @throws \DateInvalidTimeZoneException When $timezone is invalid
+     */
     public function withTimeZone(\DateTimeZone|string $timezone): static
     {
+        if (\PHP_VERSION_ID >= 80300 && \is_string($timezone)) {
+            $timezone = new \DateTimeZone($timezone);
+        } elseif (\is_string($timezone)) {
+            try {
+                $timezone = new \DateTimeZone($timezone);
+            } catch (\Exception $e) {
+                throw new \DateInvalidTimeZoneException($e->getMessage(), $e->getCode(), $e);
+            }
+        }
+
         $clone = clone $this;
-        $clone->timezone = \is_string($timezone) ? new \DateTimeZone($timezone) : $timezone;
+        $clone->timezone = $timezone;
 
         return $clone;
     }

--- a/src/Symfony/Component/Clock/NativeClock.php
+++ b/src/Symfony/Component/Clock/NativeClock.php
@@ -20,13 +20,12 @@ final class NativeClock implements ClockInterface
 {
     private \DateTimeZone $timezone;
 
+    /**
+     * @throws \DateInvalidTimeZoneException When $timezone is invalid
+     */
     public function __construct(\DateTimeZone|string $timezone = null)
     {
-        if (\is_string($timezone ??= date_default_timezone_get())) {
-            $this->timezone = new \DateTimeZone($timezone);
-        } else {
-            $this->timezone = $timezone;
-        }
+        $this->timezone = \is_string($timezone ??= date_default_timezone_get()) ? $this->withTimeZone($timezone)->timezone : $timezone;
     }
 
     public function now(): \DateTimeImmutable
@@ -45,10 +44,23 @@ final class NativeClock implements ClockInterface
         }
     }
 
+    /**
+     * @throws \DateInvalidTimeZoneException When $timezone is invalid
+     */
     public function withTimeZone(\DateTimeZone|string $timezone): static
     {
+        if (\PHP_VERSION_ID >= 80300 && \is_string($timezone)) {
+            $timezone = new \DateTimeZone($timezone);
+        } elseif (\is_string($timezone)) {
+            try {
+                $timezone = new \DateTimeZone($timezone);
+            } catch (\Exception $e) {
+                throw new \DateInvalidTimeZoneException($e->getMessage(), $e->getCode(), $e);
+            }
+        }
+
         $clone = clone $this;
-        $clone->timezone = \is_string($timezone) ? new \DateTimeZone($timezone) : $timezone;
+        $clone->timezone = $timezone;
 
         return $clone;
     }

--- a/src/Symfony/Component/Clock/Tests/MockClockTest.php
+++ b/src/Symfony/Component/Clock/Tests/MockClockTest.php
@@ -92,26 +92,19 @@ class MockClockTest extends TestCase
 
     public static function provideInvalidModifyStrings(): iterable
     {
-        yield 'Named holiday is not recognized' => [
-            'Halloween',
-            'Invalid modifier: "Halloween". Could not modify MockClock.',
-        ];
-
-        yield 'empty string' => [
-            '',
-            'Invalid modifier: "". Could not modify MockClock.',
-        ];
+        yield 'Named holiday is not recognized' => ['Halloween'];
+        yield 'empty string' => [''];
     }
 
     /**
      * @dataProvider provideInvalidModifyStrings
      */
-    public function testModifyThrowsOnInvalidString(string $modifiedNow, string $expectedMessage)
+    public function testModifyThrowsOnInvalidString(string $modifiedNow)
     {
         $clock = new MockClock((new \DateTimeImmutable('2112-09-17 23:53:00.999Z'))->setTimezone(new \DateTimeZone('UTC')));
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedMessage);
+        $this->expectException(\DateMalformedStringException::class);
+        $this->expectExceptionMessage("Failed to parse time string ($modifiedNow)");
 
         $clock->modify($modifiedNow);
     }

--- a/src/Symfony/Component/Clock/composer.json
+++ b/src/Symfony/Component/Clock/composer.json
@@ -20,7 +20,8 @@
     },
     "require": {
         "php": ">=8.1",
-        "psr/clock": "^1.0"
+        "psr/clock": "^1.0",
+        "symfony/polyfill-php83": "^1.28"
     },
     "autoload": {
         "files": [ "Resources/now.php" ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR leverages https://github.com/symfony/polyfill/pull/440 and https://wiki.php.net/rfc/datetime-exceptions to provide consistent error handling when malformed dates/timezones are given.