### PR TITLE
[AssetMapper] Fixing jsdelivr regex to catch 2x export syntax in a row

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -25,7 +25,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     public const URL_PATTERN_VERSION = 'https://data.jsdelivr.com/v1/packages/npm/%s/resolved?specifier=%s';
     public const URL_PATTERN_DIST = 'https://cdn.jsdelivr.net/npm/%s@%s%s/+esm';
 
-    public const IMPORT_REGEX = '{from"/npm/([^@]*@?[\S]+)@([^/]+)/\+esm"}';
+    public const IMPORT_REGEX = '{from"/npm/([^@]*@?\S+?)@([^/]+)/\+esm"}';
 
     private HttpClientInterface $httpClient;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | Not needed

Hi!

I found a new variant on the import syntax used by jsdelivr. This updates the regex to cover it and enhances the test suite around this pattern matching. The source of the problem is this content: https://cdn.jsdelivr.net/npm/@vue/runtime-dom@3.3.4/+esm

Cheers!
