### PR TITLE
fix typo in ImportMapConfigReader.php

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -114,7 +114,7 @@ class ImportMapConfigReader
          *     "debug:asset-map" command to see the full list of paths.
          *
          * - "entrypoint" (JavaScript only) set to true for any module that will
-         *     be used as an the "entrypoint" (and passed to the importmap() Twig function).
+         *     be used as an "entrypoint" (and passed to the importmap() Twig function).
          *
          * The "importmap:require" command can be used to add new entries to this file.
          *


### PR DESCRIPTION
fix typo "an the" to "an"

| Q             | A
| ------------- | ---
| Branch?       | 6.4
-->
| License       | MIT
