### PR TITLE
[Messenger] Fix routing to multiple fallback transports

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -56,17 +56,19 @@ class SendersLocatorTest extends TestCase
     {
         $firstSender = $this->createMock(SenderInterface::class);
         $secondSender = $this->createMock(SenderInterface::class);
+        $thirdSender = $this->createMock(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'first' => $firstSender,
             'second' => $secondSender,
+            'third' => $thirdSender,
         ]);
         $locator = new SendersLocator([
             DummyMessage::class => ['first'],
-            '*' => ['second'],
+            '*' => ['second', 'third'],
         ], $sendersLocator);
 
         $this->assertSame(['first' => $firstSender], iterator_to_array($locator->getSenders(new Envelope(new DummyMessage('a')))), 'Unexpected senders for configured message');
-        $this->assertSame(['second' => $secondSender], iterator_to_array($locator->getSenders(new Envelope(new SecondMessage()))), 'Unexpected senders for unconfigured message');
+        $this->assertSame(['second' => $secondSender, 'third' => $thirdSender], iterator_to_array($locator->getSenders(new Envelope(new SecondMessage()))), 'Unexpected senders for unconfigured message');
     }
 
     private function createContainer(array $senders): ContainerInterface

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -50,13 +50,13 @@ class SendersLocator implements SendersLocatorInterface
         $seen = [];
 
         foreach (HandlersLocator::listTypes($envelope) as $type) {
-            foreach ($this->sendersMap[$type] ?? [] as $senderAlias) {
-                if (str_ends_with($type, '*') && $seen) {
-                    // the '*' acts as a fallback, if other senders already matched
-                    // with previous types, skip the senders bound to the fallback
-                    continue;
-                }
+            if (str_ends_with($type, '*') && $seen) {
+                // the '*' acts as a fallback, if other senders already matched
+                // with previous types, skip the senders bound to the fallback
+                continue;
+            }
 
+            foreach ($this->sendersMap[$type] ?? [] as $senderAlias) {
                 if (!\in_array($senderAlias, $seen, true)) {
                     $seen[] = $senderAlias;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The change made in https://github.com/symfony/symfony/pull/48121 means that it's not possible to route into multiple transport as fallback like

```yaml
framework:
  messenger:
    routing:
      My\Message\*: [async, audit]
```

F.e. the message `My\Message\ToBeSentToTwoSenders` would only reach `async`.

The comment in the code mentions 

> if other senders already matched **with previous types**, skip the senders bound to the fallback

While in reality how it works is

> if other senders already matched, skip the senders bound to the fallback

After the changes in this MR it works as mentioned in the original comment, meaning it does not skip for the same type, but routes to all transports for that type.

---

This is not a BC break because anyone who has more than one transport in a wildcard rule has never received anything matching the wildcard on other than the 1st transport – so only if you had a misconfiguration in the first place you're affected.
