### PR TITLE
[Scheduler] Make debug:scheduler output more useful

### DIFF
--- a/src/Symfony/Component/Scheduler/Command/DebugCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/DebugCommand.php
@@ -114,6 +114,6 @@ final class DebugCommand extends Command
             return null;
         }
 
-        return [(string) $trigger, $recurringMessage->getProvider()::class, $next];
+        return [(string) $trigger, $recurringMessage->getProvider()->getId(), $next];
     }
 }

--- a/src/Symfony/Component/Scheduler/RecurringMessage.php
+++ b/src/Symfony/Component/Scheduler/RecurringMessage.php
@@ -75,11 +75,12 @@ final class RecurringMessage implements MessageProviderInterface
             return new self($trigger, $message);
         }
 
+        $description = '';
         try {
             $description = $message instanceof \Stringable ? (string) $message : serialize($message);
         } catch (\Exception) {
-            $description = $message::class;
         }
+        $description = sprintf('%s(%s)', $message::class, $description);
 
         return new self($trigger, new StaticMessageProvider([$message], $description));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT

Before:

```
 -------------------- ----------------------------------------------------------- --------------------------------- 
  Trigger              Provider                                                    Next Run                         
 -------------------- ----------------------------------------------------------- --------------------------------- 
  every 1 second       Symfony\Component\Scheduler\Trigger\StaticMessageProvider   Sun, 01 Oct 2023 08:02:33 +0000  
  every next tuesday   Symfony\Component\Scheduler\Trigger\StaticMessageProvider   Tue, 03 Oct 2023 08:02:32 +0000  
  every 2 seconds      Symfony\Component\Scheduler\Trigger\StaticMessageProvider   Sun, 01 Oct 2023 08:02:34 +0000  
  * * * * *            Symfony\Component\Scheduler\Trigger\StaticMessageProvider   Sun, 01 Oct 2023 08:03:00 +0000  
  every 2 seconds      Symfony\Component\Scheduler\Trigger\StaticMessageProvider   Sun, 01 Oct 2023 08:02:34 +0000  
  every 3 seconds      Symfony\Component\Scheduler\Trigger\StaticMessageProvider   Sun, 01 Oct 2023 08:02:35 +0000  
 -------------------- ----------------------------------------------------------- --------------------------------- 
```

After:

```
 -------------------- ------------------------------------------------------------------------------- --------------------------------- 
  Trigger              Provider                                                                        Next Run                         
 -------------------- ------------------------------------------------------------------------------- --------------------------------- 
  every 1 second       App\Messenger\SomeJob(every second)                                             Sun, 01 Oct 2023 08:21:44 +0000  
  every next tuesday   App\Messenger\SomeJob(every 3 seconds)                                          Tue, 03 Oct 2023 08:21:43 +0000  
  every 2 seconds      App\Messenger\SomeJob(PT2S)                                                     Sun, 01 Oct 2023 08:21:44 +0000  
  * * * * *            Symfony\Component\Console\Messenger\RunCommandMessage(foo hello -v)             Sun, 01 Oct 2023 08:22:00 +0000  
  every 2 seconds      Symfony\Component\Scheduler\Messenger\ServiceCallMessage(@App\SomeGreatLogic)   Sun, 01 Oct 2023 08:21:45 +0000  
  every 3 seconds      Symfony\Component\Scheduler\Messenger\ServiceCallMessage(@App\SomeGreatLogic)   Sun, 01 Oct 2023 08:21:46 +0000  
 -------------------- ------------------------------------------------------------------------------- ---------------------------------
```
