### PR TITLE
[AssetMapper] Update README documentation link

### DIFF
--- a/src/Symfony/Component/AssetMapper/README.md
+++ b/src/Symfony/Component/AssetMapper/README.md
@@ -9,7 +9,7 @@ to allow writing modern JavaScript without a build system.
 Resources
 ---------
 
- * [Documentation](https://symfony.com/doc/current/components/asset_mapper/introduction.html)
+ * [Documentation](https://symfony.com/doc/current/frontend/asset_mapper.html)
  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Update the README file with the current documentation URL
