### PR TITLE
[Scheduler] Fix stateful scheduler

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `AbstractTriggerDecorator`
  * Make `ScheduledStamp` "send-able"
  * Add `ScheduledStamp` to `RedispatchMessage`
+ * Add `from()` to `CheckpointInterface`
 
 6.3
 ---

--- a/src/Symfony/Component/Scheduler/Generator/Checkpoint.php
+++ b/src/Symfony/Component/Scheduler/Generator/Checkpoint.php
@@ -16,6 +16,7 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 final class Checkpoint implements CheckpointInterface
 {
+    private \DateTimeImmutable $from;
     private \DateTimeImmutable $time;
     private int $index = -1;
     private bool $reset = false;
@@ -41,12 +42,20 @@ final class Checkpoint implements CheckpointInterface
             $this->save($now, -1);
         }
 
-        $this->time ??= $now;
         if ($this->cache) {
-            $this->save(...$this->cache->get($this->name, fn () => [$now, -1]));
+            [$this->time, $this->index, $this->from] = $this->cache->get($this->name, fn () => [$now, -1, $now]) + [2 => $now];
+            $this->save($this->time, $this->index);
         }
 
+        $this->time ??= $now;
+        $this->from ??= $now;
+
         return true;
+    }
+
+    public function from(): \DateTimeImmutable
+    {
+        return $this->from;
     }
 
     public function time(): \DateTimeImmutable
@@ -63,7 +72,8 @@ final class Checkpoint implements CheckpointInterface
     {
         $this->time = $time;
         $this->index = $index;
-        $this->cache?->get($this->name, fn () => [$time, $index], \INF);
+        $this->from ??= $time;
+        $this->cache?->get($this->name, fn () => [$time, $index, $this->from], \INF);
     }
 
     /**

--- a/src/Symfony/Component/Scheduler/Generator/CheckpointInterface.php
+++ b/src/Symfony/Component/Scheduler/Generator/CheckpointInterface.php
@@ -15,6 +15,8 @@ interface CheckpointInterface
 {
     public function acquire(\DateTimeImmutable $now): bool;
 
+    public function from(): \DateTimeImmutable;
+
     public function time(): \DateTimeImmutable;
 
     public function index(): int;

--- a/src/Symfony/Component/Scheduler/RecurringMessage.php
+++ b/src/Symfony/Component/Scheduler/RecurringMessage.php
@@ -40,7 +40,7 @@ final class RecurringMessage
      * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
      * @see https://php.net/datetime.formats.relative
      */
-    public static function every(string|int|\DateInterval $frequency, object $message, string|\DateTimeImmutable $from = new \DateTimeImmutable(), string|\DateTimeImmutable $until = new \DateTimeImmutable('3000-01-01')): self
+    public static function every(string|int|\DateInterval $frequency, object $message, string|\DateTimeImmutable|null $from = null, string|\DateTimeImmutable $until = new \DateTimeImmutable('3000-01-01')): self
     {
         return new self(new PeriodicalTrigger($frequency, $from, $until), $message);
     }

--- a/src/Symfony/Component/Scheduler/Tests/Generator/CheckpointTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/CheckpointTest.php
@@ -48,7 +48,7 @@ class CheckpointTest extends TestCase
         $this->assertTrue($checkpoint->acquire($now));
         $this->assertEquals($now, $checkpoint->time());
         $this->assertEquals(-1, $checkpoint->index());
-        $this->assertEquals([$now, -1], $cache->get('cache', fn () => []));
+        $this->assertEquals([$now, -1, $now], $cache->get('cache', fn () => []));
     }
 
     public function testWithStateLoadStateOnAcquiring()
@@ -58,10 +58,10 @@ class CheckpointTest extends TestCase
 
         $cache->get('cache', fn () => [$now, 0], \INF);
 
-        $this->assertTrue($checkpoint->acquire($now->modify('1 min')));
+        $this->assertTrue($checkpoint->acquire($startedAt = $now->modify('1 min')));
         $this->assertEquals($now, $checkpoint->time());
         $this->assertEquals(0, $checkpoint->index());
-        $this->assertEquals([$now, 0], $cache->get('cache', fn () => []));
+        $this->assertEquals([$now, 0, $startedAt], $cache->get('cache', fn () => []));
     }
 
     public function testWithLockInitStateOnFirstAcquiring()
@@ -72,11 +72,12 @@ class CheckpointTest extends TestCase
 
         $this->assertTrue($checkpoint->acquire($now));
         $this->assertEquals($now, $checkpoint->time());
+        $this->assertEquals($now, $checkpoint->from());
         $this->assertEquals(-1, $checkpoint->index());
         $this->assertTrue($lock->isAcquired());
     }
 
-    public function testwithLockLoadStateOnAcquiring()
+    public function testWithLockLoadStateOnAcquiring()
     {
         $lock = new Lock(new Key('lock'), new InMemoryStore());
         $checkpoint = new Checkpoint('dummy', $lock);
@@ -86,6 +87,7 @@ class CheckpointTest extends TestCase
 
         $this->assertTrue($checkpoint->acquire($now->modify('1 min')));
         $this->assertEquals($now, $checkpoint->time());
+        $this->assertEquals($now, $checkpoint->from());
         $this->assertEquals(0, $checkpoint->index());
         $this->assertTrue($lock->isAcquired());
     }
@@ -105,12 +107,13 @@ class CheckpointTest extends TestCase
     {
         $checkpoint = new Checkpoint('cache', new NoLock(), $cache = new ArrayAdapter());
         $now = new \DateTimeImmutable('2020-02-20 20:20:20Z');
-        $checkpoint->acquire($now->modify('-1 hour'));
+        $checkpoint->acquire($startedAt = $now->modify('-1 hour'));
         $checkpoint->save($now, 3);
 
         $this->assertSame($now, $checkpoint->time());
         $this->assertSame(3, $checkpoint->index());
-        $this->assertEquals([$now, 3], $cache->get('cache', fn () => []));
+        $this->assertSame($startedAt, $checkpoint->from());
+        $this->assertEquals([$now, 3, $startedAt], $cache->get('cache', fn () => []));
     }
 
     public function testWithLockSave()
@@ -119,11 +122,12 @@ class CheckpointTest extends TestCase
         $checkpoint = new Checkpoint('dummy', $lock);
         $now = new \DateTimeImmutable('2020-02-20 20:20:20Z');
 
-        $checkpoint->acquire($now->modify('-1 hour'));
+        $checkpoint->acquire($startTime = $now->modify('-1 hour'));
         $checkpoint->save($now, 3);
 
         $this->assertSame($now, $checkpoint->time());
         $this->assertSame(3, $checkpoint->index());
+        $this->assertSame($startTime, $checkpoint->from());
     }
 
     public function testWithLockAndCacheSave()
@@ -132,12 +136,12 @@ class CheckpointTest extends TestCase
         $checkpoint = new Checkpoint('dummy', $lock, $cache = new ArrayAdapter());
         $now = new \DateTimeImmutable('2020-02-20 20:20:20Z');
 
-        $checkpoint->acquire($now->modify('-1 hour'));
+        $checkpoint->acquire($startTime = $now->modify('-1 hour'));
         $checkpoint->save($now, 3);
 
         $this->assertSame($now, $checkpoint->time());
         $this->assertSame(3, $checkpoint->index());
-        $this->assertEquals([$now, 3], $cache->get('dummy', fn () => []));
+        $this->assertEquals([$now, 3, $startTime], $cache->get('dummy', fn () => []));
     }
 
     public function testWithCacheFullCycle()
@@ -161,7 +165,7 @@ class CheckpointTest extends TestCase
         $this->assertSame(3, $lastIndex);
         $this->assertEquals($now, $checkpoint->time());
         $this->assertSame(0, $checkpoint->index());
-        $this->assertEquals([$now, 0], $cache->get('cache', fn () => []));
+        $this->assertEquals([$now, 0, $now], $cache->get('cache', fn () => []));
     }
 
     public function testWithLockResetStateAfterLockedAcquiring()

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
@@ -184,7 +184,7 @@ class PeriodicalTriggerTest extends TestCase
         yield [
             $trigger,
             new \DateTimeImmutable('2020-02-20T01:59:00+02:00'),
-            new \DateTimeImmutable('2020-02-20T02:09:00+02:00'),
+            new \DateTimeImmutable('2020-02-20T02:00:00+02:00'),
         ];
         yield [
             $trigger,

--- a/src/Symfony/Component/Scheduler/Trigger/AbstractDecoratedTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/AbstractDecoratedTrigger.php
@@ -14,10 +14,17 @@ namespace Symfony\Component\Scheduler\Trigger;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-abstract class AbstractDecoratedTrigger implements TriggerInterface
+abstract class AbstractDecoratedTrigger implements StatefulTriggerInterface
 {
     public function __construct(private TriggerInterface $inner)
     {
+    }
+
+    public function continue(\DateTimeImmutable $startedAt): void
+    {
+        if ($this->inner instanceof StatefulTriggerInterface) {
+            $this->inner->continue($startedAt);
+        }
     }
 
     final public function inner(): TriggerInterface

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -13,17 +13,18 @@ namespace Symfony\Component\Scheduler\Trigger;
 
 use Symfony\Component\Scheduler\Exception\InvalidArgumentException;
 
-class PeriodicalTrigger implements TriggerInterface
+class PeriodicalTrigger implements StatefulTriggerInterface
 {
     private float $intervalInSeconds = 0.0;
-    private \DateTimeImmutable $from;
+    private ?\DateTimeImmutable $from;
     private \DateTimeImmutable $until;
     private \DatePeriod $period;
     private string $description;
+    private string|int|float|\DateInterval $interval;
 
     public function __construct(
         string|int|float|\DateInterval $interval,
-        string|\DateTimeImmutable $from = new \DateTimeImmutable(),
+        string|\DateTimeImmutable|null $from = null,
         string|\DateTimeImmutable $until = new \DateTimeImmutable('3000-01-01'),
     ) {
         $this->from = \is_string($from) ? new \DateTimeImmutable($from) : $from;
@@ -70,7 +71,7 @@ class PeriodicalTrigger implements TriggerInterface
                     $this->description = sprintf('every %s seconds', $this->intervalInSeconds);
                 }
             } else {
-                $this->period = new \DatePeriod($this->from, $i, $this->until);
+                $this->interval = $i;
             }
         } catch (\Exception $e) {
             throw new InvalidArgumentException(sprintf('Invalid interval "%s": ', $interval instanceof \DateInterval ? 'instance of \DateInterval' : $interval).$e->getMessage(), 0, $e);
@@ -82,15 +83,22 @@ class PeriodicalTrigger implements TriggerInterface
         return $this->description;
     }
 
+    public function continue(\DateTimeImmutable $startedAt): void
+    {
+        $this->from ??= $startedAt;
+    }
+
     public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable
     {
+        $this->from ??= $run;
+
         if ($this->intervalInSeconds) {
             if ($this->until <= $run) {
                 return null;
             }
 
-            $fromDate = min($this->from, $run);
-            $from = $fromDate->format('U.u');
+            $fromDate = $this->from;
+            $from = (float) $fromDate->format('U.u');
             $delta = $run->format('U.u') - $from;
             $recurrencesPassed = floor($delta / $this->intervalInSeconds);
             $nextRunTimestamp = sprintf('%.6F', ($recurrencesPassed + 1) * $this->intervalInSeconds + $from);
@@ -103,6 +111,7 @@ class PeriodicalTrigger implements TriggerInterface
             return $this->until > $nextRun ? $nextRun : null;
         }
 
+        $this->period ??= new \DatePeriod($this->from, $this->interval, $this->until);
         $iterator = $this->period->getIterator();
         while ($run >= $next = $iterator->current()) {
             $iterator->next();
@@ -130,6 +139,6 @@ class PeriodicalTrigger implements TriggerInterface
 
     private function calcInterval(\DateInterval $interval): float
     {
-        return $this->from->setTimestamp(0)->add($interval)->format('U.u');
+        return (float) (new \DateTimeImmutable('@0'))->add($interval)->format('U.u');
     }
 }

--- a/src/Symfony/Component/Scheduler/Trigger/StatefulTriggerInterface.php
+++ b/src/Symfony/Component/Scheduler/Trigger/StatefulTriggerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Scheduler\Trigger;
+
+interface StatefulTriggerInterface extends TriggerInterface
+{
+    public function continue(\DateTimeImmutable $startedAt): void;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51646, #51384
| License       | MIT

Stateful scheduler seems rather broken at the moment, see https://github.com/symfony/symfony/issues/51384#issuecomment-1703915652.

Let's fix it by storing the original first run start time, that way it's always possible to recalculate the state.


Catching-up works now:
```
[23:14:11.709710] Worker started
[23:14:11.759318] every 2 seconds
[23:14:11.760291] every 2 seconds
[23:14:11.761257] every 2 seconds
[23:14:11.763244] every 2 seconds
[23:14:12.637054] every 2 seconds
[23:14:14.620595] every 2 seconds
[23:14:16.632170] every 2 seconds
```

Whereas before it would only start on from the current item, possibly skipping previous items like stated in #51646. _(is this a bc break?)_

I will be waiting for input from authors of the related issues.

---

One test is failing because because `getNextRunDate` is called with `2020-02-20T01:59:00+02:00` and then next run date is expected at `2020-02-20T02:09:00+02:00` but we get `2020-02-20T02:00:00+02:00` because that's set as `from`. I don't quite get the logic, I would assume that it is expected to be run immediately on `from` :thinking: 