### PR TITLE
[ErrorHandler] Handle PHP 8.3 `highlight_file` function output changes 

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -123,13 +123,25 @@ final class CodeExtension extends AbstractExtension
             // highlight_file could throw warnings
             // see https://bugs.php.net/25725
             $code = @highlight_file($file, true);
-            // remove main code/span tags
-            $code = preg_replace('#^<code.*?>\s*<span.*?>(.*)</span>\s*</code>#s', '\\1', $code);
-            // split multiline spans
-            $code = preg_replace_callback('#<span ([^>]++)>((?:[^<]*+<br \/>)++[^<]*+)</span>#', function ($m) {
-                return "<span $m[1]>".str_replace('<br />', "</span><br /><span $m[1]>", $m[2]).'</span>';
-            }, $code);
-            $content = explode('<br />', $code);
+            if (\PHP_VERSION_ID >= 80300) {
+                // remove main pre/code tags
+                $code = preg_replace('#^<pre.*?>\s*<code.*?>(.*)</code>\s*</pre>#s', '\\1', $code);
+                // split multiline code tags
+                $code = preg_replace_callback('#<code ([^>]++)>((?:[^<]*+\\n)++[^<]*+)</code>#', function ($m) {
+                    return "<code $m[1]>".str_replace("\n", "</code>\n<code $m[1]>", $m[2]).'</code>';
+                }, $code);
+                // Convert spaces to html entities to preserve indentation when rendered
+                $code = str_replace(' ', '&nbsp;', $code);
+                $content = explode("\n", $code);
+            } else {
+                // remove main code/span tags
+                $code = preg_replace('#^<code.*?>\s*<span.*?>(.*)</span>\s*</code>#s', '\\1', $code);
+                // split multiline spans
+                $code = preg_replace_callback('#<span ([^>]++)>((?:[^<]*+<br \/>)++[^<]*+)</span>#', function ($m) {
+                    return "<span $m[1]>".str_replace('<br />', "</span><br /><span $m[1]>", $m[2]).'</span>';
+                }, $code);
+                $content = explode('<br />', $code);
+            }
 
             $lines = [];
             if (0 > $srcContext) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | PHP 8.3 Compatibility
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

PHP 8.3 changes the output from the `highlight_file` function as described here: https://php.watch/versions/8.3/highlight_file-highlight_string-html-changes

I accidentally ran into this head first when using PHP 8.3.0-RC1 in development with Symfony 6.4-dev when my error had no code rendered 

Also affected the `{{ '/path/to/file.html.twig'|file_excerpt(140,5) }}` twig code ` file_except` renderer - easier to replicate with that code just throw it into your twig file with a valid `/path/to/file.html.twig` - before this PR there would be no output, after this PR the file except would be shown. 

Same fix applied to both files.

![ScreenShot-2023-09-06-21 42 56](https://github.com/symfony/symfony/assets/400092/6a7b8302-dad3-44d8-a228-9bbfbaa13b34)

After this fix the code rendered returned.

![ScreenShot-2023-09-06-21 29 54](https://github.com/symfony/symfony/assets/400092/3d107496-d867-4c77-839a-f013567f6523)


