### PR TITLE
[Asset] fix asset packages when using json-manifest

### DIFF
--- a/src/Symfony/Component/Asset/Package.php
+++ b/src/Symfony/Component/Asset/Package.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Asset;
 
 use Symfony\Component\Asset\Context\ContextInterface;
 use Symfony\Component\Asset\Context\NullContext;
+use Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy;
 use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 
 /**
@@ -41,6 +42,15 @@ class Package implements PackageInterface
     {
         if ($this->isAbsoluteUrl($path)) {
             return $path;
+        }
+
+        if ($this->versionStrategy instanceof JsonManifestVersionStrategy) {
+            $basePath = $this->getBasePath();
+            // Only prepend basePath when using packages
+            if ($basePath !== '/') {
+                $basePath = substr($basePath, 1);
+                $path = $basePath.$path;
+            }
         }
 
         return $this->versionStrategy->applyVersion($path);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51875
| License       | MIT


pass full path instead of filename only

