### PR TITLE
[AssetMapper] Allow simple, relative paths in importmap.php

### DIFF
--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Mark the component as non experimental
  * Add CSS support to the importmap
  * Add "entrypoints" concept to the importmap
+ * Allow relative path strings in the importmap
  * Add `PreAssetsCompileEvent` event when running `asset-map:compile`
  * Add support for importmap paths to use the Asset component (for subdirectories)
  * Removed the `importmap:export` command

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -107,4 +107,9 @@ class ImportMapConfigReader
 
         EOF);
     }
+
+    public function getRootDirectory(): string
+    {
+        return \dirname($this->importMapConfigPath);
+    }
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
@@ -19,10 +19,10 @@ namespace Symfony\Component\AssetMapper\ImportMap;
 final class ImportMapEntry
 {
     public function __construct(
-        /**
-         * The logical path to this asset if local or downloaded.
-         */
         public readonly string $importName,
+        /**
+         * The path to the asset if local or downloaded.
+         */
         public readonly ?string $path = null,
         public readonly ?string $url = null,
         public readonly bool $isDownloaded = false,

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -102,4 +102,10 @@ EOF;
 
         $this->assertSame($originalImportMapData, $newImportMapData);
     }
+
+    public function testGetRootDirectory()
+    {
+        $configReader = new ImportMapConfigReader(__DIR__.'/../fixtures/importmap.php');
+        $this->assertSame(__DIR__.'/../fixtures', $configReader->getRootDirectory());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | TODO

This PR is based on top of #51543 - so that needs to be merged first.

Currently, the `path` key in `importmap.php` MUST be the logic path to an file. Especially when trying to refer to assets in a bundle, this forces us to use paths that... don't look very obvious to users - e.g.

```php
    'app' => [
        'path' => 'app.js',
    ],
    '@symfony/stimulus-bundle' => [
        'path' => '@symfony/stimulus-bundle/loader.js',
    ],
```

This PR adds support for relative paths (starting with `.`). This means the `importmap.php` file can look like this now:

```php
    'app' => [
        'path' => './assets/app.js',
    ],
    '@symfony/stimulus-bundle' => [
        'path' => './vendor/symfony/stimulus-bundle/assets/dist/loader.js',
    ],
```

Those paths are now simple. One less thing to explain to people.