### PR TITLE
[Validator] Validate file with empty host

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -71,6 +71,12 @@ class UrlValidator extends ConstraintValidator
             $value = ($constraint->normalizer)($value);
         }
 
+
+        if (in_array('file', $constraint->protocols, true) &&
+            preg_match('~^file://(?:/ (?:[\pL\pN\-._\~!$&\'()*+,;=:@]|%%[0-9A-Fa-f]{2})* )*$~ixu', $value)) {
+            return;
+        }
+
         $pattern = $constraint->relativeProtocol ? str_replace('(%s):', '(?:(%s):)?', static::PATTERN) : static::PATTERN;
         $pattern = sprintf($pattern, implode('|', $constraint->protocols));
 

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -71,8 +71,7 @@ class UrlValidator extends ConstraintValidator
             $value = ($constraint->normalizer)($value);
         }
 
-
-        if (in_array('file', $constraint->protocols, true) &&
+        if (\in_array('file', $constraint->protocols, true) &&
             preg_match('~^file://(?:/ (?:[\pL\pN\-._\~!$&\'()*+,;=:@]|%%[0-9A-Fa-f]{2})* )*$~ixu', $value)) {
             return;
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -309,7 +309,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ['ftp://example.com'],
             ['file://127.0.0.1'],
             ['git://[::1]/'],
-            ['file://path'],
+            ['file:///path'],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -309,6 +309,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ['ftp://example.com'],
             ['file://127.0.0.1'],
             ['git://[::1]/'],
+            ['file://path'],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51908 
| License       | MIT

Url validator accept file scheme with empty hostname. Value `file:///path` (empty hostname) is now a valid uri :)


