### PR TITLE
[HttpClient] Fix type error with http_version 1.1

### DIFF
--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -122,7 +122,7 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
         if ($options['http_version']) {
             $request->setProtocolVersions(match ((float) $options['http_version']) {
                 1.0 => ['1.0'],
-                1.1 => $request->setProtocolVersions(['1.1', '1.0']),
+                1.1 => ['1.1', '1.0'],
                 default => ['2', '1.1', '1.0'],
             });
         }


### PR DESCRIPTION
Fix a type error by removing a nested setProtocolVersions() call in AmpHttpClient::request()

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #51868
| License       | MIT

### Description

In commit [46a66956](https://github.com/symfony/symfony/commit/46a66956) the lines 114-118 of AmpHttpClient.php were changed to use the `match()` expression instead of `switch-case`:

```diff
-            switch ((float) $options['http_version']) {
-                case 1.0: $request->setProtocolVersions(['1.0']); break;
-                case 1.1: $request->setProtocolVersions(['1.1', '1.0']); break;
-                default: $request->setProtocolVersions(['2', '1.1', '1.0']); break;
-            }
+            $request->setProtocolVersions(match ((float) $options['http_version']) {
+                1.0 => ['1.0'],
+                1.1 => $request->setProtocolVersions(['1.1', '1.0']),
+                default => ['2', '1.1', '1.0'],
+            });
```

If the provided `$options['http_version']` is `1.1`, the code will call `$request->setProtocolVersions()` inside the `match()`, unlike with 1.0 and the default case. The `match` will use the return value of `setProtocolVersions()`, but since it's a void function, the return value is `null`.  

This then results in a `TypeError` as `setProtocolVersions()` (the "outer" one) expects an array.

### How to reproduce

```php
// First, run "composer require symfony/http-client" and " composer require amphp/http-client"
// Then, execute this file:
require_once __DIR__.'/vendor/autoload.php';
use Symfony\Component\HttpClient\AmpHttpClient;

$client = new AmpHttpClient();

$response = $client->request(
    'GET',
    'http://example.com',
    [
      'http_version' => '1.1'
    ]
);

// The script will fail with the TypeError and never reach this point
var_dump($response->getStatusCode());
```

### Solution

Change line 116 to match line 115 & 117:
```diff
$request->setProtocolVersions(match ((float) $options['http_version']) {
    1.0 => ['1.0'],
-   1.1 => $request->setProtocolVersions(['1.1', '1.0']),
+   1.1 => ['1.1', '1.0'],
    default => ['2', '1.1', '1.0'],
});
```
