### PR TITLE
Deprecate `Kernel::stripComments()`

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -107,6 +107,7 @@ HttpKernel
 
  * [BC break] `BundleInterface` no longer extends `ContainerAwareInterface`
  * [BC break] Add native return types to `TraceableEventDispatcher` and to `MergeExtensionConfigurationPass`
+ * Deprecate `Kernel::stripComments()`
 
 Messenger
 ---------

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add argument `$validationFailedStatusCode` to `#[MapQueryString]` and `#[MapRequestPayload]`
  * Add argument `$debug` to `Logger`
  * Add class `DebugLoggerConfigurator`
+ * Deprecate `Kernel::stripComments()`
 
 6.3
 ---

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -774,9 +774,13 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      *
      * We don't use the PHP php_strip_whitespace() function
      * as we want the content to be readable and well-formatted.
+     *
+     * @deprecated since Symfony 6.4 without replacement
      */
     public static function stripComments(string $source): string
     {
+        trigger_deprecation('symfony/http-kernel', '6.4', 'Method "%s()" is deprecated without replacement.', __METHOD__);
+
         if (!\function_exists('token_get_all')) {
             return $source;
         }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -249,9 +249,13 @@ class KernelTest extends TestCase
 
     /**
      * @dataProvider getStripCommentsCodes
+     *
+     * @group legacy
      */
     public function testStripComments(string $source, string $expected)
     {
+        $this->expectDeprecation('Since symfony/http-kernel 6.4: Method "Symfony\Component\HttpKernel\Kernel::stripComments()" is deprecated without replacement.');
+
         $output = Kernel::stripComments($source);
 
         // Heredocs are preserved, making the output mixing Unix and Windows line


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR replace `method_exists` by `class_exists` in order to check if component is available. It harmonize codebase

~This PR remove checking if method `Kernel::setIgnore` exists.~

~This method was introduced in symfony 2.3 (https://github.com/symfony/symfony/pull/18048), so now it's always available~