### PR TITLE
Replace usages of SkippedTestSuiteError with markTestSkipped() call

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTestCase.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Relay\Relay;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
@@ -34,12 +33,12 @@ abstract class AbstractRedisAdapterTestCase extends AdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('redis')) {
-            throw new SkippedTestSuiteError('Extension redis required.');
+            self::markTestSkipped('Extension redis required.');
         }
         try {
             (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
-            throw new SkippedTestSuiteError(getenv('REDIS_HOST').': '.$e->getMessage());
+            self::markTestSkipped(getenv('REDIS_HOST').': '.$e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
@@ -35,7 +34,7 @@ class CouchbaseBucketAdapterTest extends AdapterTestCase
     public static function setupBeforeClass(): void
     {
         if (!CouchbaseBucketAdapter::isSupported()) {
-            throw new SkippedTestSuiteError('Couchbase >= 2.6.0 < 3.0.0 is required.');
+            self::markTestSkipped('Couchbase >= 2.6.0 < 3.0.0 is required.');
         }
 
         self::$client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 use Symfony\Component\Cache\Tests\Fixtures\DriverWrapper;
@@ -33,7 +32,7 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
-            throw new SkippedTestSuiteError('Extension pdo_sqlite required.');
+            self::markTestSkipped('Extension pdo_sqlite required.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
@@ -33,14 +32,14 @@ class MemcachedAdapterTest extends AdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!MemcachedAdapter::isSupported()) {
-            throw new SkippedTestSuiteError('Extension memcached > 3.1.5 required.');
+            self::markTestSkipped('Extension memcached > 3.1.5 required.');
         }
         self::$client = AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), ['binary_protocol' => false]);
         self::$client->get('foo');
         $code = self::$client->getResultCode();
 
         if (\Memcached::RES_SUCCESS !== $code && \Memcached::RES_NOTFOUND !== $code) {
-            throw new SkippedTestSuiteError('Memcached error: '.strtolower(self::$client->getResultMessage()));
+            self::markTestSkipped('Memcached error: '.strtolower(self::$client->getResultMessage()));
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 
@@ -25,7 +24,7 @@ class PdoAdapterTest extends AdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
-            throw new SkippedTestSuiteError('Extension pdo_sqlite required.');
+            self::markTestSkipped('Extension pdo_sqlite required.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterSentinelTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 
 /**
@@ -22,13 +21,13 @@ class PredisAdapterSentinelTest extends AbstractRedisAdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\Predis\Client::class)) {
-            throw new SkippedTestSuiteError('The Predis\Client class is required.');
+            self::markTestSkipped('The Predis\Client class is required.');
         }
         if (!$hosts = getenv('REDIS_SENTINEL_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_SENTINEL_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_SENTINEL_HOSTS env var is not defined.');
         }
         if (!$service = getenv('REDIS_SENTINEL_SERVICE')) {
-            throw new SkippedTestSuiteError('REDIS_SENTINEL_SERVICE env var is not defined.');
+            self::markTestSkipped('REDIS_SENTINEL_SERVICE env var is not defined.');
         }
 
         self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => $service, 'class' => \Predis\Client::class]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 /**
@@ -22,7 +21,7 @@ class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
 
         self::$redis = RedisAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['class' => \Predis\Client::class, 'redis_cluster' => true, 'prefix' => 'prefix_']);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
@@ -24,13 +23,13 @@ class RedisAdapterSentinelTest extends AbstractRedisAdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisSentinel::class)) {
-            throw new SkippedTestSuiteError('The RedisSentinel class is required.');
+            self::markTestSkipped('The RedisSentinel class is required.');
         }
         if (!$hosts = getenv('REDIS_SENTINEL_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_SENTINEL_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_SENTINEL_HOSTS env var is not defined.');
         }
         if (!$service = getenv('REDIS_SENTINEL_SERVICE')) {
-            throw new SkippedTestSuiteError('REDIS_SENTINEL_SERVICE env var is not defined.');
+            self::markTestSkipped('REDIS_SENTINEL_SERVICE env var is not defined.');
         }
 
         self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => $service, 'prefix' => 'prefix_']);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @group integration
  */
@@ -22,7 +20,7 @@ class RedisArrayAdapterTest extends AbstractRedisAdapterTestCase
     {
         parent::setupBeforeClass();
         if (!class_exists(\RedisArray::class)) {
-            throw new SkippedTestSuiteError('The RedisArray class is required.');
+            self::markTestSkipped('The RedisArray class is required.');
         }
         self::$redis = new \RedisArray([getenv('REDIS_HOST')], ['lazy_connect' => true]);
         self::$redis->setOption(\Redis::OPT_PREFIX, 'prefix_');

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
@@ -26,10 +25,10 @@ class RedisClusterAdapterTest extends AbstractRedisAdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisCluster::class)) {
-            throw new SkippedTestSuiteError('The RedisCluster class is required.');
+            self::markTestSkipped('The RedisCluster class is required.');
         }
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
 
         self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['lazy' => true, 'redis_cluster' => true]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RelayAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RelayAdapterSentinelTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Relay\Relay;
 use Relay\Sentinel;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
@@ -24,13 +23,13 @@ class RelayAdapterSentinelTest extends AbstractRedisAdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(Sentinel::class)) {
-            throw new SkippedTestSuiteError('The Relay\Sentinel class is required.');
+            self::markTestSkipped('The Relay\Sentinel class is required.');
         }
         if (!$hosts = getenv('REDIS_SENTINEL_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_SENTINEL_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_SENTINEL_HOSTS env var is not defined.');
         }
         if (!$service = getenv('REDIS_SENTINEL_SERVICE')) {
-            throw new SkippedTestSuiteError('REDIS_SENTINEL_SERVICE env var is not defined.');
+            self::markTestSkipped('REDIS_SENTINEL_SERVICE env var is not defined.');
         }
 
         self::$redis = AbstractAdapter::createConnection(

--- a/src/Symfony/Component/Cache/Tests/Adapter/RelayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RelayAdapterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Relay\Relay;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
@@ -30,7 +29,7 @@ class RelayAdapterTest extends AbstractRedisAdapterTestCase
         try {
             new Relay(...explode(':', getenv('REDIS_HOST')));
         } catch (\Relay\Exception $e) {
-            throw new SkippedTestSuiteError(getenv('REDIS_HOST').': '.$e->getMessage());
+            self::markTestSkipped(getenv('REDIS_HOST').': '.$e->getMessage());
         }
         self::$redis = AbstractAdapter::createConnection('redis://'.getenv('REDIS_HOST'), ['lazy' => true, 'class' => Relay::class]);
         self::assertInstanceOf(RelayProxy::class, self::$redis);

--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Traits;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Traits\RedisTrait;
 
@@ -20,7 +19,7 @@ class RedisTraitTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         if (!getenv('REDIS_CLUSTER_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
     }
 
@@ -30,10 +29,10 @@ class RedisTraitTest extends TestCase
     public function testCreateConnection(string $dsn, string $expectedClass)
     {
         if (!class_exists($expectedClass)) {
-            throw new SkippedTestSuiteError(sprintf('The "%s" class is required.', $expectedClass));
+            self::markTestSkipped(sprintf('The "%s" class is required.', $expectedClass));
         }
         if (!getenv('REDIS_CLUSTER_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
 
         $mock = self::getObjectForTrait(RedisTrait::class);

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpClient\Tests;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\ClientState;
@@ -318,7 +317,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         }
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            throw new SkippedTestSuiteError('Testing with the "vulcain" is not supported on Windows.');
+            self::markTestSkipped('Testing with the "vulcain" is not supported on Windows.');
         }
 
         $process = new Process(['vulcain'], null, [
@@ -335,14 +334,14 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
 
         if (!$process->isRunning()) {
             if ('\\' !== \DIRECTORY_SEPARATOR && 127 === $process->getExitCode()) {
-                throw new SkippedTestSuiteError('vulcain binary is missing');
+                self::markTestSkipped('vulcain binary is missing');
             }
 
             if ('\\' !== \DIRECTORY_SEPARATOR && 126 === $process->getExitCode()) {
-                throw new SkippedTestSuiteError('vulcain binary is not executable');
+                self::markTestSkipped('vulcain binary is not executable');
             }
 
-            throw new SkippedTestSuiteError((new ProcessFailedException($process))->getMessage());
+            self::markTestSkipped((new ProcessFailedException($process))->getMessage());
         }
 
         self::$vulcainStarted = true;

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 
 class ResponseFunctionalTest extends TestCase
@@ -26,7 +25,7 @@ class ResponseFunctionalTest extends TestCase
             2 => ['file', '/dev/null', 'w'],
         ];
         if (!self::$server = @proc_open('exec '.\PHP_BINARY.' -S localhost:8054', $spec, $pipes, __DIR__.'/Fixtures/response-functional')) {
-            throw new SkippedTestSuiteError('PHP server unable to start.');
+            self::markTestSkipped('PHP server unable to start.');
         }
         sleep(1);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 
 class AbstractSessionHandlerTest extends TestCase
@@ -26,7 +25,7 @@ class AbstractSessionHandlerTest extends TestCase
             2 => ['file', '/dev/null', 'w'],
         ];
         if (!self::$server = @proc_open('exec '.\PHP_BINARY.' -S localhost:8053', $spec, $pipes, __DIR__.'/Fixtures')) {
-            throw new SkippedTestSuiteError('PHP server unable to start.');
+            self::markTestSkipped('PHP server unable to start.');
         }
         sleep(1);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @group integration
  */
@@ -21,11 +19,11 @@ class RedisClusterSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisCluster::class)) {
-            throw new SkippedTestSuiteError('The RedisCluster class is required.');
+            self::markTestSkipped('The RedisCluster class is required.');
         }
 
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
@@ -31,7 +30,7 @@ class MemcachedStoreTest extends AbstractStoreTestCase
     public static function setUpBeforeClass(): void
     {
         if (version_compare(phpversion('memcached'), '3.1.6', '<')) {
-            throw new SkippedTestSuiteError('Extension memcached > 3.1.5 required.');
+            self::markTestSkipped('Extension memcached > 3.1.5 required.');
         }
 
         $memcached = new \Memcached();
@@ -40,7 +39,7 @@ class MemcachedStoreTest extends AbstractStoreTestCase
         $code = $memcached->getResultCode();
 
         if (\Memcached::RES_SUCCESS !== $code && \Memcached::RES_NOTFOUND !== $code) {
-            throw new SkippedTestSuiteError('Unable to connect to the memcache host');
+            self::markTestSkipped('Unable to connect to the memcache host');
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Lock\Tests\Store;
 
 use MongoDB\Client;
 use MongoDB\Driver\Exception\ConnectionTimeoutException;
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
@@ -33,14 +32,14 @@ class MongoDbStoreTest extends AbstractStoreTestCase
     public static function setupBeforeClass(): void
     {
         if (!class_exists(\MongoDB\Client::class)) {
-            throw new SkippedTestSuiteError('The mongodb/mongodb package is required.');
+            self::markTestSkipped('The mongodb/mongodb package is required.');
         }
 
         $client = self::getMongoClient();
         try {
             $client->listDatabases();
         } catch (ConnectionTimeoutException $e) {
-            throw new SkippedTestSuiteError('MongoDB server not found.');
+            self::markTestSkipped('MongoDB server not found.');
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -26,7 +24,7 @@ class PredisStoreTest extends AbstractRedisStoreTestCase
         try {
             $redis->connect();
         } catch (\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -25,12 +23,12 @@ class RedisArrayStoreTest extends AbstractRedisStoreTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisArray::class)) {
-            throw new SkippedTestSuiteError('The RedisArray class is required.');
+            self::markTestSkipped('The RedisArray class is required.');
         }
         try {
             (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -25,10 +23,10 @@ class RedisClusterStoreTest extends AbstractRedisStoreTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisCluster::class)) {
-            throw new SkippedTestSuiteError('The RedisCluster class is required.');
+            self::markTestSkipped('The RedisCluster class is required.');
         }
         if (!getenv('REDIS_CLUSTER_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Store\RedisStore;
 
@@ -31,7 +30,7 @@ class RedisStoreTest extends AbstractRedisStoreTestCase
         try {
             (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RelayStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RelayStoreTest.php
@@ -11,7 +11,6 @@
 
 namespace Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Relay\Relay;
 use Symfony\Component\Lock\Tests\Store\AbstractRedisStoreTestCase;
 use Symfony\Component\Lock\Tests\Store\SharedLockStoreTestTrait;
@@ -30,7 +29,7 @@ class RelayStoreTest extends AbstractRedisStoreTestCase
         try {
             new Relay(...explode(':', getenv('REDIS_HOST')));
         } catch (\Relay\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Semaphore/Tests/Store/PredisStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/PredisStoreTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Semaphore\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
@@ -24,7 +22,7 @@ class PredisStoreTest extends AbstractRedisStoreTestCase
         try {
             $redis->connect();
         } catch (\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Semaphore/Tests/Store/RedisArrayStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/RedisArrayStoreTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Semaphore\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -23,12 +21,12 @@ class RedisArrayStoreTest extends AbstractRedisStoreTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisArray::class)) {
-            throw new SkippedTestSuiteError('The RedisArray class is required.');
+            self::markTestSkipped('The RedisArray class is required.');
         }
         try {
             (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Semaphore/Tests/Store/RedisClusterStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/RedisClusterStoreTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Semaphore\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -23,10 +21,10 @@ class RedisClusterStoreTest extends AbstractRedisStoreTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisCluster::class)) {
-            throw new SkippedTestSuiteError('The RedisCluster class is required.');
+            self::markTestSkipped('The RedisCluster class is required.');
         }
         if (!getenv('REDIS_CLUSTER_HOSTS')) {
-            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
     }
 

--- a/src/Symfony/Component/Semaphore/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/RedisStoreTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Semaphore\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
-
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -30,7 +28,7 @@ class RedisStoreTest extends AbstractRedisStoreTestCase
         try {
             (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Semaphore/Tests/Store/RelayStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/RelayStoreTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Semaphore\Tests\Store;
 
-use PHPUnit\Framework\SkippedTestSuiteError;
 use Relay\Relay;
 
 /**
@@ -29,7 +28,7 @@ class RelayStoreTest extends AbstractRedisStoreTestCase
         try {
             new Relay(...explode(':', getenv('REDIS_HOST')));
         } catch (\Relay\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            self::markTestSkipped($e->getMessage());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT


Just a simple clean up to replace the usages of `SkippedTestSuiteError` with a call to `markTestSkipped()`.

This is a follow up for #51775.
