### PR TITLE
[FrameworkBundle] Fix support for `translator.default_path` in XML

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -191,6 +191,7 @@
         <xsd:attribute name="logging" type="xsd:boolean" />
         <xsd:attribute name="formatter" type="xsd:string" />
         <xsd:attribute name="cache-dir" type="xsd:string" />
+        <xsd:attribute name="default-path" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="pseudo_localization">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18872

The docs is currently wrong assuming there is an element `default-path` using XML config,  https://symfony.com/doc/current/translation.html#configuration.

It appears it's missing in the XSD, but IMO it should be added as an attribute.