### PR TITLE
[FrameworkBundle] Deprecate not setting both `framework.session.save_path` and `framework.session.handler_id` at the same time

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -90,6 +90,7 @@ FrameworkBundle
  * Deprecate not setting the `framework.session.cookie_secure` config option; it will default to `auto` in 7.0
  * Deprecate not setting the `framework.session.cookie_samesite` config option; it will default to `lax` in 7.0
  * Deprecate not setting the `framework.session.handler_id` config option; it will default to `session.handler.native_file` when `framework.session.save_path` is set or `null` otherwise in 7.0
+ * Deprecate not setting the `framework.session.save_path` config option when `framework.session.handler_id` is not set; it will default to `null` in 7.0
  * Deprecate not setting the `framework.uid.default_uuid_version` config option; it will default to `7` in 7.0
  * Deprecate not setting the `framework.uid.time_based_uuid_version` config option; it will default to `7` in 7.0
  * Deprecate not setting the `framework.validation.email_validation_mode` config option; it will default to `html5` in 7.0

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Deprecate not setting the `framework.session.cookie_secure` config option; it will default to `auto` in 7.0
  * Deprecate not setting the `framework.session.cookie_samesite` config option; it will default to `lax` in 7.0
  * Deprecate not setting the `framework.session.handler_id` config option; it will default to `session.handler.native_file` when `framework.session.save_path` is set or `null` otherwise in 7.0
+ * Deprecate not setting the `framework.session.save_path` config option when `framework.session.handler_id` is not set; it will default to `null` in 7.0
  * Deprecate not setting the `framework.uid.default_uuid_version` config option; it will default to `7` in 7.0
  * Deprecate not setting the `framework.uid.time_based_uuid_version` config option; it will default to `7` in 7.0
  * Deprecate not setting the `framework.validation.email_validation_mode` config option; it will default to `html5` in 7.0

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -670,11 +670,19 @@ class Configuration implements ConfigurationInterface
                         }
 
                         if (!\array_key_exists('handler_id', $v['session'])) {
-                            trigger_deprecation('symfony/framework-bundle', '6.4', 'Not setting the "framework.session.handler_id" config option is deprecated. It will default to "session.handler.native_file" when "framework.session.save_path" is set or "null" otherwise in 7.0.');
+                            if (!\array_key_exists('save_path', $v['session'])) {
+                                trigger_deprecation('symfony/framework-bundle', '6.4', 'Not setting the "framework.session.save_path" config option when the "framework.session.handler_id" config option is not set either is deprecated. Both options will default to "null" in 7.0.');
+                            } else {
+                                trigger_deprecation('symfony/framework-bundle', '6.4', 'Not setting the "framework.session.handler_id" config option is deprecated. It will default to "session.handler.native_file" when "framework.session.save_path" is set or "null" otherwise in 7.0.');
+                            }
                         }
                     }
 
-                    $v['session'] += ['cookie_samesite' => null, 'handler_id' => 'session.handler.native_file'];
+                    $v['session'] += [
+                        'cookie_samesite' => null,
+                        'handler_id' => 'session.handler.native_file',
+                        'save_path' => '%kernel.cache_dir%/sessions',
+                    ];
 
                     return $v;
                 })
@@ -706,7 +714,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('gc_divisor')->end()
                         ->scalarNode('gc_probability')->defaultValue(1)->end()
                         ->scalarNode('gc_maxlifetime')->end()
-                        ->scalarNode('save_path')->defaultValue('%kernel.cache_dir%/sessions')->end()
+                        ->scalarNode('save_path')->end()
                         ->integerNode('metadata_update_threshold')
                             ->defaultValue(0)
                             ->info('seconds to wait between 2 session metadata updates')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is the follow-up of https://github.com/symfony/symfony/pull/51428#discussion_r1299750437