### PR TITLE
[Mailer] Support getting sendmail path from php.ini

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
@@ -38,13 +38,24 @@ class SendmailTransportTest extends TestCase
 
     public function testToString()
     {
+        $previousSendmailPath = \ini_set('sendmail_path', '');
         $t = new SendmailTransport();
         $this->assertEquals('smtp://sendmail', (string) $t);
     }
 
     public function testToStringNonSmtp()
     {
+        $previousSendmailPath = \ini_set('sendmail_path', '');
         $t = new SendmailTransport('/usr/sbin/sendmail -t -i');
+        \ini_set('sendmail_path', $previousSendmailPath);
+        $this->assertEquals('sendmail://default', (string) $t);
+    }
+
+    public function testToStringPhpConfig()
+    {
+        $previousSendmailPath = \ini_set('sendmail_path', '/usr/sbin/sendmail -t -i');
+        $t = new SendmailTransport();
+        \ini_set('sendmail_path', $previousSendmailPath);
         $this->assertEquals('sendmail://default', (string) $t);
     }
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
@@ -42,6 +42,12 @@ class SendmailTransportTest extends TestCase
         $this->assertEquals('smtp://sendmail', (string) $t);
     }
 
+    public function testToStringNonSmtp()
+    {
+        $t = new SendmailTransport('/usr/sbin/sendmail -t -i');
+        $this->assertEquals('sendmail://default', (string) $t);
+    }
+
     public function testToIsUsedWhenRecipientsAreNotSet()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -33,7 +33,8 @@ use Symfony\Component\Mime\RawMessage;
  */
 class SendmailTransport extends AbstractTransport
 {
-    private string $command = '/usr/sbin/sendmail -bs';
+    private const SENDMAIL_FHS_PATH = '/usr/sbin/sendmail -bs';
+    private string $command;
     private ProcessStream $stream;
     private ?SmtpTransport $transport = null;
 
@@ -59,6 +60,8 @@ class SendmailTransport extends AbstractTransport
             }
 
             $this->command = $command;
+        } else {
+            $this->command = \ini_get('sendmail_path') ?: self::SENDMAIL_FHS_PATH;
         }
 
         $this->stream = new ProcessStream();

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -83,7 +83,7 @@ class SendmailTransport extends AbstractTransport
             return (string) $this->transport;
         }
 
-        return 'smtp://sendmail';
+        return 'sendmail://default';
     }
 
     protected function doSend(SentMessage $message): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

Not all environments have sendmail installed in `/usr/sbin`.
Let’s ask for the path using `ini_get`.
See also https://github.com/symfony/swiftmailer-bundle/pull/302
