### PR TITLE
[FrameworkBundle][Validator] Deprecate annotation occurrences

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -93,6 +93,8 @@ FrameworkBundle
  * Deprecate not setting the `framework.uid.default_uuid_version` config option; it will default to `7` in 7.0
  * Deprecate not setting the `framework.uid.time_based_uuid_version` config option; it will default to `7` in 7.0
  * Deprecate not setting the `framework.validation.email_validation_mode` config option; it will default to `html5` in 7.0
+ * Deprecate `framework.validation.enable_annotations`, use `framework.validation.enable_attributes` instead
+ * Deprecate `framework.serializer.enable_annotations`, use `framework.serializer.enable_attributes` instead
 
 HttpFoundation
 --------------
@@ -157,3 +159,6 @@ Validator
  * Deprecate passing an annotation reader to the constructor signature of `AnnotationLoader`
  * Deprecate `ValidatorBuilder::setDoctrineAnnotationReader()`
  * Deprecate `ValidatorBuilder::addDefaultDoctrineAnnotationReader()`
+ * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead
+ * Deprecate `ValidatorBuilder::disableAnnotationMapping()`, use `ValidatorBuilder::disableAttributeMapping()` instead
+ * Deprecate `AnnotationLoader`, use `AttributeLoader` instead

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Bridge\Doctrine\Tests\Validator\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class UniqueEntityTest extends TestCase
 {
     public function testAttributeWithDefaultProperty()
     {
         $metadata = new ClassMetadata(UniqueEntityDummyOne::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         /** @var UniqueEntity $constraint */
@@ -35,7 +35,7 @@ class UniqueEntityTest extends TestCase
     public function testAttributeWithCustomizedService()
     {
         $metadata = new ClassMetadata(UniqueEntityDummyTwo::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         /** @var UniqueEntity $constraint */
@@ -50,7 +50,7 @@ class UniqueEntityTest extends TestCase
     public function testAttributeWithGroupsAndPaylod()
     {
         $metadata = new ClassMetadata(UniqueEntityDummyThree::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         /** @var UniqueEntity $constraint */

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -39,7 +39,7 @@ class DoctrineLoaderTest extends TestCase
     public function testLoadClassMetadata()
     {
         $validator = Validation::createValidatorBuilder()
-            ->enableAnnotationMapping(true)
+            ->enableAttributeMapping()
             ->addLoader(new DoctrineLoader(DoctrineTestHelper::createTestEntityManager(), '{^Symfony\\\\Bridge\\\\Doctrine\\\\Tests\\\\Fixtures\\\\DoctrineLoader}'))
             ->getValidator()
         ;
@@ -142,7 +142,7 @@ class DoctrineLoaderTest extends TestCase
     {
         $validator = Validation::createValidatorBuilder()
             ->addMethodMapping('loadValidatorMetadata')
-            ->enableAnnotationMapping(true)
+            ->enableAttributeMapping()
             ->addLoader(new DoctrineLoader(DoctrineTestHelper::createTestEntityManager(), '{^Symfony\\\\Bridge\\\\Doctrine\\\\Tests\\\\Fixtures\\\\DoctrineLoader}'))
             ->getValidator()
         ;
@@ -159,7 +159,7 @@ class DoctrineLoaderTest extends TestCase
     public function testFieldMappingsConfiguration()
     {
         $validator = Validation::createValidatorBuilder()
-            ->enableAnnotationMapping(true)
+            ->enableAttributeMapping()
             ->addXmlMappings([__DIR__.'/../Resources/validator/BaseUser.xml'])
             ->addLoader(
                 new DoctrineLoader(
@@ -200,7 +200,7 @@ class DoctrineLoaderTest extends TestCase
     public function testClassNoAutoMapping()
     {
         $validator = Validation::createValidatorBuilder()
-            ->enableAnnotationMapping(true)
+            ->enableAttributeMapping()
             ->addLoader(new DoctrineLoader(DoctrineTestHelper::createTestEntityManager(), '{.*}'))
             ->getValidator();
 

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -41,7 +41,7 @@
         "symfony/stopwatch": "^5.4|^6.0|^7.0",
         "symfony/translation": "^5.4|^6.0|^7.0",
         "symfony/uid": "^5.4|^6.0|^7.0",
-        "symfony/validator": "^5.4.25|~6.2.12|^6.3.1|^7.0",
+        "symfony/validator": "^6.4|^7.0",
         "symfony/var-dumper": "^5.4|^6.0|^7.0",
         "doctrine/collections": "^1.0|^2.0",
         "doctrine/data-fixtures": "^1.1",
@@ -63,7 +63,7 @@
         "symfony/property-info": "<5.4",
         "symfony/security-bundle": "<5.4",
         "symfony/security-core": "<6.4",
-        "symfony/validator": "<5.4.25|>=6,<6.2.12|>=6.3,<6.3.1"
+        "symfony/validator": "<6.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\Doctrine\\": "" },

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -21,6 +21,8 @@ CHANGELOG
  * Deprecate not setting the `framework.uid.default_uuid_version` config option; it will default to `7` in 7.0
  * Deprecate not setting the `framework.uid.time_based_uuid_version` config option; it will default to `7` in 7.0
  * Deprecate not setting the `framework.validation.email_validation_mode` config option; it will default to `html5` in 7.0
+ * Deprecate `framework.validation.enable_annotations`, use `framework.validation.enable_attributes` instead
+ * Deprecate `framework.serializer.enable_annotations`, use `framework.serializer.enable_attributes` instead
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1024,6 +1024,16 @@ class Configuration implements ConfigurationInterface
                         trigger_deprecation('symfony/framework-bundle', '6.4', 'Not setting the "framework.validation.email_validation_mode" config option is deprecated. It will default to "html5" in 7.0.');
                     }
 
+                    if (isset($v['enable_annotations'])) {
+                        trigger_deprecation('symfony/framework-bundle', '6.4', 'Option "enable_annotations" at "framework.validation" is deprecated. Use the "enable_attributes" option instead.');
+
+                        if (!isset($v['enable_attributes'])) {
+                            $v['enable_attributes'] = $v['enable_annotations'];
+                        } else {
+                            throw new LogicException('The "enable_annotations" and "enable_attributes" options at path "framework.validation" must not be both set. Only the "enable_attributes" option must be used.');
+                        }
+                    }
+
                     return $v;
                 })
             ->end()
@@ -1033,7 +1043,8 @@ class Configuration implements ConfigurationInterface
                     ->{$enableIfStandalone('symfony/validator', Validation::class)}()
                     ->children()
                         ->scalarNode('cache')->end()
-                        ->booleanNode('enable_annotations')->{!class_exists(FullStack::class) ? 'defaultTrue' : 'defaultFalse'}()->end()
+                        ->booleanNode('enable_annotations')->end()
+                        ->booleanNode('enable_attributes')->{!class_exists(FullStack::class) ? 'defaultTrue' : 'defaultFalse'}()->end()
                         ->arrayNode('static_method')
                             ->defaultValue(['loadValidatorMetadata'])
                             ->prototype('scalar')->end()
@@ -1139,10 +1150,25 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('serializer')
+                    ->validate()
+                    ->always(function ($v) {
+                        if (isset($v['enable_annotations'])) {
+                            trigger_deprecation('symfony/framework-bundle', '6.4', 'Option "enable_annotations" at "framework.serializer" is deprecated. Use the "enable_attributes" option instead.');
+
+                            if (!isset($v['enable_attributes'])) {
+                                $v['enable_attributes'] = $v['enable_annotations'];
+                            } else {
+                                throw new LogicException('The "enable_annotations" and "enable_attributes" options at path "framework.serializer" must not be both set. Only the "enable_attributes" option must be used.');
+                            }
+                        }
+
+                        return $v;
+                    })->end()
                     ->info('serializer configuration')
                     ->{$enableIfStandalone('symfony/serializer', Serializer::class)}()
                     ->children()
-                        ->booleanNode('enable_annotations')->{!class_exists(FullStack::class) ? 'defaultTrue' : 'defaultFalse'}()->end()
+                        ->booleanNode('enable_annotations')->end()
+                        ->booleanNode('enable_attributes')->{!class_exists(FullStack::class) ? 'defaultTrue' : 'defaultFalse'}()->end()
                         ->scalarNode('name_converter')->end()
                         ->scalarNode('circular_reference_handler')->end()
                         ->scalarNode('max_depth_handler')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1657,8 +1657,8 @@ class FrameworkExtension extends Extension
         $definition = $container->findDefinition('validator.email');
         $definition->replaceArgument(0, $config['email_validation_mode']);
 
-        if (\array_key_exists('enable_annotations', $config) && $config['enable_annotations']) {
-            $validatorBuilder->addMethodCall('enableAnnotationMapping', [true]);
+        if (\array_key_exists('enable_attributes', $config) && $config['enable_attributes']) {
+            $validatorBuilder->addMethodCall('enableAttributeMapping', [true]);
             if ($this->isInitializedConfigEnabled('annotations') && method_exists(ValidatorBuilder::class, 'setDoctrineAnnotationReader')) {
                 $validatorBuilder->addMethodCall('setDoctrineAnnotationReader', [new Reference('annotation_reader')]);
             }
@@ -1930,7 +1930,7 @@ class FrameworkExtension extends Extension
         }
 
         $serializerLoaders = [];
-        if (isset($config['enable_annotations']) && $config['enable_annotations']) {
+        if (isset($config['enable_attributes']) && $config['enable_attributes']) {
             if ($container->getParameter('kernel.debug')) {
                 $container->removeDefinition('serializer.mapping.cache_class_metadata_factory');
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -269,6 +269,7 @@
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="cache" type="xsd:string" />
         <xsd:attribute name="enable-annotations" type="xsd:boolean" />
+        <xsd:attribute name="enable-attributes" type="xsd:boolean" />
         <xsd:attribute name="static-method" type="xsd:boolean" />
         <xsd:attribute name="translation-domain" type="xsd:string" />
         <xsd:attribute name="strict-email" type="xsd:boolean" />
@@ -322,6 +323,7 @@
         </xsd:choice>
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="enable-annotations" type="xsd:boolean" />
+        <xsd:attribute name="enable-attributes" type="xsd:boolean" />
         <xsd:attribute name="name-converter" type="xsd:string" />
         <xsd:attribute name="circular-reference-handler" type="xsd:string" />
         <xsd:attribute name="max-depth-handler" type="xsd:string" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
@@ -26,7 +26,7 @@ class ValidatorCacheWarmerTest extends TestCase
         $validatorBuilder->addXmlMapping(__DIR__.'/../Fixtures/Validation/Resources/person.xml');
         $validatorBuilder->addYamlMapping(__DIR__.'/../Fixtures/Validation/Resources/author.yml');
         $validatorBuilder->addMethodMapping('loadValidatorMetadata');
-        $validatorBuilder->enableAnnotationMapping();
+        $validatorBuilder->enableAttributeMapping();
 
         $file = sys_get_temp_dir().'/cache-validator.php';
         @unlink($file);
@@ -46,7 +46,7 @@ class ValidatorCacheWarmerTest extends TestCase
     {
         $validatorBuilder = new ValidatorBuilder();
         $validatorBuilder->addYamlMapping(__DIR__.'/../Fixtures/Validation/Resources/categories.yml');
-        $validatorBuilder->enableAnnotationMapping();
+        $validatorBuilder->enableAttributeMapping();
 
         $file = sys_get_temp_dir().'/cache-validator-with-annotations.php';
         @unlink($file);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -591,7 +591,7 @@ class ConfigurationTest extends TestCase
             ],
             'validation' => [
                 'enabled' => !class_exists(FullStack::class),
-                'enable_annotations' => !class_exists(FullStack::class),
+                'enable_attributes' => !class_exists(FullStack::class),
                 'static_method' => ['loadValidatorMetadata'],
                 'translation_domain' => 'validators',
                 'mapping' => [
@@ -612,7 +612,7 @@ class ConfigurationTest extends TestCase
             'serializer' => [
                 'default_context' => ['foo' => 'bar', JsonDecode::DETAILED_ERROR_MESSAGES => true],
                 'enabled' => true,
-                'enable_annotations' => !class_exists(FullStack::class),
+                'enable_attributes' => !class_exists(FullStack::class),
                 'mapping' => ['paths' => []],
             ],
             'property_access' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -63,7 +63,7 @@ $container->loadFromExtension('framework', [
     'annotations' => false,
     'serializer' => [
         'enabled' => true,
-        'enable_annotations' => true,
+        'enable_attributes' => true,
         'name_converter' => 'serializer.name_converter.camel_case_to_snake_case',
         'circular_reference_handler' => 'my.circular.reference.handler',
         'max_depth_handler' => 'my.max.depth.handler',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping.php
@@ -6,7 +6,7 @@ $container->loadFromExtension('framework', [
     'php_errors' => ['log' => true],
     'annotations' => false,
     'serializer' => [
-        'enable_annotations' => true,
+        'enable_attributes' => true,
         'mapping' => [
             'paths' => [
                 '%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping_without_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping_without_annotations.php
@@ -6,7 +6,7 @@ $container->loadFromExtension('framework', [
     'handle_all_throwables' => true,
     'php_errors' => ['log' => true],
     'serializer' => [
-        'enable_annotations' => false,
+        'enable_attributes' => false,
         'mapping' => [
             'paths' => [
                 '%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_attributes.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_attributes.php
@@ -8,7 +8,7 @@ $container->loadFromExtension('framework', [
     'secret' => 's3cr3t',
     'validation' => [
         'enabled' => true,
-        'enable_annotations' => true,
+        'enable_attributes' => true,
         'email_validation_mode' => 'html5',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_legacy_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_legacy_annotations.php
@@ -10,7 +10,7 @@ $container->loadFromExtension('framework', [
     'secret' => 's3cr3t',
     'validation' => [
         'enabled' => true,
-        'enable_annotations' => true,
+        'enable_attributes' => true,
         'email_validation_mode' => 'html5',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -34,7 +34,7 @@
         <framework:validation enabled="true" email-validation-mode="html5" />
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" circular-reference-handler="my.circular.reference.handler" max-depth-handler="my.max.depth.handler">
+        <framework:serializer enabled="true" enable-attributes="true" name-converter="serializer.name_converter.camel_case_to_snake_case" circular-reference-handler="my.circular.reference.handler" max-depth-handler="my.max.depth.handler">
             <framework:default-context>
                 <framework:enable_max_depth>true</framework:enable_max_depth>
             </framework:default-context>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping.xml
@@ -7,7 +7,7 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:serializer enable-annotations="true">
+        <framework:serializer enable-attributes="true">
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files</framework:path>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/serialization.yml</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping_without_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping_without_annotations.xml
@@ -7,7 +7,7 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:serializer enable-annotations="false">
+        <framework:serializer enable-attributes="false">
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files</framework:path>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/serialization.yml</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_attributes.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_attributes.xml
@@ -9,7 +9,7 @@
     <framework:config secret="s3cr3t" http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:validation enabled="true" enable-annotations="true" email-validation-mode="html5" />
+        <framework:validation enabled="true" enable-attributes="true" email-validation-mode="html5" />
     </framework:config>
 
     <services>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_legacy_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_legacy_annotations.xml
@@ -9,7 +9,7 @@
     <framework:config secret="s3cr3t" http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="true" />
         <framework:php-errors log="true" />
-        <framework:validation enabled="true" enable-annotations="true" email-validation-mode="html5" />
+        <framework:validation enabled="true" enable-attributes="true" email-validation-mode="html5" />
     </framework:config>
 
     <services>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -53,7 +53,7 @@ framework:
     annotations: false
     serializer:
          enabled:                    true
-         enable_annotations:         true
+         enable_attributes:          true
          name_converter:             serializer.name_converter.camel_case_to_snake_case
          circular_reference_handler: my.circular.reference.handler
          max_depth_handler:          my.max.depth.handler

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping.yml
@@ -5,7 +5,7 @@ framework:
         log: true
     annotations: false
     serializer:
-        enable_annotations: true
+        enable_attributes: true
         mapping:
             paths:
                 - "%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping_without_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping_without_annotations.yml
@@ -5,7 +5,7 @@ framework:
     php_errors:
         log: true
     serializer:
-        enable_annotations: false
+        enable_attributes: false
         mapping:
             paths:
                 - "%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_attributes.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_attributes.yml
@@ -7,7 +7,7 @@ framework:
     secret: s3cr3t
     validation:
         enabled:     true
-        enable_annotations: true
+        enable_attributes: true
         email_validation_mode: html5
 
 services:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_legacy_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_legacy_annotations.yml
@@ -8,7 +8,7 @@ framework:
     secret: s3cr3t
     validation:
         enabled:     true
-        enable_annotations: true
+        enable_attributes: true
         email_validation_mode: html5
 
 services:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1241,7 +1241,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame([$xmlMappings], $calls[3][1]);
         $i = 3;
         if ($annotations) {
-            $this->assertSame('enableAnnotationMapping', $calls[++$i][0]);
+            $this->assertSame('enableAttributeMapping', $calls[++$i][0]);
         }
         $this->assertSame('addMethodMapping', $calls[++$i][0]);
         $this->assertSame(['loadValidatorMetadata'], $calls[$i][1]);
@@ -1251,7 +1251,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testValidationService()
     {
-        $container = $this->createContainerFromFile('validation_annotations', ['kernel.charset' => 'UTF-8'], false);
+        $container = $this->createContainerFromFile('validation_attributes', ['kernel.charset' => 'UTF-8'], false);
 
         $this->assertInstanceOf(ValidatorInterface::class, $container->get('validator.alias'));
     }
@@ -1282,14 +1282,14 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertEquals('file%link%format', $container->getParameter('debug.file_link_format'));
     }
 
-    public function testValidationAnnotations()
+    public function testValidationAttributes()
     {
-        $container = $this->createContainerFromFile('validation_annotations');
+        $container = $this->createContainerFromFile('validation_attributes');
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
         $this->assertCount(7, $calls);
-        $this->assertSame('enableAnnotationMapping', $calls[4][0]);
+        $this->assertSame('enableAttributeMapping', $calls[4][0]);
         $this->assertSame('addMethodMapping', $calls[5][0]);
         $this->assertSame(['loadValidatorMetadata'], $calls[5][1]);
         $this->assertSame('setMappingCache', $calls[6][0]);
@@ -1309,7 +1309,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
         $this->assertCount(8, $calls);
-        $this->assertSame('enableAnnotationMapping', $calls[4][0]);
+        $this->assertSame('enableAttributeMapping', $calls[4][0]);
         if (method_exists(ValidatorBuilder::class, 'setDoctrineAnnotationReader')) {
             $this->assertSame('setDoctrineAnnotationReader', $calls[5][0]);
             $this->assertEquals([new Reference('annotation_reader')], $calls[5][1]);
@@ -1328,7 +1328,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         require_once __DIR__.'/Fixtures/TestBundle/TestBundle.php';
 
-        $container = $this->createContainerFromFile('validation_annotations', [
+        $container = $this->createContainerFromFile('validation_attributes', [
             'kernel.bundles' => ['TestBundle' => 'Symfony\\Bundle\\FrameworkBundle\\Tests\\TestBundle'],
             'kernel.bundles_metadata' => ['TestBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/TestBundle']],
         ]);
@@ -1338,7 +1338,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertCount(8, $calls);
         $this->assertSame('addXmlMappings', $calls[3][0]);
         $this->assertSame('addYamlMappings', $calls[4][0]);
-        $this->assertSame('enableAnnotationMapping', $calls[5][0]);
+        $this->assertSame('enableAttributeMapping', $calls[5][0]);
         $this->assertSame('addMethodMapping', $calls[6][0]);
         $this->assertSame(['loadValidatorMetadata'], $calls[6][1]);
         $this->assertSame('setMappingCache', $calls[7][0]);
@@ -1364,7 +1364,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         require_once __DIR__.'/Fixtures/CustomPathBundle/src/CustomPathBundle.php';
 
-        $container = $this->createContainerFromFile('validation_annotations', [
+        $container = $this->createContainerFromFile('validation_attributes', [
             'kernel.bundles' => ['CustomPathBundle' => 'Symfony\\Bundle\\FrameworkBundle\\Tests\\CustomPathBundle'],
             'kernel.bundles_metadata' => ['TestBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/CustomPathBundle']],
         ]);
@@ -1399,7 +1399,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame('addXmlMappings', $calls[3][0]);
         $i = 3;
         if ($annotations) {
-            $this->assertSame('enableAnnotationMapping', $calls[++$i][0]);
+            $this->assertSame('enableAttributeMapping', $calls[++$i][0]);
         }
         $this->assertSame('setMappingCache', $calls[++$i][0]);
         $this->assertEquals([new Reference('validator.mapping.cache.adapter')], $calls[$i][1]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -4,7 +4,7 @@ framework:
     handle_all_throwables: true
     secret:        test
     router:        { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
-    validation:    { enabled: true, enable_annotations: true, email_validation_mode: html5 }
+    validation:    { enabled: true, enable_attributes: true, email_validation_mode: html5 }
     csrf_protection: true
     form:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -64,7 +64,7 @@
         "symfony/string": "^5.4|^6.0|^7.0",
         "symfony/translation": "^6.2.8|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",
-        "symfony/validator": "^6.3|^7.0",
+        "symfony/validator": "^6.4|^7.0",
         "symfony/workflow": "^5.4|^6.0|^7.0",
         "symfony/yaml": "^5.4|^6.0|^7.0",
         "symfony/property-info": "^5.4|^6.0|^7.0",
@@ -98,7 +98,7 @@
         "symfony/translation": "<6.2.8",
         "symfony/twig-bridge": "<5.4",
         "symfony/twig-bundle": "<5.4",
-        "symfony/validator": "<6.3",
+        "symfony/validator": "<6.4",
         "symfony/web-profiler-bundle": "<5.4",
         "symfony/workflow": "<5.4"
     },

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -4,7 +4,7 @@ framework:
     handle_all_throwables: true
     secret: test
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
-    validation: { enabled: true, enable_annotations: true, email_validation_mode: html5 }
+    validation: { enabled: true, enable_attributes: true, email_validation_mode: html5 }
     csrf_protection: true
     form:
         enabled: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -4,7 +4,7 @@ framework:
     handle_all_throwables: true
     secret: test
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
-    validation: { enabled: true, enable_annotations: true, email_validation_mode: html5 }
+    validation: { enabled: true, enable_attributes: true, email_validation_mode: html5 }
     assets: ~
     csrf_protection: true
     form:

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -39,7 +39,7 @@
         "symfony/dom-crawler": "^5.4|^6.0|^7.0",
         "symfony/expression-language": "^5.4|^6.0|^7.0",
         "symfony/form": "^5.4|^6.0|^7.0",
-        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/http-client": "^5.4|^6.0|^7.0",
         "symfony/ldap": "^5.4|^6.0|^7.0",
         "symfony/process": "^5.4|^6.0|^7.0",
@@ -48,7 +48,7 @@
         "symfony/translation": "^5.4|^6.0|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",
         "symfony/twig-bridge": "^5.4|^6.0|^7.0",
-        "symfony/validator": "^5.4|^6.0|^7.0",
+        "symfony/validator": "^6.4|^7.0",
         "symfony/yaml": "^5.4|^6.0|^7.0",
         "twig/twig": "^2.13|^3.0.4",
         "web-token/jwt-checker": "^3.1",
@@ -61,7 +61,7 @@
     "conflict": {
         "symfony/browser-kit": "<5.4",
         "symfony/console": "<5.4",
-        "symfony/framework-bundle": "<6.3",
+        "symfony/framework-bundle": "<6.4",
         "symfony/http-client": "<5.4",
         "symfony/ldap": "<5.4",
         "symfony/twig-bundle": "<5.4"

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -521,7 +521,7 @@ class RequestPayloadValueResolverTest extends TestCase
         $payload->title = 'A long title, so the validation passes';
 
         $serializer = new Serializer([new ObjectNormalizer()]);
-        $validator = (new ValidatorBuilder())->enableAnnotationMapping()->getValidator();
+        $validator = (new ValidatorBuilder())->enableAttributeMapping()->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $request = Request::create('/', $method, $input);
@@ -547,7 +547,7 @@ class RequestPayloadValueResolverTest extends TestCase
         $input = ['price' => '50', 'title' => 'Too short'];
 
         $serializer = new Serializer([new ObjectNormalizer()]);
-        $validator = (new ValidatorBuilder())->enableAnnotationMapping()->getValidator();
+        $validator = (new ValidatorBuilder())->enableAttributeMapping()->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('valid', RequestPayload::class, false, false, null, false, [

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -43,7 +43,7 @@
         "symfony/translation": "^5.4|^6.0|^7.0",
         "symfony/translation-contracts": "^2.5|^3",
         "symfony/uid": "^5.4|^6.0|^7.0",
-        "symfony/validator": "^6.3|^7.0",
+        "symfony/validator": "^6.4|^7.0",
         "symfony/var-exporter": "^6.2|^7.0",
         "psr/cache": "^1.0|^2.0|^3.0",
         "twig/twig": "^2.13|^3.0.4"

--- a/src/Symfony/Component/Routing/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/DirectoryLoader.php
@@ -45,7 +45,7 @@ class DirectoryLoader extends FileLoader
 
     public function supports(mixed $resource, string $type = null): bool
     {
-        // only when type is forced to directory, not to conflict with AnnotationLoader
+        // only when type is forced to directory, not to conflict with AttributeLoader
 
         return 'directory' === $type;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Core\Tests\Validator\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class UserPasswordTest extends TestCase
 {
@@ -40,7 +40,7 @@ class UserPasswordTest extends TestCase
         yield 'named arguments' => [new UserPassword(service: 'my_service')];
 
         $metadata = new ClassMetadata(UserPasswordDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         yield 'attribute' => [$metadata->properties['b']->constraints[0]];
     }
@@ -48,7 +48,7 @@ class UserPasswordTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(UserPasswordDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -32,7 +32,7 @@
         "symfony/ldap": "^5.4|^6.0|^7.0",
         "symfony/string": "^5.4|^6.0|^7.0",
         "symfony/translation": "^5.4|^6.0|^7.0",
-        "symfony/validator": "^5.4|^6.0|^7.0",
+        "symfony/validator": "^6.4|^7.0",
         "psr/log": "^1|^2|^3"
     },
     "conflict": {

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -12,6 +12,9 @@ CHANGELOG
  * Deprecate `ValidatorBuilder::addDefaultDoctrineAnnotationReader()`
  * Add `number`, `finite-number` and `finite-float` types to `Type` constraint
  * Add the `withSeconds` option to the `Time` constraint that allows to pass time without seconds
+ * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead
+ * Deprecate `ValidatorBuilder::disableAnnotationMapping()`, use `ValidatorBuilder::disableAttributeMapping()` instead
+ * Deprecate `AnnotationLoader`, use `AttributeLoader` instead
 
 6.3
 ---

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -22,6 +22,8 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 /**
  * Loads validation metadata using a Doctrine annotation {@link Reader} or using PHP 8 attributes.
  *
+ * @deprecated since Symfony 6.4, use {@see AttributeLoader} instead
+ *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Alexander M. Turek <me@derrabus.de>
  */

--- a/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Mapping\Loader;
+
+/**
+ * Loads validation metadata using PHP attributes.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Alexander M. Turek <me@derrabus.de>
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class AttributeLoader extends AnnotationLoader
+{
+    public function __construct()
+    {
+        parent::__construct(null);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Validator\Command\DebugCommand;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Tests\Dummy\DummyClassOne;
 
 /**
@@ -26,7 +26,7 @@ class DebugCommandTest extends TestCase
 {
     public function testOutputWithClassArgument()
     {
-        $command = new DebugCommand(new LazyLoadingMetadataFactory(new AnnotationLoader()));
+        $command = new DebugCommand(new LazyLoadingMetadataFactory(new AttributeLoader()));
 
         $tester = new CommandTester($command);
         $tester->execute(['class' => DummyClassOne::class], ['decorated' => false]);
@@ -82,7 +82,7 @@ TXT
 
     public function testOutputWithPathArgument()
     {
-        $command = new DebugCommand(new LazyLoadingMetadataFactory(new AnnotationLoader()));
+        $command = new DebugCommand(new LazyLoadingMetadataFactory(new AttributeLoader()));
 
         $tester = new CommandTester($command);
         $tester->execute(['class' => __DIR__.'/../Dummy'], ['decorated' => false]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints\BicValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class BicValidatorTest extends ConstraintValidatorTestCase
@@ -74,7 +74,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidComparisonToPropertyPathFromAttribute()
     {
         $classMetadata = new ClassMetadata(BicDummy::class);
-        (new AnnotationLoader())->loadClassMetadata($classMetadata);
+        (new AttributeLoader())->loadClassMetadata($classMetadata);
 
         [$constraint] = $classMetadata->properties['bic1']->constraints;
 
@@ -116,7 +116,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidComparisonToValueFromAttribute()
     {
         $classMetadata = new ClassMetadata(BicDummy::class);
-        (new AnnotationLoader())->loadClassMetadata($classMetadata);
+        (new AttributeLoader())->loadClassMetadata($classMetadata);
 
         [$constraint] = $classMetadata->properties['bic1']->constraints;
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\CardScheme;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class CardSchemeTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(CardSchemeDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/CascadeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CascadeTest.php
@@ -15,14 +15,14 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Cascade;
 use Symfony\Component\Validator\Mapping\CascadingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class CascadeTest extends TestCase
 {
     public function testCascadeAttribute()
     {
         $metadata = new ClassMetadata(CascadeDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertSame(CascadingStrategy::NONE, $metadata->getCascadingStrategy());
         self::assertTrue($loader->loadClassMetadata($metadata));
         self::assertSame(CascadingStrategy::CASCADE, $metadata->getCascadingStrategy());

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintChoiceWithPreset;
 
 class ChoiceTest extends TestCase
@@ -29,7 +29,7 @@ class ChoiceTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(ChoiceDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         /** @var Choice $aConstraint */

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints\Cidr;
 use Symfony\Component\Validator\Constraints\Ip;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class CidrTest extends TestCase
 {
@@ -123,7 +123,7 @@ class CidrTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(CidrDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class CountTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(CountDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Country;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class CountryTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(CountryDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\CssColor;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
@@ -24,7 +24,7 @@ final class CssColorTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(CssColorDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Currency;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class CurrencyTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(CurrencyDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Date;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class DateTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(DateDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class DateTimeTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(DateTimeDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/DisableAutoMappingTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DisableAutoMappingTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints\DisableAutoMapping;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Mapping\AutoMappingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -34,7 +34,7 @@ class DisableAutoMappingTest extends TestCase
     public function testDisableAutoMappingAttribute()
     {
         $metadata = new ClassMetadata(DisableAutoMappingDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertSame(AutoMappingStrategy::NONE, $metadata->getAutoMappingStrategy());
         self::assertTrue($loader->loadClassMetadata($metadata));
         self::assertSame(AutoMappingStrategy::DISABLED, $metadata->getAutoMappingStrategy());

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\DivisibleBy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class DivisibleByTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(DivisibleByDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class EmailTest extends TestCase
 {
@@ -64,7 +64,7 @@ class EmailTest extends TestCase
     public function testAttribute()
     {
         $metadata = new ClassMetadata(EmailDummy::class);
-        (new AnnotationLoader())->loadClassMetadata($metadata);
+        (new AttributeLoader())->loadClassMetadata($metadata);
 
         [$aConstraint] = $metadata->properties['a']->constraints;
         self::assertNull($aConstraint->mode);

--- a/src/Symfony/Component/Validator/Tests/Constraints/EnableAutoMappingTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EnableAutoMappingTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints\EnableAutoMapping;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Mapping\AutoMappingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -34,7 +34,7 @@ class EnableAutoMappingTest extends TestCase
     public function testDisableAutoMappingAttribute()
     {
         $metadata = new ClassMetadata(EnableAutoMappingDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertSame(AutoMappingStrategy::NONE, $metadata->getAutoMappingStrategy());
         self::assertTrue($loader->loadClassMetadata($metadata));
         self::assertSame(AutoMappingStrategy::ENABLED, $metadata->getAutoMappingStrategy());

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class EqualToTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(EqualToDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\ExpressionLanguageSyntax;
 use Symfony\Component\Validator\Constraints\ExpressionLanguageSyntaxValidator;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @group legacy
@@ -44,7 +44,7 @@ class ExpressionLanguageSyntaxTest extends TestCase
         yield 'named arguments' => [new ExpressionLanguageSyntax(service: 'my_service')];
 
         $metadata = new ClassMetadata(ExpressionLanguageSyntaxDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         yield 'attribute' => [$metadata->properties['b']->constraints[0]];
     }
@@ -52,7 +52,7 @@ class ExpressionLanguageSyntaxTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(ExpressionLanguageSyntaxDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertNull($aConstraint->service);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\ExpressionSyntax;
 use Symfony\Component\Validator\Constraints\ExpressionSyntaxValidator;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class ExpressionSyntaxTest extends TestCase
 {
@@ -41,7 +41,7 @@ class ExpressionSyntaxTest extends TestCase
         yield 'named arguments' => [new ExpressionSyntax(service: 'my_service')];
 
         $metadata = new ClassMetadata(ExpressionSyntaxDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         yield 'attribute' => [$metadata->properties['b']->constraints[0]];
     }
@@ -49,7 +49,7 @@ class ExpressionSyntaxTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(ExpressionSyntaxDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertNull($aConstraint->service);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class ExpressionTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(ExpressionDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertSame('value == "1"', $aConstraint->expression);

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class FileTest extends TestCase
 {
@@ -144,7 +144,7 @@ class FileTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(FileDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertNull($aConstraint->maxSize);

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class GreaterThanOrEqualTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(GreaterThanOrEqualDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class GreaterThanTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(GreaterThanDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/HostnameTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/HostnameTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Hostname;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class HostnameTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(HostnameDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraints\Iban;
 use Symfony\Component\Validator\Constraints\IbanValidator;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class IbanValidatorTest extends ConstraintValidatorTestCase
@@ -439,7 +439,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
     public function testLoadFromAttribute()
     {
         $classMetadata = new ClassMetadata(IbanDummy::class);
-        (new AnnotationLoader())->loadClassMetadata($classMetadata);
+        (new AttributeLoader())->loadClassMetadata($classMetadata);
 
         [$constraint] = $classMetadata->properties['iban']->constraints;
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\IdenticalTo;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class IdenticalToTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(IdenticalToDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class ImageTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(ImageDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Ip;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Renan Taranto <renantaranto@gmail.com>
@@ -46,7 +46,7 @@ class IpTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(IpDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Isbn;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class IsbnTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(IsbnDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsinTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsinTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Isin;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class IsinTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(IsinDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Issn;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class IssnTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(IssnDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/JsonTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/JsonTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Json;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class JsonTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(JsonDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Language;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class LanguageTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(LanguageDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Renan Taranto <renantaranto@gmail.com>
@@ -82,7 +82,7 @@ class LengthTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(LengthDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class LessThanOrEqualTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(LessThanOrEqualDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\LessThan;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class LessThanTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(LessThanDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Locale;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class LocaleTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(LocaleDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Luhn;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class LuhnTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(LuhnDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/NegativeOrZeroTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NegativeOrZeroTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NegativeOrZero;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class NegativeOrZeroTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(NegativeOrZeroDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/NegativeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NegativeTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Negative;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class NegativeTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(NegativeDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Renan Taranto <renantaranto@gmail.com>
@@ -32,7 +32,7 @@ class NotBlankTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(NotBlankDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotCompromisedPassword;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -31,7 +31,7 @@ class NotCompromisedPasswordTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(NotCompromisedPasswordDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotEqualTo;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class NotEqualToTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(NotEqualToDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotIdenticalTo;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class NotIdenticalToTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(NotIdenticalToDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/PositiveOrZeroTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PositiveOrZeroTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\PositiveOrZero;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class PositiveOrZeroTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(PositiveOrZeroDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/PositiveTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PositiveTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Positive;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class PositiveTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(PositiveDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -113,7 +113,7 @@ class RegexTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(RegexDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Time;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class TimeTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(TimeDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Timezone;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
@@ -69,7 +69,7 @@ class TimezoneTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(TimezoneDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertSame(\DateTimeZone::ALL, $aConstraint->zone);

--- a/src/Symfony/Component/Validator/Tests/Constraints/TraverseTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TraverseTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Mapping\TraversalStrategy;
 
 class TraverseTest extends TestCase
@@ -22,7 +22,7 @@ class TraverseTest extends TestCase
     public function testPositiveAttributes()
     {
         $metadata = new ClassMetadata(TraverseDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
         self::assertSame(TraversalStrategy::TRAVERSE, $metadata->getTraversalStrategy());
     }
@@ -30,7 +30,7 @@ class TraverseTest extends TestCase
     public function testNegativeAttribute()
     {
         $metadata = new ClassMetadata(DoNotTraverseMe::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
         self::assertSame(TraversalStrategy::NONE, $metadata->getTraversalStrategy());
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class TypeTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(TypeDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertSame('integer', $aConstraint->type);

--- a/src/Symfony/Component/Validator/Tests/Constraints/UlidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UlidTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Ulid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class UlidTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(UlidDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueTest.php
@@ -15,14 +15,14 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Unique;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class UniqueTest extends TestCase
 {
     public function testAttributes()
     {
         $metadata = new ClassMetadata(UniqueDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Renan Taranto <renantaranto@gmail.com>
@@ -46,7 +46,7 @@ class UrlTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(UrlDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertSame(['http', 'https'], $aConstraint->protocols);

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Uuid;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Renan Taranto <renantaranto@gmail.com>
@@ -46,7 +46,7 @@ class UuidTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetadata(UuidDummy::class);
-        self::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertSame(Uuid::ALL_VERSIONS, $aConstraint->versions);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -38,7 +38,7 @@ class ValidTest extends TestCase
     public function testAttributes()
     {
         $metadata = new ClassMetaData(ValidDummy::class);
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidValidatorTest.php
@@ -20,7 +20,7 @@ class ValidValidatorTest extends TestCase
     public function testPropertyPathsArePassedToNestedContexts()
     {
         $validatorBuilder = new ValidatorBuilder();
-        $validator = $validatorBuilder->enableAnnotationMapping()->getValidator();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
 
         $violations = $validator->validate(new Foo(), null, ['nested']);
 
@@ -31,7 +31,7 @@ class ValidValidatorTest extends TestCase
     public function testNullValues()
     {
         $validatorBuilder = new ValidatorBuilder();
-        $validator = $validatorBuilder->enableAnnotationMapping()->getValidator();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
 
         $foo = new Foo();
         $foo->fooBar = null;

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Tests\Constraints\Fixtures\WhenTestWithAttributes;
 
 final class WhenTest extends TestCase
@@ -130,7 +131,7 @@ final class WhenTest extends TestCase
 
     public function testAttributes()
     {
-        $loader = new AnnotationLoader();
+        $loader = new AttributeLoader();
         $metadata = new ClassMetadata(WhenTestWithAttributes::class);
 
         self::assertTrue($loader->loadClassMetadata($metadata));

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -92,7 +92,7 @@ class PropertyInfoLoaderTest extends TestCase
         $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{.*}');
 
         $validator = Validation::createValidatorBuilder()
-            ->enableAnnotationMapping()
+            ->enableAttributeMapping()
             ->addLoader($propertyInfoLoader)
             ->getValidator()
         ;
@@ -230,7 +230,7 @@ class PropertyInfoLoaderTest extends TestCase
 
         $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{.*}');
         $validator = Validation::createValidatorBuilder()
-            ->enableAnnotationMapping()
+            ->enableAttributeMapping()
             ->addLoader($propertyInfoLoader)
             ->getValidator()
         ;

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -81,6 +81,7 @@ class ValidatorBuilderTest extends TestCase
      */
     public function testEnableAnnotationMappingWithDefaultDoctrineAnnotationReader()
     {
+        $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::enableAnnotationMapping()" is deprecated, use "enableAttributeMapping()" instead.');
         $this->assertSame($this->builder, $this->builder->enableAnnotationMapping());
 
         $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::addDefaultDoctrineAnnotationReader()" is deprecated without replacement.');
@@ -102,6 +103,7 @@ class ValidatorBuilderTest extends TestCase
     {
         $reader = $this->createMock(Reader::class);
 
+        $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::enableAnnotationMapping()" is deprecated, use "enableAttributeMapping()" instead.');
         $this->assertSame($this->builder, $this->builder->enableAnnotationMapping());
 
         $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::setDoctrineAnnotationReader()" is deprecated without replacement.');
@@ -116,9 +118,27 @@ class ValidatorBuilderTest extends TestCase
         $this->assertSame($reader, $r->getValue($loaders[0]));
     }
 
-    public function testDisableAnnotationMapping()
+    /**
+     * @group legacy
+     */
+    public function testExpectDeprecationWhenEnablingAnnotationMapping()
     {
+        $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::enableAnnotationMapping()" is deprecated, use "enableAttributeMapping()" instead.');
+        $this->assertSame($this->builder, $this->builder->enableAnnotationMapping());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testExpectDeprecationWhenDisablingAnnotationMapping()
+    {
+        $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::disableAnnotationMapping()" is deprecated, use "disableAttributeMapping()" instead.');
         $this->assertSame($this->builder, $this->builder->disableAnnotationMapping());
+    }
+
+    public function testDisableAttributeMapping()
+    {
+        $this->assertSame($this->builder, $this->builder->disableAttributeMapping());
     }
 
     public function testSetMappingCache()

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Mapping\Loader\LoaderChain;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
@@ -49,7 +50,7 @@ class ValidatorBuilder
     private array $yamlMappings = [];
     private array $methodMappings = [];
     private ?Reader $annotationReader = null;
-    private bool $enableAnnotationMapping = false;
+    private bool $enableAttributeMapping = false;
     private ?MetadataFactoryInterface $metadataFactory = null;
     private ConstraintValidatorFactoryInterface $validatorFactory;
     private ?CacheItemPoolInterface $mappingCache = null;
@@ -187,30 +188,54 @@ class ValidatorBuilder
     }
 
     /**
-     * Enables annotation and attribute based constraint mapping.
+     * @deprecated since Symfony 6.4, use "enableAttributeMapping()" instead.
      *
      * @return $this
      */
     public function enableAnnotationMapping(): static
     {
+        trigger_deprecation('symfony/validator', '6.4', 'Method "%s()" is deprecated, use "enableAttributeMapping()" instead.', __METHOD__);
+
+        return $this->enableAttributeMapping();
+    }
+
+    /**
+     * Enables attribute-based constraint mapping.
+     *
+     * @return $this
+     */
+    public function enableAttributeMapping(): static
+    {
         if (null !== $this->metadataFactory) {
-            throw new ValidatorException('You cannot enable annotation mapping after setting a custom metadata factory. Configure your metadata factory instead.');
+            throw new ValidatorException('You cannot enable attribute mapping after setting a custom metadata factory. Configure your metadata factory instead.');
         }
 
-        $this->enableAnnotationMapping = true;
+        $this->enableAttributeMapping = true;
 
         return $this;
     }
 
     /**
-     * Disables annotation and attribute based constraint mapping.
+     * @deprecated since Symfony 6.4, use "disableAttributeMapping()" instead
      *
      * @return $this
      */
     public function disableAnnotationMapping(): static
     {
-        $this->enableAnnotationMapping = false;
+        trigger_deprecation('symfony/validator', '6.4', 'Method "%s()" is deprecated, use "disableAttributeMapping()" instead.', __METHOD__);
+
+        return $this->disableAttributeMapping();
+    }
+
+    /**
+     * Disables attribute-based constraint mapping.
+     *
+     * @return $this
+     */
+    public function disableAttributeMapping(): static
+    {
         $this->annotationReader = null;
+        $this->enableAttributeMapping = false;
 
         return $this;
     }
@@ -250,7 +275,7 @@ class ValidatorBuilder
      */
     public function setMetadataFactory(MetadataFactoryInterface $metadataFactory): static
     {
-        if (\count($this->xmlMappings) > 0 || \count($this->yamlMappings) > 0 || \count($this->methodMappings) > 0 || $this->enableAnnotationMapping) {
+        if (\count($this->xmlMappings) > 0 || \count($this->yamlMappings) > 0 || \count($this->methodMappings) > 0 || $this->enableAttributeMapping) {
             throw new ValidatorException('You cannot set a custom metadata factory after adding custom mappings. You should do either of both.');
         }
 
@@ -344,8 +369,10 @@ class ValidatorBuilder
             $loaders[] = new StaticMethodLoader($methodName);
         }
 
-        if ($this->enableAnnotationMapping) {
+        if ($this->enableAttributeMapping && $this->annotationReader) {
             $loaders[] = new AnnotationLoader($this->annotationReader);
+        } elseif ($this->enableAttributeMapping) {
+            $loaders[] = new AttributeLoader();
         }
 
         return array_merge($loaders, $this->loaders);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Part of https://github.com/symfony/symfony/issues/51381
| License       | MIT
| Doc PR        | -

 * Deprecate `framework.validation.enable_annotations` in favor of `framework.validation.enable_attributes`
 * Deprecate `framework.serializer.enable_annotations` in favor of use `framework.serializer.enable_attributes`
 * Deprecate `ValidatorBuilder::enableAnnotationMapping()` in favor of `ValidatorBuilder::enableAttributeMapping()`
 * Deprecate `ValidatorBuilder::disableAnnotationMapping()` in favor of `ValidatorBuilder::disableAttributeMapping()`
 * Deprecate `AnnotationLoader` in favor of `AttributeLoader`