### PR TITLE
[Form] use `never` return type in form events

### DIFF
--- a/src/Symfony/Component/Form/Event/PostSetDataEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSetDataEvent.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\FormEvent;
  */
 final class PostSetDataEvent extends FormEvent
 {
-    public function setData(mixed $data): void
+    public function setData(mixed $data): never
     {
         throw new BadMethodCallException('Form data cannot be changed during "form.post_set_data", you should use "form.pre_set_data" instead.');
     }

--- a/src/Symfony/Component/Form/Event/PostSubmitEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSubmitEvent.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\FormEvent;
  */
 final class PostSubmitEvent extends FormEvent
 {
-    public function setData(mixed $data): void
+    public function setData(mixed $data): never
     {
         throw new BadMethodCallException('Form data cannot be changed during "form.post_submit", you should use "form.pre_submit" or "form.submit" instead.');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

Symfony 7.0 uses PHP 8.2, so we can leverage `never` instead of `void` return type.