### PR TITLE
[Validator] Make v7 conflict with doctrine-bridge < v7

### DIFF
--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -43,6 +43,7 @@
     "conflict": {
         "doctrine/lexer": "<1.1",
         "symfony/dependency-injection": "<6.4",
+        "symfony/doctrine-bridge": "<7.0",
         "symfony/expression-language": "<6.4",
         "symfony/http-kernel": "<6.4",
         "symfony/intl": "<6.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Instead of https://github.com/symfony/symfony/pull/51630