### PR TITLE
[Messenger] RejectRedeliveredMessageException should not be retried

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `HandlerDescriptor::getOptions`
  * Add support for multiple Redis Sentinel hosts
  * Add `--all` option to the `messenger:failed:remove` command
+ * `RejectRedeliveredMessageException` implements `UnrecoverableExceptionInterface` in order to not be retried
 
 6.3
 ---

--- a/src/Symfony/Component/Messenger/Exception/RejectRedeliveredMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/RejectRedeliveredMessageException.php
@@ -14,6 +14,6 @@ namespace Symfony\Component\Messenger\Exception;
 /**
  * @author Tobias Schultze <http://tobion.de>
  */
-class RejectRedeliveredMessageException extends RuntimeException
+class RejectRedeliveredMessageException extends RuntimeException implements UnrecoverableExceptionInterface
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | I think it is not needed

Hello,

when a `RejectRedeliveredMessageException` is thrown once, it is actually retried because it does not implement `UnrecoverableExceptionInterface` but we know it will always because the stamp `AmqpReceivedStamp` will always be there