### PR TITLE
[AssetMapper] Add outdated command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -20,6 +20,7 @@ use Symfony\Component\AssetMapper\Command\AssetMapperCompileCommand;
 use Symfony\Component\AssetMapper\Command\DebugAssetMapperCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapAuditCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapInstallCommand;
+use Symfony\Component\AssetMapper\Command\ImportMapOutdatedCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapRemoveCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapRequireCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapUpdateCommand;
@@ -32,6 +33,7 @@ use Symfony\Component\AssetMapper\ImportMap\ImportMapAuditor;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapManager;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapRenderer;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapUpdateChecker;
 use Symfony\Component\AssetMapper\ImportMap\RemotePackageDownloader;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\JsDelivrEsmResolver;
 use Symfony\Component\AssetMapper\MapperAwareAssetPackage;
@@ -179,6 +181,11 @@ return static function (ContainerConfigurator $container) {
             service('asset_mapper.importmap.config_reader'),
             service('http_client'),
         ])
+        ->set('asset_mapper.importmap.update_checker', ImportMapUpdateChecker::class)
+        ->args([
+            service('asset_mapper.importmap.config_reader'),
+            service('http_client'),
+        ])
 
         ->set('asset_mapper.importmap.command.require', ImportMapRequireCommand::class)
             ->args([
@@ -204,6 +211,10 @@ return static function (ContainerConfigurator $container) {
 
         ->set('asset_mapper.importmap.command.audit', ImportMapAuditCommand::class)
             ->args([service('asset_mapper.importmap.auditor')])
+            ->tag('console.command')
+
+        ->set('asset_mapper.importmap.command.outdated', ImportMapOutdatedCommand::class)
+            ->args([service('asset_mapper.importmap.update_checker')])
             ->tag('console.command')
     ;
 };

--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Add a `importmap:install` command to download all missing downloaded packages
  * Allow specifying packages to update for the `importmap:update` command
  * Add a `importmap:audit` command to check for security vulnerability advisories in dependencies
+ * Add a `importmap:outdated` command to check for outdated packages
 
 6.3
 ---

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapOutdatedCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapOutdatedCommand.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Command;
+
+use Symfony\Component\AssetMapper\ImportMap\ImportMapUpdateChecker;
+use Symfony\Component\AssetMapper\ImportMap\PackageUpdateInfo;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'importmap:outdated', description: 'List outdated JavaScript packages and their latest versions')]
+final class ImportMapOutdatedCommand extends Command
+{
+    private const COLOR_MAPPING = [
+        'update-possible' => 'yellow',
+        'semver-safe-update' => 'red',
+    ];
+
+    public function __construct(
+        private readonly ImportMapUpdateChecker $updateChecker,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                name: 'packages',
+                mode: InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+                description: 'A list of packages to check',
+            )
+            ->addOption(
+                name: 'format',
+                mode: InputOption::VALUE_REQUIRED,
+                description: sprintf('The output format ("%s")', implode(', ', $this->getAvailableFormatOptions())),
+                default: 'txt',
+            )
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command will list the latest updates available for the 3rd party packages in <comment>importmap.php</comment>.
+Versions showing in <fg=red>red</> are semver compatible versions and you should upgrading.
+Versions showing in <fg=yellow>yellow</> are major updates that include backward compatibility breaks according to semver.
+
+   <info>php %command.full_name%</info>
+
+Or specific packages only:
+
+   <info>php %command.full_name% <packages></info>
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $packages = $input->getArgument('packages');
+        $packagesUpdateInfos = $this->updateChecker->getAvailableUpdates($packages);
+        $packagesUpdateInfos = array_filter($packagesUpdateInfos, fn ($packageUpdateInfo) => $packageUpdateInfo->hasUpdate());
+        if (0 === \count($packagesUpdateInfos)) {
+            return Command::SUCCESS;
+        }
+
+        $displayData = array_map(fn ($importName, $packageUpdateInfo) => [
+            'name' => $importName,
+            'current' => $packageUpdateInfo->currentVersion,
+            'latest' => $packageUpdateInfo->latestVersion,
+            'latest-status' => PackageUpdateInfo::UPDATE_TYPE_MAJOR === $packageUpdateInfo->updateType ? 'update-possible' : 'semver-safe-update',
+        ], array_keys($packagesUpdateInfos), $packagesUpdateInfos);
+
+        if ('json' === $input->getOption('format')) {
+            $io->writeln(json_encode($displayData, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        } else {
+            $table = $io->createTable();
+            $table->setHeaders(['Package', 'Current', 'Latest']);
+            foreach ($displayData as $datum) {
+                $color = self::COLOR_MAPPING[$datum['latest-status']] ?? 'default';
+                $table->addRow([
+                    sprintf('<fg=%s>%s</>', $color, $datum['name']),
+                    $datum['current'],
+                    sprintf('<fg=%s>%s</>', $color, $datum['latest']),
+                ]);
+            }
+            $table->render();
+        }
+
+        return Command::FAILURE;
+    }
+
+    private function getAvailableFormatOptions(): array
+    {
+        return ['txt', 'json'];
+    }
+}

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -68,12 +68,16 @@ class ImportMapConfigReader
                 throw new RuntimeException(sprintf('The importmap entry "%s" cannot have both a "path" and "version" option.', $importName));
             }
 
+            [$packageName, $filePath] = self::splitPackageNameAndFilePath($importName);
+
             $entries->add(new ImportMapEntry(
                 $importName,
                 path: $path,
                 version: $version,
                 type: $type,
                 isEntrypoint: $isEntry,
+                packageName: $packageName,
+                filePath: $filePath,
             ));
         }
 
@@ -143,5 +147,19 @@ class ImportMapConfigReader
         }
 
         return substr($url, $lastAt + 1, $nextSlash - $lastAt - 1);
+    }
+
+    public static function splitPackageNameAndFilePath(string $packageName): array
+    {
+        $filePath = '';
+        $i = strpos($packageName, '/');
+
+        if ($i && (!str_starts_with($packageName, '@') || $i = strpos($packageName, '/', $i + 1))) {
+            // @vendor/package/filepath or package/filepath
+            $filePath = substr($packageName, $i);
+            $packageName = substr($packageName, 0, $i);
+        }
+
+        return [$packageName, $filePath];
     }
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
@@ -27,6 +27,8 @@ final class ImportMapEntry
         public readonly ?string $version = null,
         public readonly ImportMapType $type = ImportMapType::JS,
         public readonly bool $isEntrypoint = false,
+        public readonly ?string $packageName = null,
+        public readonly ?string $filePath = null,
     ) {
     }
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapUpdateChecker.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapUpdateChecker.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\ImportMap;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ImportMapUpdateChecker
+{
+    private const URL_PACKAGE_METADATA = 'https://registry.npmjs.org/%s';
+
+    public function __construct(
+        private readonly ImportMapConfigReader $importMapConfigReader,
+        private readonly HttpClientInterface $httpClient,
+    ) {
+    }
+
+    /**
+     * @param string[] $packages
+     *
+     * @return PackageUpdateInfo[]
+     */
+    public function getAvailableUpdates(array $packages = []): array
+    {
+        $entries = $this->importMapConfigReader->getEntries();
+        $updateInfos = [];
+        $responses = [];
+        foreach ($entries as $entry) {
+            if (null === $entry->packageName || null === $entry->version) {
+                continue;
+            }
+            if (\count($packages) && !\in_array($entry->packageName, $packages, true)) {
+                continue;
+            }
+
+            $responses[$entry->importName] = $this->httpClient->request('GET', sprintf(self::URL_PACKAGE_METADATA, $entry->packageName), ['headers' => ['Accept' => 'application/vnd.npm.install-v1+json']]);
+        }
+
+        foreach ($responses as $importName => $response) {
+            $entry = $entries->get($importName);
+            if (200 !== $response->getStatusCode()) {
+                throw new \RuntimeException(sprintf('Unable to get latest version for package "%s".', $entry->packageName));
+            }
+            $updateInfo = new PackageUpdateInfo($entry->packageName, $entry->version);
+            try {
+                $updateInfo->latestVersion = json_decode($response->getContent(), true)['dist-tags']['latest'];
+                $updateInfo->updateType = $this->getUpdateType($updateInfo->currentVersion, $updateInfo->latestVersion);
+            } catch (\Exception $e) {
+                throw new \RuntimeException(sprintf('Unable to get latest version for package "%s".', $entry->packageName), 0, $e);
+            }
+            $updateInfos[$importName] = $updateInfo;
+        }
+
+        return $updateInfos;
+    }
+
+    private function getVersionPart(string $version, int $part): ?string
+    {
+        return explode('.', $version)[$part] ?? $version;
+    }
+
+    private function getUpdateType(string $currentVersion, string $latestVersion): string
+    {
+        if (version_compare($currentVersion, $latestVersion, '>')) {
+            return PackageUpdateInfo::UPDATE_TYPE_DOWNGRADE;
+        }
+        if (version_compare($currentVersion, $latestVersion, '==')) {
+            return PackageUpdateInfo::UPDATE_TYPE_UP_TO_DATE;
+        }
+        if ($this->getVersionPart($currentVersion, 0) < $this->getVersionPart($latestVersion, 0)) {
+            return PackageUpdateInfo::UPDATE_TYPE_MAJOR;
+        }
+        if ($this->getVersionPart($currentVersion, 1) < $this->getVersionPart($latestVersion, 1)) {
+            return PackageUpdateInfo::UPDATE_TYPE_MINOR;
+        }
+        if ($this->getVersionPart($currentVersion, 2) < $this->getVersionPart($latestVersion, 2)) {
+            return PackageUpdateInfo::UPDATE_TYPE_PATCH;
+        }
+
+        throw new \LogicException(sprintf('Unable to determine update type for "%s" and "%s".', $currentVersion, $latestVersion));
+    }
+}

--- a/src/Symfony/Component/AssetMapper/ImportMap/PackageUpdateInfo.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/PackageUpdateInfo.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\ImportMap;
+
+class PackageUpdateInfo
+{
+    public const UPDATE_TYPE_DOWNGRADE = 'downgrade';
+    public const UPDATE_TYPE_UP_TO_DATE = 'up-to-date';
+    public const UPDATE_TYPE_MAJOR = 'major';
+    public const UPDATE_TYPE_MINOR = 'minor';
+    public const UPDATE_TYPE_PATCH = 'patch';
+
+    public function __construct(
+        public readonly string $packageName,
+        public readonly string $currentVersion,
+        public ?string $latestVersion = null,
+        public ?string $updateType = null,
+    ) {
+    }
+
+    public function hasUpdate(): bool
+    {
+        return !\in_array($this->updateType, [self::UPDATE_TYPE_DOWNGRADE, self::UPDATE_TYPE_DOWNGRADE, self::UPDATE_TYPE_UP_TO_DATE]);
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -56,6 +56,12 @@ return [
         'path' => 'entry.js',
         'entrypoint' => true,
     ],
+    'package/with_file.js' => [
+        'version' => '1.0.0',
+    ],
+    '@vendor/package/path/to/file.js' => [
+        'version' => '1.0.0',
+    ],
 ];
 EOF;
         file_put_contents(__DIR__.'/../fixtures/importmaps_for_writing/importmap.php', $importMap);
@@ -65,7 +71,7 @@ EOF;
         $this->assertInstanceOf(ImportMapEntries::class, $entries);
         /** @var ImportMapEntry[] $allEntries */
         $allEntries = iterator_to_array($entries);
-        $this->assertCount(4, $allEntries);
+        $this->assertCount(6, $allEntries);
 
         $remotePackageEntry = $allEntries[0];
         $this->assertSame('remote_package', $remotePackageEntry->importName);
@@ -73,6 +79,8 @@ EOF;
         $this->assertSame('3.2.1', $remotePackageEntry->version);
         $this->assertSame('js', $remotePackageEntry->type->value);
         $this->assertFalse($remotePackageEntry->isEntrypoint);
+        $this->assertSame('remote_package', $remotePackageEntry->packageName);
+        $this->assertEquals('', $remotePackageEntry->filePath);
 
         $localPackageEntry = $allEntries[1];
         $this->assertNull($localPackageEntry->version);
@@ -81,8 +89,13 @@ EOF;
         $typeCssEntry = $allEntries[2];
         $this->assertSame('css', $typeCssEntry->type->value);
 
-        $entryPointEntry = $allEntries[3];
-        $this->assertTrue($entryPointEntry->isEntrypoint);
+        $packageWithFileEntry = $allEntries[4];
+        $this->assertSame('package', $packageWithFileEntry->packageName);
+        $this->assertSame('/with_file.js', $packageWithFileEntry->filePath);
+
+        $packageWithFileEntry = $allEntries[5];
+        $this->assertSame('@vendor/package', $packageWithFileEntry->packageName);
+        $this->assertSame('/path/to/file.js', $packageWithFileEntry->filePath);
 
         // now save the original raw data from importmap.php and delete the file
         $originalImportMapData = (static fn () => include __DIR__.'/../fixtures/importmaps_for_writing/importmap.php')();

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -78,7 +78,8 @@ class ImportMapManagerTest extends TestCase
             [
                 new ImportMapEntry(
                     '@hotwired/stimulus',
-                    version: '1.2.3'
+                    version: '1.2.3',
+                    packageName: '@hotwired/stimulus',
                 ),
             ],
             [
@@ -689,6 +690,8 @@ class ImportMapManagerTest extends TestCase
                         'path' => $entry->path,
                         'type' => $entry->type->value,
                         'entrypoint' => $entry->isEntrypoint,
+                        'packageName' => $entry->packageName,
+                        'filePath' => $entry->packageName,
                     ];
                 }
 
@@ -1055,10 +1058,10 @@ class ImportMapManagerTest extends TestCase
     {
         $this->remotePackageDownloader->expects($this->any())
             ->method('getDownloadedPath')
-            ->willReturnCallback(function (string $packageName) use ($importMapEntries) {
+            ->willReturnCallback(function (string $importName) use ($importMapEntries) {
                 foreach ($importMapEntries as $entry) {
-                    if ($entry->importName === $packageName) {
-                        return self::$writableRoot.'/assets/vendor/'.$packageName.'.js';
+                    if ($entry->importName === $importName) {
+                        return self::$writableRoot.'/assets/vendor/'.$importName.'.js';
                     }
                 }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapUpdateCheckerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapUpdateCheckerTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests\ImportMap;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapEntries;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapUpdateChecker;
+use Symfony\Component\AssetMapper\ImportMap\PackageUpdateInfo;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class ImportMapUpdateCheckerTest extends TestCase
+{
+    private ImportMapConfigReader $importMapConfigReader;
+    private ImportMapUpdateChecker $updateChecker;
+
+    protected function setUp(): void
+    {
+        $this->importMapConfigReader = $this->createMock(ImportMapConfigReader::class);
+        $httpClient = new MockHttpClient();
+        $httpClient->setResponseFactory(self::responseFactory(...));
+        $this->updateChecker = new ImportMapUpdateChecker($this->importMapConfigReader, $httpClient);
+    }
+
+    public function testGetAvailableUpdates()
+    {
+        $this->importMapConfigReader->method('getEntries')->willReturn(new ImportMapEntries([
+            '@hotwired/stimulus' => new ImportMapEntry(
+                importName: '@hotwired/stimulus',
+                version: '3.2.1',
+                packageName: '@hotwired/stimulus',
+            ),
+            'json5' => new ImportMapEntry(
+                importName: 'json5',
+                version: '1.0.0',
+                packageName: 'json5',
+            ),
+            'bootstrap' => new ImportMapEntry(
+                importName: 'bootstrap',
+                version: '5.3.1',
+                packageName: 'bootstrap',
+            ),
+            'bootstrap/dist/css/bootstrap.min.css' => new ImportMapEntry(
+                importName: 'bootstrap/dist/css/bootstrap.min.css',
+                version: '5.3.1',
+                type: ImportMapType::CSS,
+                packageName: 'bootstrap',
+            ),
+            'lodash' => new ImportMapEntry(
+                importName: 'lodash',
+                version: '4.17.21',
+                packageName: 'lodash',
+            ),
+            // Local package won't appear in update list
+            'app' => new ImportMapEntry(
+                importName: 'app',
+                path: 'assets/app.js',
+            ),
+        ]));
+
+        $updates = $this->updateChecker->getAvailableUpdates();
+
+        $this->assertEquals([
+            '@hotwired/stimulus' => new PackageUpdateInfo(
+                packageName: '@hotwired/stimulus',
+                currentVersion: '3.2.1',
+                latestVersion: '4.0.1',
+                updateType: 'major'
+            ),
+            'json5' => new PackageUpdateInfo(
+                packageName: 'json5',
+                currentVersion: '1.0.0',
+                latestVersion: '1.2.0',
+                updateType: 'minor'
+            ),
+            'bootstrap' => new PackageUpdateInfo(
+                packageName: 'bootstrap',
+                currentVersion: '5.3.1',
+                latestVersion: '5.3.2',
+                updateType: 'patch'
+            ),
+            'bootstrap/dist/css/bootstrap.min.css' => new PackageUpdateInfo(
+                packageName: 'bootstrap',
+                currentVersion: '5.3.1',
+                latestVersion: '5.3.2',
+                updateType: 'patch'
+            ),
+            'lodash' => new PackageUpdateInfo(
+                packageName: 'lodash',
+                currentVersion: '4.17.21',
+                latestVersion: '4.17.21',
+                updateType: 'up-to-date'
+            ),
+        ], $updates);
+    }
+
+    /**
+     * @dataProvider provideImportMapEntry
+     *
+     * @param ImportMapEntry[]    $entries
+     * @param PackageUpdateInfo[] $expectedUpdateInfo
+     */
+    public function testGetAvailableUpdatesForSinglePackage(array $entries, array $expectedUpdateInfo, ?\Exception $expectedException)
+    {
+        $this->importMapConfigReader->method('getEntries')->willReturn(new ImportMapEntries($entries));
+        if (null !== $expectedException) {
+            $this->expectException($expectedException::class);
+            $this->updateChecker->getAvailableUpdates(array_map(fn ($entry) => $entry->packageName, $entries));
+        } else {
+            $update = $this->updateChecker->getAvailableUpdates(array_map(fn ($entry) => $entry->packageName, $entries));
+            $this->assertEquals($expectedUpdateInfo, $update);
+        }
+    }
+
+    private function provideImportMapEntry()
+    {
+        yield [
+            ['@hotwired/stimulus' => new ImportMapEntry(
+                importName: '@hotwired/stimulus',
+                version: '3.2.1',
+                packageName: '@hotwired/stimulus',
+            ),
+            ],
+            ['@hotwired/stimulus' => new PackageUpdateInfo(
+                packageName: '@hotwired/stimulus',
+                currentVersion: '3.2.1',
+                latestVersion: '4.0.1',
+                updateType: 'major'
+            ), ],
+            null,
+        ];
+        yield [
+            [
+                'bootstrap/dist/css/bootstrap.min.css' => new ImportMapEntry(
+                    importName: 'bootstrap/dist/css/bootstrap.min.css',
+                    version: '5.3.1',
+                    packageName: 'bootstrap',
+                ),
+            ],
+            ['bootstrap/dist/css/bootstrap.min.css' => new PackageUpdateInfo(
+                packageName: 'bootstrap',
+                currentVersion: '5.3.1',
+                latestVersion: '5.3.2',
+                updateType: 'patch'
+            ), ],
+            null,
+        ];
+        yield [
+            [
+                'bootstrap' => new ImportMapEntry(
+                    importName: 'bootstrap',
+                    version: 'not_a_version',
+                    packageName: 'bootstrap',
+                ),
+            ],
+            [],
+            new \RuntimeException('Unable to get latest available version for package "bootstrap".'),
+        ];
+        yield [
+            [
+                new ImportMapEntry(
+                    importName: 'invalid_package_name',
+                    version: '1.0.0',
+                    packageName: 'invalid_package_name',
+                ),
+            ],
+            [],
+            new \RuntimeException('Unable to get latest available version for package "invalid_package_name".'),
+        ];
+    }
+
+    private function responseFactory($method, $url): MockResponse
+    {
+        $this->assertSame('GET', $method);
+        $map = [
+            'https://registry.npmjs.org/@hotwired/stimulus' => new MockResponse(json_encode([
+                'dist-tags' => ['latest' => '4.0.1'], // Major update
+            ])),
+            'https://registry.npmjs.org/json5' => new MockResponse(json_encode([
+                'dist-tags' => ['latest' => '1.2.0'], // Minor update
+            ])),
+            'https://registry.npmjs.org/bootstrap' => new MockResponse(json_encode([
+                'dist-tags' => ['latest' => '5.3.2'], // Patch update
+            ])),
+            'https://registry.npmjs.org/lodash' => new MockResponse(json_encode([
+                'dist-tags' => ['latest' => '4.17.21'], // no update
+            ])),
+        ];
+
+        return $map[$url] ?? new MockResponse('Not found', ['http_code' => 404]);
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/PackageUpdateInfoTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/PackageUpdateInfoTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests\ImportMap;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\ImportMap\PackageUpdateInfo;
+
+class PackageUpdateInfoTest extends TestCase
+{
+    /**
+     * @dataProvider provideValidConstructorArguments
+     */
+    public function testConstructor($importName, $currentVersion, $latestVersion, $updateType)
+    {
+        $packageUpdateInfo = new PackageUpdateInfo(
+            packageName: $importName,
+            currentVersion: $currentVersion,
+            latestVersion: $latestVersion,
+            updateType: $updateType,
+        );
+
+        $this->assertSame($importName, $packageUpdateInfo->packageName);
+        $this->assertSame($currentVersion, $packageUpdateInfo->currentVersion);
+        $this->assertSame($latestVersion, $packageUpdateInfo->latestVersion);
+        $this->assertSame($updateType, $packageUpdateInfo->updateType);
+    }
+
+    public function provideValidConstructorArguments()
+    {
+        return [
+            ['@hotwired/stimulus', '5.2.1', 'string', 'downgrade'],
+            ['@hotwired/stimulus', 'v3.2.1', '3.2.1', 'up-to-date'],
+            ['@hotwired/stimulus', '3.0.0-beta', 'v1.0.0', 'major'],
+            ['@hotwired/stimulus', 'string', null, null],
+        ];
+    }
+
+    /**
+     * @dataProvider provideHasUpdateArguments
+     */
+    public function testHasUpdate($updateType, $expectUpdate)
+    {
+        $packageUpdateInfo = new PackageUpdateInfo(
+            packageName: 'packageName',
+            currentVersion: '1.0.0',
+            updateType: $updateType,
+        );
+        $this->assertSame($expectUpdate, $packageUpdateInfo->hasUpdate());
+    }
+
+    public function provideHasUpdateArguments()
+    {
+        return [
+            ['downgrade', false],
+            ['up-to-date', false],
+            ['major', true],
+            ['minor', true],
+            ['patch', true],
+        ];
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -293,7 +293,7 @@ class JsDelivrEsmResolverTest extends TestCase
     public static function provideDownloadPackagesTests()
     {
         yield 'single package' => [
-            ['lodash' => new ImportMapEntry('lodash', version: '1.2.3')],
+            ['lodash' => new ImportMapEntry('lodash', version: '1.2.3', packageName: 'lodash')],
             [
                 [
                     'url' => '/lodash@1.2.3/+esm',
@@ -306,7 +306,7 @@ class JsDelivrEsmResolverTest extends TestCase
         ];
 
         yield 'package with path' => [
-            ['lodash' => new ImportMapEntry('chart.js/auto', version: '4.5.6')],
+            ['lodash' => new ImportMapEntry('chart.js/auto', version: '4.5.6', packageName: 'chart.js', filePath: '/auto')],
             [
                 [
                     'url' => '/chart.js@4.5.6/auto/+esm',
@@ -319,7 +319,7 @@ class JsDelivrEsmResolverTest extends TestCase
         ];
 
         yield 'css file' => [
-            ['lodash' => new ImportMapEntry('bootstrap/dist/bootstrap.css', version: '5.0.6', type: ImportMapType::CSS)],
+            ['lodash' => new ImportMapEntry('bootstrap/dist/bootstrap.css', version: '5.0.6', type: ImportMapType::CSS, packageName: 'bootstrap', filePath: '/dist/bootstrap.css')],
             [
                 [
                     'url' => '/bootstrap@5.0.6/dist/bootstrap.css',
@@ -333,9 +333,9 @@ class JsDelivrEsmResolverTest extends TestCase
 
         yield 'multiple files' => [
             [
-                'lodash' => new ImportMapEntry('lodash', version: '1.2.3'),
-                'chart.js/auto' => new ImportMapEntry('chart.js/auto', version: '4.5.6'),
-                'bootstrap/dist/bootstrap.css' => new ImportMapEntry('bootstrap/dist/bootstrap.css', version: '5.0.6', type: ImportMapType::CSS),
+                'lodash' => new ImportMapEntry('lodash', version: '1.2.3', packageName: 'lodash'),
+                'chart.js/auto' => new ImportMapEntry('chart.js/auto', version: '4.5.6', packageName: 'chart.js', filePath: '/auto'),
+                'bootstrap/dist/bootstrap.css' => new ImportMapEntry('bootstrap/dist/bootstrap.css', version: '5.0.6', type: ImportMapType::CSS, packageName: 'bootstrap', filePath: '/dist/bootstrap.css'),
             ],
             [
                 [
@@ -360,7 +360,7 @@ class JsDelivrEsmResolverTest extends TestCase
 
         yield 'make imports relative' => [
             [
-                '@chart.js/auto' => new ImportMapEntry('chart.js/auto', version: '1.2.3'),
+                '@chart.js/auto' => new ImportMapEntry('chart.js/auto', version: '1.2.3', packageName: 'chart.js', filePath: '/auto'),
             ],
             [
                 [
@@ -375,7 +375,7 @@ class JsDelivrEsmResolverTest extends TestCase
 
         yield 'js importmap is removed' => [
             [
-                '@chart.js/auto' => new ImportMapEntry('chart.js/auto', version: '1.2.3'),
+                '@chart.js/auto' => new ImportMapEntry('chart.js/auto', version: '1.2.3', packageName: 'chart.js', filePath: '/auto'),
             ],
             [
                 [
@@ -390,7 +390,7 @@ class JsDelivrEsmResolverTest extends TestCase
         ];
 
         yield 'css file removes importmap' => [
-            ['lodash' => new ImportMapEntry('bootstrap/dist/bootstrap.css', version: '5.0.6', type: ImportMapType::CSS)],
+            ['lodash' => new ImportMapEntry('bootstrap/dist/bootstrap.css', version: '5.0.6', type: ImportMapType::CSS, packageName: 'bootstrap', filePath: '/dist/bootstrap.css')],
             [
                 [
                     'url' => '/bootstrap@5.0.6/dist/bootstrap.css',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT

As suggested by @WebMamba, I added a new command for the AssetMapper component to list outdated 3rd party packages. It is inspired by the `composer outdated` command so I tried to replicate its options as much as I could. 
It reads the importmap.php and extract packages version to query the https://registry.npmjs.org/%package% API and read the latest version from metadata.

![image](https://github.com/symfony/symfony/assets/11990607/189f66a0-dda0-4916-a91b-988ebe8f9fb3)


:warning: The code is base on #51650 branch so it is not ready to be merged yet, but I'd be happy to get some reviews and feedback in the meantime. This is my first PR on symfony, so there will probably be a lot to say !

- [x] gather feedback
- [x] wait for #51650 to be merged and rebase
- [x] write documentation