### PR TITLE
[Mailer] [Mailgun] fix parsing of payload timestamp to event date value (DateTimeImmutable) in MailgunPayloadConverter

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php
@@ -50,8 +50,8 @@ final class MailgunPayloadConverter implements PayloadConverterInterface
             };
             $event = new MailerEngagementEvent($name, $payload['id'], $payload);
         }
-        if (!$date = \DateTimeImmutable::createFromFormat('U.u', $payload['timestamp'])) {
-            throw new ParseException(sprintf('Invalid date "%s".', $payload['timestamp']));
+        if (!$date = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $payload['timestamp']))) {
+            throw new ParseException(sprintf('Invalid date "%s".', sprintf('%.6F', $payload['timestamp'])));
         }
         $event->setDate($date);
         $event->setRecipientEmail($payload['recipient']);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/clicks.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/clicks.php
@@ -6,6 +6,6 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::CLICK, 'Ase7i2zsRYeDXztHG
 $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521243339.873676));
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521243339.873676'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/delivered_messages.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/delivered_messages.json
@@ -6,7 +6,7 @@
     },
     "event-data": {
         "id": "CPgfbmQMTCKtHW6uIWtuVe",
-        "timestamp": 1521472262.908181,
+        "timestamp": 1521472262.000002,
         "log-level": "info",
         "event": "delivered",
         "delivery-status": {

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/delivered_messages.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/delivered_messages.php
@@ -6,7 +6,7 @@ $wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, 'CPgfbmQMTCKtHW6uI
 $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521472262.908181));
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521472262.000002'));
 $wh->setReason('OK');
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/opens.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/opens.php
@@ -6,6 +6,6 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::OPEN, 'Ase7i2zsRYeDXztHGE
 $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521243339.873676));
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521243339.873676'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/permanent_failure.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/permanent_failure.php
@@ -6,7 +6,7 @@ $wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, 'G9Bn5sl1TC6nu79C8C0b
 $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521233195.375624));
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521233195.375624'));
 $wh->setReason('No Such User Here');
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/spam_complaints.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/spam_complaints.php
@@ -6,6 +6,6 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::SPAM, '-Agny091SquKnsrW2N
 $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521233123.501324));
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521233123.501324'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/suppression_failure.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/suppression_failure.php
@@ -6,7 +6,7 @@ $wh = new MailerDeliveryEvent(MailerDeliveryEvent::DROPPED, 'G9Bn5sl1TC6nu79C8C0
 $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521233195.375624));
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521233195.375624'));
 $wh->setReason('Not delivering to previously bounced address');
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/temporary_failure.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/temporary_failure.php
@@ -6,7 +6,7 @@ $wh = new MailerDeliveryEvent(MailerDeliveryEvent::DEFERRED, 'Fs7-5t81S2ispqxqDw
 $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521472262.908181));
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521472262.908181'));
 $wh->setReason("4.2.2 The email account that you tried to reach is over quota. Please direct\n4.2.2 the recipient to\n4.2.2  https://support.example.com/mail/?p=422");
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/unsubscribes.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/unsubscribes.php
@@ -6,6 +6,6 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::UNSUBSCRIBE, 'Ase7i2zsRYe
 $wh->setRecipientEmail('alice@example.com');
 $wh->setTags(['my_tag_1', 'my_tag_2']);
 $wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', 1521243339.873676));
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521243339.873676'));
 
 return $wh;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| Tickets       | Fix #51522 
| License       | MIT

Fix parsing of $payload['timestamp'] in Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php

Details:
MailgunPayloadConverter uses 

`\DateTimeImmutable::createFromFormat('U.u', $payload['timestamp'])`

in line 53 to convert the payload timestamp value to a DateTimeImmutable.

`\DateTimeImmutable::createFromFormat expects a string as its second parameter. $payload['timestamp'] is a float. 
`\DateTimeImmutable::createFromFormat will try to convert a float to a string, but does not always provide a string that the function then  recognizes as being in 'U.u' format.

This bugfix replaces $payload['timestamp'] with sprintf('%.6F', $payload['timestamp']) in MailgunPayloadConverter, lines 53 and 54. 

It also changes the timestamp in  Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/delivered_messages.json to 1521472262.000002, which provides a case in which \DateTimeImmutable::createFromFormat('U.u', $payload['timestamp']) returns false (at least in my setup). Floats are replaced with strings in calls to  \DateTimeImmutable::createFromFormat in Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/*.php  

