### PR TITLE
[Messenger] Fix forced bus name gone after an error in delayed message handling

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/DelayedMessageHandlingException.php
+++ b/src/Symfony/Component/Messenger/Exception/DelayedMessageHandlingException.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Exception;
 
+use Symfony\Component\Messenger\Envelope;
+
 /**
  * When handling queued messages from {@link DispatchAfterCurrentBusMiddleware},
  * some handlers caused an exception. This exception contains all those handler exceptions.
@@ -20,9 +22,12 @@ namespace Symfony\Component\Messenger\Exception;
 class DelayedMessageHandlingException extends RuntimeException
 {
     private array $exceptions;
+    private Envelope $envelope;
 
-    public function __construct(array $exceptions)
+    public function __construct(array $exceptions, Envelope $envelope)
     {
+        $this->envelope = $envelope;
+
         $exceptionMessages = implode(", \n", array_map(
             fn (\Throwable $e) => $e::class.': '.$e->getMessage(),
             $exceptions
@@ -42,5 +47,10 @@ class DelayedMessageHandlingException extends RuntimeException
     public function getExceptions(): array
     {
         return $this->exceptions;
+    }
+
+    public function getEnvelope(): Envelope
+    {
+        return $this->envelope;
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -97,7 +97,7 @@ class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface
 
         $this->isRootDispatchCallRunning = false;
         if (\count($exceptions) > 0) {
-            throw new DelayedMessageHandlingException($exceptions);
+            throw new DelayedMessageHandlingException($exceptions, $returnedEnvelope);
         }
 
         return $returnedEnvelope;

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -22,6 +22,7 @@ use Symfony\Component\Messenger\Event\WorkerRateLimitedEvent;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
+use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\RejectRedeliveredMessageException;
 use Symfony\Component\Messenger\Exception\RuntimeException;
@@ -186,7 +187,7 @@ class Worker
                     $receiver->reject($envelope);
                 }
 
-                if ($e instanceof HandlerFailedException) {
+                if ($e instanceof HandlerFailedException || $e instanceof DelayedMessageHandlingException) {
                     $envelope = $e->getEnvelope();
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT


When consuming messages from an external source which do not have metadata/headers like bus name, you have to force the bus name with `--bus` in the `messenger:consume` command. However, if in the message handler you dispatch another message with `DispatchAfterCurrentBusStamp`, which then fails, end result is that the original message from external source is retried, but that forced bus name (`BusNameStamp`) is lost – so it will be retried on default bus instead. This isn't intended behavior, is it?

---

Not sure if changing `DelayedMessageHandlingException::__construct` signature is considered a BC break, it is not marked as internal so I am a bit worried :thinking: 
