### PR TITLE
Removed unnecessary apostrophes for better compatibility with exec()

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1618,7 +1618,7 @@ class Process implements \IteratorAggregate
             return '""';
         }
         if ('\\' !== \DIRECTORY_SEPARATOR) {
-            return "'".str_replace("'", "'\\''", $argument)."'";
+            return str_replace("'", "'\\''", $argument);
         }
         if (str_contains($argument, "\0")) {
             $argument = str_replace("\0", '?', $argument);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | none
| License       | MIT

Operating system: Ubuntu 22.04. 
Kernel: 6.2.0-32-generic  

Currently, Process adds apostrophes for each part of the command. This results in ffmpeg not working. For some reason exec() can't find the command with apostrophe's around it. 

This doesn't work (throws a 127 Command not found):  
`exec 'ffmpeg' '-y -i' '"tst.flac"' '-f mp4' '"tst.mp4"'`

This works: 
`exec ffmpeg -y -i "tst.flac" -f mp4 "tst.mp4"`


Ran tests against 6.4 . Nothing was broken. 


