### PR TITLE
[Console] Revert adding return type on Command::execute()

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -65,6 +65,13 @@ diff --git a/src/Symfony/Component/Console/Command/Command.php b/src/Symfony/Com
 +    protected function configure(): void
      {
      }
+@@ -181,5 +181,5 @@ class Command
+      * @see setCode()
+      */
+-    protected function execute(InputInterface $input, OutputInterface $output)
++    protected function execute(InputInterface $input, OutputInterface $output): int
+     {
+         throw new LogicException('You must override the execute() method in the concrete command class.');
 @@ -195,5 +195,5 @@ class Command
       * @return void
       */

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -180,7 +180,7 @@ class Command
      *
      * @see setCode()
      */
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         throw new LogicException('You must override the execute() method in the concrete command class.');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I tried running a Symfony v7 "webapp-pack" and this is all that is needed to not force doctrine to release new major versions to support it.