### PR TITLE
[Messenger] Resend failed retries back to failure transport

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -52,11 +52,6 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
 
         $envelope = $event->getEnvelope();
 
-        // avoid re-sending to the failed sender
-        if (null !== $envelope->last(SentToFailureTransportStamp::class)) {
-            return;
-        }
-
         $envelope = $envelope->with(
             new SentToFailureTransportStamp($event->getReceiverName()),
             new DelayStamp(0),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 / 5.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51815 
| License       | MIT

i want to argue this is a bugfix :)

i can confirm with this fix, you can indefinitely retry failures, till they succeed, are deleted manually, or are handled explicitly by other means. What should NOT happen is systems implicitly rejecting/acking messages without any confirmation whatsoever.

cc @fabpot, @weaverryan 