### PR TITLE
[Yaml] Fix parsing of block scalars in arrays

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -199,10 +199,15 @@ class Parser
                             || self::preg_match('#^(?P<key>'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\{\[].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $this->trimTag($values['value']), $matches)
                         )
                     ) {
-                        // this is a compact notation element, add to next block and parse
                         $block = $values['value'];
-                        if ($this->isNextLineIndented()) {
+                        if (isset($matches['value']) && $matches['value'] === '>-') {
+                            // this is a block scalar indicator. The real value is on the next lines.
                             $block .= "\n".$this->getNextEmbedBlock($this->getCurrentLineIndentation() + \strlen($values['leadspaces']) + 1);
+                        } else {
+                            // this is a compact notation element, add to next block and parse
+                            if ($this->isNextLineIndented()) {
+                                $block .= "\n".$this->getNextEmbedBlock($this->getCurrentLineIndentation() + \strlen($values['leadspaces']) + 1);
+                            }
                         }
 
                         $data[] = $this->parseBlock($this->getRealCurrentLineNb(), $block, $flags);

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -200,7 +200,7 @@ class Parser
                         )
                     ) {
                         $block = $values['value'];
-                        if (isset($matches['value']) && $matches['value'] === '>-') {
+                        if (isset($matches['value']) && '>-' === $matches['value']) {
                             // this is a block scalar indicator. The real value is on the next lines.
                             $block .= "\n".$this->getNextEmbedBlock($this->getCurrentLineIndentation() + \strlen($values['leadspaces']) + 1);
                         } else {

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2690,6 +2690,44 @@ YAML;
         return $tests;
     }
 
+    public function testBlockScalarArray()
+    {
+        $yaml = <<<'YAML'
+anyOf:
+  - $ref: >-
+      #/string/bar
+anyOfMultiline:
+  - $ref: >-
+      #/string/bar
+      second line
+nested:
+  anyOf:
+    - $ref: >-
+        #/string/bar
+YAML;
+        $expected = [
+            'anyOf' => [
+                0 => [
+                    '$ref' => '#/string/bar',
+                ],
+            ],
+            'anyOfMultiline' => [
+                0 => [
+                    '$ref' => '#/string/bar second line',
+                ],
+            ],
+            'nested' => [
+                'anyOf' => [
+                    0 => [
+                        '$ref' => '#/string/bar',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $this->parser->parse($yaml));
+    }
+
     /**
      * @dataProvider indentedMappingData
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4/6.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT


## Valid Yaml

```yaml
anyOf:
  - $ref: >-
      #/string/bar
nested:
  anyOf:
    - $ref: >-
        #/string/bar
```

## Failing Test diff
```diff
 Array &0 (
     'anyOf' => Array &1 (
         0 => Array &2 (
-            '$ref' => ''
+            '$ref' => '#/string/bar'
         )
     )
     'nested' => Array &5 (
         'anyOf' => Array &6 (
             0 => Array &7 (
-                '$ref' => ''
+                '$ref' => '#/string/bar'
             )
         )
     )
 )
```

## Notes
Similar cases that use block scalar folding are correctly handled by the parser. However, if the block scalar folding is in arrays the returned value is an empty string.

An example YAML file which is resulting in a broken parse is the Stripe OpenApi spec which [can be found here.](https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.yaml) There are exactly 100 broken values when parsed.

I didn't consider this as a BC break since I assume that an empty string as a return value is in no ones interest. Feel free to let me know if you think otherwise and want me to target another branch.