### PR TITLE
[Cache] Add type to redis scan call to avoid using default "" which r…

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -476,7 +476,7 @@ trait RedisTrait
 
             $cursor = null;
             do {
-                $keys = $host instanceof \Predis\ClientInterface ? $host->scan($cursor, 'MATCH', $pattern, 'COUNT', 1000) : $host->scan($cursor, $pattern, 1000);
+                $keys = $host instanceof \Predis\ClientInterface ? $host->scan($cursor, 'MATCH', $pattern, 'COUNT', 1000) : $host->scan($cursor, $pattern, 1000, 'string');
                 if (isset($keys[1]) && \is_array($keys[1])) {
                     $cursor = $keys[0];
                     $keys = $keys[1];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The `cache:pool:clear` command is not clearing the existing redis keys correctly. The method is being call without a valid `type`, which gets a empty array as response.

The redis `MONITOR` command shows the following type of call:
```"SCAN" "0" "COUNT" "1000" "MATCH" "<prefix>:*" "TYPE" ""```

Correct would be to set the `TYPE` to `string`.
```"SCAN" "0" "COUNT" "1000" "MATCH" "<prefix>:*" "TYPE" "string"```

See Documentation: https://redis.io/commands/type/

This PullRequest also fix the deprecation:
```Deprecated: Redis::scan(): Passing null to parameter #4 ($type) of type ?string is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: Redis::scan(): Passing null to parameter #4 ($type) of type ?string is deprecated at /var/www/vendor/symfony/cache/Traits/Redis6Proxy.php:893)"```