### PR TITLE
[Security] Remove `isAuthenticated` and `setAuthenticated` token methods in tests

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -563,15 +563,6 @@ class CustomToken implements TokenInterface
         return $this->getUserIdentifier();
     }
 
-    public function isAuthenticated(): bool
-    {
-        return true;
-    }
-
-    public function setAuthenticated(bool $isAuthenticated)
-    {
-    }
-
     public function eraseCredentials(): void
     {
     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

`isAuthenticated` and `setAuthenticated` methods are not in TokenInterface anymore, so we can remove it in tests

