### PR TITLE
[Security] Do not call `UserBadge->setUserLoader(UserProvider...)` when the loader is already provided by `AccessTokenHandler` implementation

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -59,7 +59,7 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
         }
 
         $userBadge = $this->accessTokenHandler->getUserBadgeFrom($accessToken);
-        if ($this->userProvider) {
+        if (null === $userBadge->getUserLoader() && $this->userProvider) {
             $userBadge->setUserLoader($this->userProvider->loadUserByIdentifier(...));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51446
| License       | MIT
| Doc PR        | N/A

restore previous behavior to fix the linked issue

https://github.com/symfony/symfony/commit/99a35f0fc32a7b5250aab5530129bae318c95209#diff-de9707bb338188f62878f2ebd42e7a7bf9547f6d0bf07a4fcd9c386c263c601bL62-R62
