### PR TITLE
Add "dev" keyword to symfony/symfony package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/symfony",
     "type": "library",
     "description": "The Symfony PHP framework",
-    "keywords": ["framework"],
+    "keywords": ["framework", "dev"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/contracts",
     "type": "library",
     "description": "A set of abstractions extracted out of the Symfony components",
-    "keywords": ["abstractions", "contracts", "decoupling", "interfaces", "interoperability", "standards"],
+    "keywords": ["abstractions", "contracts", "decoupling", "interfaces", "interoperability", "standards", "dev"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

We're periodically wondering about how we should tell people that they should require individual symfony packages instead of the meta repo. Marking the symfony/symfony package as "abandonned" on packagist is very close on a technical level, but semantically it's inaccurate.

I thought we might want to declare symfony/symfony as "for dev". WDYT?

![image](https://github.com/symfony/symfony/assets/243674/d342c8f1-2d8d-46d1-a406-7c2e1cc24695)
