### PR TITLE
[DebugBundle][HttpKernel] Remove checking if `CliDumper::setDisplayOptions` method exists

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -20,7 +20,6 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\VarDumper\Caster\ReflectionCaster;
-use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 /**
@@ -85,13 +84,11 @@ class DebugExtension extends Extension
             ;
         }
 
-        if (method_exists(CliDumper::class, 'setDisplayOptions')) {
-            $container->getDefinition('var_dumper.cli_dumper')
-                ->addMethodCall('setDisplayOptions', [[
-                    'fileLinkFormat' => new Reference('debug.file_link_formatter', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE),
-                ]])
-            ;
-        }
+        $container->getDefinition('var_dumper.cli_dumper')
+            ->addMethodCall('setDisplayOptions', [[
+                'fileLinkFormat' => new Reference('debug.file_link_formatter', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE),
+            ]])
+        ;
 
         if (!class_exists(Command::class) || !class_exists(ServerLogCommand::class)) {
             $container->removeDefinition('monolog.command.server_log');

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -122,9 +122,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                 $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
             } else {
                 $dumper = new CliDumper('php://output', $this->charset);
-                if (method_exists($dumper, 'setDisplayOptions')) {
-                    $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
-                }
+                $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
             }
 
             foreach ($this->data as $dump) {
@@ -238,9 +236,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                 $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
             } else {
                 $dumper = new CliDumper('php://output', $this->charset);
-                if (method_exists($dumper, 'setDisplayOptions')) {
-                    $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
-                }
+                $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
             }
 
             foreach ($this->data as $i => $dump) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR remove checking if method `CliDumper::setDisplayOptions` exists.

This method was introduced in symfony 4.3 (https://github.com/symfony/symfony/pull/29235/files#diff-0f87a0e604b55c0f8a2d5e0e849afdf6728ce7228ae44cee64d5d1e1c7040387R122), so with the following requirements, it's always available

- HttpKernel: conflict with `"symfony/var-dumper": "<6.3",`
- DebugBundle: require `"symfony/var-dumper": "^5.4|^6.0|^7.0",`

