### PR TITLE
[Serializer] Fix parsing XML root node attributes

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -159,15 +159,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             return $rootNode->nodeValue;
         }
 
-        $data = [];
-
-        foreach ($rootNode->attributes as $attrKey => $attr) {
-            $data['@'.$attrKey] = $attr->nodeValue;
-        }
-
-        $data['#'] = $rootNode->nodeValue;
-
-        return $data;
+        return array_merge($this->parseXmlAttributes($rootNode, $context), ['#' => $rootNode->nodeValue]);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -315,6 +315,21 @@ XML;
         $this->assertSame(['@index' => 0.123, '#' => 'Name'], $this->encoder->decode($source, 'xml'));
     }
 
+    public function testNoTypeCastRootAttribute()
+    {
+        $source = <<<XML
+<?xml version="1.0"?>
+<document a="123"></document>
+XML;
+
+        $data = $this->encoder->decode($source, 'xml', ['xml_type_cast_attributes' => false]);
+        $expected = [
+            '@a' => '123',
+            '#' => '',
+        ];
+        $this->assertSame($expected, $data);
+    }
+
     public function testNoTypeCastAttribute()
     {
         $source = <<<XML


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #51594
| License       | MIT
| Doc PR        | N/A

Add missing parsing of root node attributes