### PR TITLE
[AssetMapper] Automatically preload CSS files if WebLink available

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -174,6 +174,7 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.charset'),
                 abstract_arg('polyfill URL'),
                 abstract_arg('script HTML attributes'),
+                service('request_stack'),
             ])
 
         ->set('asset_mapper.importmap.auditor', ImportMapAuditor::class)

--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add "entrypoints" concept to the importmap
  * Always download packages locally instead of using a CDN
  * Allow relative path strings in the importmap
+ * Automatically set `_links` attribute for preload CSS files for WebLink integration
  * Add `PreAssetsCompileEvent` event when running `asset-map:compile`
  * Add support for importmap paths to use the Asset component (for subdirectories)
  * Removed the `importmap:export` command

--- a/src/Symfony/Component/AssetMapper/composer.json
+++ b/src/Symfony/Component/AssetMapper/composer.json
@@ -29,7 +29,8 @@
         "symfony/finder": "^5.4|^6.0|^7.0",
         "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/http-foundation": "^5.4|^6.0|^7.0",
-        "symfony/http-kernel": "^5.4|^6.0|^7.0"
+        "symfony/http-kernel": "^5.4|^6.0|^7.0",
+        "symfony/web-link": "^5.4|^6.0|^7.0"
     },
     "conflict": {
         "symfony/framework-bundle": "<6.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT

Hi!

In AssetMapper 6.4, we now know which CSS files will be rendered on the page. So, I think there is now downside to adding a `Link` header in the response to load those CSS files, but someone tell me if I'm missing something.

The only possible situation I can think of where this isn't wanted is if you decided to handle your critical CSS manually (i.e. with normal `<link rel="stylesheet">` tags in `base.html.twig`) and load a few less-critical CSS files through the ImportMap system. In that case, we would preload only these "less-critical" CSS, which could take a slight priority over the others. But I think the benefit this would give to most apps outweighs this. We could always add an opt-out later.

Cheers!