### PR TITLE
[Console][Form][FrameworkBundle][HttpKernel][PropertyInfo][Validator][WebProfilerBundle] Remove optional before required param

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -13166,8 +13166,8 @@ diff --git a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.p
 @@ -127,5 +127,5 @@ interface ExecutionContextInterface
       * @return void
       */
--    public function setNode(mixed $value, ?object $object, MetadataInterface $metadata = null, string $propertyPath);
-+    public function setNode(mixed $value, ?object $object, MetadataInterface $metadata = null, string $propertyPath): void;
+-    public function setNode(mixed $value, ?object $object, ?MetadataInterface $metadata, string $propertyPath);
++    public function setNode(mixed $value, ?object $object, ?MetadataInterface $metadata, string $propertyPath): void;
  
      /**
 @@ -136,5 +136,5 @@ interface ExecutionContextInterface

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
@@ -21,7 +21,7 @@ class AutowiredServices
     private EventDispatcherInterface $dispatcher;
     private CacheItemPoolInterface $cachePool;
 
-    public function __construct(Reader $annotationReader = null, EventDispatcherInterface $dispatcher, CacheItemPoolInterface $cachePool)
+    public function __construct(?Reader $annotationReader, EventDispatcherInterface $dispatcher, CacheItemPoolInterface $cachePool)
     {
         $this->annotationReader = $annotationReader;
         $this->dispatcher = $dispatcher;

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -40,7 +40,7 @@ class ProfilerController
     private ?ContentSecurityPolicyHandler $cspHandler;
     private ?string $baseDir;
 
-    public function __construct(UrlGeneratorInterface $generator, Profiler $profiler = null, Environment $twig, array $templates, ContentSecurityPolicyHandler $cspHandler = null, string $baseDir = null)
+    public function __construct(UrlGeneratorInterface $generator, ?Profiler $profiler, Environment $twig, array $templates, ContentSecurityPolicyHandler $cspHandler = null, string $baseDir = null)
     {
         $this->generator = $generator;
         $this->profiler = $profiler;

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -40,7 +40,7 @@ class RouterController
      */
     private iterable $expressionLanguageProviders;
 
-    public function __construct(Profiler $profiler = null, Environment $twig, UrlMatcherInterface $matcher = null, RouteCollection $routes = null, iterable $expressionLanguageProviders = [])
+    public function __construct(?Profiler $profiler, Environment $twig, UrlMatcherInterface $matcher = null, RouteCollection $routes = null, iterable $expressionLanguageProviders = [])
     {
         $this->profiler = $profiler;
         $this->twig = $twig;

--- a/src/Symfony/Component/Console/Tests/CI/GithubActionReporterTest.php
+++ b/src/Symfony/Component/Console/Tests/CI/GithubActionReporterTest.php
@@ -34,7 +34,7 @@ class GithubActionReporterTest extends TestCase
     /**
      * @dataProvider annotationsFormatProvider
      */
-    public function testAnnotationsFormat(string $type, string $message, string $file = null, int $line = null, int $col = null, string $expected)
+    public function testAnnotationsFormat(string $type, string $message, ?string $file, ?int $line, ?int $col, string $expected)
     {
         $reporter = new GithubActionReporter($buffer = new BufferedOutput());
 

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -259,7 +259,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
         return $output;
     }
 
-    private function &recursiveBuildFinalFormTree(FormInterface $form = null, FormView $view, array &$outputByHash): array
+    private function &recursiveBuildFinalFormTree(?FormInterface $form, FormView $view, array &$outputByHash): array
     {
         $viewHash = spl_object_hash($view);
         $formHash = null;

--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -34,7 +34,7 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
      *
      * @param FragmentRendererInterface $inlineStrategy The inline strategy to use when the surrogate is not supported
      */
-    public function __construct(SurrogateInterface $surrogate = null, FragmentRendererInterface $inlineStrategy, UriSigner $signer = null)
+    public function __construct(?SurrogateInterface $surrogate, FragmentRendererInterface $inlineStrategy, UriSigner $signer = null)
     {
         $this->surrogate = $surrogate;
         $this->inlineStrategy = $inlineStrategy;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -36,7 +36,7 @@ class PhpDocExtractorTest extends TestCase
     /**
      * @dataProvider typesProvider
      */
-    public function testExtract($property, array $type = null, $shortDescription, $longDescription)
+    public function testExtract($property, ?array $type, $shortDescription, $longDescription)
     {
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
         $this->assertSame($shortDescription, $this->extractor->getShortDescription('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
@@ -131,7 +131,7 @@ class PhpDocExtractorTest extends TestCase
     /**
      * @dataProvider provideCollectionTypes
      */
-    public function testExtractCollection($property, array $type = null, $shortDescription, $longDescription)
+    public function testExtractCollection($property, ?array $type, $shortDescription, $longDescription)
     {
         $this->testExtract($property, $type, $shortDescription, $longDescription);
     }

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -121,7 +121,7 @@ class ExecutionContext implements ExecutionContextInterface
         $this->cachedObjectsRefs = new \SplObjectStorage();
     }
 
-    public function setNode(mixed $value, ?object $object, MetadataInterface $metadata = null, string $propertyPath): void
+    public function setNode(mixed $value, ?object $object, ?MetadataInterface $metadata, string $propertyPath): void
     {
         $this->value = $value;
         $this->object = $object;

--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -126,7 +126,7 @@ interface ExecutionContextInterface
      *
      * @return void
      */
-    public function setNode(mixed $value, ?object $object, MetadataInterface $metadata = null, string $propertyPath);
+    public function setNode(mixed $value, ?object $object, ?MetadataInterface $metadata, string $propertyPath);
 
     /**
      * Warning: Should not be called by user code, to be used by the validator engine only.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

I'm guessing this trick was used to make arguments nullable for PHP prior to 7.1, but since Symfony now requires at least PHP 8.1 it shouldn't be necessary any more. As far as I can tell there's no breaking change: https://3v4l.org/USkgi .

There are still four places that this is used, but I believe those to be intentional test cases:
https://github.com/symfony/symfony/blob/38506585012540306b4a7166a4812d35ad6b8a3c/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php#L179-L184
https://github.com/symfony/symfony/blob/38506585012540306b4a7166a4812d35ad6b8a3c/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/MultipleArgumentsOptionalScalarNotReallyOptional.php#L8-L13
https://github.com/symfony/symfony/blob/38506585012540306b4a7166a4812d35ad6b8a3c/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php#L653-L655
https://github.com/symfony/symfony/blob/38506585012540306b4a7166a4812d35ad6b8a3c/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php#L589-L598