### PR TITLE
[Mailer] [Mailgun] Fix outlook sender

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -61,6 +61,8 @@ class MailgunApiTransportTest extends TestCase
         $deliveryTime = (new \DateTimeImmutable('2020-03-20 13:01:00'))->format(\DateTimeInterface::RFC2822);
 
         $email = new Email();
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+        $email->getHeaders()->addTextHeader('h:sender', $envelope->getSender()->toString());
         $email->getHeaders()->addTextHeader('h:X-Mailgun-Variables', $json);
         $email->getHeaders()->addTextHeader('h:foo', 'foo-value');
         $email->getHeaders()->addTextHeader('t:text', 'text-value');
@@ -69,7 +71,6 @@ class MailgunApiTransportTest extends TestCase
         $email->getHeaders()->addTextHeader('template', 'template-value');
         $email->getHeaders()->addTextHeader('recipient-variables', 'recipient-variables-value');
         $email->getHeaders()->addTextHeader('amp-html', 'amp-html-value');
-        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
@@ -78,6 +79,8 @@ class MailgunApiTransportTest extends TestCase
         $this->assertArrayHasKey('h:X-Mailgun-Variables', $payload);
         $this->assertEquals($json, $payload['h:X-Mailgun-Variables']);
 
+        $this->assertArrayHasKey('h:sender', $payload);
+        $this->assertEquals($envelope->getSender()->toString(), $payload['h:sender']);
         $this->assertArrayHasKey('h:foo', $payload);
         $this->assertEquals('foo-value', $payload['h:foo']);
         $this->assertArrayHasKey('t:text', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
@@ -69,6 +69,8 @@ class MailgunHttpTransportTest extends TestCase
             $this->assertStringContainsString('Subject: Hello!', $content);
             $this->assertStringContainsString('To: Saif Eddin <saif.gmati@symfony.com>', $content);
             $this->assertStringContainsString('From: Fabien <fabpot@symfony.com>', $content);
+            $this->assertStringContainsString('Sender: Senior Fabien Eddin <fabpot@symfony.com>', $content);
+            $this->assertStringContainsString('h:sender: "Senior Fabien Eddin" <fabpot@symfony.com>', $content);
             $this->assertStringContainsString('Hello There!', $content);
 
             return new MockResponse(json_encode(['id' => 'foobar']), [
@@ -79,10 +81,16 @@ class MailgunHttpTransportTest extends TestCase
         $transport->setPort(8984);
 
         $mail = new Email();
+        $toAddress = new Address('saif.gmati@symfony.com', 'Saif Eddin');
+        $fromAddress = new Address('fabpot@symfony.com', 'Fabien');
+        $senderAddress = new Address('fabpot@symfony.com', 'Senior Fabien Eddin');
         $mail->subject('Hello!')
-            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
-            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->to($toAddress)
+            ->from($fromAddress)
+            ->sender($senderAddress)
             ->text('Hello There!');
+
+        $mail->getHeaders()->addHeader('h:sender', $mail->getSender()->toString());
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -87,6 +87,7 @@ class MailgunApiTransport extends AbstractApiTransport
     private function getPayload(Email $email, Envelope $envelope): array
     {
         $headers = $email->getHeaders();
+        $headers->addHeader('h:sender', $envelope->getSender()->toString());
         $html = $email->getHtmlBody();
         if (null !== $html && \is_resource($html)) {
             if (stream_get_meta_data($html)['seekable'] ?? false) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
@@ -53,6 +53,7 @@ class MailgunHttpTransport extends AbstractHttpTransport
     protected function doSendHttp(SentMessage $message): ResponseInterface
     {
         $body = new FormDataPart([
+            'h:sender' => $message->getEnvelope()->getSender()->toString(),
             'to' => implode(',', $this->stringifyAddresses($message->getEnvelope()->getRecipients())),
             'message' => new DataPart($message->toString(), 'message.mime'),
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/issues/51596
| License       | MIT


This PR solves the problem related to displaying the sender in the OutLook email client when sending an email from a subdomain.
Check more details by following these links:
https://serverfault.com/questions/1097879/sender-and-from-header-domain-mismatch-causes-malformed-display-in-outlook
https://stackoverflow.com/questions/28401673/removing-on-behalf-of-when-sending-mail-using-mailgun/45445015#45445015


