### PR TITLE
[DoctrineBridge] Pass `Request` to `EntityValueResolver`'s expression

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -199,7 +199,10 @@ final class EntityValueResolver implements ValueResolverInterface
         }
 
         $repository = $manager->getRepository($options->class);
-        $variables = array_merge($request->attributes->all(), ['repository' => $repository]);
+        $variables = array_merge($request->attributes->all(), [
+            'repository' => $repository,
+            'request' => $request,
+        ]);
 
         try {
             return $this->expressionLanguage->evaluate($options->expr, $variables);

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate not constructing `DoctrineDataCollector` with an instance of `DebugDataHolder`
  * Deprecate `DoctrineDataCollector::addLogger()`, use a `DebugDataHolder` instead
  * Deprecate `ContainerAwareLoader`, use dependency injection in your fixtures instead
+ * Always pass the `Request` object to `EntityValueResolver`'s expression
 
 6.3
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -334,6 +334,7 @@ class EntityValueResolverTest extends TestCase
             ->method('evaluate')
             ->with('repository.findOneByCustomMethod(id)', [
                 'repository' => $repository,
+                'request' => $request,
                 'id' => 5,
             ])
             ->willReturn($object = new \stdClass());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51694
| License       | MIT

Passes the `Request` object to `EntityValueResolver`'s expression.