### PR TITLE
Update the list of sponsors for Symfony 6.4 🙏

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,32 +17,19 @@ Installation
 Sponsor
 -------
 
-Symfony 6.3 is [backed][27] by
+Symfony 6.4 is [backed][27] by
 - [SensioLabs][28]
-- [Shopware][29]
-- [Les-Tilleuls.coop][30]
-- [basecom][31]
+- [packagist.com][29]
 
 As the creator of Symfony, **SensioLabs** supports companies using Symfony,
 with an offering encompassing consultancy, expertise, services, training, and
 technical assistance to ensure the success of web application development projects.
 
-**Shopware** offers you cutting-edge, highly adaptable ecommerce solutions trusted
-by the world's most acclaimed brands. Create outstanding customer experiences,
-innovate fast, and accelerate your growth in the ever-evolving space of digital
-commerce. You decide how far you want to go, and we'll be by your side.
+Private **Packagist.com** is a fast, reliable, and secure Composer repository for
+your private packages. It mirrors all your open-source dependencies for better
+availability and monitors them for security vulnerabilities.
 
-**Les-Tilleuls.coop** is a team of 70+ Symfony experts who can help you design,
-develop and fix your projects. We provide a wide range of professional services
-including development, consulting, coaching, training and audits. We also are
-highly skilled in JS, Go and DevOps. We are a worker cooperative!
-
-As a professional software service provider, **basecom** implements customized
-solutions in the areas of e-commerce, PIM solutions and web portals. With their
-experience and certified expertise, they have been one of the most renowned
-Symfony specialists in Germany for many years.
-
-Help Symfony by [sponsoring][32] its development!
+Help Symfony by [sponsoring][30] its development!
 
 Documentation
 -------------
@@ -106,7 +93,5 @@ and supported by [Symfony contributors][19].
 [26]: https://symfony.com/book
 [27]: https://symfony.com/backers
 [28]: https://sensiolabs.com
-[29]: https://www.shopware.com
-[30]: https://les-tilleuls.coop
-[31]: https://basecom.de
-[32]: https://symfony.com/sponsor
+[29]: https://packagist.com
+[30]: https://symfony.com/sponsor

--- a/src/Symfony/Bundle/FrameworkBundle/README.md
+++ b/src/Symfony/Bundle/FrameworkBundle/README.md
@@ -7,15 +7,7 @@ Symfony full-stack framework.
 Sponsor
 -------
 
-The FrameworkBundle for Symfony 6.3 is [backed][1] by [alximy][2].
-
-A team of passionate humans from very different backgrounds, sharing their love of
-PHP, Symfony and its ecosystem. Their CTO, Expert developers, tech leads, can help
-you learn or develop the tools you need, and perform audits or tailored workshops.
-They value contributing to the Open Source community and are willing to mentor new
-contributors in their team or yours.
-
-Help Symfony by [sponsoring][3] its development!
+Help Symfony by [sponsoring][1] its development!
 
 Resources
 ---------
@@ -25,6 +17,4 @@ Resources
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
 
-[1]: https://symfony.com/backers
-[2]: https://alximy.io/
 [3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Console/README.md
+++ b/src/Symfony/Component/Console/README.md
@@ -7,14 +7,7 @@ interfaces.
 Sponsor
 -------
 
-The Console component for Symfony 6.3 is [backed][1] by [Les-Tilleuls.coop][2].
-
-Les-Tilleuls.coop is a team of 70+ Symfony experts who can help you design, develop and
-fix your projects. They provide a wide range of professional services including development,
-consulting, coaching, training and audits. They also are highly skilled in JS, Go and DevOps.
-They are a worker cooperative!
-
-Help Symfony by [sponsoring][3] its development!
+Help Symfony by [sponsoring][1] its development!
 
 Resources
 ---------
@@ -31,6 +24,4 @@ Credits
 `Resources/bin/hiddeninput.exe` is a third party binary provided within this
 component. Find sources and license at https://github.com/Seldaek/hidden-input.
 
-[1]: https://symfony.com/backers
-[2]: https://les-tilleuls.coop
-[3]: https://symfony.com/sponsor
+[1]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Messenger/README.md
+++ b/src/Symfony/Component/Messenger/README.md
@@ -7,7 +7,7 @@ other applications or via message queues.
 Sponsor
 -------
 
-The Messenger component for Symfony 6.2 is [backed][1] by [SensioLabs][2].
+The Messenger component for Symfony 6.4 is [backed][1] by [SensioLabs][2].
 
 As the creator of Symfony, SensioLabs supports companies using Symfony, with an
 offering encompassing consultancy, expertise, services, training, and technical

--- a/src/Symfony/Component/Notifier/README.md
+++ b/src/Symfony/Component/Notifier/README.md
@@ -6,19 +6,7 @@ The Notifier component sends notifications via one or more channels (email, SMS,
 Sponsor
 -------
 
-The Notifier component for Symfony 6.2 is [backed][1] by [Prisma Media][2].
-
-Prisma Media has become in 40 years the n°1 French publishing group, on print and
-digitally, with 20 flagship brands of the news magazines : Femme Actuelle, GEO,
-Capital, Gala or Télé-Loisirs… Today, more than 42 million French people are in
-contact with one of our brand each month, either by leafing through a magazine,
-surfing the web, subscribing one our mobile or tablet application or listening to
-our podcasts' series. Prisma Media has successfully transformed one's business
-model : from a historic player in the world of paper, it has become in 5 years
-one of the first publishers of multi-media editorial content, and one of the
-first creators of digital solutions.
-
-Help Symfony by [sponsoring][3] its development!
+Help Symfony by [sponsoring][1] its development!
 
 Resources
 ---------
@@ -29,6 +17,4 @@ Resources
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
 
-[1]: https://symfony.com/backers
-[2]: https://www.prismamedia.com
-[3]: https://symfony.com/sponsor
+[1]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Security/Core/README.md
+++ b/src/Symfony/Component/Security/Core/README.md
@@ -41,7 +41,7 @@ if (!$accessDecisionManager->decide($token, ['ROLE_ADMIN'])) {
 Sponsor
 -------
 
-The Security component for Symfony 6.3 is [backed][1] by [SymfonyCasts][2].
+The Security component for Symfony 6.4 is [backed][1] by [SymfonyCasts][2].
 
 Learn Symfony faster by watching real projects being built and actively coding
 along with them. SymfonyCasts bridges that learning gap, bringing you video

--- a/src/Symfony/Component/Security/Csrf/README.md
+++ b/src/Symfony/Component/Security/Csrf/README.md
@@ -7,7 +7,7 @@ The Security CSRF (cross-site request forgery) component provides a class
 Sponsor
 -------
 
-The Security component for Symfony 6.3 is [backed][1] by [SymfonyCasts][2].
+The Security component for Symfony 6.4 is [backed][1] by [SymfonyCasts][2].
 
 Learn Symfony faster by watching real projects being built and actively coding
 along with them. SymfonyCasts bridges that learning gap, bringing you video

--- a/src/Symfony/Component/Security/Http/README.md
+++ b/src/Symfony/Component/Security/Http/README.md
@@ -15,7 +15,7 @@ $ composer require symfony/security-http
 Sponsor
 -------
 
-The Security component for Symfony 6.3 is [backed][1] by [SymfonyCasts][2].
+The Security component for Symfony 6.4 is [backed][1] by [SymfonyCasts][2].
 
 Learn Symfony faster by watching real projects being built and actively coding
 along with them. SymfonyCasts bridges that learning gap, bringing you video

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/README.md
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/README.md
@@ -23,11 +23,7 @@ where:
 Sponsor
 -------
 
-This bridge for Symfony 6.3 is [backed][1] by [Crowdin][2].
-
-Crowdin is a cloud-based localization management software helping teams to go global and stay agile.
-
-Help Symfony by [sponsoring][3] its development!
+Help Symfony by [sponsoring][1] its development!
 
 Resources
 ---------
@@ -37,6 +33,4 @@ Resources
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
 
-[1]: https://symfony.com/backers
-[2]: https://crowdin.com
-[3]: https://symfony.com/sponsor
+[1]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Translation/README.md
+++ b/src/Symfony/Component/Translation/README.md
@@ -26,11 +26,7 @@ echo $translator->trans('Hello World!'); // outputs « Bonjour ! »
 Sponsor
 -------
 
-The Translation component for Symfony 6.3 is [backed][1] by:
-
- * [Crowdin][2], a cloud-based localization management software helping teams to go global and stay agile.
-
-Help Symfony by [sponsoring][3] its development!
+Help Symfony by [sponsoring][1] its development!
 
 Resources
 ---------
@@ -41,6 +37,4 @@ Resources
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
 
-[1]: https://symfony.com/backers
-[2]: https://crowdin.com
-[3]: https://symfony.com/sponsor
+[1]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Workflow/README.md
+++ b/src/Symfony/Component/Workflow/README.md
@@ -7,18 +7,7 @@ machine.
 Sponsor
 -------
 
-The Workflow component for Symfony 6.2 is [backed][1] by [bitExpert][2].
-
-Their pulse is cross-technology software development that beats with every line of code.
-The basic principle for their solutions, products, and services is innovation, quality,
-commitment, and professionalism.
-
-bitExpert actively supports Open-Source and the software development community through various
-activities: Contributing to the Open-Source projects they love, organizing & hosting meetups,
-speaking at conferences, and organizing unKonf - an unconference focused on web
-and software development practices.
-
-Help Symfony by [sponsoring][3] its development!
+Help Symfony by [sponsoring][1] its development!
 
 Resources
 ---------
@@ -29,6 +18,4 @@ Resources
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
 
-[1]: https://symfony.com/backers
-[2]: https://www.bitexpert.de
-[3]: https://symfony.com/sponsor
+[1]: https://symfony.com/sponsor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Symfony 6.4 LTS is sponsored by:
- packagist.com :package: @naderman @Seldaek 
- SensioLabs :green_heart: 

But also by SymfonyCasts for the Security components @weaverryan 

:pray: 

We are [looking for more sponsors](https://symfony.com/blog/symfony-sponsoring-program) !

I invite anyone interested in sponsoring any versions x components of Symfony to [reach us ASAP](https://symfony.com/support?product=SFB#products) (I removed sponsors of 6.3 but I'm sure some of them would be happy to renew ;) .)

(Note that I'm personally going to be AFK for the next 2 weeks :palm_tree: .)