### PR TITLE
[AssetMapper] Make importmap:install command download the same version

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -143,6 +143,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('importmap.php path'),
                 abstract_arg('vendor directory'),
                 service('asset_mapper.importmap.resolver'),
+                service('http_client'),
             ])
         ->alias(ImportMapManager::class, 'asset_mapper.importmap.manager')
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -13,10 +13,11 @@ namespace Symfony\Component\AssetMapper\ImportMap;
 
 use Symfony\Component\AssetMapper\AssetDependency;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
-use Symfony\Component\AssetMapper\Exception\RuntimeException;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface;
 use Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface;
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\VarExporter\VarExporter;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Kévin Dunglas <kevin@dunglas.dev>
@@ -55,6 +56,7 @@ class ImportMapManager
     private array $importMapEntries;
     private array $modulesToPreload;
     private string $json;
+    private readonly HttpClientInterface $httpClient;
 
     public function __construct(
         private readonly AssetMapperInterface $assetMapper,
@@ -62,7 +64,9 @@ class ImportMapManager
         private readonly string $importMapConfigPath,
         private readonly string $vendorDir,
         private readonly PackageResolverInterface $resolver,
+        HttpClientInterface $httpClient = null,
     ) {
+        $this->httpClient = $httpClient ?? HttpClient::create();
     }
 
     public function getModulesToPreload(): array
@@ -112,31 +116,27 @@ class ImportMapManager
     /**
      * Downloads all missing downloaded packages.
      *
-     * @return ImportMapEntry[] The downloaded packages
+     * @return string[] The downloaded packages
      */
     public function downloadMissingPackages(): array
     {
         $entries = $this->loadImportMapEntries();
-        $packagesToDownload = [];
+        $downloadedPackages = [];
 
         foreach ($entries as $entry) {
             if (!$entry->isDownloaded || $this->assetMapper->getAsset($entry->path)) {
                 continue;
             }
 
-            $parts = self::parsePackageName($entry->url);
-
-            $packagesToDownload[] = new PackageRequireOptions(
-                $parts['package'],
-                $parts['version'] ?? throw new RuntimeException(sprintf('Cannot get a version for the "%s" package.', $parts['package'])),
-                true,
-                $entry->preload,
-                $parts['alias'] ?? $parts['package'],
-                isset($parts['registry']) && $parts['registry'] ? $parts['registry'] : null,
+            $this->downloadPackage(
+                $entry->importName,
+                $this->httpClient->request('GET', $entry->url)->getContent(),
             );
+
+            $downloadedPackages[] = $entry->importName;
         }
 
-        return $this->require($packagesToDownload);
+        return $downloadedPackages;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR improves the behaviour of the new `importmap:install` command by downloading the same version of the files that were already installed, given we already have the URL.