### PR TITLE
[DebugBundle] Remove obsolete VarDumper feature detection

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -43,14 +43,10 @@ class DebugExtension extends Extension
         $container->getDefinition('var_dumper.cloner')
             ->addMethodCall('setMaxItems', [$config['max_items']])
             ->addMethodCall('setMinDepth', [$config['min_depth']])
-            ->addMethodCall('setMaxString', [$config['max_string_length']]);
+            ->addMethodCall('setMaxString', [$config['max_string_length']])
+            ->addMethodCall('addCasters', [ReflectionCaster::UNSET_CLOSURE_FILE_INFO]);
 
-        if (method_exists(ReflectionCaster::class, 'unsetClosureFileInfo')) {
-            $container->getDefinition('var_dumper.cloner')
-                ->addMethodCall('addCasters', [ReflectionCaster::UNSET_CLOSURE_FILE_INFO]);
-        }
-
-        if (method_exists(HtmlDumper::class, 'setTheme') && 'dark' !== $config['theme']) {
+        if ('dark' !== $config['theme']) {
             $container->getDefinition('var_dumper.html_dumper')
                 ->addMethodCall('setTheme', [$config['theme']]);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR removes detection for features introduced with #30301 (Symfony 4.3) and #27261 (Symfony 4.2).