### PR TITLE
[MonologBridge] Fix error cannot use object of type as array

### DIFF
--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -188,7 +188,7 @@ final class ConsoleFormatter implements FormatterInterface
             $this->dumper->setColors($colors);
         }
 
-        if (($data['data'] ?? null) instanceof Data) {
+        if (\is_array($data) && ($data['data'] ?? null) instanceof Data) {
             $data = $data['data'];
         } elseif (!$data instanceof Data) {
             $data = $this->cloner->cloneVar($data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes 
| New feature?  | - 
| Deprecations? |  -
| Tickets       | - 
| License       | MIT

Bug was introduced in #51091

```
  "e" => Error {
    #message: "Cannot use object of type Symfony\Component\Lock\Key as array"
    #code: 0
    #file: "./excluded/symfony/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php"
    #line: 191
    -previous: Error {
      #message: "Cannot use object of type Symfony\Component\Lock\Key as array"
      #code: 0
      #file: "./excluded/symfony/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php"
      #line: 191
      trace: {
        ./excluded/symfony/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php:191 {
          Symfony\Bridge\Monolog\Formatter\ConsoleFormatter->dumpData(mixed $data, bool $colors = null): string^
          › 
          › if (($data['data'] ?? null) instanceof Data) {
          ›     $data = $data['data'];
        }
        ./excluded/symfony/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php:171 { …}
        ./excluded/symfony/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php:101 { …}
        ./vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php:42 { …}
        ./excluded/symfony/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php:85 { …}
        ./vendor/monolog/monolog/src/Monolog/Logger.php:379 { …}
        ./vendor/monolog/monolog/src/Monolog/Logger.php:580 { …}
        ./excluded/symfony/src/Symfony/Component/Lock/Lock.php:89 { …}
```