### PR TITLE
Update the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,14 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | 6.4 for features / 5.4, or 6.3 for bug fixes <!-- see below -->
+| Branch?       | 6.4 for features / 5.4 or 6.3 for bug fixes <!-- see below -->
 | Bug fix?      | yes/no
 | New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
 | Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
 | Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
 | License       | MIT
-| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
+
 <!--
-Replace this notice by a short README for your feature/bugfix.
+Replace this notice by a description of your feature/bugfix.
 This will help reviewers and should be a good start for the documentation.
 
 Additionally (see https://symfony.com/releases):


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In `symfony/symfony-docs` we have a lot of pending PRs labeled as "Waiting Code Merge": https://github.com/symfony/symfony-docs/pulls?q=is%3Apr+is%3Aopen+label%3A%22Waiting+Code+Merge%22

This is because we ask code contributors to create a doc PR for each new feature proposed. I don't think this is needed because:

* It requires a non-trivial effort from contributors and that doc PR could be useless if the code PR is closed without merging.
* It "pollutes" the `symfony/symfony-docs` backlog (currently, more than 30% of pending PRs are "Waiting Code Merge").

What we need instead is:

* Good PR descriptions (with code examples, configs, etc.) so we can review them properly
* After the code PR is merged, please (1) write the doc yourself (2) or help us write it by answering questions, providing more examples, etc.

Thanks!