### PR TITLE
[Mailer] bug - fix EsmtpTransport variable $code definition

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -192,6 +192,28 @@ class EsmtpTransportTest extends TestCase
             $stream->getCommands()
         );
     }
+
+    public function testConstructorWithEmptyAuthenticator()
+    {
+        $stream = new DummyStream();
+        $transport = new EsmtpTransport(stream: $stream);
+        $transport->setUsername('testuser');
+        $transport->setPassword('p4ssw0rd');
+        $transport->setAuthenticators([]); // if no authenticators defined, then there needs to be a TransportException
+
+        $message = new Email();
+        $message->from('sender@example.org');
+        $message->addTo('recipient@example.org');
+        $message->text('.');
+
+        try {
+            $transport->send($message);
+            $this->fail('Symfony\Component\Mailer\Exception\TransportException to be thrown');
+        } catch (TransportException $e) {
+            $this->assertStringStartsWith('Failed to find an authenticator supported by the SMTP server, which currently supports: "plain", "login", "cram-md5", "xoauth2".', $e->getMessage());
+            $this->assertEquals(504, $e->getCode());
+        }
+    }
 }
 
 class CustomEsmtpTransport extends EsmtpTransport

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -184,6 +184,7 @@ class EsmtpTransport extends SmtpTransport
             return;
         }
 
+        $code = null;
         $authNames = [];
         $errors = [];
         $modes = array_map('strtolower', $modes);
@@ -192,7 +193,6 @@ class EsmtpTransport extends SmtpTransport
                 continue;
             }
 
-            $code = null;
             $authNames[] = $authenticator->getAuthKeyword();
             try {
                 $authenticator->authenticate($this);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

This PR contains a basic fix of a bug in SymfonyMailer component (`Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport` class).

If we use `EsmtpTransport` like the given example, it needs to throw TransportException which has been defined in the `handleAuth()` of `EsmtpTransport` class. (Because we called `setAuthenticators()` with empty array and the function emptied the authenticators. We can imagine that we forget to set authenticators.)

```
$stream = new DummyStream();
$transport = new EsmtpTransport(stream: $stream);
$transport->setUsername('testuser');
$transport->setPassword('p4ssw0rd');
$transport->setAuthenticators([]);
..
..
$transport->send(...);
```

This code piece needs to throw following TransportException with code 504;
```
Failed to find an authenticator supported by the SMTP server, which currently supports: "plain", "login", "cram-md5", "xoauth2".
```

However it shows a PHP Error;
```
Undefined variable $code
```

I included a unit test function `testConstructorWithEmptyAuthenticator()` inside of the `EsmtpTransportTest` class with a fix of the problem.