### PR TITLE
Fix typo in method resolvePackages

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -77,7 +77,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
             $requiredPackages[$i][4] = $version;
 
             if (!$filePath) {
-                $cssEntrypointResponses[$options->packageName] = $this->httpClient->request('GET', sprintf(self::URL_PATTERN_ENTRYPOINT, $packageName, $version));
+                $cssEntrypointResponses[$packageName] = $this->httpClient->request('GET', sprintf(self::URL_PATTERN_ENTRYPOINT, $packageName, $version));
             }
         }
 
@@ -130,7 +130,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 continue;
             }
 
-            $packagesToRequire[] = new PackageRequireOptions($packageName.$cssFile, $version);
+            $packagesToRequire[] = new PackageRequireOptions($package.$cssFile, $version);
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The wrong var is used in the loop

Reproduce bugs:

```php
php bin/console importmap:require bootstrap
php bin/console importmap:install
php bin/console importmap:update
```

6.4 targetted because the code with bug was just commited a couple of days ago
