### PR TITLE
add all missing properties

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -412,9 +412,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         true
                     );
                     $context['not_normalizable_value_exceptions'][] = $exception;
-
-                    return $reflectionClass->newInstanceWithoutConstructor();
                 }
+            }
+
+            if(count($context['not_normalizable_value_exceptions'])) {
+                return $reflectionClass->newInstanceWithoutConstructor();
             }
 
             if ($constructor->isConstructor()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Current behavior: If multiple arguments are missing in the constructor, only the first argument is listed as missing in the array.

Expected behavior: All missing arguments are listed.