### PR TITLE
[Messenger] Fix cloned TraceableStack not unstacking the stack independently 

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
@@ -94,4 +94,9 @@ class TraceableStack implements StackInterface
         }
         $this->currentEvent = null;
     }
+
+    public function __clone()
+    {
+        $this->stack = clone $this->stack;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51564
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixed a bug with cloned `TraceableStack` not unstacking the stack independently from the original due to the __clone() method not yet being implemented. Clones of `StackMiddleware` currently unstack the stack independently, but not `TraceableStack`.
