### PR TITLE
[AssetMapper] Allowing for files to be written to some non-local location

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
@@ -79,7 +79,7 @@ class XmlFrameworkExtensionTest extends FrameworkExtensionTestCase
         $container = $this->createContainerFromFile('asset_mapper');
 
         $definition = $container->getDefinition('asset_mapper.public_assets_path_resolver');
-        $this->assertSame('/assets_path/', $definition->getArgument(1));
+        $this->assertSame('/assets_path/', $definition->getArgument(0));
 
         $definition = $container->getDefinition('asset_mapper.dev_server_subscriber');
         $this->assertSame(['zip' => 'application/zip'], $definition->getArgument(2));

--- a/src/Symfony/Component/AssetMapper/AssetMapper.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapper.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\AssetMapper;
 
 use Symfony\Component\AssetMapper\Factory\MappedAssetFactoryInterface;
-use Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface;
 
 /**
  * Finds and returns assets in the pipeline.
@@ -28,7 +27,7 @@ class AssetMapper implements AssetMapperInterface
     public function __construct(
         private readonly AssetMapperRepository $mapperRepository,
         private readonly MappedAssetFactoryInterface $mappedAssetFactory,
-        private readonly PublicAssetsPathResolverInterface $assetsPathResolver,
+        private readonly CompiledAssetMapperConfigReader $compiledConfigReader,
     ) {
     }
 
@@ -78,12 +77,10 @@ class AssetMapper implements AssetMapperInterface
     private function loadManifest(): array
     {
         if (null === $this->manifestData) {
-            $path = $this->assetsPathResolver->getPublicFilesystemPath().'/'.self::MANIFEST_FILE_NAME;
-
-            if (!is_file($path)) {
+            if (!$this->compiledConfigReader->configExists(self::MANIFEST_FILE_NAME)) {
                 $this->manifestData = [];
             } else {
-                $this->manifestData = json_decode(file_get_contents($path), true);
+                $this->manifestData = $this->compiledConfigReader->loadConfig(self::MANIFEST_FILE_NAME);
             }
         }
 

--- a/src/Symfony/Component/AssetMapper/CompiledAssetMapperConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/CompiledAssetMapperConfigReader.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper;
+
+use Symfony\Component\Filesystem\Path;
+
+/**
+ * Reads and writes compiled configuration files for asset mapper.
+ */
+class CompiledAssetMapperConfigReader
+{
+    public function __construct(private readonly string $directory)
+    {
+    }
+
+    public function configExists(string $filename): bool
+    {
+        return is_file(Path::join($this->directory, $filename));
+    }
+
+    public function loadConfig(string $filename): array
+    {
+        return json_decode(file_get_contents(Path::join($this->directory, $filename)), true, 512, \JSON_THROW_ON_ERROR);
+    }
+
+    public function saveConfig(string $filename, array $data): string
+    {
+        $path = Path::join($this->directory, $filename);
+        @mkdir(\dirname($path), 0777, true);
+        file_put_contents($path, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+
+    public function removeConfig(string $filename): void
+    {
+        $path = Path::join($this->directory, $filename);
+
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Event/PreAssetsCompileEvent.php
+++ b/src/Symfony/Component/AssetMapper/Event/PreAssetsCompileEvent.php
@@ -21,18 +21,11 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class PreAssetsCompileEvent extends Event
 {
-    private string $outputDir;
     private OutputInterface $output;
 
-    public function __construct(string $outputDir, OutputInterface $output)
+    public function __construct(OutputInterface $output)
     {
-        $this->outputDir = $outputDir;
         $this->output = $output;
-    }
-
-    public function getOutputDir(): string
-    {
-        return $this->outputDir;
     }
 
     public function getOutput(): OutputInterface

--- a/src/Symfony/Component/AssetMapper/Path/LocalPublicAssetsFilesystem.php
+++ b/src/Symfony/Component/AssetMapper/Path/LocalPublicAssetsFilesystem.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Path;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+class LocalPublicAssetsFilesystem implements PublicAssetsFilesystemInterface
+{
+    private Filesystem $filesystem;
+
+    public function __construct(private readonly string $publicDir)
+    {
+        $this->filesystem = new Filesystem();
+    }
+
+    public function write(string $path, string $contents): void
+    {
+        $targetPath = $this->publicDir.'/'.ltrim($path, '/');
+
+        $this->filesystem->dumpFile($targetPath, $contents);
+    }
+
+    public function copy(string $originPath, string $path): void
+    {
+        $targetPath = $this->publicDir.'/'.ltrim($path, '/');
+
+        $this->filesystem->copy($originPath, $targetPath, true);
+    }
+
+    public function getDestinationPath(): string
+    {
+        return $this->publicDir;
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Path/PublicAssetsFilesystemInterface.php
+++ b/src/Symfony/Component/AssetMapper/Path/PublicAssetsFilesystemInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Path;
+
+/**
+ * Writes asset files to their public location.
+ */
+interface PublicAssetsFilesystemInterface
+{
+    /**
+     * Write the contents of a file to the public location.
+     */
+    public function write(string $path, string $contents): void;
+
+    /**
+     * Copy a local file to the public location.
+     */
+    public function copy(string $originPath, string $path): void;
+
+    /**
+     * A string representation of the public directory, used for feedback.
+     */
+    public function getDestinationPath(): string;
+}

--- a/src/Symfony/Component/AssetMapper/Path/PublicAssetsPathResolver.php
+++ b/src/Symfony/Component/AssetMapper/Path/PublicAssetsPathResolver.php
@@ -16,9 +16,7 @@ class PublicAssetsPathResolver implements PublicAssetsPathResolverInterface
     private readonly string $publicPrefix;
 
     public function __construct(
-        private readonly string $projectRootDir,
         string $publicPrefix = '/assets/',
-        private readonly string $publicDirName = 'public',
     ) {
         // ensure that the public prefix always ends with a single slash
         $this->publicPrefix = rtrim($publicPrefix, '/').'/';
@@ -27,10 +25,5 @@ class PublicAssetsPathResolver implements PublicAssetsPathResolverInterface
     public function resolvePublicPath(string $logicalPath): string
     {
         return $this->publicPrefix.ltrim($logicalPath, '/');
-    }
-
-    public function getPublicFilesystemPath(): string
-    {
-        return rtrim(rtrim($this->projectRootDir, '/').'/'.$this->publicDirName.$this->publicPrefix, '/');
     }
 }

--- a/src/Symfony/Component/AssetMapper/Path/PublicAssetsPathResolverInterface.php
+++ b/src/Symfony/Component/AssetMapper/Path/PublicAssetsPathResolverInterface.php
@@ -17,9 +17,4 @@ interface PublicAssetsPathResolverInterface
      * The path that should be prefixed on all asset paths to point to the output location.
      */
     public function resolvePublicPath(string $logicalPath): string;
-
-    /**
-     * Returns the filesystem path to where assets are stored when compiled.
-     */
-    public function getPublicFilesystemPath(): string;
 }

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
@@ -15,9 +15,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\AssetMapper\AssetMapper;
 use Symfony\Component\AssetMapper\AssetMapperRepository;
+use Symfony\Component\AssetMapper\CompiledAssetMapperConfigReader;
 use Symfony\Component\AssetMapper\Factory\MappedAssetFactoryInterface;
 use Symfony\Component\AssetMapper\MappedAsset;
-use Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface;
 
 class AssetMapperTest extends TestCase
 {
@@ -90,17 +90,21 @@ class AssetMapperTest extends TestCase
     {
         $dirs = ['dir1' => '', 'dir2' => '', 'dir3' => ''];
         $repository = new AssetMapperRepository($dirs, __DIR__.'/Fixtures');
-        $pathResolver = $this->createMock(PublicAssetsPathResolverInterface::class);
-        $pathResolver->expects($this->any())
-            ->method('getPublicFilesystemPath')
-            ->willReturn(__DIR__.'/Fixtures/test_public/final-assets');
+        $compiledConfigReader = $this->createMock(CompiledAssetMapperConfigReader::class);
+        $compiledConfigReader->expects($this->any())
+            ->method('configExists')
+            ->with(AssetMapper::MANIFEST_FILE_NAME)
+            ->willReturn(true);
+        $compiledConfigReader->expects($this->any())
+            ->method('loadConfig')
+            ->willReturn(['file4.js' => '/final-assets/file4.checksumfrommanifest.js']);
 
         $this->mappedAssetFactory = $this->createMock(MappedAssetFactoryInterface::class);
 
         return new AssetMapper(
             $repository,
             $this->mappedAssetFactory,
-            $pathResolver,
+            $compiledConfigReader,
         );
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
@@ -51,7 +51,7 @@ class AssetMapperCompileCommandTest extends TestCase
         $this->filesystem->mkdir($targetBuildDir);
         file_put_contents($targetBuildDir.'/manifest.json', '{}');
         file_put_contents($targetBuildDir.'/importmap.json', '{}');
-        file_put_contents($targetBuildDir.'/entrypoint.file6.json', '[]]');
+        file_put_contents($targetBuildDir.'/entrypoint.file6.json', '[]');
 
         $command = $application->find('asset-map:compile');
         $tester = new CommandTester($command);
@@ -119,7 +119,6 @@ class AssetMapperCompileCommandTest extends TestCase
         $listenerCalled = false;
         $dispatcher->addListener(PreAssetsCompileEvent::class, function (PreAssetsCompileEvent $event) use (&$listenerCalled) {
             $listenerCalled = true;
-            $this->assertSame(realpath(__DIR__.'/../Fixtures').'/public/assets', $event->getOutputDir());
             $this->assertInstanceOf(OutputInterface::class, $event->getOutput());
         });
 

--- a/src/Symfony/Component/AssetMapper/Tests/CompiledAssetMapperConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/CompiledAssetMapperConfigReaderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\CompiledAssetMapperConfigReader;
+use Symfony\Component\Filesystem\Filesystem;
+
+class CompiledAssetMapperConfigReaderTest extends TestCase
+{
+    private Filesystem $filesystem;
+    private string $writableRoot;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->writableRoot = __DIR__.'/../Fixtures/importmaps_for_writing';
+        if (!file_exists(__DIR__.'/../Fixtures/importmaps_for_writing')) {
+            $this->filesystem->mkdir($this->writableRoot);
+        }
+        // realpath to help path comparisons in the tests
+        $this->writableRoot = realpath($this->writableRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->writableRoot);
+    }
+
+    public function testConfigExists()
+    {
+        $reader = new CompiledAssetMapperConfigReader($this->writableRoot);
+        $this->assertFalse($reader->configExists('foo.json'));
+        $this->filesystem->touch($this->writableRoot.'/foo.json');
+        $this->assertTrue($reader->configExists('foo.json'));
+    }
+
+    public function testLoadConfig()
+    {
+        $reader = new CompiledAssetMapperConfigReader($this->writableRoot);
+        $this->filesystem->dumpFile($this->writableRoot.'/foo.json', '{"foo": "bar"}');
+        $this->assertEquals(['foo' => 'bar'], $reader->loadConfig('foo.json'));
+    }
+
+    public function testSaveConfig()
+    {
+        $reader = new CompiledAssetMapperConfigReader($this->writableRoot);
+        $this->assertEquals($this->writableRoot.'/foo.json', $reader->saveConfig('foo.json', ['foo' => 'bar']));
+        $this->assertEquals(['foo' => 'bar'], json_decode(file_get_contents($this->writableRoot.'/foo.json'), true));
+    }
+
+    public function testRemoveConfig()
+    {
+        $reader = new CompiledAssetMapperConfigReader($this->writableRoot);
+        $this->filesystem->touch($this->writableRoot.'/foo.json');
+        $this->assertTrue($reader->configExists('foo.json'));
+        $reader->removeConfig('foo.json');
+        $this->assertFalse($reader->configExists('foo.json'));
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Fixtures/test_public/final-assets/manifest.json
+++ b/src/Symfony/Component/AssetMapper/Tests/Fixtures/test_public/final-assets/manifest.json
@@ -1,3 +1,0 @@
-{
-    "file4.js": "/final-assets/file4.checksumfrommanifest.js"
-}

--- a/src/Symfony/Component/AssetMapper/Tests/Path/LocalPublicAssetsFilesystemTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Path/LocalPublicAssetsFilesystemTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests\Path;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\Path\LocalPublicAssetsFilesystem;
+use Symfony\Component\Filesystem\Filesystem;
+
+class LocalPublicAssetsFilesystemTest extends TestCase
+{
+    private Filesystem $filesystem;
+    private static string $writableRoot = __DIR__.'/../Fixtures/importmaps_for_writing';
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        if (!file_exists(__DIR__.'/../Fixtures/importmaps_for_writing')) {
+            $this->filesystem->mkdir(self::$writableRoot);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove(self::$writableRoot);
+    }
+
+    public function testWrite()
+    {
+        $filesystem = new LocalPublicAssetsFilesystem(self::$writableRoot);
+        $filesystem->write('foo/bar.js', 'foobar');
+        $this->assertFileExists(self::$writableRoot.'/foo/bar.js');
+        $this->assertSame('foobar', file_get_contents(self::$writableRoot.'/foo/bar.js'));
+
+        // with a directory
+        $filesystem->write('foo/baz/bar.js', 'foobar');
+        $this->assertFileExists(self::$writableRoot.'/foo/baz/bar.js');
+    }
+
+    public function testCopy()
+    {
+        $filesystem = new LocalPublicAssetsFilesystem(self::$writableRoot);
+        $filesystem->copy(__DIR__.'/../Fixtures/importmaps/assets/pizza/index.js', 'foo/bar.js');
+        $this->assertFileExists(self::$writableRoot.'/foo/bar.js');
+        $this->assertSame("console.log('pizza/index.js');", trim(file_get_contents(self::$writableRoot.'/foo/bar.js')));
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Path/PublicAssetsPathResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Path/PublicAssetsPathResolverTest.php
@@ -19,38 +19,17 @@ class PublicAssetsPathResolverTest extends TestCase
     public function testResolvePublicPath()
     {
         $resolver = new PublicAssetsPathResolver(
-            '/projectRootDir/',
             '/assets-prefix/',
-            'publicDirName',
         );
         $this->assertSame('/assets-prefix/', $resolver->resolvePublicPath(''));
         $this->assertSame('/assets-prefix/foo/bar', $resolver->resolvePublicPath('/foo/bar'));
         $this->assertSame('/assets-prefix/foo/bar', $resolver->resolvePublicPath('foo/bar'));
 
         $resolver = new PublicAssetsPathResolver(
-            '/projectRootDir/',
             '/assets-prefix', // The trailing slash should be added automatically
-            'publicDirName',
         );
         $this->assertSame('/assets-prefix/', $resolver->resolvePublicPath(''));
         $this->assertSame('/assets-prefix/foo/bar', $resolver->resolvePublicPath('/foo/bar'));
         $this->assertSame('/assets-prefix/foo/bar', $resolver->resolvePublicPath('foo/bar'));
-    }
-
-    public function testGetPublicFilesystemPath()
-    {
-        $resolver = new PublicAssetsPathResolver(
-            '/path/to/projectRootDir/',
-            '/assets-prefix',
-            'publicDirName',
-        );
-        $this->assertSame('/path/to/projectRootDir/publicDirName/assets-prefix', $resolver->getPublicFilesystemPath());
-
-        $resolver = new PublicAssetsPathResolver(
-            '/path/to/projectRootDir',
-            '/assets-prefix/',
-            'publicDirName',
-        );
-        $this->assertSame('/path/to/projectRootDir/publicDirName/assets-prefix', $resolver->getPublicFilesystemPath());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #50221
| License       | MIT

Hi!

An attempt at making AssetMapper flexible enough to support non-local filesystems. The "hook point" would be that you could replace the `asset_mapper.local_public_assets_filesystem` service with your own that implements `PublicAssetsFilesystemInterface`. I'm not worried about making the hook point *super* user-friendly: I just want the system to support this now, as trying to add this later (when we need to protect BC) will be harder.

Cheers!
