### PR TITLE
[Validator] Deprecate `ValidatorBuilder::enableAnnotationMapping()` and `ValidatorBuilder::disableAnnotationMapping()`

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -157,3 +157,5 @@ Validator
  * Deprecate passing an annotation reader to the constructor signature of `AnnotationLoader`
  * Deprecate `ValidatorBuilder::setDoctrineAnnotationReader()`
  * Deprecate `ValidatorBuilder::addDefaultDoctrineAnnotationReader()`
+ * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead
+ * Deprecate `ValidatorBuilder::disableAnnotationMapping()`, use `ValidatorBuilder::disableAttributeMapping()` instead

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
  * Deprecate `ValidatorBuilder::addDefaultDoctrineAnnotationReader()`
  * Add `number`, `finite-number` and `finite-float` types to `Type` constraint
  * Add the `withSeconds` option to the `Time` constraint that allows to pass time without seconds
+ * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead
+ * Deprecate `ValidatorBuilder::disableAnnotationMapping()`, use `ValidatorBuilder::disableAttributeMapping()` instead
 
 6.3
 ---

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidValidatorTest.php
@@ -20,7 +20,7 @@ class ValidValidatorTest extends TestCase
     public function testPropertyPathsArePassedToNestedContexts()
     {
         $validatorBuilder = new ValidatorBuilder();
-        $validator = $validatorBuilder->enableAnnotationMapping()->getValidator();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
 
         $violations = $validator->validate(new Foo(), null, ['nested']);
 
@@ -31,7 +31,7 @@ class ValidValidatorTest extends TestCase
     public function testNullValues()
     {
         $validatorBuilder = new ValidatorBuilder();
-        $validator = $validatorBuilder->enableAnnotationMapping()->getValidator();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
 
         $foo = new Foo();
         $foo->fooBar = null;

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -92,7 +92,7 @@ class PropertyInfoLoaderTest extends TestCase
         $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{.*}');
 
         $validator = Validation::createValidatorBuilder()
-            ->enableAnnotationMapping()
+            ->enableAttributeMapping()
             ->addLoader($propertyInfoLoader)
             ->getValidator()
         ;
@@ -230,7 +230,7 @@ class PropertyInfoLoaderTest extends TestCase
 
         $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{.*}');
         $validator = Validation::createValidatorBuilder()
-            ->enableAnnotationMapping()
+            ->enableAttributeMapping()
             ->addLoader($propertyInfoLoader)
             ->getValidator()
         ;

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -81,7 +81,7 @@ class ValidatorBuilderTest extends TestCase
      */
     public function testEnableAnnotationMappingWithDefaultDoctrineAnnotationReader()
     {
-        $this->assertSame($this->builder, $this->builder->enableAnnotationMapping());
+        $this->assertSame($this->builder, $this->builder->enableAttributeMapping());
 
         $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::addDefaultDoctrineAnnotationReader()" is deprecated without replacement.');
         $this->assertSame($this->builder, $this->builder->addDefaultDoctrineAnnotationReader());
@@ -102,7 +102,7 @@ class ValidatorBuilderTest extends TestCase
     {
         $reader = $this->createMock(Reader::class);
 
-        $this->assertSame($this->builder, $this->builder->enableAnnotationMapping());
+        $this->assertSame($this->builder, $this->builder->enableAttributeMapping());
 
         $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::setDoctrineAnnotationReader()" is deprecated without replacement.');
         $this->assertSame($this->builder, $this->builder->setDoctrineAnnotationReader($reader));
@@ -116,9 +116,27 @@ class ValidatorBuilderTest extends TestCase
         $this->assertSame($reader, $r->getValue($loaders[0]));
     }
 
-    public function testDisableAnnotationMapping()
+    /**
+     * @group legacy
+     */
+    public function testExpectDeprecationWhenEnablingAnnotationMapping()
     {
-        $this->assertSame($this->builder, $this->builder->disableAnnotationMapping());
+        $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::enableAnnotationMapping()" is deprecated, use "enableAttributeMapping()" instead.');
+        $this->builder->enableAnnotationMapping();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testExpectDeprecationWhenDisablingAnnotationMapping()
+    {
+        $this->expectDeprecation('Since symfony/validator 6.4: Method "Symfony\Component\Validator\ValidatorBuilder::disableAnnotationMapping()" is deprecated, use "disableAttributeMapping()" instead.');
+        $this->builder->disableAnnotationMapping();
+    }
+
+    public function testDisableAttributeMapping()
+    {
+        $this->assertSame($this->builder, $this->builder->disableAttributeMapping());
     }
 
     public function testSetMappingCache()

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -49,7 +49,7 @@ class ValidatorBuilder
     private array $yamlMappings = [];
     private array $methodMappings = [];
     private ?Reader $annotationReader = null;
-    private bool $enableAnnotationMapping = false;
+    private bool $enableAttributeMapping = false;
     private ?MetadataFactoryInterface $metadataFactory = null;
     private ConstraintValidatorFactoryInterface $validatorFactory;
     private ?CacheItemPoolInterface $mappingCache = null;
@@ -187,30 +187,55 @@ class ValidatorBuilder
     }
 
     /**
-     * Enables annotation and attribute based constraint mapping.
+     * @deprecated since Symfony 6.4, use "enableAttributeMapping()" instead.
      *
      * @return $this
      */
     public function enableAnnotationMapping(): static
     {
+        trigger_deprecation('symfony/validator', '6.4', 'Method "%s()" is deprecated, use "enableAttributeMapping()" instead.', __METHOD__);
+
+        return $this->enableAttributeMapping();
+    }
+
+    /**
+     * Enables attribute based constraint mapping.
+     *
+     * @return $this
+     */
+    public function enableAttributeMapping(): static
+    {
         if (null !== $this->metadataFactory) {
             throw new ValidatorException('You cannot enable annotation mapping after setting a custom metadata factory. Configure your metadata factory instead.');
         }
 
-        $this->enableAnnotationMapping = true;
+        $this->enableAttributeMapping = true;
 
         return $this;
     }
 
     /**
-     * Disables annotation and attribute based constraint mapping.
+     * @deprecated since Symfony 6.4, use "disableAttributeMapping()" instead
      *
      * @return $this
      */
     public function disableAnnotationMapping(): static
     {
-        $this->enableAnnotationMapping = false;
+        trigger_deprecation('symfony/validator', '6.4', 'Method "%s()" is deprecated, use "disableAttributeMapping()" instead.', __METHOD__);
+
         $this->annotationReader = null;
+
+        return $this->disableAttributeMapping();
+    }
+
+    /**
+     * Disables attribute based constraint mapping.
+     *
+     * @return $this
+     */
+    public function disableAttributeMapping(): static
+    {
+        $this->enableAttributeMapping = false;
 
         return $this;
     }
@@ -250,7 +275,7 @@ class ValidatorBuilder
      */
     public function setMetadataFactory(MetadataFactoryInterface $metadataFactory): static
     {
-        if (\count($this->xmlMappings) > 0 || \count($this->yamlMappings) > 0 || \count($this->methodMappings) > 0 || $this->enableAnnotationMapping) {
+        if (\count($this->xmlMappings) > 0 || \count($this->yamlMappings) > 0 || \count($this->methodMappings) > 0 || $this->enableAttributeMapping) {
             throw new ValidatorException('You cannot set a custom metadata factory after adding custom mappings. You should do either of both.');
         }
 
@@ -344,7 +369,7 @@ class ValidatorBuilder
             $loaders[] = new StaticMethodLoader($methodName);
         }
 
-        if ($this->enableAnnotationMapping) {
+        if ($this->enableAttributeMapping) {
             $loaders[] = new AnnotationLoader($this->annotationReader);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Part of https://github.com/symfony/symfony/issues/51381
| License       | MIT
| Doc PR        | -

Required by https://github.com/symfony/symfony/pull/51425