### PR TITLE
[FrameworkBundle] Change BrowserKitAssertionsTrait::getClient() to be protected

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG
  * Deprecate `framework.serializer.enable_annotations`, use `framework.serializer.enable_attributes` instead
  * Add `array $tokenAttributes = []` optional parameter to `KernelBrowser::loginUser()`
  * Add support for relative URLs in BrowserKit's redirect assertion.
+ * Change BrowserKitAssertionsTrait::getClient() to be protected
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -162,7 +162,7 @@ trait BrowserKitAssertionsTrait
         self::assertThat(self::getClient(), $constraint, $message);
     }
 
-    private static function getClient(AbstractBrowser $newClient = null): ?AbstractBrowser
+    protected static function getClient(AbstractBrowser $newClient = null): ?AbstractBrowser
     {
         static $client;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40817
| License       | MIT

Make `BrowserKitAssertionsTrait::getClient()` protected (see ticket for use cases).
As `getRequest()` and `getResponse()` can easily be retrieved from `getClient()`, they are still private.
