### PR TITLE
[FrameworkBundle] [Test] add token attributes in `KernelBrowser::loginUser()`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
  * Deprecate not setting the `framework.validation.email_validation_mode` config option; it will default to `html5` in 7.0
  * Deprecate `framework.validation.enable_annotations`, use `framework.validation.enable_attributes` instead
  * Deprecate `framework.serializer.enable_annotations`, use `framework.serializer.enable_attributes` instead
+ * Add `array $tokenAttributes = []` optional parameter to `KernelBrowser::loginUser()`
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -107,12 +107,15 @@ class KernelBrowser extends HttpKernelBrowser
     }
 
     /**
-     * @param UserInterface $user
+     * @param UserInterface        $user
+     * @param array<string, mixed> $tokenAttributes
      *
      * @return $this
      */
-    public function loginUser(object $user, string $firewallContext = 'main'): static
+    public function loginUser(object $user, string $firewallContext = 'main'/* , array $tokenAttributes = [] */): static
     {
+        $tokenAttributes = 2 < \func_num_args() ? func_get_arg(2) : [];
+
         if (!interface_exists(UserInterface::class)) {
             throw new \LogicException(sprintf('"%s" requires symfony/security-core to be installed. Try running "composer require symfony/security-core".', __METHOD__));
         }
@@ -122,6 +125,7 @@ class KernelBrowser extends HttpKernelBrowser
         }
 
         $token = new TestBrowserToken($user->getRoles(), $user, $firewallContext);
+        $token->setAttributes($tokenAttributes);
         // required for compatibility with Symfony 5.4
         if (method_exists($token, 'isAuthenticated')) {
             $token->setAuthenticated(true, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

We have an advanced use case where we define custom attributes in tokens from success handlers.
Then, we use them for access controls.
Currently we cannot define those attributes when testing and using the `loginUser()` method, and so we needed to copy paste the whole logic to do it.

What do you think about this feature?

I did not add tests because the method does not have any yet, should we add some?

It's my first contribution, thanks to my brother @HeahDude for his help 🙏🏽 

