### PR TITLE
[FrameworkBundle] Fix call to invalid method in NotificationAssertionsTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/NotificationAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/NotificationAssertionsTrait.php
@@ -29,7 +29,7 @@ trait NotificationAssertionsTrait
 
     public static function assertQueuedNotificationCount(int $count, string $transportName = null, string $message = ''): void
     {
-        self::assertThat(self::getMessageMailerEvents(), new NotifierConstraint\NotificationCount($count, $transportName, true), $message);
+        self::assertThat(self::getNotificationEvents(), new NotifierConstraint\NotificationCount($count, $transportName, true), $message);
     }
 
     public static function assertNotificationIsQueued(MessageEvent $event, string $message = ''): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

