### PR TITLE
[Uid] Make child methods match parent's argument names

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -87,7 +87,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable
     abstract public function toBinary(): string;
 
     /**
-     * Returns the identifier as a base58 case sensitive string.
+     * Returns the identifier as a base58 case-sensitive string.
      *
      * @example 2AifFTC3zXgZzK5fPrrprL (len=22)
      */
@@ -97,7 +97,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable
     }
 
     /**
-     * Returns the identifier as a base32 case insensitive string.
+     * Returns the identifier as a base32 case-insensitive string.
      *
      * @see https://tools.ietf.org/html/rfc4648#section-6
      *
@@ -120,7 +120,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable
     }
 
     /**
-     * Returns the identifier as a RFC4122 case insensitive string.
+     * Returns the identifier as a RFC4122 case-insensitive string.
      *
      * @see https://tools.ietf.org/html/rfc4122#section-3
      *
@@ -138,7 +138,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable
     }
 
     /**
-     * Returns the identifier as a prefixed hexadecimal case insensitive string.
+     * Returns the identifier as a prefixed hexadecimal case-insensitive string.
      *
      * @example 0x09748193048a4bfbb8258528cf74fdc1 (len=34)
      */

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -43,56 +43,56 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
         }
     }
 
-    public static function isValid(string $ulid): bool
+    public static function isValid(string $uid): bool
     {
-        if (26 !== \strlen($ulid)) {
+        if (26 !== \strlen($uid)) {
             return false;
         }
 
-        if (26 !== strspn($ulid, '0123456789ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz')) {
+        if (26 !== strspn($uid, '0123456789ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz')) {
             return false;
         }
 
-        return $ulid[0] <= '7';
+        return $uid[0] <= '7';
     }
 
-    public static function fromString(string $ulid): static
+    public static function fromString(string $uid): static
     {
-        if (36 === \strlen($ulid) && preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$}Di', $ulid)) {
-            $ulid = uuid_parse($ulid);
-        } elseif (22 === \strlen($ulid) && 22 === strspn($ulid, BinaryUtil::BASE58[''])) {
-            $ulid = str_pad(BinaryUtil::fromBase($ulid, BinaryUtil::BASE58), 16, "\0", \STR_PAD_LEFT);
+        if (36 === \strlen($uid) && preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$}Di', $uid)) {
+            $uid = uuid_parse($uid);
+        } elseif (22 === \strlen($uid) && 22 === strspn($uid, BinaryUtil::BASE58[''])) {
+            $uid = str_pad(BinaryUtil::fromBase($uid, BinaryUtil::BASE58), 16, "\0", \STR_PAD_LEFT);
         }
 
-        if (16 !== \strlen($ulid)) {
-            return match (strtr($ulid, 'z', 'Z')) {
+        if (16 !== \strlen($uid)) {
+            return match (strtr($uid, 'z', 'Z')) {
                 self::NIL => new NilUlid(),
                 self::MAX => new MaxUlid(),
-                default => new static($ulid),
+                default => new static($uid),
             };
         }
 
-        $ulid = bin2hex($ulid);
-        $ulid = sprintf('%02s%04s%04s%04s%04s%04s%04s',
-            base_convert(substr($ulid, 0, 2), 16, 32),
-            base_convert(substr($ulid, 2, 5), 16, 32),
-            base_convert(substr($ulid, 7, 5), 16, 32),
-            base_convert(substr($ulid, 12, 5), 16, 32),
-            base_convert(substr($ulid, 17, 5), 16, 32),
-            base_convert(substr($ulid, 22, 5), 16, 32),
-            base_convert(substr($ulid, 27, 5), 16, 32)
+        $uid = bin2hex($uid);
+        $uid = sprintf('%02s%04s%04s%04s%04s%04s%04s',
+            base_convert(substr($uid, 0, 2), 16, 32),
+            base_convert(substr($uid, 2, 5), 16, 32),
+            base_convert(substr($uid, 7, 5), 16, 32),
+            base_convert(substr($uid, 12, 5), 16, 32),
+            base_convert(substr($uid, 17, 5), 16, 32),
+            base_convert(substr($uid, 22, 5), 16, 32),
+            base_convert(substr($uid, 27, 5), 16, 32)
         );
 
-        if (self::NIL === $ulid) {
+        if (self::NIL === $uid) {
             return new NilUlid();
         }
 
-        if (self::MAX === $ulid = strtr($ulid, 'abcdefghijklmnopqrstuv', 'ABCDEFGHJKMNPQRSTVWXYZ')) {
+        if (self::MAX === $uid = strtr($uid, 'abcdefghijklmnopqrstuv', 'ABCDEFGHJKMNPQRSTVWXYZ')) {
             return new MaxUlid();
         }
 
         $u = new static(self::NIL);
-        $u->uid = $ulid;
+        $u->uid = $uid;
 
         return $u;
     }

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -42,50 +42,50 @@ class Uuid extends AbstractUid
         }
     }
 
-    public static function fromString(string $uuid): static
+    public static function fromString(string $uid): static
     {
-        if (22 === \strlen($uuid) && 22 === strspn($uuid, BinaryUtil::BASE58[''])) {
-            $uuid = str_pad(BinaryUtil::fromBase($uuid, BinaryUtil::BASE58), 16, "\0", \STR_PAD_LEFT);
+        if (22 === \strlen($uid) && 22 === strspn($uid, BinaryUtil::BASE58[''])) {
+            $uid = str_pad(BinaryUtil::fromBase($uid, BinaryUtil::BASE58), 16, "\0", \STR_PAD_LEFT);
         }
 
-        if (16 === \strlen($uuid)) {
+        if (16 === \strlen($uid)) {
             // don't use uuid_unparse(), it's slower
-            $uuid = bin2hex($uuid);
-            $uuid = substr_replace($uuid, '-', 8, 0);
-            $uuid = substr_replace($uuid, '-', 13, 0);
-            $uuid = substr_replace($uuid, '-', 18, 0);
-            $uuid = substr_replace($uuid, '-', 23, 0);
-        } elseif (26 === \strlen($uuid) && Ulid::isValid($uuid)) {
+            $uid = bin2hex($uid);
+            $uid = substr_replace($uid, '-', 8, 0);
+            $uid = substr_replace($uid, '-', 13, 0);
+            $uid = substr_replace($uid, '-', 18, 0);
+            $uid = substr_replace($uid, '-', 23, 0);
+        } elseif (26 === \strlen($uid) && Ulid::isValid($uid)) {
             $ulid = new NilUlid();
-            $ulid->uid = strtoupper($uuid);
-            $uuid = $ulid->toRfc4122();
+            $ulid->uid = strtoupper($uid);
+            $uid = $ulid->toRfc4122();
         }
 
-        if (__CLASS__ !== static::class || 36 !== \strlen($uuid)) {
-            return new static($uuid);
+        if (__CLASS__ !== static::class || 36 !== \strlen($uid)) {
+            return new static($uid);
         }
 
-        if (self::NIL === $uuid) {
+        if (self::NIL === $uid) {
             return new NilUuid();
         }
 
-        if (self::MAX === $uuid = strtr($uuid, 'F', 'f')) {
+        if (self::MAX === $uid = strtr($uid, 'F', 'f')) {
             return new MaxUuid();
         }
 
-        if (!\in_array($uuid[19], ['8', '9', 'a', 'b', 'A', 'B'], true)) {
-            return new self($uuid);
+        if (!\in_array($uid[19], ['8', '9', 'a', 'b', 'A', 'B'], true)) {
+            return new self($uid);
         }
 
-        return match ((int) $uuid[14]) {
-            UuidV1::TYPE => new UuidV1($uuid),
-            UuidV3::TYPE => new UuidV3($uuid),
-            UuidV4::TYPE => new UuidV4($uuid),
-            UuidV5::TYPE => new UuidV5($uuid),
-            UuidV6::TYPE => new UuidV6($uuid),
-            UuidV7::TYPE => new UuidV7($uuid),
-            UuidV8::TYPE => new UuidV8($uuid),
-            default => new self($uuid),
+        return match ((int) $uid[14]) {
+            UuidV1::TYPE => new UuidV1($uid),
+            UuidV3::TYPE => new UuidV3($uid),
+            UuidV4::TYPE => new UuidV4($uid),
+            UuidV5::TYPE => new UuidV5($uid),
+            UuidV6::TYPE => new UuidV6($uid),
+            UuidV7::TYPE => new UuidV7($uid),
+            UuidV8::TYPE => new UuidV8($uid),
+            default => new self($uid),
         };
     }
 
@@ -130,21 +130,21 @@ class Uuid extends AbstractUid
         return new UuidV8($uuid);
     }
 
-    public static function isValid(string $uuid): bool
+    public static function isValid(string $uid): bool
     {
-        if (self::NIL === $uuid && \in_array(static::class, [__CLASS__, NilUuid::class], true)) {
+        if (self::NIL === $uid && \in_array(static::class, [__CLASS__, NilUuid::class], true)) {
             return true;
         }
 
-        if (self::MAX === strtr($uuid, 'F', 'f') && \in_array(static::class, [__CLASS__, MaxUuid::class], true)) {
+        if (self::MAX === strtr($uid, 'F', 'f') && \in_array(static::class, [__CLASS__, MaxUuid::class], true)) {
             return true;
         }
 
-        if (!preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){2}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$}Di', $uuid)) {
+        if (!preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){2}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$}Di', $uid)) {
             return false;
         }
 
-        return __CLASS__ === static::class || static::TYPE === (int) $uuid[14];
+        return __CLASS__ === static::class || static::TYPE === (int) $uid[14];
     }
 
     public function toBinary(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`AbstractUid` defines methods with arguments named `$uid`, and I believe child methods should follow these names unless there's a reason I am now aware of?
