### PR TITLE
[Serializer] Add Default and "class name" default groups

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -38,11 +38,15 @@ class SerializerExtractor implements PropertyListExtractorInterface
             return null;
         }
 
+        $groups = $context['serializer_groups'] ?? [];
+        $groupsHasBeenDefined = [] !== $groups;
+        $groups = array_merge($groups, ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class]);
+
         $properties = [];
         $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            if (!$serializerAttributeMetadata->isIgnored() && (null === $context['serializer_groups'] || array_intersect($context['serializer_groups'], $serializerAttributeMetadata->getGroups()))) {
+            if (!$serializerAttributeMetadata->isIgnored() && (!$groupsHasBeenDefined || array_intersect(array_merge($serializerAttributeMetadata->getGroups(), ['*']), $groups))) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -43,6 +43,8 @@ class SerializerExtractorTest extends TestCase
     public function testGetPropertiesWithIgnoredProperties()
     {
         $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['a']]));
+        $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['Default']]));
+        $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['IgnorePropertyDummy']]));
     }
 
     public function testGetPropertiesWithAnyGroup()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/IgnorePropertyDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/IgnorePropertyDummy.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Attribute\Ignore;
  */
 class IgnorePropertyDummy
 {
-    #[Groups(['a'])]
+    #[Groups(['a', 'Default', 'IgnorePropertyDummy'])]
     public $visibleProperty;
 
     #[Groups(['a']), Ignore]

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `DateTimeNormalizer::CAST_KEY` context option
+ * Add `Default` and "class name" default groups
 
 7.0
 ---

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -128,13 +128,16 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             }
 
             $metadataGroups = $metadata->getGroups();
-            $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
 
-            if ($contextGroups && !$metadataGroups) {
+            $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
+            $contextGroupsHasBeenDefined = [] !== $contextGroups;
+            $contextGroups = array_merge($contextGroups, ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class]);
+
+            if ($contextGroupsHasBeenDefined && !$metadataGroups) {
                 continue;
             }
 
-            if ($metadataGroups && !array_intersect($metadataGroups, $contextGroups) && !\in_array('*', $contextGroups, true)) {
+            if ($metadataGroups && !array_intersect(array_merge($metadataGroups, ['*']), $contextGroups)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
@@ -27,6 +27,10 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     protected $quux;
     private $fooBar;
     private $symfony;
+    #[Groups(['Default'])]
+    private $default;
+    #[Groups(['GroupDummy'])]
+    private $className;
 
     #[Groups(['b'])]
     public function setBar($bar)
@@ -79,5 +83,25 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     public function setQuux($quux): void
     {
         $this->quux = $quux;
+    }
+
+    public function setDefault($default)
+    {
+        $this->default = $default;
+    }
+
+    public function getDefault()
+    {
+        return $this->default;
+    }
+
+    public function setClassName($className)
+    {
+        $this->className = $className;
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
@@ -63,6 +63,14 @@ class TestClassMetadataFactory
             $symfony->addGroup('name_converter');
         }
 
+        $default = new AttributeMetadata('default');
+        $default->addGroup('Default');
+        $expected->addAttributeMetadata($default);
+
+        $className = new AttributeMetadata('className');
+        $className->addGroup('GroupDummy');
+        $expected->addAttributeMetadata($className);
+
         // load reflection class so that the comparison passes
         $expected->getReflectionClass();
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/GroupsTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/GroupsTestTrait.php
@@ -31,13 +31,18 @@ trait GroupsTestTrait
         $obj = new GroupDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
+        $obj->setQuux('quux');
         $obj->setFooBar('fooBar');
         $obj->setSymfony('symfony');
         $obj->setKevin('kevin');
         $obj->setCoopTilleuls('coopTilleuls');
+        $obj->setDefault('default');
+        $obj->setClassName('className');
 
         $this->assertEquals([
             'bar' => 'bar',
+            'default' => 'default',
+            'className' => 'className',
         ], $normalizer->normalize($obj, null, ['groups' => ['c']]));
 
         $this->assertEquals([
@@ -47,7 +52,26 @@ trait GroupsTestTrait
             'bar' => 'bar',
             'kevin' => 'kevin',
             'coopTilleuls' => 'coopTilleuls',
+            'default' => 'default',
+            'className' => 'className',
         ], $normalizer->normalize($obj, null, ['groups' => ['a', 'c']]));
+
+        $this->assertEquals([
+            'default' => 'default',
+            'className' => 'className',
+        ], $normalizer->normalize($obj, null, ['groups' => ['unknown']]));
+
+        $this->assertEquals([
+            'quux' => 'quux',
+            'symfony' => 'symfony',
+            'foo' => 'foo',
+            'fooBar' => 'fooBar',
+            'bar' => 'bar',
+            'kevin' => 'kevin',
+            'coopTilleuls' => 'coopTilleuls',
+            'default' => 'default',
+            'className' => 'className',
+        ], $normalizer->normalize($obj));
     }
 
     public function testGroupsDenormalize()
@@ -55,27 +79,49 @@ trait GroupsTestTrait
         $normalizer = $this->getDenormalizerForGroups();
 
         $obj = new GroupDummy();
+        $obj->setDefault('default');
+        $obj->setClassName('className');
+
+        $data = [
+            'foo' => 'foo',
+            'bar' => 'bar',
+            'quux' => 'quux',
+            'default' => 'default',
+            'className' => 'className',
+        ];
+
+        $denormalized = $normalizer->denormalize(
+            $data,
+            GroupDummy::class,
+            null,
+            ['groups' => ['unknown']]
+        );
+        $this->assertEquals($obj, $denormalized);
+
         $obj->setFoo('foo');
 
-        $data = ['foo' => 'foo', 'bar' => 'bar'];
-
-        $normalized = $normalizer->denormalize(
+        $denormalized = $normalizer->denormalize(
             $data,
             GroupDummy::class,
             null,
             ['groups' => ['a']]
         );
-        $this->assertEquals($obj, $normalized);
+        $this->assertEquals($obj, $denormalized);
 
         $obj->setBar('bar');
 
-        $normalized = $normalizer->denormalize(
+        $denormalized = $normalizer->denormalize(
             $data,
             GroupDummy::class,
             null,
             ['groups' => ['a', 'b']]
         );
-        $this->assertEquals($obj, $normalized);
+        $this->assertEquals($obj, $denormalized);
+
+        $obj->setQuux('quux');
+
+        $denormalized = $normalizer->denormalize($data, GroupDummy::class);
+        $this->assertEquals($obj, $denormalized);
     }
 
     public function testNormalizeNoPropertyInGroup()
@@ -84,7 +130,12 @@ trait GroupsTestTrait
 
         $obj = new GroupDummy();
         $obj->setFoo('foo');
+        $obj->setDefault('default');
+        $obj->setClassName('className');
 
-        $this->assertEquals([], $normalizer->normalize($obj, null, ['groups' => ['notExist']]));
+        $this->assertEquals([
+            'default' => 'default',
+            'className' => 'className',
+        ], $normalizer->normalize($obj, null, ['groups' => ['notExist']]));
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -295,6 +295,8 @@ class GetSetMethodNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
+                'default' => null,
+                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [GetSetMethodNormalizer::GROUPS => ['name_converter']])
         );

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -482,6 +482,8 @@ class ObjectNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
+                'default' => null,
+                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [ObjectNormalizer::GROUPS => ['name_converter']])
         );

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -184,7 +184,18 @@ class PropertyNormalizerTest extends TestCase
         $group->setKevin('Kevin');
         $group->setCoopTilleuls('coop');
         $this->assertEquals(
-            ['foo' => 'foo', 'bar' => 'bar', 'quux' => 'quux', 'kevin' => 'Kevin', 'coopTilleuls' => 'coop', 'fooBar' => null, 'symfony' => null, 'baz' => 'baz'],
+            [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'quux' => 'quux',
+                'kevin' => 'Kevin',
+                'coopTilleuls' => 'coop',
+                'fooBar' => null,
+                'symfony' => null,
+                'baz' => 'baz',
+                'default' => null,
+                'className' => null,
+            ],
             $this->normalizer->normalize($group, 'any')
         );
     }
@@ -303,6 +314,8 @@ class PropertyNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
+                'default' => null,
+                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [PropertyNormalizer::GROUPS => ['name_converter']])
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #32622
| License       | MIT
| Doc PR        | TODO

Add `Default` and "class name" groups to the (de)normalization context, following Validator's component naming convention.
