### PR TITLE
Remove `setAccessible` reflection call in tests

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/HttpFoundationFactoryTest.php
@@ -208,7 +208,6 @@ class HttpFoundationFactoryTest extends TestCase
     {
         $reflection = new \ReflectionClass($this->factory);
         $createUploadedFile = $reflection->getMethod('createUploadedFile');
-        $createUploadedFile->setAccessible(true);
 
         return $createUploadedFile->invokeArgs($this->factory, [$uploadedFile]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I checked all codebase, and found only this occurence when php >8.1 is required

>     Note: As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default. 

https://www.php.net/manual/en/reflectionmethod.setaccessible
https://www.php.net/manual/en/reflectionproperty.setaccessible.php
