### PR TITLE
[AssetMapper] Allow specifying packages to update with importmap:update

### DIFF
--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Mark the component as non experimental
  * Add a `importmap:install` command to download all missing downloaded packages
+ * Allow specifying packages to update for the `importmap:update` command
 
 6.3
 ---

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -88,7 +88,7 @@ class ImportMapManager
      */
     public function require(array $packages): array
     {
-        return $this->updateImportMapConfig(false, $packages, []);
+        return $this->updateImportMapConfig(false, $packages, [], []);
     }
 
     /**
@@ -98,15 +98,17 @@ class ImportMapManager
      */
     public function remove(array $packages): void
     {
-        $this->updateImportMapConfig(false, [], $packages);
+        $this->updateImportMapConfig(false, [], $packages, []);
     }
 
     /**
-     * Updates all existing packages to the latest version.
+     * Updates either all existing packages or the specified ones to the latest version.
+     *
+     * @return ImportMapEntry[]
      */
-    public function update(): array
+    public function update(array $packages = []): array
     {
-        return $this->updateImportMapConfig(true, [], []);
+        return $this->updateImportMapConfig(true, [], [], $packages);
     }
 
     /**
@@ -190,7 +192,7 @@ class ImportMapManager
      *
      * @return ImportMapEntry[]
      */
-    private function updateImportMapConfig(bool $update, array $packagesToRequire, array $packagesToRemove): array
+    private function updateImportMapConfig(bool $update, array $packagesToRequire, array $packagesToRemove, array $packagesToUpdate): array
     {
         $currentEntries = $this->loadImportMapEntries();
 
@@ -205,7 +207,7 @@ class ImportMapManager
 
         if ($update) {
             foreach ($currentEntries as $importName => $entry) {
-                if (null === $entry->url) {
+                if (null === $entry->url || (0 !== \count($packagesToUpdate) && !\in_array($importName, $packagesToUpdate, true))) {
                     continue;
                 }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -373,6 +373,64 @@ class ImportMapManagerTest extends TestCase
         $this->assertSame('contents of cowsay.js', $actualContents);
     }
 
+    public function testUpdateWithSpecificPackages()
+    {
+        $rootDir = __DIR__.'/../fixtures/importmaps_for_writing';
+        $manager = $this->createImportMapManager(['assets' => ''], $rootDir);
+
+        $map = [
+            'lodash' => [
+                'url' => 'https://ga.jspm.io/npm:lodash@1.2.3/lodash.js',
+            ],
+            'cowsay' => [
+                'url' => 'https://ga.jspm.io/npm:cowsay@4.5.6/cowsay.umd.js',
+                'downloaded_to' => 'vendor/cowsay.js',
+            ],
+            'bootstrap' => [
+                'url' => 'https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.esm.js',
+                'preload' => true,
+            ],
+            'app' => [
+                'path' => 'app.js',
+            ],
+        ];
+        $mapString = var_export($map, true);
+        file_put_contents($rootDir.'/importmap.php', "<?php\n\nreturn {$mapString};\n");
+        $this->filesystem->mkdir($rootDir.'/assets/vendor');
+        file_put_contents($rootDir.'/assets/vendor/cowsay.js', 'cowsay.js original contents');
+        file_put_contents($rootDir.'/assets/app.js', 'app.js contents');
+
+        $this->packageResolver->expects($this->once())
+            ->method('resolvePackages')
+            ->willReturn([
+                self::resolvedPackage('cowsay', 'https://ga.jspm.io/npm:cowsay@4.5.9/cowsay.umd.js', download: true, content: 'updated contents of cowsay.js'),
+            ])
+        ;
+
+        $manager->update(['cowsay']);
+        $actualImportMap = require $rootDir.'/importmap.php';
+        $expectedImportMap = [
+            'lodash' => [
+                'url' => 'https://ga.jspm.io/npm:lodash@1.2.3/lodash.js',
+            ],
+            'cowsay' => [
+                'url' => 'https://ga.jspm.io/npm:cowsay@4.5.9/cowsay.umd.js',
+                'downloaded_to' => 'vendor/cowsay.js',
+            ],
+            'bootstrap' => [
+                'url' => 'https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.esm.js',
+                'preload' => true,
+            ],
+            'app' => [
+                'path' => 'app.js',
+            ],
+        ];
+        $this->assertEquals($expectedImportMap, $actualImportMap);
+        $this->assertFileExists($rootDir.'/assets/vendor/cowsay.js');
+        $actualContents = file_get_contents($rootDir.'/assets/vendor/cowsay.js');
+        $this->assertSame('updated contents of cowsay.js', $actualContents);
+    }
+
     public function testDownloadMissingPackages()
     {
         $rootDir = __DIR__.'/../fixtures/download';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Currently, the `importmap:update` command updates all packages.

This PR allows specifying which packages the developer wants to update.