### PR TITLE
fix ReflectionMethod with php8.3 in MicroKernelTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -164,7 +164,7 @@ trait MicroKernelTrait
             $container->addObjectResource($this);
             $container->fileExists($this->getBundlesPath());
 
-            $configureContainer = new \ReflectionMethod($this, 'configureContainer');
+            $configureContainer = (new \ReflectionClass($this))->getMethod('configureContainer');
             $configuratorClass = $configureContainer->getNumberOfParameters() > 0 && ($type = $configureContainer->getParameters()[0]->getType()) instanceof \ReflectionNamedType && !$type->isBuiltin() ? $type->getName() : null;
 
             if ($configuratorClass && !is_a(ContainerConfigurator::class, $configuratorClass, true)) {
@@ -207,7 +207,7 @@ trait MicroKernelTrait
         $kernelLoader->setCurrentDir(\dirname($file));
         $collection = new RouteCollection();
 
-        $configureRoutes = new \ReflectionMethod($this, 'configureRoutes');
+        $configureRoutes = (new \ReflectionClass($this))->getMethod('configureRoutes');
         $configuratorClass = $configureRoutes->getNumberOfParameters() > 0 && ($type = $configureRoutes->getParameters()[0]->getType()) instanceof \ReflectionNamedType && !$type->isBuiltin() ? $type->getName() : null;
 
         if ($configuratorClass && !is_a(RoutingConfigurator::class, $configuratorClass, true)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 for features / 5.4, or 6.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When using php 8.3RC1 the MicroKernelTrait is unable to get the ReflectionMethod for `configureContainer`. this is due to this change in php: https://github.com/php/php-src/issues/9470 

```
ReflectionException: Method EosUptrade\FIS\Tests\TestKernel::configureContainer() does not exist

/var/www/vendor/symfony/framework-bundle/Kernel/MicroKernelTrait.php:161
/var/www/vendor/symfony/dependency-injection/Loader/ClosureLoader.php:36
/var/www/vendor/symfony/config/Loader/DelegatingLoader.php:37
/var/www/vendor/symfony/framework-bundle/Kernel/MicroKernelTrait.php:136
/var/www/vendor/symfony/http-kernel/Kernel.php:604
/var/www/vendor/symfony/http-kernel/Kernel.php:505
/var/www/vendor/symfony/http-kernel/Kernel.php:757
/var/www/vendor/symfony/http-kernel/Kernel.php:126
/var/www/src/Kernel.php:17
/var/www/tests/TestKernel.php:16
/var/www/vendor/symfony/framework-bundle/Test/KernelTestCase.php:73
/var/www/tests/Application/Regression/FIS1153.php:21
/var/www/vendor/bin/phpunit:127
```

I am a little confused, if this is a bug in php or should be addressed here. the fix is simple and straight forward.
let me know what you think.

