### PR TITLE
[Cache] Fix two initializations of Redis Sentinel

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -223,29 +223,28 @@ trait RedisTrait
                         break;
                     }
 
-                    if (version_compare(phpversion('redis'), '6.0.0', '>=') && $isRedisExt) {
-                        $options = [
-                            'host' => $host,
-                            'port' => $port,
-                            'connectTimeout' => $params['timeout'],
-                            'persistent' => $params['persistent_id'],
-                            'retryInterval' => $params['retry_interval'],
-                            'readTimeout' => $params['read_timeout'],
-                        ];
+                    try {
+                        if (version_compare(phpversion('redis'), '6.0.0', '>=') && $isRedisExt) {
+                            $options = [
+                                'host' => $host,
+                                'port' => $port,
+                                'connectTimeout' => $params['timeout'],
+                                'persistent' => $params['persistent_id'],
+                                'retryInterval' => $params['retry_interval'],
+                                'readTimeout' => $params['read_timeout'],
+                            ];
 
-                        if ($passAuth) {
-                            $options['auth'] = $params['auth'];
+                            if ($passAuth) {
+                                $options['auth'] = $params['auth'];
+                            }
+
+                            $sentinel = new \RedisSentinel($options);
+                        } else {
+                            $extra = $passAuth ? [$params['auth']] : [];
+
+                            $sentinel = new $sentinelClass($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...$extra);
                         }
 
-                        $sentinel = new \RedisSentinel($options);
-                    } else {
-                        $extra = $passAuth ? [$params['auth']] : [];
-
-                        $sentinel = new $sentinelClass($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...$extra);
-                    }
-
-                    try {
-                        $sentinel = new $sentinelClass($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...$extra);
                         if ($address = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
                             [$host, $port] = $address;
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT

After #51687 and #51683 have been merged, there are now two initializations of Redis Sentinel, which also leads to the integration test failure mentioned in [this comment](https://github.com/symfony/symfony/pull/51687#issuecomment-1739298845). This PR fixes this.