### PR TITLE
[HttpClient] Fix TraceableResponse if response has no destruct method

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
@@ -57,7 +57,9 @@ class TraceableResponse implements ResponseInterface, StreamableInterface
     public function __destruct()
     {
         try {
-            $this->response->__destruct();
+            if (method_exists($this->response, '__destruct')) {
+                $this->response->__destruct();
+            }
         } finally {
             if ($this->event && $this->event->isStarted()) {
                 $this->event->stop();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

Use case : I've created an HttpClient mock that returns a response as an anonymous object implementing the interface. This anonymous object doesn't need the `__destruct` method and create this error.

<img width="1052" alt="Capture d’écran 2023-09-14 à 22 56 27" src="https://github.com/symfony/symfony/assets/12966574/ac0f60c0-a441-499e-9bf7-54c105ff9e23">
