### PR TITLE
[FrameworkBundle] Add `LoggerAssertionsTrait` which provide shortcuts to assert a log has been written

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * Add `LoggerAssertionsTrait`
  * Add `AbstractController::renderBlock()` and `renderBlockView()`
  * Add native return type to `Translator` and to `Application::reset()`
  * Deprecate the integration of Doctrine annotations, either uninstall the `doctrine/annotations` package or disable the integration by setting `framework.annotations` to `false`

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -25,6 +25,7 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 abstract class KernelTestCase extends TestCase
 {
+    use LoggerAssertionsTrait;
     use MailerAssertionsTrait;
     use NotificationAssertionsTrait;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Test/LoggerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/LoggerAssertionsTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Monolog\LogRecord;
+
+trait LoggerAssertionsTrait
+{
+    public static function assertLogExists(string $expectedLog, string $level = Logger::DEBUG): void
+    {
+        /** @var TestHandler $logger */
+        $logger = self::getContainer()->get('monolog.handler.test');
+
+        self::assertTrue($logger->hasRecordThatPasses(
+            function (array|LogRecord $record) use ($expectedLog) {
+                return $record['message'] === $expectedLog;
+            },
+            $level,
+        ));
+    }
+
+    public static function assertLogMatches(string $expectedRegex, string $level = Logger::DEBUG): void
+    {
+        /** @var TestHandler $logger */
+        $logger = self::getContainer()->get('monolog.handler.test');
+
+        self::assertTrue($logger->hasRecordThatMatches($expectedRegex, $level));
+    }
+
+    public static function assertLogContains(string $expectedLog, string $level = Logger::DEBUG): void
+    {
+        /** @var TestHandler $logger */
+        $logger = self::getContainer()->get('monolog.handler.test');
+
+        self::assertTrue($logger->hasRecordThatContains($expectedLog, $level));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Test/LoggerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/LoggerAssertionsTrait.php
@@ -19,6 +19,8 @@ trait LoggerAssertionsTrait
 {
     public static function assertLogExists(string $expectedLog, string $level = Logger::DEBUG): void
     {
+        self::ensureMonologHandlerIsAvailable();
+
         /** @var TestHandler $logger */
         $logger = self::getContainer()->get('monolog.handler.test');
 
@@ -32,6 +34,8 @@ trait LoggerAssertionsTrait
 
     public static function assertLogMatches(string $expectedRegex, string $level = Logger::DEBUG): void
     {
+        self::ensureMonologHandlerIsAvailable();
+
         /** @var TestHandler $logger */
         $logger = self::getContainer()->get('monolog.handler.test');
 
@@ -40,9 +44,21 @@ trait LoggerAssertionsTrait
 
     public static function assertLogContains(string $expectedLog, string $level = Logger::DEBUG): void
     {
+        self::ensureMonologHandlerIsAvailable();
+
         /** @var TestHandler $logger */
         $logger = self::getContainer()->get('monolog.handler.test');
 
         self::assertTrue($logger->hasRecordThatContains($expectedLog, $level));
+    }
+
+    /**
+     * @internal
+     */
+    private static function ensureMonologHandlerIsAvailable(): void
+    {
+        if (!self::getContainer()->has('monolog.handler.test')) {
+            self::fail('The "monolog.handler.test" service is not available. Try registering the service "Monolog\Handler\TestHandler" as "monolog.handler.test" in your test configuration.');
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/LoggerController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/LoggerController.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final class LoggerController
+{
+    public function index(LoggerInterface $logger)
+    {
+        $logger->debug('test1_'.__CLASS__);
+        $logger->debug('test2_'.__CLASS__);
+        $logger->debug('test3_'.__CLASS__);
+
+        return new Response();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Logger/TestLogger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Logger/TestLogger.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Logger;
+
+use Monolog\Logger;
+
+class TestLogger extends Logger
+{
+    public array $logs = [];
+
+    public function __construct($handler)
+    {
+        parent::__construct(__CLASS__, [$handler]);
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Logger/TestLoggerWithoutHandler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Logger/TestLoggerWithoutHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Logger;
+
+use Monolog\Logger;
+
+class TestLoggerWithoutHandler extends Logger
+{
+    public array $logs = [];
+
+    public function __construct()
+    {
+        parent::__construct(__CLASS__);
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -68,3 +68,7 @@ uid:
 send_notification:
     path:     /send_notification
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\NotificationController::indexAction }
+
+log:
+    path:     /log
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\LoggerController::index }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/LoggerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/LoggerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+final class LoggerTest extends AbstractWebTestCase
+{
+    public function testLoggerAssertion()
+    {
+        $client = $this->createClient(['test_case' => 'Logger', 'root_config' => 'config.yml', 'debug' => true]);
+        $client->request('GET', '/log');
+
+        $this->assertLogExists('test1_Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\LoggerController');
+        $this->assertLogMatches('/(test2_).*(LoggerController)/');
+        $this->assertLogContains('test3');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/LoggerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/LoggerTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use PHPUnit\Framework\AssertionFailedError;
+
 final class LoggerTest extends AbstractWebTestCase
 {
     public function testLoggerAssertion()
@@ -21,5 +23,29 @@ final class LoggerTest extends AbstractWebTestCase
         $this->assertLogExists('test1_Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\LoggerController');
         $this->assertLogMatches('/(test2_).*(LoggerController)/');
         $this->assertLogContains('test3');
+    }
+
+    public function testLoggerAssertionWithoutTestHandler()
+    {
+        $client = $this->createClient(['test_case' => 'LoggerWithoutHandler', 'root_config' => 'config.yml', 'debug' => true]);
+        $client->request('GET', '/log');
+
+        try {
+            $this->assertLogExists('test1_Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\LoggerController');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('The "monolog.handler.test" service is not available. Try registering the service "Monolog\Handler\TestHandler" as "monolog.handler.test" in your test configuration.', $e->getMessage());
+        }
+
+        try {
+            $this->assertLogMatches('/(test2_).*(LoggerController)/');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('The "monolog.handler.test" service is not available. Try registering the service "Monolog\Handler\TestHandler" as "monolog.handler.test" in your test configuration.', $e->getMessage());
+        }
+
+        try {
+            $this->assertLogContains('test3');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('The "monolog.handler.test" service is not available. Try registering the service "Monolog\Handler\TestHandler" as "monolog.handler.test" in your test configuration.', $e->getMessage());
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Logger/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Logger/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Logger/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Logger/config.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: services.yml }
+
+framework:
+    profiler: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Logger/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Logger/routing.yml
@@ -1,0 +1,2 @@
+_loggertest_bundle:
+    resource: '@TestBundle/Resources/config/routing.yml'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Logger/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Logger/services.yml
@@ -1,0 +1,13 @@
+services:
+    _defaults:
+        public: true
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\LoggerController:
+        tags: ['controller.service_arguments']
+
+    monolog.handler.test:
+        class: Monolog\Handler\TestHandler
+
+    logger:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Logger\TestLogger
+        arguments: ['@monolog.handler.test']

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/LoggerWithoutHandler/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/LoggerWithoutHandler/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/LoggerWithoutHandler/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/LoggerWithoutHandler/config.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: services.yml }
+
+framework:
+    profiler: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/LoggerWithoutHandler/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/LoggerWithoutHandler/routing.yml
@@ -1,0 +1,2 @@
+_loggertest_bundle:
+    resource: '@TestBundle/Resources/config/routing.yml'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/LoggerWithoutHandler/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/LoggerWithoutHandler/services.yml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        public: true
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\LoggerController:
+        tags: ['controller.service_arguments']
+
+    logger:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Logger\TestLoggerWithoutHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Like #50662, this PR brings a new collection to enhance assertions to help users to ensure some logs has been written during a Request processing.

In a controller:
```php
public function index(LoggerInterface $logger)
{
    $logger->debug('test1_' . __CLASS__);
    $logger->debug('test2_' . __CLASS__);
    $logger->debug('test3_' . __CLASS__);

    return new Response();
}
```

In the test:

```php
public function testLoggerAssertion()
{
    $client = $this->createClient();
    $client->request('GET', '/log');

    $this->assertLogExists('test1_Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\LoggerController');
    $this->assertLogMatches("/(test2_).*(LoggerController)/");
    $this->assertLogContains('test3');
}
```

## Todo

- [ ] Write doc