### PR TITLE
[Workflow] deprecate `GuardEvent::getContext` method

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -162,3 +162,8 @@ Validator
  * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead
  * Deprecate `ValidatorBuilder::disableAnnotationMapping()`, use `ValidatorBuilder::disableAttributeMapping()` instead
  * Deprecate `AnnotationLoader`, use `AttributeLoader` instead
+
+Workflow
+--------
+
+* Deprecate `GuardEvent::getContext()` method that will be removed in 7.0

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add a profiler
  * Add support for multiline descriptions in PlantUML diagrams
  * Add PHP attributes to register listeners and guards
+ * Deprecate `GuardEvent::getContext()` method that will be removed in 7.0
 
 6.2
 ---

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -32,6 +32,13 @@ final class GuardEvent extends Event
         $this->transitionBlockerList = new TransitionBlockerList();
     }
 
+    public function getContext(): array
+    {
+        trigger_deprecation('symfony/workflow', '6.4', 'The %s::getContext() method is deprecated and will be removed in 7.0. You should no longer call this method as it always returns an empty array when invoked within a guard listener.', __CLASS__);
+
+        return parent::getContext();
+    }
+
     public function getTransition(): Transition
     {
         return parent::getTransition();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

As discussed with @lyrixx, this method is confusing as the context given as the 3rd argument to the `WorflowInterface::appy()` method is never passed along to the guard events. According to @lyrixx, the guard listeners must take any decisions based on the subject itself and not on the given contextual data (which are supposed to remain metadata). As a consequence, calling the `getContext` method on a `GuardEvent` object always returns an empty context.

To prevent confusion and lower the BC breakage in 7.x, we advocate for deprecating this method in 6.4 and make it throw an exception in 7.0. Application codes should not call this method anyway as it always returns an empty array.

EDIT: a second approach in Symfony 7.x is to remove the `getContext` method from the base abstract class and reimplement it as a dedicated trait that is used by all the other event classes except `GuardEvent`. This approach is probably a bit cleaner as the method will completly be dropped from the `GuardEvent` class scope.

Any thoughts?