### PR TITLE
Fix for Mailer OOM for large attachments

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -48,12 +48,10 @@ class RawMessage implements \Serializable
             return;
         }
 
-        $message = '';
-        foreach ($this->message as $chunk) {
-            $message .= $chunk;
+        $message = $this->message;
+        foreach ($message as $chunk) {
             yield $chunk;
         }
-        $this->message = $message;
     }
 
     /**


### PR DESCRIPTION
Q | A
-- | --
Branch? | 5.4
Bug fix? | yes
New feature? | no
Deprecations? | no
Tickets | Fix #51764
License | MIT

This PR provides a workaround to EMail OOM by keeping $this->message as iterable and not being converted into a string. 
