### PR TITLE
[PropertyInfo] Make isWriteable() more consistent with isReadable() when checking snake_case properties

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Make properties writable when a setter in camelCase exists, similar to the camelCase getter
+
 6.1
 ---
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -205,6 +205,13 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return true;
         }
 
+        // First test with the camelized property name
+        [$reflectionMethod] = $this->getMutatorMethod($class, $this->camelize($property));
+        if (null !== $reflectionMethod) {
+            return true;
+        }
+
+        // Otherwise check for the old way
         [$reflectionMethod] = $this->getMutatorMethod($class, $property);
 
         return null !== $reflectionMethod;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\SnakeCaseDummy;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -407,6 +408,20 @@ class ReflectionExtractorTest extends TestCase
             ['Guid', true],
             ['guid', false],
         ];
+    }
+
+    public function testIsReadableSnakeCase()
+    {
+        $this->assertTrue($this->extractor->isReadable(SnakeCaseDummy::class, 'snake_property'));
+        $this->assertTrue($this->extractor->isReadable(SnakeCaseDummy::class, 'snake_readonly'));
+    }
+
+    public function testIsWriteableSnakeCase()
+    {
+        $this->assertTrue($this->extractor->isWritable(SnakeCaseDummy::class, 'snake_property'));
+        $this->assertFalse($this->extractor->isWritable(SnakeCaseDummy::class, 'snake_readonly'));
+        // Ensure that it's still possible to write to the property using the (old) snake name
+        $this->assertTrue($this->extractor->isWritable(SnakeCaseDummy::class, 'snake_method'));
     }
 
     public function testSingularize()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/SnakeCaseDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/SnakeCaseDummy.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class SnakeCaseDummy
+{
+    private string $snake_property;
+    private string $snake_readOnly;
+    private string $snake_method;
+
+    public function getSnakeProperty()
+    {
+        return $this->snake_property;
+    }
+
+    public function getSnakeReadOnly()
+    {
+        return $this->snake_readOnly;
+    }
+
+    public function setSnakeProperty($snake_property)
+    {
+        $this->snake_property = $snake_property;
+    }
+
+    public function setSnake_method($snake_method)
+    {
+        $this->snake_method = $snake_method;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Related with issues #29933 and #16889
| License       | MIT
| Doc PR        | 

Currently PropertyInfo is a bit inconsistent in the behavior of isWriteable() and isReadable() when using it with properties in snake_case format, which are only accessible via a getter and setter. To be readable the getter function has to be in camel_case (e.g. `getSnakeCase()`), while the setter function has to remain in the snake case format (e.g. `setSnake_case()`).

In this example class:
```php
class Dummy {
  private string $snake_case;

  public function getSnakeCase(): string
  { }

  public function setSnakeCase(string $snake_case): void
  { }
 
}
````

the property `snake_case` is considered readable like you would expect, but not writeable, even though the property has a useable setter and the value can be actually be modified fine by something like the PropertyAccess component.
To make the property actually considered writeable, the setter would need to be named `setSnake_case`, which is pretty inconsistent with the behavior of isReadable and makes it very hard to use this component on snake_case properties.

This inconsistencies are caused by the fact, that `isReadable` in ReflectionExtractor uses the `getReadInfo()` function which does a camelization of the property name internally, while the `isWriteable()` function uses the `getMutatorMethod()` function which just perform a capitalization of the first letter.

This PR fixes this inconsistencies between isReadable() and isWriteable() by allowing to use a camelCase style setter to be considered writeable, as this is much more common then to use the mix of snake and camelCase currently required.

The getWriteInfo() function is not useable here, because it needs both a add and remove Function on collection setters to give proper infos, while the current `isWriteable()` implementation considers a class with just a add or a remove function as writeable. Therefore the property name just gets camelized before being feed into the `getMutatorMethod()`, which gives the desired result.

To maximize backwards compatibility, if no camelCase style setter is found, it is still checked for a snake_case setter, so that classes having these, are still considered writeable after the change.

The current behavior is causing some inconsistencies in higher level libraries, which rely on this component. In API Platform for example properties in snake_case are considered read only even though they have a (camel case) setter, because of this. See issue: https://github.com/api-platform/core/issues/5641 and https://github.com/api-platform/core/issues/1554

