### PR TITLE
[ErrorHandler] no intersection type with callable

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -848,6 +848,10 @@ class DebugClassLoader
         $phpTypes = [];
         $docTypes = [];
 
+        if (\count($typesMap) > 1 && array_key_exists('callable', $typesMap)) {
+            return;
+        }
+
         foreach ($typesMap as $n => $t) {
             if ('null' === $n) {
                 $nullable = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | not sure please let me know which one to target
| Bug fix?      | yes
| License       | MIT

https://wiki.php.net/rfc/pure-intersection-types#supported_types says:

>  Although an intersection with callable can make sense (e.g. string&callable), we think it is unwise and points to a bug.

We can't patch a return type if there's a callable intersecting with other types, which can theoretically be supported. 

Blocks #51741.
