### PR TITLE
Fixed attachment base64 content string in MailerSendApiTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
@@ -147,7 +147,7 @@ final class MailerSendApiTransport extends AbstractApiTransport
             $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
 
             $att = [
-                'content' => $attachment->bodyToString(),
+                'content' => base64_encode($attachment->getBody()),
                 'filename' => $filename,
             ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51492
| License       | MIT

- Fix base64 encoded body string of larger attachments in MailerSendApiTransport