### PR TITLE
[FrameworkBundle] Always use buildDir as `ConfigBuilderGenerator` outputDir

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -44,7 +44,7 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
      */
     public function warmUp(string $cacheDir)
     {
-        $generator = new ConfigBuilderGenerator($cacheDir);
+        $generator = new ConfigBuilderGenerator($this->kernel->getBuildDir());
 
         foreach ($this->kernel->getBundles() as $bundle) {
             $extension = $bundle->getContainerExtension();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
+
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\ConfigBuilderCacheWarmer;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Kernel;
+
+class ConfigBuilderCacheWarmerTest extends TestCase
+{
+    private $varDir;
+
+    protected function setUp(): void
+    {
+        $this->varDir = sys_get_temp_dir().'/'.uniqid();
+        $fs = new Filesystem();
+        $fs->mkdir($this->varDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $fs = new Filesystem();
+        $fs->remove($this->varDir);
+        unset($this->varDir);
+    }
+
+    public function testBuildDirIsUsedAsConfigBuilderOutputDir()
+    {
+        $kernel = new class($this->varDir) extends Kernel {
+            private $varDir;
+
+            public function __construct(string $varDir)
+            {
+                parent::__construct('test', false);
+
+                $this->varDir = $varDir;
+            }
+
+            public function registerBundles(): iterable
+            {
+                yield new FrameworkBundle();
+            }
+
+            public function getBuildDir(): string
+            {
+                return $this->varDir.'/build';
+            }
+
+            public function getCacheDir(): string
+            {
+                return $this->varDir.'/cache';
+            }
+
+            public function registerContainerConfiguration(LoaderInterface $loader)
+            {
+            }
+        };
+        $kernel->boot();
+
+        $warmer = new ConfigBuilderCacheWarmer($kernel);
+        $warmer->warmUp($kernel->getCacheDir());
+
+        self::assertDirectoryExists($kernel->getBuildDir().'/Symfony');
+        self::assertDirectoryDoesNotExist($kernel->getCacheDir().'/Symfony');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51582
| License       | MIT
| Doc PR        | -

The `ConfigBuilderGenerator` is instantiated in three places, two of which use `kernel.build_dir` as the output dir, and one which uses `kernel.cache_dir`:
- https://github.com/symfony/symfony/blob/29f427fcbd78b700a1b253c7927e51017d964f59/src/Symfony/Component/HttpKernel/Kernel.php#L736
- https://github.com/symfony/symfony/blob/29f427fcbd78b700a1b253c7927e51017d964f59/src/Symfony/Component/DependencyInjection/Extension/ExtensionTrait.php#L55-L61
- https://github.com/symfony/symfony/blob/29f427fcbd78b700a1b253c7927e51017d964f59/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php#L43-L45

This PR fixes this inconsistency so that `kernel.build_dir` is always used.