### PR TITLE
[Security] Make `impersonation_path()` argument mandatory and add `impersonation_url()`

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allow an array to be passed as the first argument to the `importmap()` Twig function
  * Add `TemplatedEmail::locale()` to set the locale for the email rendering
  * Add `AppVariable::getEnabledLocales()` to retrieve the enabled locales
+ * Add `impersonation_path()` and `impersonation_url()` Twig functions
 
 6.3
 ---

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -69,7 +69,16 @@ final class SecurityExtension extends AbstractExtension
         return $this->impersonateUrlGenerator->generateExitPath($exitTo);
     }
 
-    public function getImpersonatePath(string $identifier = null): string
+    public function getImpersonateUrl(string $identifier): string
+    {
+        if (null === $this->impersonateUrlGenerator) {
+            return '';
+        }
+
+        return $this->impersonateUrlGenerator->generateImpersonationUrl($identifier);
+    }
+
+    public function getImpersonatePath(string $identifier): string
     {
         if (null === $this->impersonateUrlGenerator) {
             return '';
@@ -84,6 +93,7 @@ final class SecurityExtension extends AbstractExtension
             new TwigFunction('is_granted', $this->isGranted(...)),
             new TwigFunction('impersonation_exit_url', $this->getImpersonateExitUrl(...)),
             new TwigFunction('impersonation_exit_path', $this->getImpersonateExitPath(...)),
+            new TwigFunction('impersonation_url', $this->getImpersonateUrl(...)),
             new TwigFunction('impersonation_path', $this->getImpersonatePath(...)),
         ];
     }

--- a/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
@@ -36,9 +36,18 @@ class ImpersonateUrlGenerator
         $this->firewallMap = $firewallMap;
     }
 
-    public function generateImpersonationPath(string $identifier = null): string
+    public function generateImpersonationPath(string $identifier): string
     {
         return $this->buildPath(null, $identifier);
+    }
+
+    public function generateImpersonationUrl(string $identifier): string
+    {
+        if (null === $request = $this->requestStack->getCurrentRequest()) {
+            return '';
+        }
+
+        return $request->getUriForPath($this->buildPath(null, $identifier));
     }
 
     public function generateExitPath(string $targetUri = null): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT

Follow-up of https://github.com/symfony/symfony/pull/50030

When documenting this function, I found out that the`identifier` argument was optional, which seemed weird to me given the function purpose.

I then had a look at the implementation, and I saw that `ImpersonateUrlGenerator::generateImpersonationPath()` accepts a nullable string. However, the underlying call to `ImpersonateUrlGenerator::buildPath()` doesn't accept a nullable string. I propose to make the `identifier` argument mandatory, which makes more sense here.

I also added the missing Changelog line and `impersonation_url()`