### PR TITLE
[DependencyInjection] `#[Autowire]` attribute should have precedence over bindings

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -183,6 +184,13 @@ class ResolveBindingsPass extends AbstractRecursivePass
                     continue;
                 }
                 if (\array_key_exists($parameter->name, $arguments) && '' !== $arguments[$parameter->name]) {
+                    continue;
+                }
+                if (
+                    $value->isAutowired()
+                    && !$value->hasTag('container.ignore_attributes')
+                    && $parameter->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)
+                ) {
                     continue;
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LocatorConsumerWithServiceSubscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LocatorConsumerWithServiceSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Contracts\Service\Attribute\Required;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+final class LocatorConsumerWithServiceSubscriber implements ServiceSubscriberInterface
+{
+    private ?ContainerInterface $container = null;
+
+    public function __construct(
+        #[TaggedLocator('foo_bar', indexAttribute: 'key')]
+        private ContainerInterface $locator,
+    ) {
+    }
+
+    public function getLocator(): ContainerInterface
+    {
+        return $this->locator;
+    }
+
+    public function getContainer(): ?ContainerInterface
+    {
+        return $this->container;
+    }
+
+    #[Required]
+    public function setContainer(ContainerInterface $container): void
+    {
+        $this->container = $container;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            'subscribed_service',
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49082
| License       | MIT
| Doc PR        | -

It seems logical (I think) that the `#[Autowire]` attribute has precedence over any bindings.