### PR TITLE
[Form] Make `FormPerformanceTestCase` compatible with PHPUnit 10

### DIFF
--- a/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Test;
 
+use Symfony\Component\Form\Test\Traits\RunTestTrait;
 use Symfony\Component\Form\Tests\VersionAwareTest;
 
 /**
@@ -23,6 +24,7 @@ use Symfony\Component\Form\Tests\VersionAwareTest;
  */
 abstract class FormPerformanceTestCase extends FormIntegrationTestCase
 {
+    use RunTestTrait;
     use VersionAwareTest;
 
     /**
@@ -31,17 +33,19 @@ abstract class FormPerformanceTestCase extends FormIntegrationTestCase
     protected $maxRunningTime = 0;
 
     /**
-     * {@inheritdoc}
+     * @return mixed
      */
-    protected function runTest()
+    private function doRunTest()
     {
         $s = microtime(true);
-        parent::runTest();
+        $result = parent::runTest();
         $time = microtime(true) - $s;
 
         if (0 != $this->maxRunningTime && $time > $this->maxRunningTime) {
             $this->fail(sprintf('expected running time: <= %s but was: %s', $this->maxRunningTime, $time));
         }
+
+        return $result;
     }
 
     /**

--- a/src/Symfony/Component/Form/Test/Traits/RunTestTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/RunTestTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Test\Traits;
+
+use PHPUnit\Framework\TestCase;
+
+if ((new \ReflectionMethod(TestCase::class, 'runTest'))->hasReturnType()) {
+    // PHPUnit 10
+    /** @internal */
+    trait RunTestTrait
+    {
+        protected function runTest(): mixed
+        {
+            return $this->doRunTest();
+        }
+    }
+} else {
+    // PHPUnit 9
+    /** @internal */
+    trait RunTestTrait
+    {
+        protected function runTest()
+        {
+            return $this->doRunTest();
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #49069 
| License       | MIT

In PHPUnit 10, `TestCase::runTest()` has a return type of `mixed`. I'm adding the return type conditionally on the one class where we override this method.