### PR TITLE
[DependencyInjection] Remove inaccurate `@throws` on `Container::get()`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -201,7 +201,6 @@ class Container implements ContainerInterface, ResetInterface
      *
      * @throws ServiceCircularReferenceException When a circular reference is detected
      * @throws ServiceNotFoundException          When the service is not defined
-     * @throws \Exception                        if an exception has been thrown when the service has been resolved
      *
      * @see Reference
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51834
| License       | MIT

This would solve the inconsistency between ContainerInterface and Container described in https://github.com/symfony/symfony/issues/51834 because currently the Container phpdoc doesn't respect the ContainerInterface one.