### PR TITLE
Conflict symfony/validator 7.0 in symfony/doctrine-bridge 6.3

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -63,7 +63,7 @@
         "symfony/proxy-manager-bridge": "<4.4.19",
         "symfony/security-bundle": "<5",
         "symfony/security-core": "<5.3",
-        "symfony/validator": "<5.4.25|>=6,<6.2.12|>=6.3,<6.3.1"
+        "symfony/validator": "<5.4.25|>=6,<6.2.12|>=6.3,<6.3.1,>=7.0"
     },
     "suggest": {
         "symfony/form": "",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 / 6.3 / 6.4 -> Revert in 7.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Currently it is possible to have `doctrine-bridge` 6.3 and `validator` 7.0 installed which ends in the following error: 

> Testing PHP Fatal error:  Declaration of Symfony\Bridge\Doctrine\Validator\DoctrineInitializer::initialize(object $object) must be compatible with Symfony\Component\Validator\ObjectInitializerInterface::initialize(object $object): void in /home/runner/work/sulu/sulu/vendor/symfony/doctrine-bridge/Validator/DoctrineInitializer.php on line 34

The conflict can be removed then on the 7.0 branch where the `: void` return type is added.

Tested it also appears on 5.4 branch so conflict there would also be good, rebased so to 5.4.

You maybe ask why `symfony/doctrine-bridge` was in my example not on `7.0`. If a project still is using `doctrine/persistence` `2.0` instead of `3.0` it can not update the bridge to 6.4 or 7.0. So it could be a common error, to avoid this I suggest to add a conflict.