### PR TITLE
[PsrHttpMessageBridge] Remove `Cookie::create()` detection

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Functional/CovertTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Functional/CovertTest.php
@@ -195,11 +195,7 @@ class CovertTest extends TestCase
             ['x-symfony' => ['3.4']]
         );
 
-        if (method_exists(Cookie::class, 'create')) {
-            $cookie = Cookie::create('city', 'Lille', new \DateTime('Wed, 13 Jan 2021 22:23:01 GMT'));
-        } else {
-            $cookie = new Cookie('city', 'Lille', new \DateTime('Wed, 13 Jan 2021 22:23:01 GMT'));
-        }
+        $cookie = Cookie::create('city', 'Lille', new \DateTime('Wed, 13 Jan 2021 22:23:01 GMT'));
 
         $sfResponse->headers->setCookie($cookie);
         $body = Psr7Stream::create();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This method exists since #28447 (Symfony 4.2)