### PR TITLE
[Notifier] Fix Smsmode HttpClient mandatory headers

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsmode/SmsmodeTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsmode/SmsmodeTransport.php
@@ -69,7 +69,10 @@ final class SmsmodeTransport extends AbstractTransport
         }
 
         $response = $this->client->request('POST', $endpoint, [
-            'headers' => ['X-Api-Key' => $this->apiKey],
+            'headers' => [
+                'X-Api-Key' => $this->apiKey,
+                'Accept' => 'application/json',
+            ],
             'json' => array_filter($options),
         ]);
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsmode/Tests/SmsmodeTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsmode/Tests/SmsmodeTransportTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\Notifier\Bridge\Smsmode\SmsmodeOptions;
 use Symfony\Component\Notifier\Bridge\Smsmode\SmsmodeTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
@@ -79,6 +78,27 @@ final class SmsmodeTransportTest extends TransportTestCase
         $sentMessage = $transport->send($message);
 
         self::assertSame('foo', $sentMessage->getMessageId());
+    }
+
+    public function testHttpClientHasMandatoryHeaderAccept()
+    {
+        $message = new SmsMessage('+33612345678', 'Hello!');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(201);
+        $response->expects(self::once())->method('getContent')->willReturn(json_encode(['messageId' => 'foo']));
+
+        $transport = $this->createTransport(new MockHttpClient(function (string $method, string $url, array $options) use ($response): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://rest.smsmode.com/sms/v1/messages', $url);
+            $this->assertSame('Accept: application/json', $options['normalized_headers']['accept'][0]);
+
+            return $response;
+        }), 'foo');
+
+        $result = $transport->send($message);
+
+        $this->assertSame('foo', $result->getMessageId());
     }
 
     public static function toStringProvider(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | 6.3
| Bug fix?      | yes
| New feature? | no
| Deprecations? | no
| Tickets | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

As mentioned in the documentation https://dev.smsmode.com/sms/v1/home in section Content-Type & URL Encoding.

HTTP request and response bodies are JSON objects, which is why Accept and Content-Type headers are mandatory and are implicitly added when the request is executed with the TEST button. If the Accept header is missing, a Not Acceptable (406) HTTP status code is returned. (Accept: application/json) The Content-Type header is only needed with POST and PATCH methods. If it is missing, an Unsupported Media Type (415)
