### PR TITLE
[FrameworkBundle] Handle tags array attributes in descriptors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -254,7 +254,7 @@ class MarkdownDescriptor extends Descriptor
                 foreach ($tagData as $parameters) {
                     $output .= "\n".'- Tag: `'.$tagName.'`';
                     foreach ($parameters as $name => $value) {
-                        $output .= "\n".'    - '.ucfirst($name).': '.$value;
+                        $output .= "\n".'    - '.ucfirst($name).': '.(\is_array($value) ? $this->formatParameter($value) : $value);
                     }
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -209,6 +209,10 @@ class TextDescriptor extends Descriptor
                             if (!isset($maxTags[$key])) {
                                 $maxTags[$key] = \strlen($key);
                             }
+                            if (\is_array($value)) {
+                                $value = $this->formatParameter($value);
+                            }
+
                             if (\strlen($value) > $maxTags[$key]) {
                                 $maxTags[$key] = \strlen($value);
                             }
@@ -233,7 +237,11 @@ class TextDescriptor extends Descriptor
                     foreach ($this->sortByPriority($definition->getTag($showTag)) as $key => $tag) {
                         $tagValues = [];
                         foreach ($tagsNames as $tagName) {
-                            $tagValues[] = $tag[$tagName] ?? '';
+                            if (\is_array($tagValue = $tag[$tagName] ?? '')) {
+                                $tagValue = $this->formatParameter($tagValue);
+                            }
+
+                            $tagValues[] = $tagValue;
                         }
                         if (0 === $key) {
                             $tableRows[] = array_merge([$serviceId], $tagValues, [$definition->getClass()]);
@@ -275,7 +283,7 @@ class TextDescriptor extends Descriptor
             $tagInformation = [];
             foreach ($tags as $tagName => $tagData) {
                 foreach ($tagData as $tagParameters) {
-                    $parameters = array_map(fn ($key, $value) => sprintf('<info>%s</info>: %s', $key, $value), array_keys($tagParameters), array_values($tagParameters));
+                    $parameters = array_map(fn ($key, $value) => sprintf('<info>%s</info>: %s', $key, \is_array($value) ? $this->formatParameter($value) : $value), array_keys($tagParameters), array_values($tagParameters));
                     $parameters = implode(', ', $parameters);
 
                     if ('' === $parameters) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -169,6 +169,7 @@ class ObjectsProvider
                 ->addTag('tag1', ['attr1' => 'val1', 'attr2' => 'val2'])
                 ->addTag('tag1', ['attr3' => 'val3'])
                 ->addTag('tag2')
+                ->addTag('tag3', ['array_attr' => ['foo', 'bar', [[[['ccc']]]]]])
                 ->addMethodCall('setMailer', [new Reference('mailer')])
                 ->setFactory([new Reference('factory.service'), 'get']),
             '.definition_3' => $definition3

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.json
@@ -36,6 +36,24 @@
             {
                 "name": "tag2",
                 "parameters": []
+            },
+            {
+                "name": "tag3",
+                "parameters": {
+                    "array_attr": [
+                        "foo",
+                        "bar",
+                        [
+                            [
+                                [
+                                    [
+                                        "ccc"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                }
             }
         ],
         "usages": [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.md
@@ -24,4 +24,6 @@
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `tag3`
+    - Array_attr: ["foo","bar",[[[["ccc"]]]]]
 - Usages: .alias_2

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
@@ -3,24 +3,26 @@
 [33mInformation for Service "[39m[32m.service_2[39m[33m"[39m
 [33m====================================[39m
 
- ----------------- --------------------------------- 
- [32m Option          [39m [32m Value                           [39m 
- ----------------- --------------------------------- 
-  Service ID        .service_2                       
-  Class             Full\Qualified\Class2            
-  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
-                    tag1 ([32mattr3[39m: val3)               
-                    tag2                             
-  Calls             setMailer                        
-  Public            no                               
-  Synthetic         yes                              
-  Lazy              no                               
-  Shared            yes                              
-  Abstract          no                               
-  Autowired         no                               
-  Autoconfigured    no                               
-  Required File     /path/to/file                    
-  Factory Service   factory.service                  
-  Factory Method    get                              
-  Usages            .alias_2                         
- ----------------- ---------------------------------
+ ----------------- ------------------------------------------------ 
+ [32m Option          [39m [32m Value                                          [39m 
+ ----------------- ------------------------------------------------ 
+  Service ID        .service_2                                      
+  Class             Full\Qualified\Class2                           
+  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)                 
+                    tag1 ([32mattr3[39m: val3)                              
+                    tag2                                            
+                    tag3 ([32marray_attr[39m: ["foo","bar",[[[["ccc"]]]]])  
+  Calls             setMailer                                       
+  Public            no                                              
+  Synthetic         yes                                             
+  Lazy              no                                              
+  Shared            yes                                             
+  Abstract          no                                              
+  Autowired         no                                              
+  Autoconfigured    no                                              
+  Required File     /path/to/file                                   
+  Factory Service   factory.service                                 
+  Factory Method    get                                             
+  Usages            .alias_2                                        
+ ----------------- ------------------------------------------------ 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.xml
@@ -14,6 +14,9 @@
       <parameter name="attr3">val3</parameter>
     </tag>
     <tag name="tag2"/>
+    <tag name="tag3">
+      <parameter name="array_attr">["foo","bar",[[[["ccc"]]]]]</parameter>
+    </tag>
   </tags>
   <usages>
     <usage>.alias_2</usage>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
@@ -33,6 +33,24 @@
                 {
                     "name": "tag2",
                     "parameters": []
+                },
+                {
+                    "name": "tag3",
+                    "parameters": {
+                        "array_attr": [
+                            "foo",
+                            "bar",
+                            [
+                                [
+                                    [
+                                        [
+                                            "ccc"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    }
                 }
             ],
             "usages": []

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
@@ -25,6 +25,8 @@ Definitions
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `tag3`
+    - Array_attr: ["foo","bar",[[[["ccc"]]]]]
 - Usages: none
 
 ### .definition_3

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
@@ -15,6 +15,9 @@
         <parameter name="attr3">val3</parameter>
       </tag>
       <tag name="tag2"/>
+      <tag name="tag3">
+        <parameter name="array_attr">["foo","bar",[[[["ccc"]]]]]</parameter>
+      </tag>
     </tags>
   </definition>
   <definition id=".definition_3" class="Full\Qualified\Class3" public="false" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="/path/to/file">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.json
@@ -33,6 +33,24 @@
                 {
                     "name": "tag2",
                     "parameters": []
+                },
+                {
+                    "name": "tag3",
+                    "parameters": {
+                        "array_attr": [
+                            "foo",
+                            "bar",
+                            [
+                                [
+                                    [
+                                        [
+                                            "ccc"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    }
                 }
             ],
             "usages": []

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
@@ -25,4 +25,6 @@ Definitions
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `tag3`
+    - Array_attr: ["foo","bar",[[[["ccc"]]]]]
 - Usages: none

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.xml
@@ -14,6 +14,9 @@
         <parameter name="attr3">val3</parameter>
       </tag>
       <tag name="tag2"/>
+      <tag name="tag3">
+        <parameter name="array_attr">["foo","bar",[[[["ccc"]]]]]</parameter>
+      </tag>
     </tags>
   </definition>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.json
@@ -38,5 +38,25 @@
             ],
             "usages": []
         }
+    ],
+    "tag3": [
+        {
+            "class": "Full\\Qualified\\Class2",
+            "public": false,
+            "synthetic": true,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "deprecated": false,
+            "file": "\/path\/to\/file",
+            "factory_service": "factory.service",
+            "factory_method": "get",
+            "calls": [
+                "setMailer"
+            ],
+            "usages": []
+        }
     ]
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.md
@@ -41,3 +41,24 @@ tag2
 - Factory Method: `get`
 - Call: `setMailer`
 - Usages: none
+
+
+tag3
+----
+
+### .definition_2
+
+- Class: `Full\Qualified\Class2`
+- Public: no
+- Synthetic: yes
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- Deprecated: no
+- File: `/path/to/file`
+- Factory Service: `factory.service`
+- Factory Method: `get`
+- Call: `setMailer`
+- Usages: none

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.txt
@@ -12,3 +12,8 @@
 
  * .definition_2
 
+[33m"tag3" tag[39m
+[33m----------[39m
+
+ * .definition_2
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.xml
@@ -16,4 +16,12 @@
       </calls>
     </definition>
   </tag>
+  <tag name="tag3">
+    <definition id=".definition_2" class="Full\Qualified\Class2" public="false" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="/path/to/file">
+      <factory service="factory.service" method="get"/>
+      <calls>
+        <call method="setMailer"/>
+      </calls>
+    </definition>
+  </tag>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.json
@@ -31,6 +31,24 @@
         {
             "name": "tag2",
             "parameters": []
+        },
+        {
+            "name": "tag3",
+            "parameters": {
+                "array_attr": [
+                    "foo",
+                    "bar",
+                    [
+                        [
+                            [
+                                [
+                                    "ccc"
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            }
         }
     ],
     "usages": []

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.md
@@ -17,4 +17,6 @@
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `tag3`
+    - Array_attr: ["foo","bar",[[[["ccc"]]]]]
 - Usages: none

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
@@ -1,22 +1,23 @@
- ----------------- --------------------------------- 
- [32m Option          [39m [32m Value                           [39m 
- ----------------- --------------------------------- 
-  Service ID        -                                
-  Class             Full\Qualified\Class2            
-  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
-                    tag1 ([32mattr3[39m: val3)               
-                    tag2                             
-  Calls             setMailer                        
-  Public            no                               
-  Synthetic         yes                              
-  Lazy              no                               
-  Shared            yes                              
-  Abstract          no                               
-  Autowired         no                               
-  Autoconfigured    no                               
-  Required File     /path/to/file                    
-  Factory Service   factory.service                  
-  Factory Method    get                              
-  Usages            none                             
- ----------------- --------------------------------- 
+ ----------------- ------------------------------------------------ 
+ [32m Option          [39m [32m Value                                          [39m 
+ ----------------- ------------------------------------------------ 
+  Service ID        -                                               
+  Class             Full\Qualified\Class2                           
+  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)                 
+                    tag1 ([32mattr3[39m: val3)                              
+                    tag2                                            
+                    tag3 ([32marray_attr[39m: ["foo","bar",[[[["ccc"]]]]])  
+  Calls             setMailer                                       
+  Public            no                                              
+  Synthetic         yes                                             
+  Lazy              no                                              
+  Shared            yes                                             
+  Abstract          no                                              
+  Autowired         no                                              
+  Autoconfigured    no                                              
+  Required File     /path/to/file                                   
+  Factory Service   factory.service                                 
+  Factory Method    get                                             
+  Usages            none                                            
+ ----------------- ------------------------------------------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.xml
@@ -13,5 +13,8 @@
       <parameter name="attr3">val3</parameter>
     </tag>
     <tag name="tag2"/>
+    <tag name="tag3">
+      <parameter name="array_attr">["foo","bar",[[[["ccc"]]]]]</parameter>
+    </tag>
   </tags>
 </definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.json
@@ -32,6 +32,24 @@
         {
             "name": "tag2",
             "parameters": []
+        },
+        {
+            "name": "tag3",
+            "parameters": {
+                "array_attr": [
+                    "foo",
+                    "bar",
+                    [
+                        [
+                            [
+                                [
+                                    "ccc"
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            }
         }
     ],
     "usages": []

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.md
@@ -18,4 +18,6 @@
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `tag3`
+    - Array_attr: ["foo","bar",[[[["ccc"]]]]]
 - Usages: none

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
@@ -1,22 +1,23 @@
- ----------------- --------------------------------- 
- [32m Option          [39m [32m Value                           [39m 
- ----------------- --------------------------------- 
-  Service ID        -                                
-  Class             Full\Qualified\Class2            
-  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
-                    tag1 ([32mattr3[39m: val3)               
-                    tag2                             
-  Calls             setMailer                        
-  Public            no                               
-  Synthetic         yes                              
-  Lazy              no                               
-  Shared            yes                              
-  Abstract          no                               
-  Autowired         no                               
-  Autoconfigured    no                               
-  Required File     /path/to/file                    
-  Factory Service   factory.service                  
-  Factory Method    get                              
-  Usages            none                             
- ----------------- --------------------------------- 
+ ----------------- ------------------------------------------------ 
+ [32m Option          [39m [32m Value                                          [39m 
+ ----------------- ------------------------------------------------ 
+  Service ID        -                                               
+  Class             Full\Qualified\Class2                           
+  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)                 
+                    tag1 ([32mattr3[39m: val3)                              
+                    tag2                                            
+                    tag3 ([32marray_attr[39m: ["foo","bar",[[[["ccc"]]]]])  
+  Calls             setMailer                                       
+  Public            no                                              
+  Synthetic         yes                                             
+  Lazy              no                                              
+  Shared            yes                                             
+  Abstract          no                                              
+  Autowired         no                                              
+  Autoconfigured    no                                              
+  Required File     /path/to/file                                   
+  Factory Service   factory.service                                 
+  Factory Method    get                                             
+  Usages            none                                            
+ ----------------- ------------------------------------------------ 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.xml
@@ -13,5 +13,8 @@
       <parameter name="attr3">val3</parameter>
     </tag>
     <tag name="tag2"/>
+    <tag name="tag3">
+      <parameter name="array_attr">["foo","bar",[[[["ccc"]]]]]</parameter>
+    </tag>
   </tags>
 </definition>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/51636
| License       | MIT
| Doc PR        | -

Targeting 6.3 since array attributes are only possible in tags since 6.2.