### PR TITLE
[Security] [Throttling] Hide username and client ip in logs

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -76,6 +76,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface
             $container->register($config['limiter'] = 'security.login_throttling.'.$firewallName.'.limiter', DefaultLoginRateLimiter::class)
                 ->addArgument(new Reference('limiter.'.$globalId))
                 ->addArgument(new Reference('limiter.'.$localId))
+                ->addArgument('%kernel.secret%')
             ;
         }
 

--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -28,11 +28,20 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
 {
     private RateLimiterFactory $globalFactory;
     private RateLimiterFactory $localFactory;
+    private string $secret;
 
-    public function __construct(RateLimiterFactory $globalFactory, RateLimiterFactory $localFactory)
+    /**
+     * @param non-empty-string $secret A secret to use for hashing the IP address and username
+     */
+    public function __construct(RateLimiterFactory $globalFactory, RateLimiterFactory $localFactory, #[\SensitiveParameter] string $secret = '')
     {
+        if ('' === $secret) {
+            trigger_deprecation('symfony/security-http', '6.4', 'Calling "%s()" with an empty secret is deprecated. A non-empty secret will be mandatory in version 7.0.', __METHOD__);
+            // throw new \Symfony\Component\Security\Core\Exception\InvalidArgumentException('A non-empty secret is required.');
+        }
         $this->globalFactory = $globalFactory;
         $this->localFactory = $localFactory;
+        $this->secret = $secret;
     }
 
     protected function getLimiters(Request $request): array
@@ -41,8 +50,13 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
         $username = preg_match('//u', $username) ? mb_strtolower($username, 'UTF-8') : strtolower($username);
 
         return [
-            $this->globalFactory->create($request->getClientIp()),
-            $this->localFactory->create($username.'-'.$request->getClientIp()),
+            $this->globalFactory->create($this->hash($request->getClientIp())),
+            $this->localFactory->create($this->hash($username.'-'.$request->getClientIp())),
         ];
+    }
+
+    private function hash(string $data): string
+    {
+        return strtr(substr(base64_encode(hash_hmac('sha256', $data, $this->secret, true)), 0, 8), '/+', '._');
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -47,7 +47,7 @@ class LoginThrottlingListenerTest extends TestCase
             'limit' => 6,
             'interval' => '1 minute',
         ], new InMemoryStorage());
-        $limiter = new DefaultLoginRateLimiter($globalLimiter, $localLimiter);
+        $limiter = new DefaultLoginRateLimiter($globalLimiter, $localLimiter, '$3cre7');
 
         $this->listener = new LoginThrottlingListener($this->requestStack, $limiter);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46362
| License       | MIT
| Doc PR        | symfony/symfony-docs#... **TODO**
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This PR is a proposal for fixing #46362. It appears the username and IP address may be both available in the log or the caching system.
The proposed feature uses the already existing kernel secret to hash the data.