### PR TITLE
[Mailer] Use idn encoded address otherwise Brevo throws an error

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
@@ -34,7 +34,7 @@ class BrevoApiTransportTest extends TestCase
         $this->assertSame($expected, (string) $transport);
     }
 
-    public static function getTransportData()
+    public static function getTransportData(): \Generator
     {
         yield [
             new BrevoApiTransport('ACCESS_KEY'),
@@ -138,6 +138,47 @@ class BrevoApiTransportTest extends TestCase
             ->addBcc('foo@bar.fr')
             ->addReplyTo('foo@bar.fr')
             ->addPart(new DataPart('body'));
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    /**
+     * IDN (internationalized domain names) like kältetechnik-xyz.de need to be transformed to ACE
+     * (ASCII Compatible Encoding) e.g.xn--kltetechnik-xyz-0kb.de, otherwise brevo api answers with 400 http code.
+     *
+     * @throws \Symfony\Component\Mailer\Exception\TransportExceptionInterface
+     */
+    public function testSendForIdnDomains()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.brevo.com:8984/v3/smtp/email', $url);
+            $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
+
+            $body = json_decode($options['body'], true);
+            // to
+            $this->assertSame('kältetechnik@xn--kltetechnik-xyz-0kb.de', $body['to'][0]['email']);
+            $this->assertSame('Kältetechnik Xyz', $body['to'][0]['name']);
+            // sender
+            $this->assertSame('info@xn--kltetechnik-xyz-0kb.de', $body['sender']['email']);
+            $this->assertSame('Kältetechnik Xyz', $body['sender']['name']);
+
+            return new MockResponse(json_encode(['messageId' => 'foobar']), [
+                'http_code' => 201,
+            ]);
+        });
+
+        $transport = new BrevoApiTransport('ACCESS_KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('kältetechnik@kältetechnik-xyz.de', 'Kältetechnik Xyz'))
+            ->from(new Address('info@kältetechnik-xyz.de', 'Kältetechnik Xyz'))
+            ->text('Hello here!')
+            ->html('Hello there!');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -172,7 +172,7 @@ final class BrevoApiTransport extends AbstractApiTransport
 
     private function formatAddress(Address $address): array
     {
-        $formattedAddress = ['email' => $address->getAddress()];
+        $formattedAddress = ['email' => $address->getEncodedAddress()];
 
         if ($address->getName()) {
             $formattedAddress['name'] = $address->getName();

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueApiTransport.php
@@ -171,7 +171,7 @@ final class SendinblueApiTransport extends AbstractApiTransport
 
     private function stringifyAddress(Address $address): array
     {
-        $stringifiedAddress = ['email' => $address->getAddress()];
+        $stringifiedAddress = ['email' => $address->getEncodedAddress()];
 
         if ($address->getName()) {
             $stringifiedAddress['name'] = $address->getName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 for features
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT


We have to use the encoded email address in case of special character domains like 'kältetechnik-xyz.de' otherwise brevo fails with 400 error.
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
