### PR TITLE
Avoid calling getInvocationCount()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
@@ -47,12 +47,13 @@ class LocaleAwareListenerTest extends TestCase
 
     public function testDefaultLocaleIsUsedOnExceptionsInOnKernelRequest()
     {
-        $matcher = $this->exactly(2);
         $this->localeAwareService
-            ->expects($matcher)
+            ->expects($this->exactly(2))
             ->method('setLocale')
-            ->willReturnCallback(function (string $locale) use ($matcher) {
-                if (1 === $matcher->getInvocationCount()) {
+            ->willReturnCallback(function (string $locale): void {
+                static $counter = 0;
+
+                if (1 === ++$counter) {
                     throw new \InvalidArgumentException();
                 }
 
@@ -93,12 +94,13 @@ class LocaleAwareListenerTest extends TestCase
 
     public function testDefaultLocaleIsUsedOnExceptionsInOnKernelFinishRequest()
     {
-        $matcher = $this->exactly(2);
         $this->localeAwareService
-            ->expects($matcher)
+            ->expects($this->exactly(2))
             ->method('setLocale')
-            ->willReturnCallback(function (string $locale) use ($matcher) {
-                if (1 === $matcher->getInvocationCount()) {
+            ->willReturnCallback(function (string $locale): void {
+                static $counter = 0;
+
+                if (1 === ++$counter) {
                     throw new \InvalidArgumentException();
                 }
 
@@ -113,7 +115,7 @@ class LocaleAwareListenerTest extends TestCase
         $this->listener->onKernelFinishRequest($event);
     }
 
-    private function createRequest($locale)
+    private function createRequest(string $locale): Request
     {
         $request = new Request();
         $request->setLocale($locale);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #49069
| License       | MIT

`getInvocationCount()` is gone in PHPUnit 10. Let's not rely on it.