### PR TITLE
[DependencyInjection] Add `#[AutowireIterator]` attribute and improve `#[AutowireLocator]`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireIterator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireIterator.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\TypedReference;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+/**
+ * Autowires an iterator of services based on a tag name or an explicit list of key => service-type pairs.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class AutowireIterator extends Autowire
+{
+    /**
+     * @see ServiceSubscriberInterface::getSubscribedServices()
+     *
+     * @param string|array<string|SubscribedService> $services A tag name or an explicit list of services
+     * @param string|string[]                        $exclude  A service or a list of services to exclude
+     */
+    public function __construct(
+        string|array $services,
+        string $indexAttribute = null,
+        string $defaultIndexMethod = null,
+        string $defaultPriorityMethod = null,
+        string|array $exclude = [],
+        bool $excludeSelf = true,
+    ) {
+        if (\is_string($services)) {
+            parent::__construct(new TaggedIteratorArgument($services, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+
+            return;
+        }
+
+        $references = [];
+
+        foreach ($services as $key => $type) {
+            $attributes = [];
+
+            if ($type instanceof SubscribedService) {
+                $key = $type->key ?? $key;
+                $attributes = $type->attributes;
+                $type = ($type->nullable ? '?' : '').($type->type ?? throw new InvalidArgumentException(sprintf('When "%s" is used, a type must be set.', SubscribedService::class)));
+            }
+
+            if (!\is_string($type) || !preg_match('/(?(DEFINE)(?<cn>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))(?(DEFINE)(?<fqcn>(?&cn)(?:\\\\(?&cn))*+))^\??(?&fqcn)(?:(?:\|(?&fqcn))*+|(?:&(?&fqcn))*+)$/', $type)) {
+                throw new InvalidArgumentException(sprintf('"%s" is not a PHP type for key "%s".', \is_string($type) ? $type : get_debug_type($type), $key));
+            }
+            $optionalBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+            if ('?' === $type[0]) {
+                $type = substr($type, 1);
+                $optionalBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
+            }
+            if (\is_int($name = $key)) {
+                $key = $type;
+                $name = null;
+            }
+
+            $references[$key] = new TypedReference($type, $type, $optionalBehavior, $name, $attributes);
+        }
+
+        parent::__construct(new IteratorArgument($references));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireLocator.php
@@ -11,32 +11,40 @@
 
 namespace Symfony\Component\DependencyInjection\Attribute;
 
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
+/**
+ * Autowires a service locator based on a tag name or an explicit list of key => service-type pairs.
+ */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 class AutowireLocator extends Autowire
 {
-    public function __construct(string ...$serviceIds)
-    {
-        $values = [];
+    /**
+     * @see ServiceSubscriberInterface::getSubscribedServices()
+     *
+     * @param string|array<string|SubscribedService> $services An explicit list of services or a tag name
+     * @param string|string[]                        $exclude  A service or a list of services to exclude
+     */
+    public function __construct(
+        string|array $services,
+        string $indexAttribute = null,
+        string $defaultIndexMethod = null,
+        string $defaultPriorityMethod = null,
+        string|array $exclude = [],
+        bool $excludeSelf = true,
+    ) {
+        $iterator = (new AutowireIterator($services, $indexAttribute, $defaultIndexMethod, $defaultPriorityMethod, (array) $exclude, $excludeSelf))->value;
 
-        foreach ($serviceIds as $key => $serviceId) {
-            if ($nullable = str_starts_with($serviceId, '?')) {
-                $serviceId = substr($serviceId, 1);
-            }
-
-            if (is_numeric($key)) {
-                $key = $serviceId;
-            }
-
-            $values[$key] = new Reference(
-                $serviceId,
-                $nullable ? ContainerInterface::IGNORE_ON_INVALID_REFERENCE : ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
-            );
+        if ($iterator instanceof TaggedIteratorArgument) {
+            $iterator = new TaggedIteratorArgument($iterator->getTag(), $iterator->getIndexAttribute(), $iterator->getDefaultIndexMethod(), true, $iterator->getDefaultPriorityMethod(), $iterator->getExclude(), $iterator->excludeSelf());
+        } elseif ($iterator instanceof IteratorArgument) {
+            $iterator = $iterator->getValues();
         }
 
-        parent::__construct(new ServiceLocatorArgument($values));
+        parent::__construct(new ServiceLocatorArgument($iterator));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/TaggedIterator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/TaggedIterator.php
@@ -11,10 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Attribute;
 
-use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
-
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class TaggedIterator extends Autowire
+class TaggedIterator extends AutowireIterator
 {
     public function __construct(
         public string $tag,
@@ -24,6 +22,6 @@ class TaggedIterator extends Autowire
         public string|array $exclude = [],
         public bool $excludeSelf = true,
     ) {
-        parent::__construct(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+        parent::__construct($tag, $indexAttribute, $defaultIndexMethod, $defaultPriorityMethod, $exclude, $excludeSelf);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/TaggedLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/TaggedLocator.php
@@ -11,11 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Attribute;
 
-use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
-use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
-
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class TaggedLocator extends Autowire
+class TaggedLocator extends AutowireLocator
 {
     public function __construct(
         public string $tag,
@@ -25,6 +22,6 @@ class TaggedLocator extends Autowire
         public string|array $exclude = [],
         public bool $excludeSelf = true,
     ) {
-        parent::__construct(new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude, $excludeSelf)));
+        parent::__construct($tag, $indexAttribute, $defaultIndexMethod, $defaultPriorityMethod, $exclude, $excludeSelf);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Allow using `#[Target]` with no arguments to state that a parameter must match a named autowiring alias
  * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
  * Add `defined` env var processor that returns `true` for defined and neither null nor empty env vars
- * Add `#[AutowireLocator]` attribute
+ * Add `#[AutowireLocator]` and `#[AutowireIterator]` attributes
 
 6.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
@@ -79,7 +79,7 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
             $attributes = [];
 
             if ($type instanceof SubscribedService) {
-                $key = $type->key;
+                $key = $type->key ?? $key;
                 $attributes = $type->attributes;
                 $type = ($type->nullable ? '?' : '').($type->type ?? throw new InvalidArgumentException(sprintf('When "%s::getSubscribedServices()" returns "%s", a type must be set.', $class, SubscribedService::class)));
             }
@@ -87,7 +87,8 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
             if (!\is_string($type) || !preg_match('/(?(DEFINE)(?<cn>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))(?(DEFINE)(?<fqcn>(?&cn)(?:\\\\(?&cn))*+))^\??(?&fqcn)(?:(?:\|(?&fqcn))*+|(?:&(?&fqcn))*+)$/', $type)) {
                 throw new InvalidArgumentException(sprintf('"%s::getSubscribedServices()" must return valid PHP types for service "%s" key "%s", "%s" returned.', $class, $this->currentId, $key, \is_string($type) ? $type : get_debug_type($type)));
             }
-            if ($optionalBehavior = '?' === $type[0]) {
+            $optionalBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+            if ('?' === $type[0]) {
                 $type = substr($type, 1);
                 $optionalBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
             }
@@ -120,7 +121,7 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
                 $name = $this->container->has($type.' $'.$camelCaseName) ? $camelCaseName : $name;
             }
 
-            $subscriberMap[$key] = new TypedReference((string) $serviceMap[$key], $type, $optionalBehavior ?: ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $name, $attributes);
+            $subscriberMap[$key] = new TypedReference((string) $serviceMap[$key], $type, $optionalBehavior, $name, $attributes);
             unset($serviceMap[$key]);
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireLocatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireLocatorTest.php
@@ -15,33 +15,33 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\TypedReference;
 
 class AutowireLocatorTest extends TestCase
 {
     public function testSimpleLocator()
     {
-        $locator = new AutowireLocator('foo', 'bar');
+        $locator = new AutowireLocator(['foo', 'bar']);
 
         $this->assertEquals(
-            new ServiceLocatorArgument(['foo' => new Reference('foo'), 'bar' => new Reference('bar')]),
+            new ServiceLocatorArgument(['foo' => new TypedReference('foo', 'foo'), 'bar' => new TypedReference('bar', 'bar')]),
             $locator->value,
         );
     }
 
     public function testComplexLocator()
     {
-        $locator = new AutowireLocator(
+        $locator = new AutowireLocator([
             '?qux',
-            foo: 'bar',
-            bar: '?baz',
-        );
+            'foo' => 'bar',
+            'bar' => '?baz',
+        ]);
 
         $this->assertEquals(
             new ServiceLocatorArgument([
-                'qux' => new Reference('qux', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
-                'foo' => new Reference('bar'),
-                'bar' => new Reference('baz', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                'qux' => new TypedReference('qux', 'qux', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                'foo' => new TypedReference('bar', 'bar', name: 'foo'),
+                'bar' => new TypedReference('baz', 'baz', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'bar'),
             ]),
             $locator->value,
         );

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -32,6 +33,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomPropert
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredInterface2;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredService1;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredService2;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutowireIteratorConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutowireLocatorConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedClass;
@@ -392,6 +394,7 @@ class IntegrationTest extends TestCase
     public function testLocatorConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('some.parameter', 'foo');
         $container->register(BarTagClass::class)
             ->setPublic(true)
         ;
@@ -411,6 +414,36 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(BarTagClass::class), $s->locator->get(BarTagClass::class));
         self::assertSame($container->get(FooTagClass::class), $s->locator->get('with_key'));
         self::assertFalse($s->locator->has('nullable'));
+        self::assertSame('foo', $s->locator->get('subscribed'));
+    }
+
+    public function testIteratorConfiguredViaAttribute()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('some.parameter', 'foo');
+        $container->register(BarTagClass::class)
+            ->setPublic(true)
+        ;
+        $container->register(FooTagClass::class)
+            ->setPublic(true)
+        ;
+        $container->register(AutowireIteratorConsumer::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        /** @var AutowireIteratorConsumer $s */
+        $s = $container->get(AutowireIteratorConsumer::class);
+
+        self::assertInstanceOf(RewindableGenerator::class, $s->iterator);
+
+        $values = iterator_to_array($s->iterator);
+        self::assertCount(3, $values);
+        self::assertSame($container->get(BarTagClass::class), $values[BarTagClass::class]);
+        self::assertSame($container->get(FooTagClass::class), $values['with_key']);
+        self::assertSame('foo', $values['subscribed']);
     }
 
     public function testTaggedServiceWithIndexAttributeAndDefaultMethodConfiguredViaAttribute()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutowireIteratorConsumer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutowireIteratorConsumer.php
@@ -11,21 +11,20 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
-use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Contracts\Service\Attribute\SubscribedService;
 
-final class AutowireLocatorConsumer
+final class AutowireIteratorConsumer
 {
     public function __construct(
-        #[AutowireLocator([
+        #[AutowireIterator([
             BarTagClass::class,
             'with_key' => FooTagClass::class,
             'nullable' => '?invalid',
             'subscribed' => new SubscribedService(type: 'string', attributes: new Autowire('%some.parameter%')),
         ])]
-        public readonly ContainerInterface $locator,
+        public readonly iterable $iterator,
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutowireLocatorConsumer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutowireLocatorConsumer.php
@@ -17,11 +17,11 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 final class AutowireLocatorConsumer
 {
     public function __construct(
-        #[AutowireLocator(
+        #[AutowireLocator([
             BarTagClass::class,
-            with_key: FooTagClass::class,
-            nullable: '?invalid',
-        )]
+            'with_key' => FooTagClass::class,
+            'nullable' => '?invalid',
+        ])]
         public readonly ContainerInterface $locator,
     ) {
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumer.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 final class TaggedIteratorConsumer
 {
     public function __construct(
-        #[TaggedIterator('foo_bar', indexAttribute: 'foo')]
+        #[AutowireIterator('foo_bar', indexAttribute: 'foo')]
         private iterable $param,
     ) {
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumer.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 
 final class TaggedLocatorConsumer
 {
     public function __construct(
-        #[TaggedLocator('foo_bar', indexAttribute: 'foo')]
+        #[AutowireLocator('foo_bar', indexAttribute: 'foo')]
         private ContainerInterface $locator,
     ) {
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -676,7 +676,7 @@ class WithTaggedIteratorAndTaggedLocator
     public function fooAction(
         #[TaggedIterator('foobar')] iterable $iterator,
         #[TaggedLocator('foobar')] ServiceLocator $locator,
-        #[AutowireLocator('bar', 'baz')] ContainerInterface $container,
+        #[AutowireLocator(['bar', 'baz'])] ContainerInterface $container,
     ) {
     }
 }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -63,6 +63,7 @@
         "symfony/http-client-contracts": "<2.5",
         "symfony/mailer": "<5.4",
         "symfony/messenger": "<5.4",
+        "symfony/service-contracts": "<3.2",
         "symfony/translation": "<5.4",
         "symfony/translation-contracts": "<2.5",
         "symfony/twig-bridge": "<5.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT

This PR is building on #51392 to add an `#[AutowireIterator]` attribute and improve `#[AutowireLocator]`.

The new `#[AutowireIterator]` attribute can be used to describe what `#[AutowireLocator]` can do, except that we get an iterator instead of a container.

And  `#[AutowireLocator]` can now be used instead of `#[TaggedLocator]`: `#[AutowireLocator('foo')]` and done.

In order to describe that you want a list of services, we cannot use named arguments anymore so we have to pass an array now: `#[AutowireLocator(['foo' => 'F', 'bar' => 'B'])]` should be used instead of `#[AutowireLocator(foo: 'F', bar: 'B')]`.

Last but not least, this adds support for nesting `SubscribedService` objects in the list of described services. This provides feature-parity with what we can do when implementing `ServiceSubscriberInterface`.

I didn't deprecate `TaggedIterator` nor `TaggedLocator`. We could, but maybe we should wait for 7.1?

TODO:
- [x] add tests - thanks @kbond!

~PS: while writing this, I realize that we may merge both tags in one, and let `AutowirePass` decide if it should build a locator or an iterator based on the type of the argument that has the attribute. We'd "just" need to find a name that'd work for that.~