### PR TITLE
Remove `getUsername` methods in tests

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/BaseUser.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/BaseUser.php
@@ -42,11 +42,6 @@ class BaseUser
         return $this->id;
     }
 
-    public function getUsername(): string
-    {
-        return $this->username;
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->username;

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
@@ -44,11 +44,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
     }
 
-    public function getUsername(): string
-    {
-        return $this->name;
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->name;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -207,11 +207,6 @@ final class UserWithoutEquatable implements UserInterface, PasswordAuthenticated
         return '';
     }
 
-    public function getUsername(): string
-    {
-        return $this->username;
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->username;

--- a/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestLegacyPasswordAuthenticatedUser.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestLegacyPasswordAuthenticatedUser.php
@@ -41,11 +41,6 @@ final class TestLegacyPasswordAuthenticatedUser implements LegacyPasswordAuthent
         return;
     }
 
-    public function getUsername(): string
-    {
-        return $this->username;
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->username;

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
@@ -199,10 +199,6 @@ class SomeUser implements PasswordAuthenticatedUserInterface
     {
     }
 
-    public function getUsername(): string
-    {
-    }
-
     public function getUserIdentifier(): string
     {
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -115,10 +115,6 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
-    public function getUsername(): string
-    {
-    }
-
     public function getUserIdentifier(): string
     {
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Fixtures/CustomUser.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Fixtures/CustomUser.php
@@ -17,11 +17,6 @@ final class CustomUser implements UserInterface
         $this->roles = $roles;
     }
 
-    public function getUsername(): string
-    {
-        return $this->username;
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->username;

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -175,10 +175,6 @@ class DummyTestPasswordAuthenticatedUser extends TestPasswordAuthenticatedUser
     {
     }
 
-    public function getUsername(): string
-    {
-    }
-
     public function getUserIdentifier(): string
     {
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -552,11 +552,6 @@ class CustomToken implements TokenInterface
         $this->user = $user;
     }
 
-    public function getUsername(): string
-    {
-        return $this->user->getUserIdentifier();
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->getUserIdentifier();

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -289,11 +289,6 @@ class TestLoginLinkHandlerUser implements UserInterface
         return '';
     }
 
-    public function getUsername(): string
-    {
-        return $this->username;
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->username;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This is allowed thanks to bumps to `^6.4|^7.0` in composer.json on 7.0 branch
