### PR TITLE
Add test for 0 and '0' in PeriodicalTrigger and fix '0' case error

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
@@ -73,6 +73,8 @@ class PeriodicalTriggerTest extends TestCase
         yield ['3600.5'];
         yield ['-3600'];
         yield [-3600];
+        yield ['0'];
+        yield [0];
     }
 
     /**

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -30,18 +30,11 @@ class PeriodicalTrigger implements StatefulTriggerInterface
         $this->from = \is_string($from) ? new \DateTimeImmutable($from) : $from;
         $this->until = \is_string($until) ? new \DateTimeImmutable($until) : $until;
 
-        if (\is_int($interval) || \is_float($interval)) {
-            if (0 >= $interval) {
+        if (\is_int($interval) || \is_float($interval) || \is_string($interval) && ctype_digit($interval)) {
+            if (0 >= (int) $interval) {
                 throw new InvalidArgumentException('The "$interval" argument must be greater than zero.');
             }
 
-            $this->intervalInSeconds = $interval;
-            $this->description = sprintf('every %d seconds', $this->intervalInSeconds);
-
-            return;
-        }
-
-        if (\is_string($interval) && ctype_digit($interval)) {
             $this->intervalInSeconds = (int) $interval;
             $this->description = sprintf('every %d seconds', $this->intervalInSeconds);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

While taking a peek at the code I found the possibility for this case slipping by the error checking.
To prevent code duplication I took the liberty to also merge the two checks since they are so similar.

Please let me know if there is any feedback on my pull request or if there are any questions.
