### PR TITLE
[Validator] Fix registering "is_valid()" for `#[Expression]`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -173,6 +173,7 @@ use Symfony\Component\Translation\PseudoLocalizationTranslator;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Validator\Constraints\ExpressionLanguageProvider;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Validator\ObjectInitializerInterface;
@@ -1663,6 +1664,10 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(ExpressionLanguage::class)) {
             $container->removeDefinition('validator.expression_language');
+        }
+
+        if (!class_exists(ExpressionLanguageProvider::class)) {
+            $container->removeDefinition('validator.expression_language_provider');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Constraints\EmailValidator;
+use Symfony\Component\Validator\Constraints\ExpressionLanguageProvider;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
 use Symfony\Component\Validator\Constraints\NoSuspiciousCharactersValidator;
 use Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator;
@@ -82,10 +83,15 @@ return static function (ContainerConfigurator $container) {
 
         ->set('validator.expression_language', ExpressionLanguage::class)
             ->args([service('cache.validator_expression_language')->nullOnInvalid()])
+            ->call('registerProvider', [
+                service('validator.expression_language_provider')->ignoreOnInvalid(),
+            ])
 
         ->set('cache.validator_expression_language')
             ->parent('cache.system')
             ->tag('cache.pool')
+
+        ->set('validator.expression_language_provider', ExpressionLanguageProvider::class)
 
         ->set('validator.email', EmailValidator::class)
             ->args([

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction('is_valid', function (...$arguments) {
+                return sprintf(
+                    '0 === $context->getValidator()->inContext($context)->validate(%s)->getViolations()->count()',
+                    implode(', ', $arguments)
+                );
+            }, function (array $variables, ...$arguments): bool {
+                return 0 === $variables['context']->getValidator()->inContext($variables['context'])->validate(...$arguments)->getViolations()->count();
+            }),
+        ];
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\ExpressionLanguage\ExpressionFunction;
-use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -22,15 +20,14 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Bernhard Schussek <bschussek@symfony.com>
  */
-class ExpressionValidator extends ConstraintValidator implements ExpressionFunctionProviderInterface
+class ExpressionValidator extends ConstraintValidator
 {
     private ExpressionLanguage $expressionLanguage;
 
     public function __construct(ExpressionLanguage $expressionLanguage = null)
     {
         if ($expressionLanguage) {
-            $this->expressionLanguage = clone $expressionLanguage;
-            $this->expressionLanguage->registerProvider($this);
+            $this->expressionLanguage = $expressionLanguage;
         }
     }
 
@@ -56,25 +53,11 @@ class ExpressionValidator extends ConstraintValidator implements ExpressionFunct
         }
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new ExpressionFunction('is_valid', function (...$arguments) {
-                return sprintf(
-                    '0 === $context->getValidator()->inContext($context)->validate(%s)->getViolations()->count()',
-                    implode(', ', $arguments)
-                );
-            }, function (array $variables, ...$arguments): bool {
-                return 0 === $variables['context']->getValidator()->inContext($variables['context'])->validate(...$arguments)->getViolations()->count();
-            }),
-        ];
-    }
-
     private function getExpressionLanguage(): ExpressionLanguage
     {
         if (!isset($this->expressionLanguage)) {
             $this->expressionLanguage = new ExpressionLanguage();
-            $this->expressionLanguage->registerProvider($this);
+            $this->expressionLanguage->registerProvider(new ExpressionLanguageProvider());
         }
 
         return $this->expressionLanguage;

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Constraints\Expression;
+use Symfony\Component\Validator\Constraints\ExpressionLanguageProvider;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
@@ -359,10 +360,8 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
      */
     public function testCompileIsValid(string $expression, array $names, string $expected)
     {
-        $provider = new ExpressionValidator();
-
         $expressionLanguage = new ExpressionLanguage();
-        $expressionLanguage->registerProvider($provider);
+        $expressionLanguage->registerProvider(new ExpressionLanguageProvider());
 
         $result = $expressionLanguage->compile($expression, $names);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #50438
| License       | MIT
| Doc PR        | -

@bendavies can you please confirm this fixes the issue for you?