### PR TITLE
[Mime] Fix email (de)serialization issues

### DIFF
--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -156,7 +156,7 @@ class DataPart extends TextPart
             throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
         }
         foreach (['body', 'charset', 'subtype', 'disposition', 'name', 'encoding'] as $name) {
-            if (null !== $this->_parent[$name] && !\is_string($this->_parent[$name])) {
+            if (null !== $this->_parent[$name] && !\is_string($this->_parent[$name]) && !$this->_parent[$name] instanceof File) {
                 throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
             }
             $r = new \ReflectionProperty(TextPart::class, $name);

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -226,7 +226,7 @@ class TextPart extends AbstractPart
     public function __sleep(): array
     {
         // convert resources to strings for serialization
-        if (null !== $this->seekable || $this->body instanceof File) {
+        if (null !== $this->seekable) {
             $this->body = $this->getBody();
             $this->seekable = null;
         }

--- a/src/Symfony/Component/Mime/Tests/Fixtures/foo_attachment.txt
+++ b/src/Symfony/Component/Mime/Tests/Fixtures/foo_attachment.txt
@@ -1,0 +1,1 @@
+foo_bar_xyz_123


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47991
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/pull/48156 fixed https://github.com/symfony/symfony/issues/47991 while introducing a big breaking change (the `File` lazy load feature is broken and that was the whole point of that class when it was introduced in https://github.com/symfony/symfony/pull/47462 as that feature existed even prior to that PR) on a minor Symfony version (updating from 6.1 to 6.2 broke our application). More context can be found here: https://github.com/symfony/symfony/pull/48156#issuecomment-1693489346

This PR aims to revert back the `attachFromPath` behavior to what it was before https://github.com/symfony/symfony/pull/48156 while still fixing the deserialization issue reported in #47991

The first commit fixes the serialization logic to work the same way it had worked on both 5.4 and 6.1 (which means we are reverting https://github.com/symfony/symfony/pull/48156), while the second commit fixes the deserialization issue reported in #47991.

I've also added tests to prevent serialization/deserialization regressions in the future.
