### PR TITLE
[PasswordHasher] Avoid passing `null` to `hash_pbkdf2()`

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/Pbkdf2PasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/Pbkdf2PasswordHasher.php
@@ -69,7 +69,7 @@ final class Pbkdf2PasswordHasher implements LegacyPasswordHasherInterface
             throw new LogicException(sprintf('The algorithm "%s" is not supported.', $this->algorithm));
         }
 
-        $digest = hash_pbkdf2($this->algorithm, $plainPassword, $salt, $this->iterations, $this->length, true);
+        $digest = hash_pbkdf2($this->algorithm, $plainPassword, $salt ?? '', $this->iterations, $this->length, true);
 
         return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Because https://www.php.net/manual/en/function.hash-pbkdf2.php is expecting `string` and not `?string`. Pertmits avoiding deprecation warning.