### PR TITLE
[Security] Add a normalization step for the user-identifier in firewalls

### DIFF
--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add encryption support to `OidcTokenHandler` (JWE)
  * Replace `$hideAccountStatusExceptions` argument with `$exposeSecurityErrors` in `AuthenticatorManager` constructor
+ * Add argument `$identifierNormalizer` to `UserBadge::__construct()` to allow normalizing the identifier
 
 7.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49269
| License       | MIT
| Doc PR        | **TODO**

With this PR, the user identifier is lowered and normalized to make sure they are case-insensitive.
When enable, please note that the user provider or the user repository should be adapt:

* user identifier stored in the future shall be lowered and normalized as well
* the queries for existing user should be adapt

This is a very first attempt to resolve issue #49269. Any comments and reactions are welcome.

-----

See also https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#user-ids