### PR TITLE
[Validator] NoSuspiciousCharacters custom error messages fix

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharacters.php
+++ b/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharacters.php
@@ -102,12 +102,12 @@ class NoSuspiciousCharacters extends Constraint
 
         parent::__construct($options, $groups, $payload);
 
-        $this->restrictionLevelMessage ??= $restrictionLevelMessage;
-        $this->invisibleMessage ??= $invisibleMessage;
-        $this->mixedNumbersMessage ??= $mixedNumbersMessage;
-        $this->hiddenOverlayMessage ??= $hiddenOverlayMessage;
-        $this->checks ??= $checks;
-        $this->restrictionLevel ??= $restrictionLevel;
-        $this->locales ??= $locales;
+        $this->restrictionLevelMessage = $restrictionLevelMessage ?? $this->restrictionLevelMessage;
+        $this->invisibleMessage = $invisibleMessage ?? $this->invisibleMessage;
+        $this->mixedNumbersMessage = $mixedNumbersMessage ?? $this->mixedNumbersMessage;
+        $this->hiddenOverlayMessage = $hiddenOverlayMessage ?? $this->hiddenOverlayMessage;
+        $this->checks = $checks ?? $this->checks;
+        $this->restrictionLevel = $restrictionLevel ?? $this->restrictionLevel;
+        $this->locales = $locales ?? $this->locales;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #51715  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

We use the ?? operator to check if the entered constructor arguments are equal to null. The previous operator (??=) was incorrect because of the default messages' values.
