### PR TITLE
[Scheduler] pre_run and post_run events

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/scheduler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/scheduler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Scheduler\EventListener\DispatchSchedulerEventListener;
 use Symfony\Component\Scheduler\Messenger\SchedulerTransportFactory;
 use Symfony\Component\Scheduler\Messenger\ServiceCallMessageHandler;
 
@@ -27,5 +28,11 @@ return static function (ContainerConfigurator $container) {
                 service('clock'),
             ])
             ->tag('messenger.transport_factory')
+        ->set('scheduler.event_listener', DispatchSchedulerEventListener::class)
+            ->args([
+                tagged_locator('scheduler.schedule_provider', 'name'),
+                service('event_dispatcher'),
+            ])
+            ->tag('kernel.event_subscriber')
     ;
 };

--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -13,6 +13,8 @@ CHANGELOG
  * Add `ScheduledStamp` to `RedispatchMessage`
  * Allow modifying Schedule instances at runtime
  * Add `MessageProviderInterface` to trigger unique messages at runtime
+ * Add `PreRunEvent` and `PostRunEvent` events
+ * Add `DispatchSchedulerEventListener`
 
 6.3
 ---

--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -30,6 +30,10 @@ class AddScheduleMessengerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        if (!$container->has('event_dispatcher')) {
+            $container->removeDefinition('scheduler.event_listener');
+        }
+
         $receivers = [];
         foreach ($container->findTaggedServiceIds('messenger.receiver') as $tags) {
             $receivers[$tags[0]['alias']] = true;

--- a/src/Symfony/Component/Scheduler/Event/PostRunEvent.php
+++ b/src/Symfony/Component/Scheduler/Event/PostRunEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Event;
+
+use Symfony\Component\Scheduler\Generator\MessageContext;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+
+class PostRunEvent
+{
+    public function __construct(
+        private readonly ScheduleProviderInterface $schedule,
+        private readonly MessageContext $messageContext,
+        private readonly object $message,
+    ) {
+    }
+
+    public function getMessageContext(): MessageContext
+    {
+        return $this->messageContext;
+    }
+
+    public function getSchedule(): ScheduleProviderInterface
+    {
+        return $this->schedule;
+    }
+
+    public function getMessage(): object
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Scheduler/Event/PreRunEvent.php
+++ b/src/Symfony/Component/Scheduler/Event/PreRunEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Event;
+
+use Symfony\Component\Scheduler\Generator\MessageContext;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+
+class PreRunEvent
+{
+    private bool $shouldCancel = false;
+
+    public function __construct(
+        private readonly ScheduleProviderInterface $schedule,
+        private readonly MessageContext $messageContext,
+        private readonly object $message,
+    ) {
+    }
+
+    public function getMessageContext(): MessageContext
+    {
+        return $this->messageContext;
+    }
+
+    public function getSchedule(): ScheduleProviderInterface
+    {
+        return $this->schedule;
+    }
+
+    public function getMessage(): object
+    {
+        return $this->message;
+    }
+
+    public function shouldCancel(bool $shouldCancel = null): bool
+    {
+        if (null !== $shouldCancel) {
+            $this->shouldCancel = $shouldCancel;
+        }
+
+        return $this->shouldCancel;
+    }
+}

--- a/src/Symfony/Component/Scheduler/EventListener/DispatchSchedulerEventListener.php
+++ b/src/Symfony/Component/Scheduler/EventListener/DispatchSchedulerEventListener.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\EventListener;
+
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Scheduler\Event\PostRunEvent;
+use Symfony\Component\Scheduler\Event\PreRunEvent;
+use Symfony\Component\Scheduler\Messenger\ScheduledStamp;
+
+class DispatchSchedulerEventListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly ContainerInterface $scheduleProviderLocator,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function onMessageHandled(WorkerMessageHandledEvent $event): void
+    {
+        $envelope = $event->getEnvelope();
+        if (!$scheduledStamp = $envelope->last(ScheduledStamp::class)) {
+            return;
+        }
+
+        if (!$this->scheduleProviderLocator->has($scheduledStamp->messageContext->name)) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new PostRunEvent($this->scheduleProviderLocator->get($scheduledStamp->messageContext->name), $scheduledStamp->messageContext, $envelope->getMessage()));
+    }
+
+    public function onMessageReceived(WorkerMessageReceivedEvent $event): void
+    {
+        $envelope = $event->getEnvelope();
+
+        if (!$scheduledStamp = $envelope->last(ScheduledStamp::class)) {
+            return;
+        }
+
+        if (!$this->scheduleProviderLocator->has($scheduledStamp->messageContext->name)) {
+            return;
+        }
+
+        $preRunEvent = new PreRunEvent($this->scheduleProviderLocator->get($scheduledStamp->messageContext->name), $scheduledStamp->messageContext, $envelope->getMessage());
+
+        $this->eventDispatcher->dispatch($preRunEvent);
+
+        if ($preRunEvent->shouldCancel()) {
+            $event->shouldHandle(false);
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageReceivedEvent::class => ['onMessageReceived'],
+            WorkerMessageHandledEvent::class => ['onMessageHandled'],
+        ];
+    }
+}

--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -93,6 +93,11 @@ final class MessageGenerator implements MessageGeneratorInterface
         $checkpoint->release($now, $this->waitUntil);
     }
 
+    public function getSchedule(): Schedule
+    {
+        return $this->schedule ??= $this->scheduleProvider->getSchedule();
+    }
+
     private function heap(\DateTimeImmutable $time, \DateTimeImmutable $startTime): TriggerHeap
     {
         if (isset($this->triggerHeap) && $this->triggerHeap->time <= $time) {
@@ -101,7 +106,7 @@ final class MessageGenerator implements MessageGeneratorInterface
 
         $heap = new TriggerHeap($time);
 
-        foreach ($this->schedule()->getRecurringMessages() as $index => $recurringMessage) {
+        foreach ($this->getSchedule()->getRecurringMessages() as $index => $recurringMessage) {
             $trigger = $recurringMessage->getTrigger();
 
             if ($trigger instanceof StatefulTriggerInterface) {
@@ -118,13 +123,8 @@ final class MessageGenerator implements MessageGeneratorInterface
         return $this->triggerHeap = $heap;
     }
 
-    private function schedule(): Schedule
-    {
-        return $this->schedule ??= $this->scheduleProvider->getSchedule();
-    }
-
     private function checkpoint(): Checkpoint
     {
-        return $this->checkpoint ??= new Checkpoint('scheduler_checkpoint_'.$this->name, $this->schedule()->getLock(), $this->schedule()->getState());
+        return $this->checkpoint ??= new Checkpoint('scheduler_checkpoint_'.$this->name, $this->getSchedule()->getLock(), $this->getSchedule()->getState());
     }
 }

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -54,4 +54,9 @@ class SchedulerTransport implements TransportInterface
     {
         throw new LogicException(sprintf('"%s" cannot send messages.', __CLASS__));
     }
+
+    public function getMessageGenerator(): MessageGeneratorInterface
+    {
+        return $this->messageGenerator;
+    }
 }

--- a/src/Symfony/Component/Scheduler/Scheduler.php
+++ b/src/Symfony/Component/Scheduler/Scheduler.php
@@ -11,8 +11,11 @@
 
 namespace Symfony\Component\Scheduler;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Clock\Clock;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Scheduler\Event\PostRunEvent;
+use Symfony\Component\Scheduler\Event\PreRunEvent;
 use Symfony\Component\Scheduler\Generator\MessageGenerator;
 
 final class Scheduler
@@ -31,6 +34,7 @@ final class Scheduler
         private readonly array $handlers,
         array $schedules,
         private readonly ClockInterface $clock = new Clock(),
+        private readonly ?EventDispatcherInterface $dispatcher = null,
     ) {
         foreach ($schedules as $schedule) {
             $this->addSchedule($schedule);
@@ -62,9 +66,25 @@ final class Scheduler
 
             $ran = false;
             foreach ($this->generators as $generator) {
-                foreach ($generator->getMessages() as $message) {
+                foreach ($generator->getMessages() as $context => $message) {
+                    if (!$this->dispatcher) {
+                        $this->handlers[$message::class]($message);
+                        $ran = true;
+
+                        continue;
+                    }
+
+                    $preRunEvent = new PreRunEvent($generator->getSchedule(), $context, $message);
+                    $this->dispatcher->dispatch($preRunEvent);
+
+                    if ($preRunEvent->shouldCancel()) {
+                        continue;
+                    }
+
                     $this->handlers[$message::class]($message);
                     $ran = true;
+
+                    $this->dispatcher->dispatch(new PostRunEvent($generator->getSchedule(), $context, $message));
                 }
             }
 

--- a/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Scheduler\Event\PreRunEvent;
+use Symfony\Component\Scheduler\EventListener\DispatchSchedulerEventListener;
+use Symfony\Component\Scheduler\Generator\MessageContext;
+use Symfony\Component\Scheduler\Messenger\ScheduledStamp;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Tests\Messenger\SomeScheduleProvider;
+use Symfony\Component\Scheduler\Trigger\TriggerInterface;
+
+class DispatchSchedulerEventListenerTest extends TestCase
+{
+    public function testDispatchSchedulerEvents()
+    {
+        $trigger = $this->createMock(TriggerInterface::class);
+        $defaultRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'default']);
+
+        $schedulerProvider = new SomeScheduleProvider([$defaultRecurringMessage]);
+        $scheduleProviderLocator = $this->createMock(ContainerInterface::class);
+        $scheduleProviderLocator->expects($this->once())->method('has')->willReturn(true);
+        $scheduleProviderLocator->expects($this->once())->method('get')->willReturn($schedulerProvider);
+
+        $context = new MessageContext('default', 'default', $trigger, $this->createMock(\DateTimeImmutable::class));
+        $envelope = (new Envelope(new \stdClass()))->with(new ScheduledStamp($context));
+
+        /** @var ContainerInterface $scheduleProviderLocator */
+        $listener = new DispatchSchedulerEventListener($scheduleProviderLocator, $eventDispatcher = new EventDispatcher());
+        $workerReceivedEvent = new WorkerMessageReceivedEvent($envelope, 'default');
+        $secondListener = new TestEventListener();
+
+        $eventDispatcher->addListener(PreRunEvent::class, [$secondListener, 'preRun']);
+        $eventDispatcher->addListener(PreRunEvent::class, [$secondListener, 'postRun']);
+        $listener->onMessageReceived($workerReceivedEvent);
+
+        $this->assertTrue($secondListener->preInvoked);
+        $this->assertTrue($secondListener->postInvoked);
+    }
+}
+
+class TestEventListener
+{
+    public string $name;
+    public bool $preInvoked = false;
+    public bool $postInvoked = false;
+
+    /* Listener methods */
+
+    public function preRun($e)
+    {
+        $this->preInvoked = true;
+    }
+
+    public function postRun($e)
+    {
+        $this->postInvoked = true;
+    }
+}

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -124,7 +124,7 @@ class MessageGeneratorTest extends TestCase
 
             public function __construct(array $schedule)
             {
-                $this->schedule = Schedule::with(...$schedule);
+                $this->schedule = (new Schedule())->with(...$schedule);
                 $this->schedule->stateful(new ArrayAdapter());
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/49803#event-10476636096
| License       | MIT

Based on https://github.com/symfony/symfony/issues/49803 @kbond  and taking into account https://github.com/symfony/symfony/pull/51553

The aim of this PR is to be able to act on the accumulated messages 'if something happens' and to be able to recalculate the heap via events (currently pre_run and post_run). 
The aim is to have access to 
- the  the schedule and therefore add/cancel a certain type of message.
- MessageContexte (e.g. access the id)
- The message itself

This PR would complement @Jeroeny https://github.com/symfony/symfony/pull/51553 PR by enabling action via events.