### PR TITLE
[Cache] fix using multiple Redis Sentinel hosts when the first one is not resolvable

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -217,8 +217,11 @@ trait RedisTrait
                     }
                     $sentinel = new \RedisSentinel($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...$extra);
 
-                    if ($address = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
-                        [$host, $port] = $address;
+                    try {
+                        if ($address = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
+                            [$host, $port] = $address;
+                        }
+                    } catch (\RedisException $e) {
                     }
                 } while (++$hostIndex < \count($hosts) && !$address);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51570
| License       | MIT
| Doc PR        | 

See ticket #51570 for details on this bugfix.

As mentioned in the ticket, I am not sure if it's wise to catch all exceptions or if it would be better to only check for specific ones. But since I cannot think about any reasons other than an unreachable host to raise any exception, I decided to catch all exceptions for now.