### PR TITLE
[Config] Allow to always use config classes

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -260,7 +260,6 @@ public function NAME(string $VAR, TYPE $VALUE): static
         $comment .= sprintf(' * @psalm-return (TValue is array ? %s : static)'."\n ", $childClass->getFqcn());
         $comment = "/**\n$comment*/\n";
 
-
         if (null === $key = $node->getKeyAttribute()) {
             $body = '
 COMMENTpublic function NAME(mixed $value = []): CLASS|static
@@ -544,10 +543,5 @@ public function NAME(string $key, mixed $value): static
         }
 
         return [] !== $r->getValue($node);
-    }
-
-    private function getType(string $classType, bool $hasNormalizationClosures): string
-    {
-        return $classType.($hasNormalizationClosures ? '|scalar' : '');
     }
 }

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -32,7 +32,6 @@ abstract class BaseNode implements NodeInterface
     protected $name;
     protected $parent;
     protected $normalizationClosures = [];
-    protected $normalizedTypes = [];
     protected $finalValidationClosures = [];
     protected $allowOverwrite = true;
     protected $required = false;
@@ -234,28 +233,6 @@ abstract class BaseNode implements NodeInterface
     public function setNormalizationClosures(array $closures)
     {
         $this->normalizationClosures = $closures;
-    }
-
-    /**
-     * Sets the list of types supported by normalization.
-     *
-     * see ExprBuilder::TYPE_* constants.
-     *
-     * @return void
-     */
-    public function setNormalizedTypes(array $types)
-    {
-        $this->normalizedTypes = $types;
-    }
-
-    /**
-     * Gets the list of types supported by normalization.
-     *
-     * see ExprBuilder::TYPE_* constants.
-     */
-    public function getNormalizedTypes(): array
-    {
-        return $this->normalizedTypes;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -406,7 +406,6 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
 
         if (isset($this->normalization)) {
             $node->setNormalizationClosures($this->normalization->before);
-            $node->setNormalizedTypes($this->normalization->declaredTypes);
             $node->setXmlRemappings($this->normalization->remappings);
         }
 

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -374,7 +374,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
 
             if ($this->default) {
                 if (!\is_array($this->defaultValue)) {
-                    throw new \InvalidArgumentException(sprintf('%s: the default value of an array node has to be an array.', $node->getPath()));
+                    throw new \InvalidArgumentException(sprintf('"%s": the default value of an array node has to be an array.', $node->getPath()));
                 }
 
                 $node->setDefaultValue($this->defaultValue);

--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -21,14 +21,7 @@ use Symfony\Component\Config\Definition\Exception\UnsetKeyException;
  */
 class ExprBuilder
 {
-    public const TYPE_ANY = 'any';
-    public const TYPE_STRING = 'string';
-    public const TYPE_NULL = 'null';
-    public const TYPE_ARRAY = 'array';
-
     protected $node;
-
-    public $allowedTypes;
     public $ifPart;
     public $thenPart;
 
@@ -45,7 +38,6 @@ class ExprBuilder
     public function always(\Closure $then = null): static
     {
         $this->ifPart = static fn () => true;
-        $this->allowedTypes = self::TYPE_ANY;
 
         if (null !== $then) {
             $this->thenPart = $then;
@@ -64,7 +56,6 @@ class ExprBuilder
     public function ifTrue(\Closure $closure = null): static
     {
         $this->ifPart = $closure ?? static fn ($v) => true === $v;
-        $this->allowedTypes = self::TYPE_ANY;
 
         return $this;
     }
@@ -77,7 +68,6 @@ class ExprBuilder
     public function ifString(): static
     {
         $this->ifPart = \is_string(...);
-        $this->allowedTypes = self::TYPE_STRING;
 
         return $this;
     }
@@ -90,7 +80,6 @@ class ExprBuilder
     public function ifNull(): static
     {
         $this->ifPart = \is_null(...);
-        $this->allowedTypes = self::TYPE_NULL;
 
         return $this;
     }
@@ -103,7 +92,6 @@ class ExprBuilder
     public function ifEmpty(): static
     {
         $this->ifPart = static fn ($v) => empty($v);
-        $this->allowedTypes = self::TYPE_ANY;
 
         return $this;
     }
@@ -116,7 +104,6 @@ class ExprBuilder
     public function ifArray(): static
     {
         $this->ifPart = \is_array(...);
-        $this->allowedTypes = self::TYPE_ARRAY;
 
         return $this;
     }
@@ -129,7 +116,6 @@ class ExprBuilder
     public function ifInArray(array $array): static
     {
         $this->ifPart = static fn ($v) => \in_array($v, $array, true);
-        $this->allowedTypes = self::TYPE_ANY;
 
         return $this;
     }
@@ -142,7 +128,6 @@ class ExprBuilder
     public function ifNotInArray(array $array): static
     {
         $this->ifPart = static fn ($v) => !\in_array($v, $array, true);
-        $this->allowedTypes = self::TYPE_ANY;
 
         return $this;
     }
@@ -155,7 +140,6 @@ class ExprBuilder
     public function castToArray(): static
     {
         $this->ifPart = static fn ($v) => !\is_array($v);
-        $this->allowedTypes = self::TYPE_ANY;
         $this->thenPart = static fn ($v) => [$v];
 
         return $this;

--- a/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
@@ -20,7 +20,6 @@ class NormalizationBuilder
 {
     protected $node;
     public $before = [];
-    public $declaredTypes = [];
     public $remappings = [];
 
     public function __construct(NodeDefinition $node)

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
@@ -42,12 +42,23 @@ class TranslatorConfig
     }
 
     /**
+     * @template TValue
+     * @param TValue $value
      * looks for translation in old fashion way
      * @deprecated The child node "books" at path "translator" is deprecated.
-    */
-    public function books(array $value = []): \Symfony\Config\AddToList\Translator\BooksConfig
+     * @return \Symfony\Config\AddToList\Translator\BooksConfig|$this
+     * @psalm-return (TValue is array ? \Symfony\Config\AddToList\Translator\BooksConfig : static)
+     */
+    public function books(mixed $value = []): \Symfony\Config\AddToList\Translator\BooksConfig|static
     {
-        if (null === $this->books) {
+        if (!\is_array($value)) {
+            $this->_usedProperties['books'] = true;
+            $this->books = $value;
+
+            return $this;
+        }
+
+        if (!$this->books instanceof \Symfony\Config\AddToList\Translator\BooksConfig) {
             $this->_usedProperties['books'] = true;
             $this->books = new \Symfony\Config\AddToList\Translator\BooksConfig($value);
         } elseif (0 < \func_num_args()) {
@@ -73,7 +84,7 @@ class TranslatorConfig
 
         if (array_key_exists('books', $value)) {
             $this->_usedProperties['books'] = true;
-            $this->books = new \Symfony\Config\AddToList\Translator\BooksConfig($value['books']);
+            $this->books = \is_array($value['books']) ? new \Symfony\Config\AddToList\Translator\BooksConfig($value['books']) : $value['books'];
             unset($value['books']);
         }
 
@@ -92,7 +103,7 @@ class TranslatorConfig
             $output['sources'] = $this->sources;
         }
         if (isset($this->_usedProperties['books'])) {
-            $output['books'] = $this->books->toArray();
+            $output['books'] = $this->books instanceof \Symfony\Config\AddToList\Translator\BooksConfig ? $this->books->toArray() : $this->books;
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
@@ -16,9 +16,22 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
     private $messenger;
     private $_usedProperties = [];
 
-    public function translator(array $value = []): \Symfony\Config\AddToList\TranslatorConfig
+    /**
+     * @template TValue
+     * @param TValue $value
+     * @return \Symfony\Config\AddToList\TranslatorConfig|$this
+     * @psalm-return (TValue is array ? \Symfony\Config\AddToList\TranslatorConfig : static)
+     */
+    public function translator(mixed $value = []): \Symfony\Config\AddToList\TranslatorConfig|static
     {
-        if (null === $this->translator) {
+        if (!\is_array($value)) {
+            $this->_usedProperties['translator'] = true;
+            $this->translator = $value;
+
+            return $this;
+        }
+
+        if (!$this->translator instanceof \Symfony\Config\AddToList\TranslatorConfig) {
             $this->_usedProperties['translator'] = true;
             $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value);
         } elseif (0 < \func_num_args()) {
@@ -28,9 +41,22 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
         return $this->translator;
     }
 
-    public function messenger(array $value = []): \Symfony\Config\AddToList\MessengerConfig
+    /**
+     * @template TValue
+     * @param TValue $value
+     * @return \Symfony\Config\AddToList\MessengerConfig|$this
+     * @psalm-return (TValue is array ? \Symfony\Config\AddToList\MessengerConfig : static)
+     */
+    public function messenger(mixed $value = []): \Symfony\Config\AddToList\MessengerConfig|static
     {
-        if (null === $this->messenger) {
+        if (!\is_array($value)) {
+            $this->_usedProperties['messenger'] = true;
+            $this->messenger = $value;
+
+            return $this;
+        }
+
+        if (!$this->messenger instanceof \Symfony\Config\AddToList\MessengerConfig) {
             $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value);
         } elseif (0 < \func_num_args()) {
@@ -49,13 +75,13 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
     {
         if (array_key_exists('translator', $value)) {
             $this->_usedProperties['translator'] = true;
-            $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value['translator']);
+            $this->translator = \is_array($value['translator']) ? new \Symfony\Config\AddToList\TranslatorConfig($value['translator']) : $value['translator'];
             unset($value['translator']);
         }
 
         if (array_key_exists('messenger', $value)) {
             $this->_usedProperties['messenger'] = true;
-            $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value['messenger']);
+            $this->messenger = \is_array($value['messenger']) ? new \Symfony\Config\AddToList\MessengerConfig($value['messenger']) : $value['messenger'];
             unset($value['messenger']);
         }
 
@@ -68,10 +94,10 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
     {
         $output = [];
         if (isset($this->_usedProperties['translator'])) {
-            $output['translator'] = $this->translator->toArray();
+            $output['translator'] = $this->translator instanceof \Symfony\Config\AddToList\TranslatorConfig ? $this->translator->toArray() : $this->translator;
         }
         if (isset($this->_usedProperties['messenger'])) {
-            $output['messenger'] = $this->messenger->toArray();
+            $output['messenger'] = $this->messenger instanceof \Symfony\Config\AddToList\MessengerConfig ? $this->messenger->toArray() : $this->messenger;
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
@@ -16,9 +16,22 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
     private $messenger;
     private $_usedProperties = [];
 
-    public function someCleverName(array $value = []): \Symfony\Config\NodeInitialValues\SomeCleverNameConfig
+    /**
+     * @template TValue
+     * @param TValue $value
+     * @return \Symfony\Config\NodeInitialValues\SomeCleverNameConfig|$this
+     * @psalm-return (TValue is array ? \Symfony\Config\NodeInitialValues\SomeCleverNameConfig : static)
+     */
+    public function someCleverName(mixed $value = []): \Symfony\Config\NodeInitialValues\SomeCleverNameConfig|static
     {
-        if (null === $this->someCleverName) {
+        if (!\is_array($value)) {
+            $this->_usedProperties['someCleverName'] = true;
+            $this->someCleverName = $value;
+
+            return $this;
+        }
+
+        if (!$this->someCleverName instanceof \Symfony\Config\NodeInitialValues\SomeCleverNameConfig) {
             $this->_usedProperties['someCleverName'] = true;
             $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value);
         } elseif (0 < \func_num_args()) {
@@ -28,9 +41,22 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
         return $this->someCleverName;
     }
 
-    public function messenger(array $value = []): \Symfony\Config\NodeInitialValues\MessengerConfig
+    /**
+     * @template TValue
+     * @param TValue $value
+     * @return \Symfony\Config\NodeInitialValues\MessengerConfig|$this
+     * @psalm-return (TValue is array ? \Symfony\Config\NodeInitialValues\MessengerConfig : static)
+     */
+    public function messenger(mixed $value = []): \Symfony\Config\NodeInitialValues\MessengerConfig|static
     {
-        if (null === $this->messenger) {
+        if (!\is_array($value)) {
+            $this->_usedProperties['messenger'] = true;
+            $this->messenger = $value;
+
+            return $this;
+        }
+
+        if (!$this->messenger instanceof \Symfony\Config\NodeInitialValues\MessengerConfig) {
             $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value);
         } elseif (0 < \func_num_args()) {
@@ -49,13 +75,13 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
     {
         if (array_key_exists('some_clever_name', $value)) {
             $this->_usedProperties['someCleverName'] = true;
-            $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value['some_clever_name']);
+            $this->someCleverName = \is_array($value['some_clever_name']) ? new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value['some_clever_name']) : $value['some_clever_name'];
             unset($value['some_clever_name']);
         }
 
         if (array_key_exists('messenger', $value)) {
             $this->_usedProperties['messenger'] = true;
-            $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value['messenger']);
+            $this->messenger = \is_array($value['messenger']) ? new \Symfony\Config\NodeInitialValues\MessengerConfig($value['messenger']) : $value['messenger'];
             unset($value['messenger']);
         }
 
@@ -68,10 +94,10 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
     {
         $output = [];
         if (isset($this->_usedProperties['someCleverName'])) {
-            $output['some_clever_name'] = $this->someCleverName->toArray();
+            $output['some_clever_name'] = $this->someCleverName instanceof \Symfony\Config\NodeInitialValues\SomeCleverNameConfig ? $this->someCleverName->toArray() : $this->someCleverName;
         }
         if (isset($this->_usedProperties['messenger'])) {
-            $output['messenger'] = $this->messenger->toArray();
+            $output['messenger'] = $this->messenger instanceof \Symfony\Config\NodeInitialValues\MessengerConfig ? $this->messenger->toArray() : $this->messenger;
         }
 
         return $output;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When the config node doesn't have normalization, using the config object is impossible.

When the config node has some array normalization (like `http_codes` in `\Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration::addHttpClientRetrySection`), it is not possible to use the config object.

This PR relates to changes introduced in:
- https://github.com/symfony/symfony/pull/46328
- https://github.com/symfony/symfony/pull/44166

<img width="50%" alt="Снимок экрана 2023-09-01 в 22 22 28" src="https://github.com/symfony/symfony/assets/6824784/ab5df284-b736-480f-bee2-3dc74d3fe433">
