### PR TITLE
[Mime] Remove caching the string message in `RawMessage::toIterable`

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -48,12 +48,9 @@ class RawMessage implements \Serializable
             return;
         }
 
-        $message = '';
         foreach ($this->message as $chunk) {
-            $message .= $chunk;
             yield $chunk;
         }
-        $this->message = $message;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51764 
| License       | MIT

https://github.com/symfony/symfony/blob/a25732727de247f327f67952160717325be3b397/src/Symfony/Component/Mime/RawMessage.php#L48

The `RawMessage::toIterable` contains some sort of cache mechanism that transforms the `message` property from type `\Generator` to `string` after traversing it for the first time. I understand that this is very interesting performance-wise when willing to access the `message` property multiple times, but I see two problems here :
- This behaviour is not explicit and we don't really expect this to happen when calling a method named 'toIterable'.
- When processing a large message (for instance: an email with many and/or large attachments), this eats up a lot of memory and we end up getting this kind of issues : #51764 

I would suggest to remove this behaviour, and I'd be happy to hear your thoughts about it.