### PR TITLE
[Security] Add changelog note about calling the constructor of `DefaultLoginRateLimiter` with an empty secret

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -136,6 +136,7 @@ Security
  * [BC break] `UserValueResolver` no longer implements `ArgumentValueResolverInterface`
  * [BC break] Make `PersistentToken` immutable
  * Deprecate accepting only `DateTime` for `TokenProviderInterface::updateToken()`, use `DateTimeInterface` instead
+ * Deprecate calling the constructor of `DefaultLoginRateLimiter` with an empty secret
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * `UserValueResolver` no longer implements `ArgumentValueResolverInterface`
+ * Deprecate calling the constructor of `DefaultLoginRateLimiter` with an empty secret
 
 6.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Related to https://github.com/symfony/symfony/pull/51550