### PR TITLE
[PasswordHasher][SecurityBundle] Fix password migration with custom hasher service with security bundle config

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -848,7 +848,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
     {
         // a custom hasher service
         if (isset($config['id'])) {
-            return new Reference($config['id']);
+            return $config['migrate_from'] ?? false ? [
+                'instance' => new Reference($config['id']),
+                'migrate_from' => $config['migrate_from'],
+            ] : new Reference($config['id']);
         }
 
         if ($config['migrate_from'] ?? false) {

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -71,6 +71,14 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
      */
     private function createHasher(array $config, bool $isExtra = false): PasswordHasherInterface
     {
+        if (isset($config['instance'])) {
+            if (!isset($config['migrate_from'])) {
+                return $config['instance'];
+            }
+
+            $config = $this->getMigratingPasswordConfig($config);
+        }
+
         if (isset($config['algorithm'])) {
             $rawConfig = $config;
             $config = $this->getHasherConfigFromAlgorithm($config);
@@ -142,24 +150,8 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
             ];
         }
 
-        if ($frompasswordHashers = ($config['migrate_from'] ?? false)) {
-            unset($config['migrate_from']);
-            $hasherChain = [$this->createHasher($config, true)];
-
-            foreach ($frompasswordHashers as $name) {
-                if (isset($this->passwordHashers[$name])) {
-                    $hasher = $this->createHasherUsingAdapter($name);
-                } else {
-                    $hasher = $this->createHasher(['algorithm' => $name], true);
-                }
-
-                $hasherChain[] = $hasher;
-            }
-
-            return [
-                'class' => MigratingPasswordHasher::class,
-                'arguments' => $hasherChain,
-            ];
+        if ($config['migrate_from'] ?? false) {
+            return $this->getMigratingPasswordConfig($config);
         }
 
         switch ($config['algorithm']) {
@@ -237,6 +229,28 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
                 $config['encode_as_base64'] ?? true,
                 $config['iterations'] ?? 5000,
             ],
+        ];
+    }
+
+    private function getMigratingPasswordConfig(array $config): array
+    {
+        $frompasswordHashers = $config['migrate_from'];
+        unset($config['migrate_from']);
+        $hasherChain = [$this->createHasher($config, true)];
+
+        foreach ($frompasswordHashers as $name) {
+            if ($this->passwordHashers[$name] ?? false) {
+                $hasher = $this->createHasherUsingAdapter($name);
+            } else {
+                $hasher = $this->createHasher(['algorithm' => $name], true);
+            }
+
+            $hasherChain[] = $hasher;
+        }
+
+        return [
+            'class' => MigratingPasswordHasher::class,
+            'arguments' => $hasherChain,
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51670 (alternative)
| License       | MIT
| Doc PR        | N/A

Supersedes #51670 as a bug fix, so the security config properly uses a for the `migrate_from` when a `MigratingPasswordHasher` when a custom hasher service id is used:

```yaml
security:
    password_hashers:
        legacy: md5
        App\User\Identity:
            id: App\Security\CustomHasher
            migrate_from:
                - legacy
```

---

> **Note** 
> 6.3 patch : https://github.com/symfony/symfony/compare/6.3...ogizanagi:63-security-custom-hasher-migrate