### PR TITLE
[TwigBridge][TwigBundle] Drop support for Twig 2

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -462,6 +462,7 @@ TwigBundle
  * Remove option `twig.autoescape`; create a class that implements your escaping strategy
    (check `FileExtensionEscapingStrategy::guess()` for inspiration) and reference it using
    the `twig.autoescape_service` option instead
+ * Drop support for Twig 2
 
 Validator
 ---------

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-xml": "*",
         "doctrine/event-manager": "^2",
         "doctrine/persistence": "^3.1",
-        "twig/twig": "^2.13|^3.0.4",
+        "twig/twig": "^3.0.4",
         "psr/cache": "^2.0|^3.0",
         "psr/clock": "^1.0",
         "psr/container": "^1.1|^2.0",

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.0
+---
+
+ * Drop support for Twig 2
+
 6.3
 ---
 

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/translation-contracts": "^2.5|^3",
-        "twig/twig": "^2.13|^3.0.4"
+        "twig/twig": "^3.0.4"
     },
     "require-dev": {
         "egulias/email-validator": "^2.1.10|^3|^4",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -70,7 +70,7 @@
         "symfony/uid": "^6.4|^7.0",
         "symfony/web-link": "^6.4|^7.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-        "twig/twig": "^2.10|^3.0"
+        "twig/twig": "^3.0.4"
     },
     "conflict": {
         "doctrine/persistence": "<1.3",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -49,7 +49,7 @@
         "symfony/twig-bridge": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0",
-        "twig/twig": "^2.13|^3.0.4",
+        "twig/twig": "^3.0.4",
         "web-token/jwt-checker": "^3.1",
         "web-token/jwt-signature-algorithm-hmac": "^3.1",
         "web-token/jwt-signature-algorithm-ecdsa": "^3.1",

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Remove option `twig.autoescape`; create a class that implements your escaping strategy
    (check `FileExtensionEscapingStrategy::guess()` for inspiration) and reference it using
    the `twig.autoescape_service` option instead
+ * Drop support for Twig 2
 
 6.4
 ---

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/twig-bridge": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
-        "twig/twig": "^2.13|^3.0.4"
+        "twig/twig": "^3.0.4"
     },
     "require-dev": {
         "symfony/asset": "^6.4|^7.0",

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/routing": "^6.4|^7.0",
         "symfony/twig-bundle": "^6.4|^7.0",
-        "twig/twig": "^2.13|^3.0.4"
+        "twig/twig": "^3.0.4"
     },
     "require-dev": {
         "symfony/browser-kit": "^6.4|^7.0",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -45,7 +45,7 @@
         "symfony/validator": "^6.4|^7.0",
         "symfony/var-exporter": "^6.4|^7.0",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "twig/twig": "^2.13|^3.0.4"
+        "twig/twig": "^3.0.4"
     },
     "provide": {
         "psr/log-implementation": "1.0|2.0|3.0"
@@ -67,7 +67,7 @@
         "symfony/twig-bridge": "<6.4",
         "symfony/validator": "<6.4",
         "symfony/var-dumper": "<6.4",
-        "twig/twig": "<2.13"
+        "twig/twig": "<3.0.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpKernel\\": "" },

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/process": "^6.4|^7.0",
         "symfony/uid": "^6.4|^7.0",
-        "twig/twig": "^2.13|^3.0.4"
+        "twig/twig": "^3.0.4"
     },
     "conflict": {
         "symfony/console": "<6.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Let's make our lives easier and only support one major version of Twig in the future. Upgrading projects from Twig 2 to 3 shouldn't be much trouble anyway.