### PR TITLE
[HttpClient] Enable using EventSourceHttpClient::connect() for both GET and POST

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `HarFileResponseFactory` testing utility, allow to replay responses from `.har` files
  * Add `max_retries` option to `RetryableHttpClient` to adjust the retry logic on a per request level
  * Add `PingWehookMessage` and `PingWebhookMessageHandler`
+ * Enable using EventSourceHttpClient::connect() for both GET and POST
 
 6.3
 ---

--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -39,9 +39,9 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
         $this->reconnectionTime = $reconnectionTime;
     }
 
-    public function connect(string $url, array $options = []): ResponseInterface
+    public function connect(string $url, array $options = [], string $method = 'GET'): ResponseInterface
     {
-        return $this->request('GET', $url, self::mergeDefaultOptions($options, [
+        return $this->request($method, $url, self::mergeDefaultOptions($options, [
             'buffer' => false,
             'headers' => [
                 'Accept' => 'text/event-stream',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Fix so connect() can be used for SSE connections that require POST, e.g. GraphQL SSE subscriptions. This so we don't have to manually create the request() and include all of the options that are used for connect().
