### PR TITLE
[HttpFoundation] Support root-level Generator in StreamedJsonResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Make `HeaderBag::getDate()`, `Response::getDate()`, `getExpires()` and `getLastModified()` return a `DateTimeImmutable`
+ * Support root-level `Generator` in `StreamedJsonResponse`
 
 6.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedJsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedJsonResponseTest.php
@@ -30,6 +30,23 @@ class StreamedJsonResponseTest extends TestCase
         $this->assertSame('{"_embedded":{"articles":["Article 1","Article 2","Article 3"],"news":["News 1","News 2","News 3"]}}', $content);
     }
 
+    public function testResponseSimpleGenerator()
+    {
+        $content = $this->createSendResponse($this->generatorSimple('Article'));
+
+        $this->assertSame('["Article 1","Article 2","Article 3"]', $content);
+    }
+
+    public function testResponseNestedGenerator()
+    {
+        $content = $this->createSendResponse((function (): iterable {
+            yield 'articles' => $this->generatorSimple('Article');
+            yield 'news' => $this->generatorSimple('News');
+        })());
+
+        $this->assertSame('{"articles":["Article 1","Article 2","Article 3"],"news":["News 1","News 2","News 3"]}', $content);
+    }
+
     public function testResponseEmptyList()
     {
         $content = $this->createSendResponse(
@@ -220,9 +237,9 @@ class StreamedJsonResponseTest extends TestCase
     }
 
     /**
-     * @param mixed[] $data
+     * @param iterable<mixed> $data
      */
-    private function createSendResponse(array $data): string
+    private function createSendResponse(iterable $data): string
     {
         $response = new StreamedJsonResponse($data);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Currently the `StreamedJsonResponse` only supports streaming nested Generators within an array data structure. 
However if a response is a list of items (for example database entities) on the root level, this isn't usable. 
I think both usecases can be supported with the change in this PR.

The root level generator doesn't account for additional nested generators yet. I could add that by doing `is_array($item)` and the call the recursive placeholder logic. 

Link to first PR that introduced StreamedJsonResponse: https://github.com/symfony/symfony/pull/47709

~~Also something I noticed is I only got intermediate output, when adding a `flush()` call after each item has been echo'd (with a `sleep(1)` after each item to see it output the parts individually).~~ Edit: I see the class' PhpDoc describes this and it's probably expected to be done in userland implementations.