### PR TITLE
[Validator] Remove `final` modifier on `PasswordStrength` and `PasswordStrengthValidator`

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead
  * Deprecate `ValidatorBuilder::disableAnnotationMapping()`, use `ValidatorBuilder::disableAttributeMapping()` instead
  * Deprecate `AnnotationLoader`, use `AttributeLoader` instead
+ * Remove `final` modifier on `PasswordStrength` and `PasswordStrengthValidator`
 
 6.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  * @author Florent Morselli <florent.morselli@spomky-labs.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final class PasswordStrength extends Constraint
+class PasswordStrength extends Constraint
 {
     public const STRENGTH_VERY_WEAK = 0;
     public const STRENGTH_WEAK = 1;

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
-final class PasswordStrengthValidator extends ConstraintValidator
+class PasswordStrengthValidator extends ConstraintValidator
 {
     /**
      * @param (\Closure(string):PasswordStrength::STRENGTH_*)|null $passwordStrengthEstimator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51439
| License       | MIT
| Doc PR        | -

More than allowing the author to do what is specified in the ticket, I see several benefits in making this change:

- I can see no validator declared `final` other than `WhenValidator` (this may be another subject but not the main one here). Such change would bring consistency to the code.
- Same for the constraint itself: none is declared final other than `PasswordStrength` at this time
- If we'd like to extend the scale of password strength but still use `PasswordStrength` (but also use its public constants), we're currently blocked as the constructor restricts the `minScore` to be between 1 and 4. These values are hard-coded and not-configurable.
- Removing `final` from the validator class `PasswordStrengthValidator` would greatly help to implement any `PasswordStrength` child validator. Indeed, we could extend this validator by passing a closure to evaluate the password strength with the extended strength scale.

Note that I kept `estimateStrength()` private instead of mutating it to protected, as I can't see any advantage of redefining it when a closure is allowed to be passed in the validator constructor.