### PR TITLE
[Notifier] Add options to Telegram Bridge for sending Location

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+* Add support for `sendLocation` API method
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
@@ -76,6 +76,32 @@ $chatMessage->options($telegramOptions);
 $chatter->send($chatMessage);
 ```
 
+Adding Location to a Message
+----------------------------
+
+With a Telegram message, you can use the `TelegramOptions` class to add
+[message options](https://core.telegram.org/bots/api).
+
+```php
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button\InlineKeyboardButton;
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\InlineKeyboardMarkup;
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('');
+
+// Create Telegram options
+$telegramOptions = (new TelegramOptions())
+    ->chatId('@symfonynotifierdev')
+    ->parseMode('MarkdownV2')
+    ->location(48.8566, 2.3522);
+
+// Add the custom options to the chat message and send the message
+$chatMessage->options($telegramOptions);
+
+$chatter->send($chatMessage);
+```
+
 Updating Messages
 -----------------
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
@@ -156,4 +156,15 @@ final class TelegramOptions implements MessageOptionsInterface
 
         return $this;
     }
+
+    /**
+     * @return $this
+     */
+    public function location(float $latitude, float $longitude): static
+    {
+        $this->options['latitude'] = $latitude;
+        $this->options['longitude'] = $longitude;
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Telegram;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -116,6 +115,7 @@ final class TelegramTransport extends AbstractTransport
             isset($options['message_id']) => 'editMessageText',
             isset($options['callback_query_id']) => 'answerCallbackQuery',
             isset($options['photo']) => 'sendPhoto',
+            (isset($options['longitude']) && isset($options['latitude'])) => 'sendLocation',
             default => 'sendMessage',
         };
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add possibility to send point on map in notification.
