### PR TITLE
[Security] Add FirewallMap::getNamedFirewallConfig()

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -57,7 +57,7 @@ class FirewallMap implements FirewallMapInterface
 
     public function getNamedFirewallConfig(string $name): ?FirewallConfig
     {
-        return $this->container->get($name);
+        return $this->container->get($name)->getConfig();
     }
 
     private function getFirewallContext(Request $request): ?FirewallContext

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -55,6 +55,11 @@ class FirewallMap implements FirewallMapInterface
         return $context->getConfig();
     }
 
+    public function getNamedFirewallConfig(string $name): ?FirewallConfig
+    {
+        return $this->container->get($name);
+    }
+
     private function getFirewallContext(Request $request): ?FirewallContext
     {
         if ($request->attributes->has('_firewall_context')) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
@@ -89,6 +90,20 @@ class FirewallMapTest extends TestCase
         $this->assertEquals($firewallConfig, $firewallMap->getFirewallConfig($request));
         $this->assertEquals('security.firewall.map.context.foo', $request->attributes->get(self::ATTRIBUTE_FIREWALL_CONTEXT));
         $this->assertEquals($expectedState, $request->attributes->get('_stateless'));
+    }
+
+    public function testGetNamedFirewallConfig()
+    {
+        $firewallContext = new FirewallContext([], null, null, $firewallConfig = new FirewallConfig('main', 'user_checker'));
+        $container = new Container();
+        $container->set('foo', $firewallContext);
+        $firewallMap = new FirewallMap($container, []);
+
+        $this->assertSame($firewallConfig, $firewallMap->getNamedFirewallConfig('foo'));
+
+        $this->expectException(ServiceNotFoundException::class);
+
+        $firewallMap->getNamedFirewallConfig('bar');
     }
 
     public static function providesStatefulStatelessRequests(): \Generator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT


there's no `Request` in CLI