### PR TITLE
[RateLimiter] Add SlidingWindowLimiter::reserve()

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -123,6 +123,11 @@ PsrHttpMessageBridge
 
  * Remove `ArgumentValueResolverInterface` from `PsrServerRequestResolver`
 
+RateLimiter
+-----------
+
+ * Deprecate `SlidingWindow::getRetryAfter`, use `SlidingWindow::calculateTimeForTokens` instead
+
 Routing
 -------
 

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add `SlidingWindowLimiter::reserve()`
+
 6.2
 ---
 

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -84,9 +84,36 @@ final class SlidingWindow implements LimiterStateInterface
         return (int) floor($this->hitCountForLastWindow * (1 - $percentOfCurrentTimeFrame) + $this->hitCount);
     }
 
+    /**
+     * @deprecated since Symfony 6.4, use {@see self::calculateTimeForTokens} instead
+     */
     public function getRetryAfter(): \DateTimeImmutable
     {
-        return \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $this->windowEndAt));
+        trigger_deprecation('symfony/ratelimiter', '6.4', 'The "%s()" method is deprecated, use "%s::calculateTimeForTokens" instead.', __METHOD__, self::class);
+
+        return \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true) + $this->calculateTimeForTokens(max(1, $this->getHitCount()), 1)));
+    }
+
+    public function calculateTimeForTokens(int $maxSize, int $tokens): float
+    {
+        $remaining = $maxSize - $this->getHitCount();
+        if ($remaining >= $tokens) {
+            return 0;
+        }
+
+        $time = microtime(true);
+        $startOfWindow = $this->windowEndAt - $this->intervalInSeconds;
+        $timePassed = $time - $startOfWindow;
+        $windowPassed = min($timePassed / $this->intervalInSeconds, 1);
+        $releasable = max(1, $maxSize - floor($this->hitCountForLastWindow * (1 - $windowPassed)));
+        $remainingWindow = $this->intervalInSeconds - $timePassed;
+        $needed = $tokens - $remaining;
+
+        if ($releasable >= $needed) {
+            return $needed * ($remainingWindow / max(1, $releasable));
+        }
+
+        return ($this->windowEndAt - $time) + ($needed - $releasable) * ($this->intervalInSeconds / $maxSize);
     }
 
     public function __serialize(): array

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowTest.php
@@ -81,12 +81,14 @@ class SlidingWindowTest extends TestCase
     {
         ClockMock::register(SlidingWindow::class);
         $window = new SlidingWindow('foo', 8);
+        $window->add();
 
         usleep(11.6 * 1e6); // wait just under 12s (8+4)
         $new = SlidingWindow::createFromPreviousWindow($window, 4);
+        $new->add();
 
         // should be 400ms left (12 - 11.6)
-        $this->assertEqualsWithDelta(0.4, $new->getRetryAfter()->format('U.u') - microtime(true), 0.2);
+        $this->assertEqualsWithDelta(0.4, $new->calculateTimeForTokens(1, 1), 0.1);
     }
 
     public function testIsExpiredUsesMicrotime()
@@ -101,18 +103,22 @@ class SlidingWindowTest extends TestCase
     public function testGetRetryAfterUsesMicrotime()
     {
         $window = new SlidingWindow('foo', 10);
+        $window->add();
 
         usleep(9.5 * 1e6);
         // should be 500ms left (10 - 9.5)
-        $this->assertEqualsWithDelta(0.5, $window->getRetryAfter()->format('U.u') - microtime(true), 0.2);
+        $this->assertEqualsWithDelta(0.5, $window->calculateTimeForTokens(1, 1), 0.1);
     }
 
     public function testCreateAtExactTime()
     {
-        ClockMock::register(SlidingWindow::class);
-        ClockMock::withClockMock(1234567890.000000);
         $window = new SlidingWindow('foo', 10);
-        $window->getRetryAfter();
-        $this->assertEquals('1234567900.000000', $window->getRetryAfter()->format('U.u'));
+        $this->assertEquals(30, $window->calculateTimeForTokens(1, 4));
+
+        $window = new SlidingWindow('foo', 10);
+        $window->add();
+        $window = SlidingWindow::createFromPreviousWindow($window, 10);
+        sleep(10);
+        $this->assertEquals(40, $window->calculateTimeForTokens(1, 4));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | yes
| Tickets | Fix https://github.com/symfony/symfony/issues/40289, Fixes #46875
| License       | MIT

This implements `LimiterInterface->reserve()` for `SlidingWindowLimiter`. I'm not sure if the lack of implementation was due to time/scope or if it's actually not possible and my approach is incorrect. But I like to give it a try anyway. Perhaps @wouterj you could elaborate on that? 

The calculation does the following:

1. Calculate tokens to be released within this window. E.g. if 4 were used in the last window, at 50% into the current, 2 are still to be released.
2. Calculate the time-per-token within the remainder of the window. If the requested tokens will be available before the end of the current window, return the time-per-token * needed-tokens. 
3. Otherwise return time-per-token of the regular interval * needed-tokens(-after the current window). 

This wasn't a [bugfix](https://github.com/symfony/symfony/pull/51592), so back to feature PR. I couldn't reopen https://github.com/symfony/symfony/pull/47557, So had to create this new PR.