### PR TITLE
[HttpFoundation] Add `ParameterBag::match` method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Make `HeaderBag::getDate()`, `Response::getDate()`, `getExpires()` and `getLastModified()` return a `DateTimeImmutable`
+ * Add `ParameterBag::match()` to check whether a parameter matches a regular expression
 
 6.3
 ---

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -124,14 +124,10 @@ class ParameterBag implements \IteratorAggregate, \Countable
             return false;
         }
 
-        if (\strlen($regexp) < 2 || ('/' !== $regexp[0] || '/' !== $regexp[\strlen($regexp) - 1])) {
-            throw new \InvalidArgumentException('Parameter "regexp" is not a valid regular expression.');
-        }
-
-        $match = preg_match($regexp, $this->getString($key));
+        $match = @preg_match($regexp, $this->getString($key));
 
         if (false === $match) {
-            throw new \InvalidArgumentException('Parameter "regexp" is not a valid regular expression.');
+            throw new \InvalidArgumentException(sprintf('Parameter "regexp" is not a valid regular expression: "%s".', preg_last_error_msg()));
         }
 
         return 1 === $match;

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -113,12 +113,10 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Checks whether the given parameter matches the given regular expression.
      *
-     * @param string $key
-     * @param string $regexp
-     * @return boolean Returns true if the paramter matches the regular expression.
-     *                 However, false is returned if the parameter is either not defined or if the parameter did not match the regular expression.
-     * 
-     * @throws \InvalidArgumentException InvalidArgumentException is thrown if regexp is not a valid regular expression.
+     * @return bool Returns true if the paramter matches the regular expression.
+     *              However, false is returned if the parameter is either not defined or if the parameter did not match the regular expression.
+     *
+     * @throws \InvalidArgumentException if regexp is not a valid regular expression
      */
     public function match(string $key, string $regexp): bool
     {
@@ -126,17 +124,17 @@ class ParameterBag implements \IteratorAggregate, \Countable
             return false;
         }
 
-        if (strlen($regexp) < 2 || ($regexp[0] !== '/' || $regexp[strlen($regexp) - 1] !== '/')) {
+        if (\strlen($regexp) < 2 || ('/' !== $regexp[0] || '/' !== $regexp[\strlen($regexp) - 1])) {
             throw new \InvalidArgumentException('Parameter "regexp" is not a valid regular expression.');
         }
-        
+
         $match = preg_match($regexp, $this->getString($key));
 
-        if ($match === false) {
+        if (false === $match) {
             throw new \InvalidArgumentException('Parameter "regexp" is not a valid regular expression.');
         }
 
-        return $match === 1;
+        return 1 === $match;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -111,6 +111,35 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Checks whether the given parameter matches the given regular expression.
+     *
+     * @param string $key
+     * @param string $regexp
+     * @return boolean Returns true if the paramter matches the regular expression.
+     *                 However, false is returned if the parameter is either not defined or if the parameter did not match the regular expression.
+     * 
+     * @throws \InvalidArgumentException InvalidArgumentException is thrown if regexp is not a valid regular expression.
+     */
+    public function match(string $key, string $regexp): bool
+    {
+        if (!$this->has($key)) {
+            return false;
+        }
+
+        if (strlen($regexp) < 2 || ($regexp[0] !== '/' || $regexp[strlen($regexp) - 1] !== '/')) {
+            throw new \InvalidArgumentException('Parameter "regexp" is not a valid regular expression.');
+        }
+        
+        $match = preg_match($regexp, $this->getString($key));
+
+        if ($match === false) {
+            throw new \InvalidArgumentException('Parameter "regexp" is not a valid regular expression.');
+        }
+
+        return $match === 1;
+    }
+
+    /**
      * Returns the alphabetic characters of the parameter value.
      */
     public function getAlpha(string $key, string $default = ''): string

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -129,9 +129,19 @@ class ParameterBagTest extends TestCase
         $bag = new ParameterBag(['foo' => 'bar']);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Parameter "regexp" is not a valid regular expression.');
+        $this->expectExceptionMessage('Parameter "regexp" is not a valid regular expression: "Internal error".');
 
         $bag->match('foo', '/\d+');
+    }
+
+    public function testMatchExceptionWithPregLastErrorMsg()
+    {
+        $bag = new ParameterBag(['foobar' => 'foobar foobar foobar']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter "regexp" is not a valid regular expression: "Backtrack limit exhausted".');
+
+        $bag->match('foobar', '/(?:\D+|<\d+>)*[!?]/');
     }
 
     public function testGetAlpha()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -114,6 +114,26 @@ class ParameterBagTest extends TestCase
         $this->assertFalse($bag->has('unknown'), '->has() return false if a parameter is not defined');
     }
 
+    public function testMatch()
+    {
+        $bag = new ParameterBag(['foo' => 'bar', 'foobar' => 'foo101bar']);
+
+        $this->assertTrue($bag->match('foo', '/^bar$/'));
+        $this->assertTrue($bag->match('foobar', '/^[a-zA-Z]{3}\d{3}[a-zA-Z]{3}$/'));
+        $this->assertFalse($bag->match('baz', '/^foobarbaz$/'));
+        $this->assertFalse($bag->match('', '/^foobarbaz$/'));
+    }
+
+    public function testMatchExceptionWithInvalidRegexp()
+    {
+        $bag = new ParameterBag(['foo' => 'bar']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter "regexp" is not a valid regular expression.');
+
+        $bag->match('foo', '/\d+');
+    }
+
     public function testGetAlpha()
     {
         $bag = new ParameterBag(['word' => 'foo_BAR_012', 'bool' => true, 'integer' => 123]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51224 
| License       | MIT
| Doc PR        | symfony/symfony-docs#18768

This PR tries to implement a feature requested in the issue mentioned in the table above.

`ParameterBag::match` allows developers to check whether a parameter matches a regular expression like this

```php
if ($request->atttributes->match(key: 'foo', regexp: '/REGEX/') {
    // do something
}
```