### PR TITLE
[Mailer] bug - reset $code variable each iteration for prevent wrong exception codes

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -193,6 +193,7 @@ class EsmtpTransport extends SmtpTransport
                 continue;
             }
 
+            $code = null;
             $authNames[] = $authenticator->getAuthKeyword();
             try {
                 $authenticator->authenticate($this);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

Follow up PR of #51568 to reset `$code` variable for each iteration to have correct `TransportException` code.

(Note: This bug does not exist in version 5.4)