### PR TITLE
[Validator] [Language] Add case-insensitive option to Validator\Constraints\Language

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Deprecate `ValidatorBuilder::enableAnnotationMapping()`, use `ValidatorBuilder::enableAttributeMapping()` instead
  * Deprecate `ValidatorBuilder::disableAnnotationMapping()`, use `ValidatorBuilder::disableAttributeMapping()` instead
  * Deprecate `AnnotationLoader`, use `AttributeLoader` instead
+ * Add `caseInsensitive` option for `Validator\Constraints\Language`
 
 6.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/Language.php
+++ b/src/Symfony/Component/Validator/Constraints/Language.php
@@ -37,11 +37,13 @@ class Language extends Constraint
 
     public $message = 'This value is not a valid language.';
     public $alpha3 = false;
+    public $caseInsensitive = false;
 
     public function __construct(
         array $options = null,
         string $message = null,
         bool $alpha3 = null,
+        bool $caseInsensitive = null,
         array $groups = null,
         mixed $payload = null
     ) {
@@ -53,5 +55,6 @@ class Language extends Constraint
 
         $this->message = $message ?? $this->message;
         $this->alpha3 = $alpha3 ?? $this->alpha3;
+        $this->caseInsensitive = $caseInsensitive ?? $this->caseInsensitive;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -43,6 +43,8 @@ class LanguageValidator extends ConstraintValidator
 
         $value = (string) $value;
 
+        $value = $constraint->caseInsensitive ? mb_strtolower($value, 'UTF-8') : $value;
+
         if ($constraint->alpha3 ? !Languages::alpha3CodeExists($value) : !Languages::exists($value)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -178,4 +178,84 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
 
         $this->assertNoViolation();
     }
+
+    /**
+     * @dataProvider getCaseInsensitiveValidLanguages
+     */
+    public function testCaseInsensitiveValidLanguages($language)
+    {
+        $constraint = new Language([
+            'message' => 'myMessage',
+            'caseInsensitive' => true,
+        ]);
+
+        $this->validator->validate($language, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getCaseInsensitiveAlpha3ValidLanguages
+     */
+    public function testCaseInsensitiveValidAlpha3Languages($language)
+    {
+        $constraint = new Language([
+            'message' => 'myMessage',
+            'alpha3' => true,
+            'caseInsensitive' => true,
+        ]);
+
+        $this->validator->validate($language, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getCaseInsensitiveAlpha3InvalidLanguages
+     */
+    public function testCaseInsensitiveInvalidAlpha3Languages($language)
+    {
+        $constraint = new Language([
+            'message' => 'myMessage',
+            'alpha3' => true,
+            'caseInsensitive' => true,
+        ]);
+
+        $this->validator->validate($language, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"' . strtolower($language) . '"')
+            ->setCode(Language::NO_SUCH_LANGUAGE_ERROR)
+            ->assertRaised();
+    }
+
+    public function getCaseInsensitiveValidLanguages()
+    {
+        return [
+            ['EN'],
+            ['eN'],
+            ['MY'],
+            ['My'],
+        ];
+    }
+
+    public static function getCaseInsensitiveAlpha3ValidLanguages()
+    {
+        return [
+            ['DEU'],
+            ['ENG'],
+            ['FRA'],
+            ['fRA'],
+            ['EnG'],
+        ];
+    }
+
+    public static function getCaseInsensitiveAlpha3InvalidLanguages()
+    {
+        return [
+            ['FOOBAR'],
+            ['zzz'],
+            ['zzZ'],
+        ];
+    }
 }


### PR DESCRIPTION
Add case-insensitive option to Validator\Constraints\Language

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49615
| License       | MIT
| Doc PR        | symfony/symfony-docs/pull/18884

Language validator now accepts case-insensitive language codes if option is set to true (es. it, IT, iT, It are all valid).
Use: pass caseInsensitive => true to Language constraint.
By default caseInsensitive is false.

This fix issue #49615

