### PR TITLE
[HtmlSanitizer] Allow league/uri v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,6 +137,7 @@
         "egulias/email-validator": "^2.1.10|^3.1|^4",
         "guzzlehttp/promises": "^1.4",
         "league/html-to-markdown": "^5.0",
+        "league/uri": "^6.5|^7.0",
         "masterminds/html5": "^2.7.2",
         "monolog/monolog": "^1.25.1|^2",
         "nyholm/psr7": "^1.0",

--- a/src/Symfony/Component/HtmlSanitizer/composer.json
+++ b/src/Symfony/Component/HtmlSanitizer/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "ext-dom": "*",
-        "league/uri": "^6.5",
+        "league/uri": "^6.5|^7.0",
         "masterminds/html5": "^2.7.2"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR simply allows league/uri v7 to be installed.

The API did not change for the two static functions called by HtmlSanitizer.