### PR TITLE
[Finder] Disable failing test about open_basedir

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderOpenBasedirTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderOpenBasedirTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests;
+
+use Symfony\Component\Finder\Finder;
+
+class FinderOpenBasedirTest extends Iterator\RealIteratorTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testIgnoreVCSIgnoredWithOpenBasedir()
+    {
+        $this->markTestIncomplete('Test case needs to be refactored so that PHPUnit can run it');
+
+        if (\ini_get('open_basedir')) {
+            $this->markTestSkipped('Cannot test when open_basedir is set');
+        }
+
+        $finder = $this->buildFinder();
+        $this->assertSame(
+            $finder,
+            $finder
+                ->ignoreVCS(true)
+                ->ignoreDotFiles(true)
+                ->ignoreVCSIgnored(true)
+        );
+
+        $this->iniSet('open_basedir', \dirname(__DIR__, 5).\PATH_SEPARATOR.self::toAbsolute('gitignore/search_root'));
+
+        $this->assertIterator(self::toAbsolute([
+            'gitignore/search_root/b.txt',
+            'gitignore/search_root/c.txt',
+            'gitignore/search_root/dir',
+            'gitignore/search_root/dir/a.txt',
+            'gitignore/search_root/dir/c.txt',
+        ]), $finder->in(self::toAbsolute('gitignore/search_root'))->getIterator());
+    }
+
+    protected function buildFinder()
+    {
+        return Finder::create()->exclude('gitignore');
+    }
+
+    protected function iniSet(string $varName, string $newValue): void
+    {
+        if ('open_basedir' === $varName && $deprecationsFile = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
+            $newValue .= \PATH_SEPARATOR.$deprecationsFile;
+        }
+
+        parent::iniSet($varName, $newValue);
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -482,35 +482,6 @@ class FinderTest extends Iterator\RealIteratorTestCase
         ]), $finder->in(self::toAbsolute('gitignore/git_root/search_root'))->getIterator());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testIgnoreVCSIgnoredWithOpenBasedir()
-    {
-        if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
-        }
-
-        $finder = $this->buildFinder();
-        $this->assertSame(
-            $finder,
-            $finder
-                ->ignoreVCS(true)
-                ->ignoreDotFiles(true)
-                ->ignoreVCSIgnored(true)
-        );
-
-        $this->iniSet('open_basedir', \dirname(__DIR__, 5).\PATH_SEPARATOR.self::toAbsolute('gitignore/search_root'));
-
-        $this->assertIterator(self::toAbsolute([
-            'gitignore/search_root/b.txt',
-            'gitignore/search_root/c.txt',
-            'gitignore/search_root/dir',
-            'gitignore/search_root/dir/a.txt',
-            'gitignore/search_root/dir/c.txt',
-        ]), $finder->in(self::toAbsolute('gitignore/search_root'))->getIterator());
-    }
-
     public function testIgnoreVCSCanBeDisabledAfterFirstIteration()
     {
         $finder = $this->buildFinder();
@@ -1056,6 +1027,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
             self::$tmpDir.\DIRECTORY_SEPARATOR.'Zephire.php',
             self::$tmpDir.\DIRECTORY_SEPARATOR.'test.php',
             __DIR__.\DIRECTORY_SEPARATOR.'GitignoreTest.php',
+            __DIR__.\DIRECTORY_SEPARATOR.'FinderOpenBasedirTest.php',
             __DIR__.\DIRECTORY_SEPARATOR.'FinderTest.php',
             __DIR__.\DIRECTORY_SEPARATOR.'GlobTest.php',
             self::$tmpDir.\DIRECTORY_SEPARATOR.'qux_0_1.php',
@@ -1623,14 +1595,5 @@ class FinderTest extends Iterator\RealIteratorTestCase
     protected function buildFinder()
     {
         return Finder::create()->exclude('gitignore');
-    }
-
-    protected function iniSet(string $varName, string $newValue): void
-    {
-        if ('open_basedir' === $varName && $deprecationsFile = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
-            $newValue .= \PATH_SEPARATOR.$deprecationsFile;
-        }
-
-        parent::iniSet('open_basedir', $newValue);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I see no other option than disabling this test case. Looks like PHPUnit needs to write a file but the body of the test cases messes it up.

```
1) Symfony\Component\Finder\Tests\FinderTest::testIgnoreVCSIgnoredWithOpenBasedir
PHPUnit\Framework\Exception: PHP Warning:  file_put_contents(): open_basedir restriction in effect. File(/tmp/phpunit_opR949) is not within the allowed path(s): (/home/nicolas/Code/symfony:/tmp/symfony_finder/gitignore/search_root:/tmp/deprec5GSXVj) in Standard input code on line 83
Warning: file_put_contents(): open_basedir restriction in effect. File(/tmp/phpunit_opR949) is not within the allowed path(s): (/home/nicolas/Code/symfony:/tmp/symfony_finder/gitignore/search_root:/tmp/deprec5GSXVj) in Standard input code on line 83
PHP Warning:  file_put_contents(/tmp/phpunit_opR949): Failed to open stream: Operation not permitted in Standard input code on line 83
Warning: file_put_contents(/tmp/phpunit_opR949): Failed to open stream: Operation not permitted in Standard input code on line 83
```