### PR TITLE
[AssetMapper] Fix unit test in assetmapper auditor

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapAuditor.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapAuditor.php
@@ -67,7 +67,7 @@ class ImportMapAuditor
         ]);
 
         if (200 !== $response->getStatusCode()) {
-            throw new RuntimeException(sprintf('Error %d auditing packages. Response:'.$response->getContent(false), $response->getStatusCode()));
+            throw new RuntimeException(sprintf('Error %d auditing packages. Response: '.$response->getContent(false), $response->getStatusCode()));
         }
 
         foreach ($response->toArray() as $advisory) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Fix a typo in `ImportMapAuditor::audit` introduced in #51650 that causes tests to fail
