### PR TITLE
[FrameworkBundle][VarDumper] Remove checking if `OutputFormatterStyle::setHref` method exist

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\Descriptor;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
-use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -34,12 +33,10 @@ use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 #[AsCommand(name: 'debug:autowiring', description: 'List classes/interfaces you can use for autowiring')]
 class DebugAutowiringCommand extends ContainerDebugCommand
 {
-    private bool $supportsHref;
     private ?FileLinkFormatter $fileLinkFormatter;
 
     public function __construct(string $name = null, FileLinkFormatter $fileLinkFormatter = null)
     {
-        $this->supportsHref = method_exists(OutputFormatterStyle::class, 'setHref');
         $this->fileLinkFormatter = $fileLinkFormatter;
         parent::__construct($name);
     }
@@ -124,7 +121,7 @@ EOF
             }
 
             $serviceLine = sprintf('<fg=yellow>%s</>', $serviceId);
-            if ($this->supportsHref && '' !== $fileLink = $this->getFileLink($previousId)) {
+            if ('' !== $fileLink = $this->getFileLink($previousId)) {
                 $serviceLine = substr($serviceId, \strlen($previousId));
                 $serviceLine = sprintf('<fg=yellow;href=%s>%s</>', $fileLink, $previousId).('' !== $serviceLine ? sprintf('<fg=yellow>%s</>', $serviceLine) : '');
             }

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\VarDumper\Tests\Command\Descriptor;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Command\Descriptor\CliDescriptor;
@@ -84,8 +83,7 @@ TXT
                     'file_link' => 'phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30',
                 ],
             ],
-            method_exists(OutputFormatterStyle::class, 'setHref') ?
-                <<<TXT
+            <<<TXT
 Received from client #1
 -----------------------
 
@@ -95,41 +93,25 @@ Received from client #1
   file     src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php  
  -------- -------------------------------------------------------------------------------- 
 
-TXT
-                :
-                <<<TXT
-Received from client #1
------------------------
-
- -------- -------------------------------------------------------------------------------- 
-  date     Fri, 14 Dec 2018 16:17:48 +0000                                                 
-  source   CliDescriptorTest.php on line 30                                                
-  file     src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php  
- -------- -------------------------------------------------------------------------------- 
-
-Open source in your IDE/browser:
-phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30
 TXT
         ];
 
-        if (method_exists(OutputFormatterStyle::class, 'setHref')) {
-            yield 'source with hyperlink' => [
-                [
-                    'source' => [
-                        'name' => 'CliDescriptorTest.php',
-                        'line' => 30,
-                        'file_relative' => 'src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php',
-                        'file_link' => 'phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30',
-                    ],
+        yield 'source with hyperlink' => [
+            [
+                'source' => [
+                    'name' => 'CliDescriptorTest.php',
+                    'line' => 30,
+                    'file_relative' => 'src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php',
+                    'file_link' => 'phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30',
                 ],
-                <<<TXT
+            ],
+            <<<TXT
 %A
   source   \033]8;;phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30\033\CliDescriptorTest.php on line 30\033]8;;\033%A
 %A
 TXT
-                , true,
-            ];
-        }
+            , true,
+        ];
 
         yield 'cli' => [
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


This PR remove checking if method `OutputFormatterStyle::setHref` exists.

This method was introduced in symfony 4.3 (https://github.com/symfony/symfony/commit/db750ed8ae80de9417e7964c532ab4bc44b4f9d4#diff-29691f0530c515295523702494d8ff3b3eda0d50d44a29294f5fcbe39edc78bdR122), so with the following requirements, it's always available

- FrameworkBundle: conflict with `"symfony/console": "<5.4",`
- VarDumper: conflict with `"symfony/console": "<5.4",`

(Applying fabbot will break unit tests)