### PR TITLE
[Notifier][Telegram] Add escaping for slashes

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Telegram;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -74,7 +73,7 @@ final class TelegramTransport extends AbstractTransport
 
         if (!isset($options['parse_mode']) || TelegramOptions::PARSE_MODE_MARKDOWN_V2 === $options['parse_mode']) {
             $options['parse_mode'] = TelegramOptions::PARSE_MODE_MARKDOWN_V2;
-            $options['text'] = preg_replace('/([_*\[\]()~`>#+\-=|{}.!])/', '\\\\$1', $message->getSubject());
+            $options['text'] = preg_replace('/([_*\[\]()~`>#+\-=|{}.!\\\\])/', '\\\\$1', $message->getSubject());
         }
 
         if (isset($options['photo'])) {

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -316,7 +316,7 @@ JSON;
 
         $expectedBody = [
             'chat_id' => 'testChannel',
-            'text' => 'I contain special characters \_ \* \[ \] \( \) \~ \` \> \# \+ \- \= \| \{ \} \. \! to send\.',
+            'text' => 'I contain special characters \_ \* \[ \] \( \) \~ \` \> \# \+ \- \= \| \{ \} \. \! \\\\ to send\.',
             'parse_mode' => 'MarkdownV2',
         ];
 
@@ -328,7 +328,7 @@ JSON;
 
         $transport = self::createTransport($client, 'testChannel');
 
-        $transport->send(new ChatMessage('I contain special characters _ * [ ] ( ) ~ ` > # + - = | { } . ! to send.'));
+        $transport->send(new ChatMessage('I contain special characters _ * [ ] ( ) ~ ` > # + - = | { } . ! \\ to send.'));
     }
 
     public function testSendPhotoWithOptions()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

If source message contains slash and reserved symbol after it Telegram handle escape incorrect.


Actual behavior:
`Hello\World\{closure}` will be escaped as `Hello\World\\{closure\}`

```
In TelegramTransport.php line 107:
                                                                                                                                                            
  [Symfony\Component\Notifier\Exception\TransportException]                                                                                                 
  Unable to post the Telegram message: Bad Request: can't parse entities: Character '{' is reserved and must be escaped with the preceding '\' (code 400).  
                                                                                                                                                            

Exception trace:
  at /app/vendor/symfony/telegram-notifier/TelegramTransport.php:107
 Symfony\Component\Notifier\Bridge\Telegram\TelegramTransport->doSend() at /app/vendor/symfony/notifier/Transport/AbstractTransport.php:80
 Symfony\Component\Notifier\Transport\AbstractTransport->send() at /app/vendor/symfony/notifier/Transport/Transports.php:60
 Symfony\Component\Notifier\Transport\Transports->send() at /app/vendor/symfony/notifier/Messenger/MessageHandler.php:32
 Symfony\Component\Notifier\Messenger\MessageHandler->__invoke() at /app/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:157
 Symfony\Component\Messenger\Middleware\HandleMessageMiddleware->callHandler() at /app/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:96
 Symfony\Component\Messenger\Middleware\HandleMessageMiddleware->handle() at /app/vendor/symfony/messenger/Middleware/SendMessageMiddleware.php:77
 Symfony\Component\Messenger\Middleware\SendMessageMiddleware->handle() at /app/vendor/symfony/messenger/Middleware/FailedMessageProcessingMiddleware.php:34
 Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware->handle() at /app/vendor/symfony/messenger/Middleware/DispatchAfterCurrentBusMiddleware.php:68
 Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware->handle() at /app/vendor/symfony/messenger/Middleware/RejectRedeliveredMessageMiddleware.php:41
 Symfony\Component\Messenger\Middleware\RejectRedeliveredMessageMiddleware->handle() at /app/vendor/symfony/messenger/Middleware/AddBusNameStampMiddleware.php:37
 Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware->handle() at /app/vendor/symfony/messenger/Middleware/TraceableMiddleware.php:40
 Symfony\Component\Messenger\Middleware\TraceableMiddleware->handle() at /app/vendor/symfony/messenger/MessageBus.php:70
 Symfony\Component\Messenger\MessageBus->dispatch() at /app/vendor/symfony/messenger/TraceableMessageBus.php:38
 Symfony\Component\Messenger\TraceableMessageBus->dispatch() at /app/vendor/symfony/notifier/Chatter.php:55
```

Expected behavior:
Slashes should be also escaped - `Hello\\World\\\{closure\}`

