### PR TITLE
[PropertyInfo] Remove checking if `AttributeMetadataInterface::setIgnore` method exists

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -42,7 +42,7 @@ class SerializerExtractor implements PropertyListExtractorInterface
         $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            $ignored = method_exists($serializerAttributeMetadata, 'isIgnored') && $serializerAttributeMetadata->isIgnored();
+            $ignored = $serializerAttributeMetadata->isIgnored();
             if (!$ignored && (null === $context['serializer_groups'] || array_intersect($context['serializer_groups'], $serializerAttributeMetadata->getGroups()))) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


This PR remove checking if method `AttributeMetadataInterface::setIgnore` exists.

This method was introduced in symfony 5.1 (https://github.com/symfony/symfony/pull/28744/files#diff-98f3aa4632c5366a34f92bfa1b2165742bf5b572da2fb4f888d8fe47465eb8eaR67), so with the following requirements, it's always available

- PropertyInfo: conflict with `"symfony/serializer": "<5.4",`