### PR TITLE
[Scheduler] Match next run timezone with "from" timezone

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
@@ -23,9 +23,9 @@ class PeriodicalTriggerTest extends TestCase
      */
     public function testConstructor(PeriodicalTrigger $trigger, bool $optimizable = true)
     {
-        $run = new \DateTimeImmutable('2922-02-22 13:34:00+00:00');
+        $run = new \DateTimeImmutable('2922-02-22 12:34:00+00:00');
 
-        $this->assertSame('2922-02-23 13:34:00+00:00', $trigger->getNextRunDate($run)->format('Y-m-d H:i:sP'));
+        $this->assertSame('2922-02-23 13:34:00+01:00', $trigger->getNextRunDate($run)->format('Y-m-d H:i:sP'));
 
         if ($optimizable) {
             // test that we are using the fast algorithm for short period of time
@@ -37,7 +37,7 @@ class PeriodicalTriggerTest extends TestCase
 
     public static function provideForConstructor(): iterable
     {
-        $from = new \DateTimeImmutable($now = '2022-02-22 13:34:00+00:00');
+        $from = new \DateTimeImmutable($now = '2022-02-22 13:34:00+01:00');
         $until = new \DateTimeImmutable($farFuture = '3000-01-01');
 
         yield [new PeriodicalTrigger(86400, $from, $until)];

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -97,7 +97,7 @@ class PeriodicalTrigger implements TriggerInterface, \Stringable
             $delta = $run->format('U.u') - $from;
             $recurrencesPassed = floor($delta / $this->intervalInSeconds);
             $nextRunTimestamp = sprintf('%.6F', ($recurrencesPassed + 1) * $this->intervalInSeconds + $from);
-            $nextRun = \DateTimeImmutable::createFromFormat('U.u', $nextRunTimestamp, $fromDate->getTimezone());
+            $nextRun = \DateTimeImmutable::createFromFormat('U.u', $nextRunTimestamp)->setTimezone($fromDate->getTimezone());
 
             if ($this->from > $nextRun) {
                 return $this->from;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

As discussed in https://github.com/symfony/symfony/pull/51651#discussion_r1326994462, when a datetime object is created from unix timestamp, the timezone constructor argument is ignored as demonstrated in https://onlinephp.io/c/b07d1 and also mentioned in [PHP documentation](https://www.php.net/manual/en/datetime.construct.php#refsect1-datetime.construct-parameters):

> The $timezone parameter and the current timezone are ignored when the $datetime parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone (e.g. 2010-01-28T15:00:00+02:00).

This change shouldn't break any existing logic, given the places where this time is used already include timezone in the date format string.


### Changes in effect

```diff
  ------------- ------------------------------------ --------------------------- 
   Message       Trigger                              Next Run                   
  ------------- ------------------------------------ --------------------------- 
-  TestMessage   PeriodicalTrigger: every 2 seconds   2023-09-16T15:54:46+00:00  
+  TestMessage   PeriodicalTrigger: every 2 seconds   2023-09-16T18:54:46+03:00  
  ------------- ------------------------------------ --------------------------- 
```
