### PR TITLE
[Mime] Forbid messages that are generators to be used more than once

### DIFF
--- a/src/Symfony/Component/Mime/Tests/RawMessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/RawMessageTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Mime\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Mime\RawMessage;
 
 class RawMessageTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @dataProvider provideMessages
      */
@@ -43,6 +46,37 @@ class RawMessageTest extends TestCase
         if ($supportReuse) {
             // calling methods more than once work
             $this->assertEquals('some string', unserialize(serialize($message))->toString());
+        }
+    }
+
+    /**
+     * @dataProvider provideMessages
+     */
+    public function testToIterable(mixed $messageParameter, bool $supportReuse)
+    {
+        $message = new RawMessage($messageParameter);
+        $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
+
+        if ($supportReuse) {
+            // calling methods more than once work
+            $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
+        }
+    }
+
+    /**
+     * @dataProvider provideMessages
+     *
+     * @group legacy
+     */
+    public function testToIterableLegacy(mixed $messageParameter, bool $supportReuse)
+    {
+        $message = new RawMessage($messageParameter);
+        $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
+
+        if (!$supportReuse) {
+            // in 7.0, the test with a generator will throw an exception
+            $this->expectDeprecation('Since symfony/mime 6.4: Sending an email with a closed generator is deprecated and will throw in 7.0.');
+            $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #51764, Fix #51874
| License       | MIT

This is a continuation of #51874, when someone tries to send the same message more than once.
@chalasr @stof 