### PR TITLE
[AssetMapper] Improve message when a downloaded asset is not found

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -412,7 +412,7 @@ class ImportMapManager
             if (null !== $entryOptions->path) {
                 if (!$asset = $this->assetMapper->getAsset($entryOptions->path)) {
                     if ($entryOptions->isDownloaded) {
-                        throw new \InvalidArgumentException(sprintf('The "%s" downloaded asset is missing. Run "php bin/console importmap:require "%s" --download".', $entryOptions->path, $entryOptions->importName));
+                        throw new \InvalidArgumentException(sprintf('The "%s" downloaded asset is missing. Run "php bin/console importmap:install".', $entryOptions->path));
                     }
 
                     throw new \InvalidArgumentException(sprintf('The asset "%s" mentioned in "%s" cannot be found in any asset map paths.', $entryOptions->path, basename($this->importMapConfigPath)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR improves the exception message introduced in #51337 by mentioning the command introduced in #51351.