### PR TITLE
[Routing] Fix routing collection defaults when adding a new route to a collection

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -114,4 +114,12 @@ class CollectionConfigurator
 
         return $this;
     }
+
+    /**
+     * This method overrides the one from LocalizedRouteTrait.
+     */
+    private function createRoute(string $path): Route
+    {
+        return (clone $this->route)->setPath($path);
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/collection-defaults.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/collection-defaults.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $collection = $routes->collection();
+    $collection
+        ->methods(['GET'])
+        ->defaults(['attribute' => true])
+        ->stateless();
+
+    $collection->add('defaultsA', '/defaultsA')
+        ->locale('en')
+        ->format('html');
+
+    $collection->add('defaultsB', '/defaultsB')
+        ->methods(['POST'])
+        ->stateless(false)
+        ->locale('en')
+        ->format('html');
+};

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -103,6 +103,31 @@ class PhpFileLoaderTest extends TestCase
         $this->assertSame('html', $defaultsRoute->getDefault('_format'));
     }
 
+    public function testLoadingRouteWithCollectionDefaults()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
+        $routes = $loader->load('collection-defaults.php');
+
+        $this->assertCount(2, $routes);
+
+        $defaultsRoute = $routes->get('defaultsA');
+        $this->assertSame(['GET'], $defaultsRoute->getMethods());
+        $this->assertArrayHasKey('attribute', $defaultsRoute->getDefaults());
+        $this->assertTrue($defaultsRoute->getDefault('_stateless'));
+        $this->assertSame('/defaultsA', $defaultsRoute->getPath());
+        $this->assertSame('en', $defaultsRoute->getDefault('_locale'));
+        $this->assertSame('html', $defaultsRoute->getDefault('_format'));
+
+        // The second route has a specific method and is not stateless, overwriting the collection settings
+        $defaultsRoute = $routes->get('defaultsB');
+        $this->assertSame(['POST'], $defaultsRoute->getMethods());
+        $this->assertArrayHasKey('attribute', $defaultsRoute->getDefaults());
+        $this->assertFalse($defaultsRoute->getDefault('_stateless'));
+        $this->assertSame('/defaultsB', $defaultsRoute->getPath());
+        $this->assertSame('en', $defaultsRoute->getDefault('_locale'));
+        $this->assertSame('html', $defaultsRoute->getDefault('_format'));
+    }
+
     public function testLoadingImportedRoutesWithDefaults()
     {
         $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

In our current Symfony project we use PHP routing files, and use routing collections that are setup before adding routes.

Before upgrading to Symfony 6.3 this meant we could add an attribute to the collection, add X routes and they would all have this routing attribute (be it stateless / methods / defaults). After upgrading to S6.3 this no longer works.

PR #49517 removed the createRoute method from the CollectionConfigurator, because it was thought to be unused, but this method was used when adding a new Route to a RouteCollection. Without the method, the createRoute method of the LocalizedRouteTrait was used.
This means that when setting up a route collection before adding routes, the new routes no longer get the collection settings.

Added a new unittest to prevent this from happening again. For now only added to the PhpFileLoaderTest, I don't know if this is also possible for XML/YML routing config to also add a test in those LoaderTests.