### PR TITLE
[Notifier] Add `debugData` property to `SentMessage` class

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
@@ -88,6 +88,7 @@ final class AllMySmsTransport extends AbstractTransport
 
         $sentMessage = new SentMessage($message, (string) $this);
         $sentMessage->setMessageId($success['smsId']);
+        $sentMessage->setDebugData(['response' => $response]);
 
         return $sentMessage;
     }

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+* Include the http response in the returned `SentMessage` object
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+* Add `debugData` property to `SentMessage` class
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Message/SentMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SentMessage.php
@@ -19,6 +19,7 @@ class SentMessage
     private MessageInterface $original;
     private string $transport;
     private ?string $messageId = null;
+    private ?array $debugData = null;
 
     public function __construct(MessageInterface $original, string $transport)
     {
@@ -44,5 +45,15 @@ class SentMessage
     public function getMessageId(): ?string
     {
         return $this->messageId;
+    }
+
+    public function getDebugData(): ?array
+    {
+        return $this->debugData;
+    }
+
+    public function setDebugData(array $data): void
+    {
+        $this->debugData = $data;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49793
| License       | MIT
| Doc PR        |

As stated in the title, adding such a property would allow transports to include additional information in the returned `SentMessage` object (e.g. http response)