### PR TITLE
[DoctrineBridge] Add `message` to #[MapEntity] for NotFoundHttpException

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -73,7 +73,7 @@ final class EntityValueResolver implements ValueResolverInterface
         }
 
         if (null === $object && !$argument->isNullable()) {
-            throw new NotFoundHttpException(sprintf('"%s" object not found by "%s".', $options->class, self::class).$message);
+            throw new NotFoundHttpException($options->message ?? (sprintf('"%s" object not found by "%s".', $options->class, self::class).$message));
         }
 
         return [$object];

--- a/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
@@ -31,6 +31,7 @@ class MapEntity extends ValueResolver
         public ?bool $evictCache = null,
         bool $disabled = false,
         string $resolver = EntityValueResolver::class,
+        public ?string $message = null,
     ) {
         parent::__construct($resolver, $disabled);
     }
@@ -46,6 +47,7 @@ class MapEntity extends ValueResolver
         $clone->stripNull ??= $defaults->stripNull ?? false;
         $clone->id ??= $defaults->id;
         $clone->evictCache ??= $defaults->evictCache ?? false;
+        $clone->message ??= $defaults->message;
 
         return $clone;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -153,7 +153,7 @@ class EntityValueResolverTest extends TestCase
         $request = new Request();
         $request->attributes->set('id', 'test');
 
-        $argument = $this->createArgument('stdClass', new MapEntity(id: 'id'));
+        $argument = $this->createArgument('stdClass', new MapEntity(id: 'id', message: 'Test'));
 
         $repository = $this->getMockBuilder(ObjectRepository::class)->getMock();
         $repository->expects($this->once())
@@ -167,6 +167,7 @@ class EntityValueResolverTest extends TestCase
             ->willReturn($repository);
 
         $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Test');
 
         $resolver->resolve($request, $argument);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Allow the message in NotFoundHttpException to be overridden with the `message` argument in `#[MapEntity]`.
