### PR TITLE
[Validator] Fix `File::$extensions`’ PHPDoc

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -73,7 +73,7 @@ class File extends Constraint
     protected $maxSize;
 
     /**
-     * @param array<string, string|string[]>|string[]|string $extensions
+     * @param array<string|string[]>|string $extensions
      */
     public function __construct(
         array $options = null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

[The documentation’s example](https://symfony.com/doc/current/reference/constraints/File.html#extensions) is incompatible with the current PHPDoc because keys can be integers **and** strings in a single array:

![image](https://github.com/symfony/symfony/assets/1898254/ab9d47be-2f8e-4e7c-9a7b-6fea3efd73c9)

It would now accept `string[][]` as well, but a false positive seems better to me than a false negative. 