### PR TITLE
Remove `GuardEvent::getContext()` method and add `HasContextTrait` trait

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -490,6 +490,7 @@ Workflow
 --------
 
  * Require explicit argument when calling `Definition::setInitialPlaces()`
+ * `GuardEvent::getContext()` method has been removed. Method was not supposed to be called within guard event listeners as it always returned an empty array anyway.
 
 Yaml
 ----

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Require explicit argument when calling `Definition::setInitialPlaces()`
+ * `GuardEvent::getContext()` method has been removed. Method was not supposed to be called within guard event listeners as it always returned an empty array anyway.
 
 6.4
 ---

--- a/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
+++ b/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
@@ -11,6 +11,18 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+
 final class AnnounceEvent extends Event
 {
+    use HasContextTrait;
+
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
+    {
+        parent::__construct($subject, $marking, $transition, $workflow);
+
+        $this->context = $context;
+    }
 }

--- a/src/Symfony/Component/Workflow/Event/CompletedEvent.php
+++ b/src/Symfony/Component/Workflow/Event/CompletedEvent.php
@@ -11,6 +11,18 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+
 final class CompletedEvent extends Event
 {
+    use HasContextTrait;
+
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
+    {
+        parent::__construct($subject, $marking, $transition, $workflow);
+
+        $this->context = $context;
+    }
 }

--- a/src/Symfony/Component/Workflow/Event/EnterEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnterEvent.php
@@ -11,6 +11,18 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+
 final class EnterEvent extends Event
 {
+    use HasContextTrait;
+
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
+    {
+        parent::__construct($subject, $marking, $transition, $workflow);
+
+        $this->context = $context;
+    }
 }

--- a/src/Symfony/Component/Workflow/Event/EnteredEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnteredEvent.php
@@ -11,6 +11,18 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+
 final class EnteredEvent extends Event
 {
+    use HasContextTrait;
+
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
+    {
+        parent::__construct($subject, $marking, $transition, $workflow);
+
+        $this->context = $context;
+    }
 }

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -23,20 +23,17 @@ use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
  */
 class Event extends BaseEvent
 {
-    protected array $context;
-
     private object $subject;
     private Marking $marking;
     private ?Transition $transition;
     private ?WorkflowInterface $workflow;
 
-    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null)
     {
         $this->subject = $subject;
         $this->marking = $marking;
         $this->transition = $transition;
         $this->workflow = $workflow;
-        $this->context = $context;
     }
 
     public function getMarking(): Marking
@@ -67,10 +64,5 @@ class Event extends BaseEvent
     public function getMetadata(string $key, string|Transition|null $subject): mixed
     {
         return $this->workflow->getMetadataStore()->getMetadata($key, $subject);
-    }
-
-    public function getContext(): array
-    {
-        return $this->context;
     }
 }

--- a/src/Symfony/Component/Workflow/Event/HasContextTrait.php
+++ b/src/Symfony/Component/Workflow/Event/HasContextTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Event;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Hugo Hamon <hugohamon@neuf.fr>
+ *
+ * @internal
+ */
+trait HasContextTrait
+{
+    private array $context = [];
+
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+}

--- a/src/Symfony/Component/Workflow/Event/LeaveEvent.php
+++ b/src/Symfony/Component/Workflow/Event/LeaveEvent.php
@@ -11,6 +11,18 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+
 final class LeaveEvent extends Event
 {
+    use HasContextTrait;
+
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
+    {
+        parent::__construct($subject, $marking, $transition, $workflow);
+
+        $this->context = $context;
+    }
 }

--- a/src/Symfony/Component/Workflow/Event/TransitionEvent.php
+++ b/src/Symfony/Component/Workflow/Event/TransitionEvent.php
@@ -11,8 +11,21 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+
 final class TransitionEvent extends Event
 {
+    use HasContextTrait;
+
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
+    {
+        parent::__construct($subject, $marking, $transition, $workflow);
+
+        $this->context = $context;
+    }
+
     public function setContext(array $context): void
     {
         $this->context = $context;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Related to #51484
| License       | MIT
| Doc PR        | ~

As discussed with @lyrixx, the `GuardEvent::getContext` method was confusing as the context given as the 3rd argument to the WorflowInterface::appy() method is never passed along to the guard events. According to @lyrixx, the guard listeners must take any decisions based on the subject itself and not on the given contextual data (which are supposed to remain metadata). As a consequence, calling the `GuardEvent::getContext()` method always returned an empty context array so far.

To prevent this confusion any longer, the method has been deprecated in Symfony 6.4 (see #51484) and removed in this PR. The `GuardEvent` class hierarchy no longer has the `getContext` method while other event classes keep having it.