### PR TITLE
[HttpKernel] Fix checking for the runtime mode in DebugLoggerConfigurator

### DIFF
--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
@@ -22,7 +22,7 @@ class DebugLoggerConfigurator
 
     public function __construct(DebugLoggerInterface $processor, bool $enable = null)
     {
-        if ($enable ?? \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
+        if ($enable ?? !\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
             $this->processor = $processor;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixing #51284, my bad. Eating your own dog food works :)