### PR TITLE
[CS] Fix command descriptions (code conventions)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -39,7 +39,7 @@ use Symfony\Component\Translation\Writer\TranslationWriterInterface;
  *
  * @final
  */
-#[AsCommand(name: 'translation:extract', description: 'Extract missing translations keys from code to translation files.')]
+#[AsCommand(name: 'translation:extract', description: 'Extract missing translations keys from code to translation files')]
 class TranslationUpdateCommand extends Command
 {
     private const ASC = 'asc';

--- a/src/Symfony/Bundle/FrameworkBundle/Command/XliffLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/XliffLintCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Translation\Command\XliffLintCommand as BaseLintCommand;
  *
  * @final
  */
-#[AsCommand(name: 'lint:xliff', description: 'Lints an XLIFF file and outputs encountered errors')]
+#[AsCommand(name: 'lint:xliff', description: 'Lint an XLIFF file and outputs encountered errors')]
 class XliffLintCommand extends BaseLintCommand
 {
     public function __construct()

--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -32,7 +32,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-#[AsCommand(name: 'asset-map:compile', description: 'Compiles all mapped assets and writes them to the final public output directory.')]
+#[AsCommand(name: 'asset-map:compile', description: 'Compile all mapped assets and writes them to the final public output directory')]
 final class AssetMapperCompileCommand extends Command
 {
     public function __construct(

--- a/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-#[AsCommand(name: 'debug:asset-map', description: 'Outputs all mapped assets.')]
+#[AsCommand(name: 'debug:asset-map', description: 'Output all mapped assets')]
 final class DebugAssetMapperCommand extends Command
 {
     private bool $didShortenPaths = false;

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapAuditCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapAuditCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(name: 'importmap:audit', description: 'Checks for security vulnerability advisories in dependencies')]
+#[AsCommand(name: 'importmap:audit', description: 'Check for security vulnerability advisories for dependencies')]
 class ImportMapAuditCommand extends Command
 {
     private const SEVERITY_COLORS = [

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @author Jonathan Scheiber <contact@jmsche.fr>
  */
-#[AsCommand(name: 'importmap:install', description: 'Downloads all assets that should be downloaded')]
+#[AsCommand(name: 'importmap:install', description: 'Download all assets that should be downloaded')]
 final class ImportMapInstallCommand extends Command
 {
     public function __construct(

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRemoveCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRemoveCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @author Kévin Dunglas <kevin@dunglas.dev>
  */
-#[AsCommand(name: 'importmap:remove', description: 'Removes JavaScript packages')]
+#[AsCommand(name: 'importmap:remove', description: 'Remove JavaScript packages')]
 final class ImportMapRemoveCommand extends Command
 {
     public function __construct(

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @author Kévin Dunglas <kevin@dunglas.dev>
  */
-#[AsCommand(name: 'importmap:require', description: 'Requires JavaScript packages')]
+#[AsCommand(name: 'importmap:require', description: 'Require JavaScript packages')]
 final class ImportMapRequireCommand extends Command
 {
     public function __construct(

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapUpdateCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapUpdateCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @author Kévin Dunglas <kevin@dunglas.dev>
  */
-#[AsCommand(name: 'importmap:update', description: 'Updates JavaScript packages to their latest versions')]
+#[AsCommand(name: 'importmap:update', description: 'Update JavaScript packages to their latest versions')]
 final class ImportMapUpdateCommand extends Command
 {
     public function __construct(

--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -26,7 +26,7 @@ use Symfony\Component\Dotenv\Dotenv;
  *
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-#[AsCommand(name: 'debug:dotenv', description: 'Lists all dotenv files with variables and values')]
+#[AsCommand(name: 'debug:dotenv', description: 'List all dotenv files with variables and values')]
 final class DebugCommand extends Command
 {
     /**
@@ -37,7 +37,7 @@ final class DebugCommand extends Command
     /**
      * @deprecated since Symfony 6.1
      */
-    protected static $defaultDescription = 'Lists all dotenv files with variables and values';
+    protected static $defaultDescription = 'List all dotenv files with variables and values';
 
     private string $kernelEnvironment;
     private string $projectDirectory;

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -26,7 +26,7 @@ use Symfony\Component\Dotenv\Dotenv;
  * @internal
  */
 #[Autoconfigure(bind: ['$projectDir' => '%kernel.project_dir%', '$defaultEnv' => '%kernel.environment%'])]
-#[AsCommand(name: 'dotenv:dump', description: 'Compiles .env files to .env.local.php')]
+#[AsCommand(name: 'dotenv:dump', description: 'Compile .env files to .env.local.php')]
 final class DotenvDumpCommand extends Command
 {
     private string $projectDir;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Fix command descriptions to enforce code conventions 
* remove ending dot
* use imperative mood

See: https://symfony.com/doc/current/contributing/code/conventions.html#naming-commands-and-options

Targetting 6.4 cause ~~not really~~ not at all a bugfix 

