### PR TITLE
[Security] Fix security tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -29,7 +29,7 @@
         "symfony/password-hasher": "^5.4|^6.0",
         "symfony/security-core": "^6.2",
         "symfony/security-csrf": "^5.4|^6.0",
-        "symfony/security-http": "^6.3"
+        "symfony/security-http": "^6.3.4"
     },
     "require-dev": {
         "doctrine/annotations": "^1.10.4|^2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes 
| New feature?  | no
| Deprecations? | no 
| Tickets       | Follows  https://github.com/symfony/symfony/pull/51622
| License       | MIT
| Doc PR        | -

Related to issue https://github.com/symfony/symfony/pull/51104, after it security bundle at least requires `symfony/security-http:6.3.4`  to keep the tests is green 
