### PR TITLE
[DoctrineBridge][Security] Rename `loadUserByUsername` tests to `loadUserByIdentifier`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -49,7 +49,7 @@ class EntityUserProviderTest extends TestCase
         $this->assertSame($user1, $provider->refreshUser($user1));
     }
 
-    public function testLoadUserByUsername()
+    public function testLoadUserByIdentifier()
     {
         $em = DoctrineTestHelper::createTestEntityManager();
         $this->createSchema($em);
@@ -64,7 +64,7 @@ class EntityUserProviderTest extends TestCase
         $this->assertSame($user, $provider->loadUserByIdentifier('user1'));
     }
 
-    public function testLoadUserByUsernameWithUserLoaderRepositoryAndWithoutProperty()
+    public function testLoadUserByIdentifierWithUserLoaderRepositoryAndWithoutProperty()
     {
         $user = new User(1, 1, 'user1');
 
@@ -86,7 +86,7 @@ class EntityUserProviderTest extends TestCase
         $this->assertSame($user, $provider->loadUserByIdentifier('user1'));
     }
 
-    public function testLoadUserByUsernameWithNonUserLoaderRepositoryAndWithoutProperty()
+    public function testLoadUserByIdentifierWithNonUserLoaderRepositoryAndWithoutProperty()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('You must either make the "Symfony\Bridge\Doctrine\Tests\Fixtures\User" entity Doctrine Repository ("Doctrine\ORM\EntityRepository") implement "Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.');
@@ -150,7 +150,7 @@ class EntityUserProviderTest extends TestCase
         $this->assertTrue($provider->supportsClass($user2::class));
     }
 
-    public function testLoadUserByUserNameShouldLoadUserWhenProperInterfaceProvided()
+    public function testLoadUserByIdentifierShouldLoadUserWhenProperInterfaceProvided()
     {
         $repository = $this->createMock(UserLoaderRepository::class);
         $repository->expects($this->once())
@@ -168,7 +168,7 @@ class EntityUserProviderTest extends TestCase
         $provider->loadUserByIdentifier('name');
     }
 
-    public function testLoadUserByUserNameShouldDeclineInvalidInterface()
+    public function testLoadUserByIdentifierShouldDeclineInvalidInterface()
     {
         $this->expectException(\InvalidArgumentException::class);
         $repository = $this->createMock(ObjectRepository::class);

--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class ChainUserProviderTest extends TestCase
 {
-    public function testLoadUserByUsername()
+    public function testLoadUserByIdentifier()
     {
         $provider1 = $this->createMock(InMemoryUserProvider::class);
         $provider1
@@ -45,7 +45,7 @@ class ChainUserProviderTest extends TestCase
         $this->assertSame($account, $provider->loadUserByIdentifier('foo'));
     }
 
-    public function testLoadUserByUsernameThrowsUserNotFoundException()
+    public function testLoadUserByIdentifierThrowsUserNotFoundException()
     {
         $this->expectException(UserNotFoundException::class);
         $provider1 = $this->createMock(InMemoryUserProvider::class);

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
@@ -68,7 +68,7 @@ class InMemoryUserProviderTest extends TestCase
         $provider->createUser(new InMemoryUser('fabien', 'foo'));
     }
 
-    public function testLoadUserByUsernameDoesNotExist()
+    public function testLoadUserByIdentifierDoesNotExist()
     {
         $this->expectException(UserNotFoundException::class);
         $provider = new InMemoryUserProvider();


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


Tests use `loadUserByIdentifier` method but name were `loadUserByUsername` (legacy)
