### PR TITLE
[RateLimiter] Fix SlidingWindow calculation

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -100,9 +100,26 @@ final class SlidingWindow implements LimiterStateInterface
         return (int) floor($this->hitCountForLastWindow * (1 - $percentOfCurrentTimeFrame) + $this->hitCount);
     }
 
-    public function getRetryAfter(): \DateTimeImmutable
+    public function calculateTimeForTokens(int $maxSize, int $tokens): float
     {
-        return \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $this->windowEndAt));
+        $remaining = $maxSize - $this->getHitCount();
+        if ($remaining >= $tokens) {
+            return 0;
+        }
+
+        $time = microtime(true);
+        $startOfWindow = $this->windowEndAt - $this->intervalInSeconds;
+        $timePassed = $time - $startOfWindow;
+        $windowPassed = min($timePassed / $this->intervalInSeconds, 1);
+        $releasable = max(1, $maxSize - floor($this->hitCountForLastWindow * (1 - $windowPassed))); // 2 * (0.7) =1, 3
+        $remainingWindow = $this->intervalInSeconds - $timePassed;
+        $needed = $tokens - $remaining;
+
+        if ($releasable >= $needed) {
+            return $needed * ($remainingWindow / max(1, $releasable));
+        }
+
+        return ($this->windowEndAt - $time) + ($needed - $releasable) * ($this->intervalInSeconds / $maxSize);
     }
 
     public function __serialize(): array

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\RateLimiter\Policy;
 
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\NoLock;
-use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
+use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
 use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Component\RateLimiter\RateLimit;
 use Symfony\Component\RateLimiter\Reservation;
@@ -53,14 +53,10 @@ final class SlidingWindowLimiter implements LimiterInterface
 
     public function reserve(int $tokens = 1, float $maxTime = null): Reservation
     {
-        throw new ReserveNotSupportedException(__CLASS__);
-    }
+        if ($tokens > $this->limit) {
+            throw new \InvalidArgumentException(sprintf('Cannot reserve more tokens (%d) than the size of the rate limiter (%d).', $tokens, $this->limit));
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function consume(int $tokens = 1): RateLimit
-    {
         $this->lock->acquire(true);
 
         try {
@@ -71,18 +67,42 @@ final class SlidingWindowLimiter implements LimiterInterface
                 $window = SlidingWindow::createFromPreviousWindow($window, $this->interval);
             }
 
+            $now = microtime(true);
             $hitCount = $window->getHitCount();
             $availableTokens = $this->getAvailableTokens($hitCount);
-            if ($availableTokens < $tokens) {
-                return new RateLimit($availableTokens, $window->getRetryAfter(), false, $this->limit);
+            if ($availableTokens >= $tokens) {
+                $window->add($tokens);
+
+                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->limit));
+            } else {
+                $waitDuration = $window->calculateTimeForTokens($this->limit, max(1, $tokens));
+
+                if (null !== $maxTime && $waitDuration > $maxTime) {
+                    // process needs to wait longer than set interval
+                    throw new MaxWaitDurationExceededException(sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
+                }
+
+                $window->add($tokens);
+
+                $reservation = new Reservation($now + $waitDuration, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
             }
 
-            $window->add($tokens);
-            $this->storage->save($window);
-
-            return new RateLimit($this->getAvailableTokens($window->getHitCount()), $window->getRetryAfter(), true, $this->limit);
+            if (0 < $tokens) {
+                $this->storage->save($window);
+            }
         } finally {
             $this->lock->release();
+        }
+
+        return $reservation;
+    }
+
+    public function consume(int $tokens = 1): RateLimit
+    {
+        try {
+            return $this->reserve($tokens, 0)->getRateLimit();
+        } catch (MaxWaitDurationExceededException $e) {
+            return $e->getRateLimit();
         }
     }
 

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\RateLimiter\Tests\Policy;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
-use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
 use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
 use Symfony\Component\RateLimiter\RateLimit;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
@@ -66,14 +65,17 @@ class SlidingWindowLimiterTest extends TestCase
 
         $start = microtime(true);
         $rateLimit->wait(); // wait 12 seconds
-        $this->assertEqualsWithDelta($start + 12, microtime(true), 1);
+        $this->assertEqualsWithDelta($start + (12 / 5), microtime(true), 1);
+        $this->assertTrue($limiter->consume()->isAccepted());
     }
 
     public function testReserve()
     {
-        $this->expectException(ReserveNotSupportedException::class);
+        $limiter = $this->createLimiter();
+        $limiter->consume(8);
 
-        $this->createLimiter()->reserve();
+        // 2 over the limit, causing the WaitDuration to become 2/10th of the 12s interval
+        $this->assertEqualsWithDelta(12 / 5, $limiter->reserve(4)->getWaitDuration(), 1);
     }
 
     private function createLimiter(): SlidingWindowLimiter

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowTest.php
@@ -81,12 +81,14 @@ class SlidingWindowTest extends TestCase
     {
         ClockMock::register(SlidingWindow::class);
         $window = new SlidingWindow('foo', 8);
+        $window->add();
 
         usleep(11.6 * 1e6); // wait just under 12s (8+4)
         $new = SlidingWindow::createFromPreviousWindow($window, 4);
+        $new->add();
 
         // should be 400ms left (12 - 11.6)
-        $this->assertEqualsWithDelta(0.4, $new->getRetryAfter()->format('U.u') - microtime(true), 0.2);
+        $this->assertEqualsWithDelta(0.4, $new->calculateTimeForTokens(1, 1), 0.1);
     }
 
     public function testIsExpiredUsesMicrotime()
@@ -101,18 +103,22 @@ class SlidingWindowTest extends TestCase
     public function testGetRetryAfterUsesMicrotime()
     {
         $window = new SlidingWindow('foo', 10);
+        $window->add();
 
         usleep(9.5 * 1e6);
         // should be 500ms left (10 - 9.5)
-        $this->assertEqualsWithDelta(0.5, $window->getRetryAfter()->format('U.u') - microtime(true), 0.2);
+        $this->assertEqualsWithDelta(0.5, $window->calculateTimeForTokens(1, 1), 0.1);
     }
 
     public function testCreateAtExactTime()
     {
-        ClockMock::register(SlidingWindow::class);
-        ClockMock::withClockMock(1234567890.000000);
         $window = new SlidingWindow('foo', 10);
-        $window->getRetryAfter();
-        $this->assertEquals('1234567900.000000', $window->getRetryAfter()->format('U.u'));
+        $this->assertEquals(30, $window->calculateTimeForTokens(1, 4));
+
+        $window = new SlidingWindow('foo', 10);
+        $window->add();
+        $window = SlidingWindow::createFromPreviousWindow($window, 10);
+        sleep(10);
+        $this->assertEquals(40, $window->calculateTimeForTokens(1, 4));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #40289
| License       | MIT


Reopened https://github.com/symfony/symfony/pull/47557 but as a bugfix PR targeting 5.4 instead. 

This implements `LimiterInterface->reserve()` for `SlidingWindowLimiter`. I'm not sure if the lack of implementation was due to time/scope or if it's actually not possible and my approach is incorrect. But I like to give it a try anyway. Perhaps @wouterj you could elaborate on that? 

The calculation does the following:

1. Calculate tokens to be released within this window. E.g. if 4 were used in the last window, at 50% into the current, 2 are still to be released.
2. Calculate the time-per-token within the remainder of the window. If the requested tokens will be available before the end of the current window, return the time-per-token * needed-tokens. 
3. Otherwise return time-per-token of the regular interval * needed-tokens(-after the current window). 

Some other things I've noticed in the RateLimiter:
- `FixedWindowLimiter` uses a `Window` class, whereas `SlidingWindowLimiter` uses a `SlidingWindow`. Shouldn't the first have a `FixedWindow` class?
- The `Window` class takes its `$windowSize` as argument, `SlidingWindow` does not. Perhaps the latter could also take this argument in this PR, since it's used in the calculation. But I guess those classes have to be backwards compatible.
- `SlidingWindow->getRetryAfter()` is no longer used and could be deprecated in favor of `calculateTimeForTokens`. Making it more like the fixed window.

