### PR TITLE
[Mime] Allow to add some headers as a strings

### DIFF
--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -147,6 +147,8 @@ final class Headers
             $method = 'addTextHeader';
         } elseif ('addIdentificationHeader' === $method) {
             $method = 'addIdHeader';
+        } elseif ('addMailboxListHeader' === $method && !\is_array($argument)) {
+            $argument = [$argument];
         }
 
         return $this->$method($name, $argument, $more);

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -69,6 +69,7 @@ class HeadersTest extends TestCase
     {
         $headers = new Headers();
         $headers->addHeader('from', ['from@example.com']);
+        $headers->addHeader('reply-to', 'reply@example.com');
         $headers->addHeader('return-path', 'return@example.com');
         $headers->addHeader('foo', 'bar');
         $headers->addHeader('date', $now = new \DateTimeImmutable());
@@ -76,6 +77,9 @@ class HeadersTest extends TestCase
 
         $this->assertInstanceOf(MailboxListHeader::class, $headers->get('from'));
         $this->assertEquals([new Address('from@example.com')], $headers->get('from')->getBody());
+
+        $this->assertInstanceOf(MailboxListHeader::class, $headers->get('reply-to'));
+        $this->assertEquals([new Address('reply@example.com')], $headers->get('reply-to')->getBody());
 
         $this->assertInstanceOf(PathHeader::class, $headers->get('return-path'));
         $this->assertEquals(new Address('return@example.com'), $headers->get('return-path')->getBody());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      |  no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51584
| License       | MIT

When adding a MailboxListHeader header, the constructor expects an array as parameter.

To simplify the UX, we now allow you to pass a string to the addHeader method in the case of a MailBoxListHeader. The header value is then converted to an array.
