### PR TITLE
[Workflow] Remove `GuardEvent::getContext()` method without replacement

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Require explicit argument when calling `Definition::setInitialPlaces()`
  * `GuardEvent::getContext()` method has been removed. Method was not supposed to be called within guard event listeners as it always returned an empty array anyway.
+ * Remove `GuardEvent::getContext()` method without replacement
 
 6.4
 ---

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -32,13 +32,6 @@ final class GuardEvent extends Event
         $this->transitionBlockerList = new TransitionBlockerList();
     }
 
-    public function getContext(): array
-    {
-        trigger_deprecation('symfony/workflow', '6.4', 'The %s::getContext() method is deprecated and will be removed in 7.0. You should no longer call this method as it always returns an empty array when invoked within a guard listener.', __CLASS__);
-
-        return parent::getContext();
-    }
-
     public function getTransition(): Transition
     {
         return parent::getTransition();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follow-up of https://github.com/symfony/symfony/pull/51484