### PR TITLE
Fix order array sum normalizedData and nestedData

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -339,7 +339,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             $normalizedData = $this->removeNestedValue($serializedPath->getElements(), $normalizedData);
         }
 
-        $normalizedData = $normalizedData + $nestedData;
+        $normalizedData = $nestedData + $normalizedData;
 
         $object = $this->instantiateObject($normalizedData, $mappedClass, $context, new \ReflectionClass($mappedClass), $allowedAttributes, $format);
         $resolvedClass = ($this->objectClassResolver)($object);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -813,6 +813,28 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame('foo', $test->foo);
         $this->assertSame('baz', $test->baz);
     }
+
+    public function testDenormalizeWithCorrectOrderOfAttributeAndProperty()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+
+        $data = [
+            'id' => 'root-level-id',
+            'data' => [
+                'id' => 'nested-id',
+            ],
+        ];
+
+        $obj = new class() {
+            /**
+             * @SerializedPath("[data][id]")
+             */
+            public $id;
+        };
+
+        $test = $normalizer->denormalize($data, $obj::class);
+        $this->assertSame('nested-id', $test->id);
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/51823
| License       | MIT

### Description

With the update of Serializer to 6.3.5, some deserialization of array to objects does behave differently (changed order of priority of configuration via attribute `#[SerializedPath]` vs. property name, when there is a key on root level with the same name as the private property.

Related to https://github.com/symfony/symfony/pull/49700.

### How to reproduce

Example to explain changed behavior:

```json
{
  "data": {
    "item": {
      "id": "id-1"
    }
  },
  "id": "id-2"
}
```

```php
final class SomeEvent
{
    #[SerializedPath('[data][item][id]')]
    public string $id;
}
```

Before 6.3.5, the value of the id was `id-1`, with the change of https://github.com/symfony/symfony/pull/49700, the value of the id becomes `id-2`.

https://github.com/symfony/symfony/pull/49700 changes `array_merge` with `array + array`. It seems that the problem stated above is related to the fact that array_merge does overwrite keys differently than array + array:

```php
$a = ['key' => 'value-a'];
$b = ['key' => 'value-b'];

var_dump(array_merge($a, $b));
// Results in:
// array(1) {
//   ["key"]=>
//   string(7) "value-b"
// }

var_dump($a + $b);
// Results in:
// array(1) {
//   ["key"]=>
//   string(7) "value-a"
// }
```

### Solution

As `array_merge` does behave slightly differently that array + array, the solution could be to switch array order to:
```diff
- $normalizedData = $normalizedData + $nestedData;
+ $normalizedData = $nestedData + $normalizedData;
```

This would result in the same, while keeping the fix (https://github.com/symfony/symfony/pull/49700) for the numeric key value