### PR TITLE
[Cache] Allow to use namespace delimiter in cache key

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -37,7 +37,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).static::NS_SEPARATOR;
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::NS_SEPARATOR).static::NS_SEPARATOR;
         $this->defaultLifetime = $defaultLifetime;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s").', $this->maxIdLength - 24, \strlen($namespace), $namespace));

--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -37,9 +37,14 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
 
     private const TAGS_PREFIX = "\1tags\1";
 
+    /**
+     * @internal
+     */
+    protected const NS_SEPARATOR = ':';
+
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).':';
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::NS_SEPARATOR).static::NS_SEPARATOR;
         $this->defaultLifetime = $defaultLifetime;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s").', $this->maxIdLength - 24, \strlen($namespace), $namespace));

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -30,6 +30,11 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
 {
     use LoggerAwareTrait;
 
+    /**
+     * @internal
+     */
+    protected const NS_SEPARATOR = ':';
+
     private bool $storeSerialized;
     private array $values = [];
     private array $tags = [];
@@ -108,7 +113,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
 
             return true;
         }
-        \assert('' !== CacheItem::validateKey($key));
+        \assert('' !== CacheItem::validateKey($key, static::NS_SEPARATOR));
 
         return isset($this->expiries[$key]) && !$this->deleteItem($key);
     }
@@ -138,7 +143,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
 
     public function deleteItem(mixed $key): bool
     {
-        \assert('' !== CacheItem::validateKey($key));
+        \assert('' !== CacheItem::validateKey($key, static::NS_SEPARATOR));
         unset($this->values[$key], $this->tags[$key], $this->expiries[$key]);
 
         return true;
@@ -357,7 +362,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
     {
         foreach ($keys as $key) {
             if (!\is_string($key) || !isset($this->expiries[$key])) {
-                CacheItem::validateKey($key);
+                CacheItem::validateKey($key, static::NS_SEPARATOR);
             }
         }
 

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -127,7 +127,7 @@ final class CacheItem implements ItemInterface
      *
      * @throws InvalidArgumentException When $key is not valid
      */
-    public static function validateKey($key): string
+    public static function validateKey($key, string $allowChars = null): string
     {
         if (!\is_string($key)) {
             throw new InvalidArgumentException(sprintf('Cache key must be string, "%s" given.', get_debug_type($key)));
@@ -135,8 +135,9 @@ final class CacheItem implements ItemInterface
         if ('' === $key) {
             throw new InvalidArgumentException('Cache key length must be greater than zero.');
         }
-        if (false !== strpbrk($key, self::RESERVED_CHARACTERS)) {
-            throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters "%s".', $key, self::RESERVED_CHARACTERS));
+        $reservedChars = null === $allowChars ? self::RESERVED_CHARACTERS : str_replace(str_split($allowChars), '', self::RESERVED_CHARACTERS);
+        if ('' !== $reservedChars && false !== strpbrk($key, $reservedChars)) {
+            throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters "%s".', $key, $reservedChars));
         }
 
         return $key;

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -21,6 +21,8 @@ use Symfony\Contracts\Cache\CallbackInterface;
 
 abstract class AdapterTestCase extends CachePoolTest
 {
+    protected static ?string $allowPsr6Keys = ':';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -38,6 +40,16 @@ abstract class AdapterTestCase extends CachePoolTest
             $this->skippedTests['testDeleteItemsInvalidKeys'] = 'Keys are checked only when assert() is enabled.';
         } catch (\Exception $e) {
         }
+    }
+
+    public static function invalidKeys(): array
+    {
+        $keys = parent::invalidKeys();
+        if (null !== static::$allowPsr6Keys) {
+            $keys = array_filter($keys, fn ($key) => !\is_string($key[0] ?? null) || false === strpbrk($key[0], static::$allowPsr6Keys));
+        }
+
+        return $keys;
     }
 
     public function testGet()

--- a/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\Cache\Psr16Cache;
  */
 class Psr16AdapterTest extends AdapterTestCase
 {
+    protected static ?string $allowPsr6Keys = null;
+
     protected $skippedTests = [
         'testPrune' => 'Psr16adapter just proxies',
         'testClearPrefix' => 'SimpleCache cannot clear by prefix',

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -57,7 +57,7 @@ class Psr16CacheTest extends SimpleCacheTest
 
     public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
-        return new Psr16Cache(new FilesystemAdapter('', $defaultLifetime));
+        return new Psr16Cache(new FilesystemTestAdapter('', $defaultLifetime));
     }
 
     public static function validKeys(): array
@@ -180,4 +180,9 @@ class NotUnserializable
     {
         throw new \Exception(__CLASS__);
     }
+}
+
+class FilesystemTestAdapter extends FilesystemAdapter
+{
+    protected const NS_SEPARATOR = '_';
 }

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -346,7 +346,7 @@ trait AbstractAdapterTrait
         if (\is_string($key) && isset($this->ids[$key])) {
             return $this->namespace.$this->namespaceVersion.$this->ids[$key];
         }
-        \assert('' !== CacheItem::validateKey($key));
+        \assert('' !== CacheItem::validateKey($key, static::NS_SEPARATOR));
         $this->ids[$key] = $key;
 
         if (\count($this->ids) > 1000) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4  
| Bug fix?      |  no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45599
| License       | MIT
| Doc PR        | -

This PR allow colon char `:` in cache key. It may be useful for redis grouping keys by pattern without creating a many pools for each namespace. 

Difference between implementation https://github.com/symfony/symfony/pull/47561
- colon is only allowed for Symfony contracts cache, the PSR-6/16 adapters keeps this validation as before.
- Allow colon in namespace name too
