### PR TITLE
Disable the dead code analysis in Psalm

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
     cacheDirectory="./.github/psalm/cache/"
     errorBaseline=".github/psalm/psalm.baseline.xml"
     findUnusedBaselineEntry="false"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT

Our psalm analysis does not analyse tests or usages of Symfony in other projects, so it reports lots of methods as unused.
For most jobs, this does not report anything because of our dynamic baseline meant to report only new things, but it creates confusion when it finds new ones (like in https://github.com/symfony/symfony/actions/runs/6224332561)

`findDeadCode` defaults to `false` in Psalm 5.x but our CI installs dev versions and does not restricts the version of Psalm that it installs so it already installs 6.x-dev (i.e. dev-master) where the default config for that is `true`.
Finding dead code might be a good default for projects. But for libraries, it is not (at least if you don't also analyse the testsuite to discover usages of tested public APIs)
