### PR TITLE
[Translation] Give current locale to `LocaleSwitcher::runWithLocale()`'s callback

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Give current locale to `LocaleSwitcher::runWithLocale()`'s callback
+
 6.3
 ---
 

--- a/src/Symfony/Component/Translation/LocaleSwitcher.php
+++ b/src/Symfony/Component/Translation/LocaleSwitcher.php
@@ -55,7 +55,7 @@ class LocaleSwitcher implements LocaleAwareInterface
      *
      * @template T
      *
-     * @param callable():T $callback
+     * @param callable(string $locale):T $callback
      *
      * @return T
      */
@@ -65,7 +65,7 @@ class LocaleSwitcher implements LocaleAwareInterface
         $this->setLocale($locale);
 
         try {
-            return $callback();
+            return $callback($locale);
         } finally {
             $this->setLocale($original);
         }

--- a/src/Symfony/Component/Translation/Tests/LocaleSwitcherTest.php
+++ b/src/Symfony/Component/Translation/Tests/LocaleSwitcherTest.php
@@ -66,10 +66,11 @@ class LocaleSwitcherTest extends TestCase
         $this->assertSame('en', $service->getLocale());
         $this->assertSame('en', $switcher->getLocale());
 
-        $switcher->runWithLocale('fr', function () use ($switcher, $service) {
+        $switcher->runWithLocale('fr', function (string $locale) use ($switcher, $service) {
             $this->assertSame('fr', \Locale::getDefault());
             $this->assertSame('fr', $service->getLocale());
             $this->assertSame('fr', $switcher->getLocale());
+            $this->assertSame('fr', $locale);
         });
 
         $this->assertSame('en', \Locale::getDefault());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no 
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no  <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


I think it would not hurt to give the $locale everytime to the callback method.

Example usage:

```php
$notificationContent = $this->localeSwitcher->runWithLocale($contact->getLocale(), function(string $locale) use ($someEntity): string {
    $title = $someEntity->getTitle($locale);

    return $this->twig->render('template.html.twig', ['title' => $title]);
});
```

Alternative solution currently is:

```php
$locale = $contact->getLocale();
$notificationContent = $this->localeSwitcher->runWithLocale($locale, function() use ($locale, $someEntity): string {
    $title = $someEntity->getTitle($locale);

    return $this->twig->render('template.html.twig', ['title' => $title]);
});
```

So this avoids creating a `$locale` variable which maybe only is necessary inside the callback method.
