### PR TITLE
[Security] Fix for TraceableAuthenticator debug when no Auth

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -54,7 +54,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
                         'resolved' => $badge->isResolved(),
                     ];
                 },
-                $this->passport->getBadges(),
+                $this->passport?->getBadges() ?? [],
             ),
         ];
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
@@ -36,4 +36,14 @@ class TraceableAuthenticatorTest extends TestCase
         $this->assertSame($passport, $traceable->authenticate($request));
         $this->assertSame($passport, $traceable->getInfo()['passport']);
     }
+
+    public function testGetInfoWithoutAuth()
+    {
+        $authenticator = $this->createMock(AuthenticatorInterface::class);
+
+        $traceable = new TraceableAuthenticator($authenticator);
+        $this->assertNull($traceable->getInfo()['passport']);
+        $this->assertIsArray($traceable->getInfo()['badges']);
+        $this->assertSame([], $traceable->getInfo()['badges']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/pull/51585#issuecomment-1712828991
| License       | MIT

Fixes regression in PR #51585 and adds unit test

![image](https://github.com/symfony/symfony/assets/400092/8645c3c4-1827-4dce-83b6-a1cdace8dfb1)
