### PR TITLE
[Validator] Un-deprecate passing an annotation reader to AnnotationLoader

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -157,7 +157,6 @@ Validator
 ---------
 
  * Deprecate Doctrine annotations support in favor of native attributes
- * Deprecate passing an annotation reader to the constructor signature of `AnnotationLoader`
  * Deprecate `ValidatorBuilder::setDoctrineAnnotationReader()`
  * Deprecate `ValidatorBuilder::addDefaultDoctrineAnnotationReader()`
  * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -7,7 +7,6 @@ CHANGELOG
  * Allow single integer for the `versions` option of the `Uuid` constraint
  * Allow single constraint to be passed to the `constraints` option of the `When` constraint
  * Deprecate Doctrine annotations support in favor of native attributes
- * Deprecate passing an annotation reader to the constructor signature of `AnnotationLoader`
  * Deprecate `ValidatorBuilder::setDoctrineAnnotationReader()`
  * Deprecate `ValidatorBuilder::addDefaultDoctrineAnnotationReader()`
  * Add `number`, `finite-number` and `finite-float` types to `Type` constraint

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -38,10 +38,6 @@ class AnnotationLoader implements LoaderInterface
 
     public function __construct(Reader $reader = null)
     {
-        if ($reader) {
-            trigger_deprecation('symfony/validator', '6.4', 'Passing a "%s" instance as argument 1 to "%s()" is deprecated, pass null or omit the parameter instead.', get_debug_type($reader), __METHOD__);
-        }
-
         $this->reader = $reader;
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -51,8 +51,6 @@ final class WhenTest extends TestCase
      */
     public function testAnnotations()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
-
         $loader = new AnnotationLoader(new AnnotationReader());
         $metadata = new ClassMetadata(WhenTestWithAnnotations::class);
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderWithHybridAnnotationsTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderWithHybridAnnotationsTest.php
@@ -18,56 +18,32 @@ use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 /**
  * @group legacy
  */
-class AnnotationLoaderWithHybridAnnotationsTest extends AnnotationLoaderTest
+class AnnotationLoaderWithHybridAnnotationsTest extends AttributeLoaderTest
 {
     use ExpectDeprecationTrait;
 
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Class "Symfony\Component\Validator\Tests\Fixtures\Attribute\Entity" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Attribute\Entity::$firstName" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
 
         parent::testLoadClassMetadataReturnsTrueIfSuccessful();
     }
 
-    public function testLoadClassMetadataReturnsFalseIfNotSuccessful()
-    {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
-
-        parent::testLoadClassMetadataReturnsFalseIfNotSuccessful();
-    }
-
     public function testLoadClassMetadata()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Class "Symfony\Component\Validator\Tests\Fixtures\Attribute\Entity" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Attribute\Entity::$firstName" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
 
         parent::testLoadClassMetadata();
     }
 
-    public function testLoadParentClassMetadata()
-    {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
-
-        parent::testLoadParentClassMetadata();
-    }
-
     public function testLoadClassMetadataAndMerge()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Class "Symfony\Component\Validator\Tests\Fixtures\Attribute\Entity" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Attribute\Entity::$firstName" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
 
         parent::testLoadClassMetadataAndMerge();
-    }
-
-    public function testLoadGroupSequenceProviderAnnotation()
-    {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
-
-        parent::testLoadGroupSequenceProviderAnnotation();
     }
 
     protected function createAnnotationLoader(): AnnotationLoader

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderWithLegacyAnnotationsTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderWithLegacyAnnotationsTest.php
@@ -18,13 +18,12 @@ use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 /**
  * @group legacy
  */
-class AnnotationLoaderWithLegacyAnnotationsTest extends AnnotationLoaderTest
+class AnnotationLoaderWithLegacyAnnotationsTest extends AttributeLoaderTest
 {
     use ExpectDeprecationTrait;
 
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Class "Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity::$firstName" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity::$childA" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
@@ -38,16 +37,8 @@ class AnnotationLoaderWithLegacyAnnotationsTest extends AnnotationLoaderTest
         parent::testLoadClassMetadataReturnsTrueIfSuccessful();
     }
 
-    public function testLoadClassMetadataReturnsFalseIfNotSuccessful()
-    {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
-
-        parent::testLoadClassMetadataReturnsFalseIfNotSuccessful();
-    }
-
     public function testLoadClassMetadata()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Class "Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity::$firstName" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity::$childA" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
@@ -63,7 +54,6 @@ class AnnotationLoaderWithLegacyAnnotationsTest extends AnnotationLoaderTest
 
     public function testLoadParentClassMetadata()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Annotation\EntityParent::$other" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
 
         parent::testLoadParentClassMetadata();
@@ -71,7 +61,6 @@ class AnnotationLoaderWithLegacyAnnotationsTest extends AnnotationLoaderTest
 
     public function testLoadClassMetadataAndMerge()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Annotation\EntityParent::$other" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Class "Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Property "Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity::$firstName" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
@@ -88,7 +77,6 @@ class AnnotationLoaderWithLegacyAnnotationsTest extends AnnotationLoaderTest
 
     public function testLoadGroupSequenceProviderAnnotation()
     {
-        $this->expectDeprecation('Since symfony/validator 6.4: Passing a "Doctrine\Common\Annotations\AnnotationReader" instance as argument 1 to "Symfony\Component\Validator\Mapping\Loader\AnnotationLoader::__construct()" is deprecated, pass null or omit the parameter instead.');
         $this->expectDeprecation('Since symfony/validator 6.4: Class "Symfony\Component\Validator\Tests\Fixtures\Annotation\GroupSequenceProviderEntity" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.');
 
         parent::testLoadGroupSequenceProviderAnnotation();

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -30,9 +30,10 @@ use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 
-class AnnotationLoaderTest extends TestCase
+class AttributeLoaderTest extends TestCase
 {
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
@@ -212,7 +213,7 @@ class AnnotationLoaderTest extends TestCase
 
     protected function createAnnotationLoader(): AnnotationLoader
     {
-        return new AnnotationLoader();
+        return new AttributeLoader();
     }
 
     protected function getFixtureNamespace(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Follow-up to #51425
| License       | MIT
| Doc PR        | N/A

#51425 deprecated the `AnnotationLoader` class and its replacement already does not accept an annotation reader anymore. Thus, the deprecation of the constructor parameter is redundant, which is why I propose to take it back.

cc @alexandre-daubois 