### PR TITLE
[Security] Add badge resolution to profiler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -28,6 +28,25 @@
             border: 0;
             padding: 0 0 8px 0;
         }
+
+        #collector-content .authenticators .badge {
+            color: var(--white);
+            display: inline-block;
+            text-align: center;
+        }
+        #collector-content .authenticators .badge.badge-resolved {
+            background-color: var(--green-500);
+        }
+        #collector-content .authenticators .badge.badge-not_resolved {
+            background-color: var(--yellow-500);
+        }
+
+        #collector-content .authenticators svg[data-icon-name="icon-tabler-check"] {
+            color: var(--green-500);
+        }
+        #collector-content .authenticators svg[data-icon-name="icon-tabler-x"] {
+            color: var(--red-500);
+        }
     </style>
 {% endblock %}
 
@@ -316,13 +335,15 @@
                 <h3 class="tab-title">Authenticators</h3>
                 <div class="tab-content">
                     {% if collector.authenticators|default([]) is not empty %}
-                        <table>
+                        <table class="authenticators">
                             <thead>
                             <tr>
                                 <th>Authenticator</th>
                                 <th>Supports</th>
+                                <th>Authenticated</th>
                                 <th>Duration</th>
                                 <th>Passport</th>
+                                <th>Badges</th>
                             </tr>
                             </thead>
 
@@ -340,8 +361,18 @@
                                 <tr>
                                     <td class="font-normal">{{ profiler_dump(authenticator.stub) }}</td>
                                     <td class="no-wrap">{{ source('@WebProfiler/Icon/' ~ (authenticator.supports ? 'yes' : 'no') ~ '.svg') }}</td>
+                                    <td class="no-wrap">{{ authenticator.authenticated is not null ? source('@WebProfiler/Icon/' ~ (authenticator.authenticated ? 'yes' : 'no') ~ '.svg') : '' }}</td>
                                     <td class="no-wrap">{{ '%0.2f'|format(authenticator.duration * 1000) }} ms</td>
                                     <td class="font-normal">{{ authenticator.passport ? profiler_dump(authenticator.passport) : '(none)' }}</td>
+                                    <td class="font-normal">
+                                        {% for badge in authenticator.badges ?? [] %}
+                                            <span class="badge badge-{{ badge.resolved ? 'resolved' : 'not_resolved' }}">
+                                            {{ badge.stub|abbr_class }}
+                                            </span>
+                                        {% else %}
+                                            (none)
+                                        {% endfor %}
+                                    </td>
                                 </tr>
 
                                 {% if loop.last %}

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
@@ -53,6 +53,8 @@ final class TraceableAuthenticatorManagerListener extends AbstractListener
                 'stub' => $this->hasVardumper ? new ClassStub($skippedAuthenticator::class) : $skippedAuthenticator::class,
                 'passport' => null,
                 'duration' => 0,
+                'authenticated' => null,
+                'badges' => [],
             ];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #36668
| License       | MIT
| Doc PR        | 

This PR add badges resolution status in Security profiler as mentioned in #36668 (" See which badges are resolved and which aren't").

### CSRF error

![image](https://github.com/symfony/symfony/assets/6114779/fbadfdeb-451f-4ac1-bd59-23f0cb121e6d)

### Wrong credentials

![image](https://github.com/symfony/symfony/assets/6114779/49246ffa-4152-448c-b82e-eebd43bad9d8)

### Authentication successful

![image](https://github.com/symfony/symfony/assets/6114779/1cb5f9a7-5dc2-460c-a744-0f89fb6b8e3b)
