### PR TITLE
[Mailer] [Smtp] Add DSN param `peer_fingerprint` for fingerprint verification

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add DSN parameter `peer_fingerprint` to verify TLS certificate fingerprint
+
 6.3
 ---
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -110,6 +110,23 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
+        /** @var SocketStream $stream */
+        $stream = $transport->getStream();
+        $streamOptions = $stream->getStreamOptions();
+        $streamOptions['ssl']['peer_fingerprint'] = '6A1CF3B08D175A284C30BC10DE19162307C7286E';
+        $stream->setStreamOptions($streamOptions);
+
+        yield [
+            new Dsn('smtps', 'example.com', '', '', 465, ['peer_fingerprint' => '6A1CF3B08D175A284C30BC10DE19162307C7286E']),
+            $transport,
+        ];
+
+        yield [
+            Dsn::fromString('smtps://:@example.com?peer_fingerprint=6A1CF3B08D175A284C30BC10DE19162307C7286E'),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
         $transport->setLocalDomain('example.com');
 
         yield [

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -29,16 +29,20 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
 
         $transport = new EsmtpTransport($host, $port, $tls, $this->dispatcher, $this->logger);
 
-        if ('' !== $dsn->getOption('verify_peer') && !filter_var($dsn->getOption('verify_peer', true), \FILTER_VALIDATE_BOOL)) {
-            /** @var SocketStream $stream */
-            $stream = $transport->getStream();
-            $streamOptions = $stream->getStreamOptions();
+        /** @var SocketStream $stream */
+        $stream = $transport->getStream();
+        $streamOptions = $stream->getStreamOptions();
 
+        if ('' !== $dsn->getOption('verify_peer') && !filter_var($dsn->getOption('verify_peer', true), \FILTER_VALIDATE_BOOL)) {
             $streamOptions['ssl']['verify_peer'] = false;
             $streamOptions['ssl']['verify_peer_name'] = false;
-
-            $stream->setStreamOptions($streamOptions);
         }
+
+        if (null !== $peerFingerprint = $dsn->getOption('peer_fingerprint')) {
+            $streamOptions['ssl']['peer_fingerprint'] = $peerFingerprint;
+        }
+
+        $stream->setStreamOptions($streamOptions);
 
         if ($user = $dsn->getUser()) {
             $transport->setUsername($user);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#18778

This allows a more secure TLS connection for SMTP on even self-signed certificates, by verifying certificate fingerprint.
