### PR TITLE
[Security] Calling the constructor of `DefaultLoginRateLimiter` with an empty secret throws an `InvalidArgumentException`

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -303,6 +303,7 @@ Security
  * Add argument `$badgeFqcn` to `Passport::addBadge()`
  * Add argument `$lifetime` to `LoginLinkHandlerInterface::createLoginLink()`
  * Require explicit argument when calling `TokenStorage::setToken()`
+ * Calling the constructor of `DefaultLoginRateLimiter` with an empty secret now throws an `InvalidArgumentException`
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add argument `$badgeFqcn` to `Passport::addBadge()`
  * Add argument `$lifetime` to `LoginLinkHandlerInterface::createLoginLink()`
+ * Calling the constructor of `DefaultLoginRateLimiter` with an empty secret now throws an `InvalidArgumentException`
 
 6.4
 ---

--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Http\RateLimiter;
 use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
@@ -36,9 +37,9 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
     public function __construct(RateLimiterFactory $globalFactory, RateLimiterFactory $localFactory, #[\SensitiveParameter] string $secret = '')
     {
         if ('' === $secret) {
-            trigger_deprecation('symfony/security-http', '6.4', 'Calling "%s()" with an empty secret is deprecated. A non-empty secret will be mandatory in version 7.0.', __METHOD__);
-            // throw new \Symfony\Component\Security\Core\Exception\InvalidArgumentException('A non-empty secret is required.');
+            throw new InvalidArgumentException('A non-empty secret is required.');
         }
+
         $this->globalFactory = $globalFactory;
         $this->localFactory = $localFactory;
         $this->secret = $secret;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -
