### PR TITLE
[PropertyInfo] Reset inner array cache to reduce memory usage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $container) {
         ->set('property_info.cache', PropertyInfoCacheExtractor::class)
             ->decorate('property_info')
             ->args([service('property_info.cache.inner'), service('cache.property_info')])
+            ->tag('kernel.reset', ['method' => 'reset'])
 
         // Extractor
         ->set('property_info.reflection_extractor', ReflectionExtractor::class)

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Adds a PSR-6 cache layer on top of an extractor.
@@ -20,7 +21,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * @final
  */
-class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, PropertyInitializableExtractorInterface
+class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, PropertyInitializableExtractorInterface, ResetInterface
 {
     private $propertyInfoExtractor;
     private $cacheItemPool;
@@ -86,6 +87,15 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     public function isInitializable(string $class, string $property, array $context = []): ?bool
     {
         return $this->extract('isInitializable', [$class, $property, $context]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        unset($this->arrayCache);
+        $this->arrayCache = [];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

For projects, where long running processes are used, `PropertyInfoCacheExtractor` slowly leaking memory due to inner array cache. 
Implemented `ResetInterface` to clear array cache when services resetter is called