### PR TITLE
[HttpClient] Fix Static Code Analyzer issue with JsonMockResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
@@ -15,6 +15,9 @@ use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 
 class JsonMockResponse extends MockResponse
 {
+    /**
+     * @param mixed $body Any value that `json_encode()` can serialize
+     */
     public function __construct(mixed $body = [], array $info = [])
     {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes (only Static Code Analyzer)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The `JsonMockResponse` will inherit the `PHPDoc` from the MockResponse class when not explicit defined.

See https://phpstan.org/r/a3174b75-4b0c-4c15-918f-afdfab4da7a4