### PR TITLE
[ErrorHandler] [POC] Blame error

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorEnhancer/BlamedErrorEnhancer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorEnhancer/BlamedErrorEnhancer.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ErrorHandler\ErrorEnhancer;
+
+use Symfony\Component\Process\Exception\ExceptionInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class BlamedErrorEnhancer implements ErrorEnhancerInterface
+{
+    private ?bool $isEnabled = null;
+
+    public function enhance(\Throwable $error): ?\Throwable
+    {
+        if (!$this->isEnabled()) {
+            return null;
+        }
+
+        $blamedTrace = array_map($this->blameStep(...), $error->getTrace());
+
+        (new \ReflectionProperty(\Error::class, 'trace'))->setValue($error, $blamedTrace);
+
+        return $error;
+    }
+
+    private function blameStep(array $step): array
+    {
+        ['file' => $file, 'line' => $line] = $step;
+
+        return $file && $line ? $step + $this->blame($file, $line) : $step;
+    }
+
+    private function blame(string $file, int $line): array
+    {
+        $process = Process::fromShellCommandline(sprintf('git blame %s -L %s,+1 -p', $file, $line));
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return [];
+        }
+
+        preg_match(<<<PATTERN
+            /author (?<author>.*)
+            author-mail <(?<authormail>.*)>
+            author-time (?<authortime>.*)
+            author-tz (?<authortz>.*)
+            committer (?<commiter>.*)
+            committer-mail <(?<commitermail>.*)>
+            committer-time (?<commitertime>.*)
+            committer-tz (?<commitertz>.*)
+            summary (?<summary>.*)/
+            PATTERN,
+            $process->getOutput(),
+            $matches,
+        );
+
+        return [
+            'author' => [
+                'name' => $matches['author'],
+                'mail' => $matches['authormail'],
+                'time' => new \DateTimeImmutable('@'.$matches['authortime'], new \DateTimeZone($matches['authortz'])),
+            ],
+            'commiter' => [
+                'name' => $matches['commiter'],
+                'mail' => $matches['commitermail'],
+                'time' => new \DateTimeImmutable('@'.$matches['commitertime'], new \DateTimeZone($matches['commitertz'])),
+            ],
+            'summary' => $matches['summary'],
+        ];
+    }
+
+    private function isEnabled(): bool
+    {
+        if (null !== $this->isEnabled) {
+            return $this->isEnabled;
+        }
+
+        if (!class_exists(Process::class)) {
+            return $this->isEnabled = false;
+        }
+
+        try {
+            Process::fromShellCommandline('type git')->mustRun();
+        } catch (ExceptionInterface $e) {
+            return $this->isEnabled = false;
+        }
+
+        return $this->isEnabled = true;
+    }
+}

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\ErrorHandler\Error\FatalError;
 use Symfony\Component\ErrorHandler\Error\OutOfMemoryError;
+use Symfony\Component\ErrorHandler\ErrorEnhancer\BlamedErrorEnhancer;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\ClassNotFoundErrorEnhancer;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\ErrorEnhancerInterface;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\UndefinedFunctionErrorEnhancer;
@@ -681,6 +682,7 @@ class ErrorHandler
             new UndefinedFunctionErrorEnhancer(),
             new UndefinedMethodErrorEnhancer(),
             new ClassNotFoundErrorEnhancer(),
+            new BlamedErrorEnhancer(),
         ];
     }
 

--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -313,6 +313,9 @@ class FlattenException
             'file' => $file,
             'line' => $line,
             'args' => [],
+            'author' => $entry['author'] ?? null,
+            'commiter' => $entry['commiter'] ?? null,
+            'summary' => $entry['summary'] ?? null,
         ];
         foreach ($trace as $entry) {
             $class = '';
@@ -332,6 +335,9 @@ class FlattenException
                 'file' => $entry['file'] ?? null,
                 'line' => $entry['line'] ?? null,
                 'args' => isset($entry['args']) ? $this->flattenArgs($entry['args']) : [],
+                'author' => $entry['author'] ?? null,
+                'commiter' => $entry['commiter'] ?? null,
+                'summary' => $entry['summary'] ?? null,
             ];
         }
 

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -343,6 +343,7 @@ header .container { display: flex; justify-content: space-between; }
 .trace-type { padding: 0 2px; }
 .trace-method { color: var(--color-error); font-weight: bold; }
 .trace-arguments { color: #777; font-weight: normal; padding-left: 2px; }
+.trace-blame { text-decoration: underline dotted gray; }
 
 .trace-code { background: var(--base-0); font-size: 12px; margin: 10px 10px 2px 10px; padding: 10px; overflow-x: auto; white-space: nowrap; }
 .trace-code ol { margin: 0; float: left; }

--- a/src/Symfony/Component/ErrorHandler/Resources/views/trace.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/trace.html.php
@@ -18,13 +18,31 @@
         <span class="block trace-file-path">
             in
             <a href="<?= $fileLink; ?>">
-                <?= implode(\DIRECTORY_SEPARATOR, array_slice($filePathParts, 0, -1)).\DIRECTORY_SEPARATOR; ?><strong><?= end($filePathParts); ?></strong>
+                <?= implode(\DIRECTORY_SEPARATOR, array_slice($filePathParts, 0, -1)).\DIRECTORY_SEPARATOR; ?><strong><?= end($filePathParts); ?></strong>:<?= $lineNumber; ?>
             </a>
             <?php if ('compact' === $style && $trace['function']) { ?>
                 <span class="trace-type"><?= $trace['type']; ?></span>
                 <span class="trace-method"><?= $trace['function']; ?></span>
             <?php } ?>
-            (line <?= $lineNumber; ?>)
+            <?php if ($trace['author']) { ?>
+                <span
+                    class="trace-blame"
+                    title="<?= sprintf(
+                        "commited by %s (%s) at %s\n%s",
+                        $trace['commiter']['name'],
+                        $trace['commiter']['mail'],
+                        $trace['commiter']['time']->format(DateTimeInterface::RFC3339),
+                        $trace['summary'],
+                    ); ?>"
+                >
+                    <?= sprintf(
+                        'by %s (%s) at %s',
+                        $trace['author']['name'],
+                        $trace['author']['mail'],
+                        $trace['author']['time']->format(DateTimeInterface::RFC3339),
+                    ); ?>
+                </span>
+            <?php } ?>
             <span class="icon icon-copy hidden" data-clipboard-text="<?php echo implode(\DIRECTORY_SEPARATOR, $filePathParts).':'.$lineNumber; ?>">
                 <?php echo $this->include('assets/images/icon-copy.svg'); ?>
             </span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As a developer or devops, when an error is thrown on my development machine or in my production monitoring tool, one of the very first thing to do is to open the files listed in the stack trace error to get more context : who has written this line of code ? How recent is this code ? What is the reason of theses changes ?

Knowing immediately who is author, along with the date and reason of its changes could bring all the required context to understand faster the situation. Moreover, if the author is "blamed" is the stack trace error, it let the door open to automate a Slack ping to the blamed author. Some nice DX imo.

Below, a printscreen of the blamed stack trace in the exception page:

![image](https://github.com/symfony/symfony/assets/4578773/b98ec121-fe07-473e-ac79-8a78e4634a64)

Below, the enhanced data added in the stack trace that could be used in the production logs, then to ping the author thanks to a monitoring/alerting tool like Datadog:

![image](https://github.com/symfony/symfony/assets/4578773/7f3864b4-d011-456c-9a65-6911e0171759)

It's a poc. If I get some interest, I can keep going the work.