### PR TITLE
Fix incompatibility between security-bundle 6.4 and security-http 7.0

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -29,7 +29,7 @@
         "symfony/password-hasher": "^5.4|^6.0|^7.0",
         "symfony/security-core": "^6.2|^7.0",
         "symfony/security-csrf": "^5.4|^6.0|^7.0",
-        "symfony/security-http": "^6.3.4|^7.0"
+        "symfony/security-http": "^6.3.4"
     },
     "require-dev": {
         "symfony/asset": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The security-bundle 6.4 is not compatible with security-http 7.0:

> PHP Fatal error: Declaration of
> `Sulu\Bundle\SecurityBundle\Security\AuthenticationEntryPoint::start(`
> `Symfony\Component\HttpFoundation\Request $request, ?Symfony\Component\Security\Core\Exception\AuthenticationException $authException = null)`
> must be compatible with
> `Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface::start(`
> `Symfony\Component\HttpFoundation\Request $request, ?Symfony\Component\Security\Core\Exception\AuthenticationException $authException = null): Symfony\Component\HttpFoundation\Response`
> in /home/runner/work/sulu/sulu/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationEntryPoint.php on line 25 

