### PR TITLE
[FrameworkBundle] PhpUnit assert Messenger

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * Add `MessengerAssertionsTrait`
  * Add `HttpClientAssertionsTrait`
  * Add `AbstractController::renderBlock()` and `renderBlockView()`
  * Add native return type to `Translator` and to `Application::reset()`

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -236,5 +236,6 @@ return static function (ContainerConfigurator $container) {
 
         ->set('messenger.sent_messages_to_transport_listener', MessagesSentToTransportsListener::class)
             ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method'=>'reset'])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportF
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\EventListener\AddErrorDetailsStampListener;
 use Symfony\Component\Messenger\EventListener\DispatchPcntlSignalListener;
+use Symfony\Component\Messenger\EventListener\MessagesSentToTransportsListener;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
@@ -232,5 +233,8 @@ return static function (ContainerConfigurator $container) {
                 service('messenger.default_bus'),
             ])
             ->tag('messenger.message_handler')
+
+        ->set('messenger.sent_messages_to_transport_listener', MessagesSentToTransportsListener::class)
+            ->tag('kernel.event_subscriber')
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -26,6 +26,7 @@ use Symfony\Contracts\Service\ResetInterface;
 abstract class KernelTestCase extends TestCase
 {
     use MailerAssertionsTrait;
+    use MessengerAssertionsTrait;
     use NotificationAssertionsTrait;
 
     protected static $class;

--- a/src/Symfony/Bundle/FrameworkBundle/Test/MessengerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MessengerAssertionsTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Component\Messenger\EventListener\MessagesSentToTransportsListener;
+use Symfony\Component\Messenger\Test\Constraint as MessengerConstraint;
+
+/*
+ * @author Marilena Ruffelaere <marilena.ruffelaere@gmail.com>
+ */
+
+trait MessengerAssertionsTrait
+{
+    /**
+     * @param int         $count   the expected number of messages
+     * @param string|null $busName The busName to consider. If null all the collected messages will be counted.
+     */
+    public static function assertMessagesByBusCount(int $count, string $busName = null, string $message = ''): void
+    {
+        self::assertThat(self::getDispatchedMessagesByBusName($busName), new MessengerConstraint\MessageCount($count, $busName), $message);
+    }
+
+    /**
+     * @param int    $count     the expected number of messages of the given class
+     * @param string $className the message object class name
+     */
+    public static function assertMessagesOfClassCount(int $count, string $className, string $message = ''): void
+    {
+        self::assertThat(self::getDispatchedMessagesByClassName($className), new MessengerConstraint\MessageCount($count, $className), $message);
+    }
+
+    public static function getDispatchedMessagesByBusName(?string $busName, bool $ordered = false): array
+    {
+        $container = static::getContainer();
+        if ($container->has('messenger.sent_messages_to_transport_listener')) {
+            /** @var MessagesSentToTransportsListener $listener */
+            $listener = $container->get('messenger.sent_messages_to_transport_listener');
+
+            return array_column($listener->getSentMessagesByBus($busName), 'message');
+        }
+        static::fail('A client must have Messenger enabled to make messages assertions .
+         Did you forget to require symfony/messenger ?');
+    }
+
+    public static function getDispatchedMessagesByClassName(string $className): array
+    {
+        $container = static::getContainer();
+
+        if ($container->has('messenger.sent_messages_to_transport_listener')) {
+            /** @var MessagesSentToTransportsListener $listener */
+            $listener = $container->get('messenger.sent_messages_to_transport_listener');
+
+            return array_column($listener->getSentMessagesByClassName($className), 'message');
+        }
+        static::fail('A client must have Messenger enabled to make messages assertions.
+        Did you forget to require symfony/messenger ? ');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Test/MessengerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MessengerAssertionsTrait.php
@@ -21,47 +21,25 @@ use Symfony\Component\Messenger\Test\Constraint as MessengerConstraint;
 trait MessengerAssertionsTrait
 {
     /**
-     * @param int         $count   the expected number of messages
-     * @param string|null $busName The busName to consider. If null all the collected messages will be counted.
+     * @param int         $count       The expected number of messages
+     * @param string|null $busName     The busName to consider
+     * @param string|null $messageFQCN The message object class name to consider
      */
-    public static function assertMessagesByBusCount(int $count, string $busName = null, string $message = ''): void
+    public static function assertMessagesCount(int $count, string $busName = null, string $messageFQCN = null, string $message = ''): void
     {
-        self::assertThat(self::getDispatchedMessagesByBusName($busName), new MessengerConstraint\MessageCount($count, $busName), $message);
+        self::assertThat(self::getDispatchedMessages($busName, $messageFQCN), new MessengerConstraint\MessageCount($count, $busName), $message);
     }
 
-    /**
-     * @param int    $count     the expected number of messages of the given class
-     * @param string $className the message object class name
-     */
-    public static function assertMessagesOfClassCount(int $count, string $className, string $message = ''): void
-    {
-        self::assertThat(self::getDispatchedMessagesByClassName($className), new MessengerConstraint\MessageCount($count, $className), $message);
-    }
-
-    public static function getDispatchedMessagesByBusName(?string $busName, bool $ordered = false): array
+    public static function getDispatchedMessages(string $busName = null, string $messageFQCN = null): array
     {
         $container = static::getContainer();
         if ($container->has('messenger.sent_messages_to_transport_listener')) {
             /** @var MessagesSentToTransportsListener $listener */
             $listener = $container->get('messenger.sent_messages_to_transport_listener');
 
-            return array_column($listener->getSentMessagesByBus($busName), 'message');
+            return array_column($listener->getSentMessages($busName, $messageFQCN), 'message');
         }
         static::fail('A client must have Messenger enabled to make messages assertions .
          Did you forget to require symfony/messenger ?');
-    }
-
-    public static function getDispatchedMessagesByClassName(string $className): array
-    {
-        $container = static::getContainer();
-
-        if ($container->has('messenger.sent_messages_to_transport_listener')) {
-            /** @var MessagesSentToTransportsListener $listener */
-            $listener = $container->get('messenger.sent_messages_to_transport_listener');
-
-            return array_column($listener->getSentMessagesByClassName($className), 'message');
-        }
-        static::fail('A client must have Messenger enabled to make messages assertions.
-        Did you forget to require symfony/messenger ? ');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/DummyCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/DummyCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger;
+
+class DummyCommand
+{
+    public function __construct(private readonly string $message)
+    {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/DummyQuery.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/DummyQuery.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger;
+
+class DummyQuery
+{
+    public function __construct(private readonly string $message)
+    {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/MessengerController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/MessengerController.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyCommand;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyQuery;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/*
+ * @author Marilena Ruffelaere <marilena.ruffelaere@gmail.com>
+ */
+
+class MessengerController
+{
+    public function indexAction(MessageBusInterface $bus, MessageBusInterface $queryBus): Response
+    {
+        $queryBus->dispatch(new Envelope(message: new DummyMessage('dummy message text'), stamps: []));
+
+        $queryBus->dispatch(new DummyQuery('First Dummy Query message'));
+
+        $bus->dispatch(new DummyCommand('First Dummy Command message'));
+
+        $queryBus->dispatch(new DummyQuery('Still searching?'));
+
+        $queryBus->dispatch(new DummyQuery('Stop searching, Symfony is amazing!'));
+
+        $bus->dispatch(new DummyCommand('Second Dummy Command message'));
+
+        return new Response();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -72,3 +72,7 @@ uid:
 send_notification:
     path:     /send_notification
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\NotificationController::indexAction }
+
+send_messenger_message:
+    path:     /send_messenger_message
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\MessengerController::indexAction }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MessengerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MessengerTest.php
@@ -26,20 +26,20 @@ final class MessengerTest extends AbstractWebTestCase
         $client = $this->createClient(['test_case' => 'Messenger', 'root_config' => 'config.yml', 'debug' => true]);
         $response = $client->request('GET', '/send_messenger_message');
 
-        $this->assertMessagesByBusCount(6);
-        $this->assertMessagesByBusCount(2, 'event.bus');
-        $this->assertMessagesByBusCount(4, 'query.bus');
+        self::assertMessagesCount(6);
+        self::assertMessagesCount(2, busName: 'event.bus');
+        self::assertMessagesCount(4, busName: 'query.bus');
 
-        $this->assertMessagesOfClassCount(2, DummyCommand::class);
-        $this->assertMessagesOfClassCount(3, DummyQuery::class);
-        $this->assertMessagesOfClassCount(1, DummyMessage::class);
+        self::assertMessagesCount(2, messageFQCN: DummyCommand::class);
+        self::assertMessagesCount(3, messageFQCN: DummyQuery::class);
+        self::assertMessagesCount(1, messageFQCN: DummyMessage::class);
 
         /** @var DummyMessage[] $dummyMessages */
-        $dummyMessages = $this::getDispatchedMessagesByClassName(DummyMessage::class);
+        $dummyMessages = self::getDispatchedMessages(messageFQCN: DummyMessage::class);
         self::assertCount(1, $dummyMessages);
         self::assertStringContainsString('dummy message text', $dummyMessages[0]->getMessage());
 
-        $messagesFromQueryBus = $this::getDispatchedMessagesByBusName('query.bus');
+        $messagesFromQueryBus = self::getDispatchedMessages(busName: 'query.bus');
         self::assertCount(4, $messagesFromQueryBus);
 
         self::assertInstanceOf(DummyMessage::class, $messagesFromQueryBus[0]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MessengerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MessengerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+/*
+ * @author Marilena Ruffelaere <marilena.ruffelaere@gmail.com>
+ */
+
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyCommand;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyQuery;
+
+final class MessengerTest extends AbstractWebTestCase
+{
+    public function testMessengerAssertion()
+    {
+        $client = $this->createClient(['test_case' => 'Messenger', 'root_config' => 'config.yml', 'debug' => true]);
+        $response = $client->request('GET', '/send_messenger_message');
+
+        $this->assertMessagesByBusCount(6);
+        $this->assertMessagesByBusCount(2, 'event.bus');
+        $this->assertMessagesByBusCount(4, 'query.bus');
+
+        $this->assertMessagesOfClassCount(2, DummyCommand::class);
+        $this->assertMessagesOfClassCount(3, DummyQuery::class);
+        $this->assertMessagesOfClassCount(1, DummyMessage::class);
+
+        /** @var DummyMessage[] $dummyMessages */
+        $dummyMessages = $this::getDispatchedMessagesByClassName(DummyMessage::class);
+        self::assertCount(1, $dummyMessages);
+        self::assertStringContainsString('dummy message text', $dummyMessages[0]->getMessage());
+
+        $messagesFromQueryBus = $this::getDispatchedMessagesByBusName('query.bus');
+        self::assertCount(4, $messagesFromQueryBus);
+
+        self::assertInstanceOf(DummyMessage::class, $messagesFromQueryBus[0]);
+
+        /* @var DummyQuery $firstQuery */
+        self::assertInstanceOf(DummyQuery::class, $firstQuery = $messagesFromQueryBus[1]);
+        self::assertStringContainsString('First Dummy Query message', $firstQuery->getMessage());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/config.yml
@@ -1,0 +1,27 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: services.yml }
+
+framework:
+
+    messenger:
+        default_bus: event.bus
+
+        buses:
+            event.bus:
+                default_middleware:
+                    allow_no_handlers: true
+
+            query.bus:
+                default_middleware:
+                    allow_no_handlers: true
+
+        transports:
+            sync: 'sync://'
+
+        routing:
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyQuery': 'sync'
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyCommand': 'sync'
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage': 'sync'
+
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/routing.yml
@@ -1,0 +1,2 @@
+_messengertest_bundle:
+    resource: '@TestBundle/Resources/config/routing.yml'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/services.yml
@@ -1,0 +1,9 @@
+
+services:
+    _defaults:
+        public: true
+
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\MessengerController:
+        tags: ['controller.service_arguments']
+

--- a/src/Symfony/Component/Messenger/EventListener/MessagesSentToTransportsListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/MessagesSentToTransportsListener.php
@@ -49,27 +49,29 @@ class MessagesSentToTransportsListener implements EventSubscriberInterface, Rese
         ];
     }
 
-    public function getSentMessages(): array
+    public function getSentMessagesByFQCN(array $messages, ?string $className): array
     {
-        return $this->sentMessages;
-    }
-
-    public function getSentMessagesByBus(?string $busName): array
-    {
-        if (null === $busName) {
-            return $this->getSentMessages();
-        }
-
-        return array_filter($this->sentMessages, fn ($message) => $message['busName'] === $busName);
-    }
-
-    public function getSentMessagesByClassName(?string $className): array
-    {
-        if (null === $className) {
-            return $this->getSentMessages();
-        }
-
         return array_filter($this->sentMessages, fn ($message) => $message['message']::class === $className);
+    }
+
+    public function getSentMessages(?string $busName, ?string $messageFQCN): array
+    {
+        if (null === $busName && null === $messageFQCN) {
+            return $this->sentMessages;
+        }
+
+        if (null === $busName) {
+            return array_filter($this->sentMessages, fn ($message) => $message['message']::class === $messageFQCN);
+        }
+
+        if (null === $messageFQCN) {
+            return array_filter($this->sentMessages, fn ($message) => $message['busName'] === $busName);
+        }
+
+        return array_filter(
+            array_filter($this->sentMessages, fn ($message) => $message['message']::class === $messageFQCN),
+            fn ($message) => $message['busName'] === $busName
+        );
     }
 
     public function reset(): void

--- a/src/Symfony/Component/Messenger/EventListener/MessagesSentToTransportsListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/MessagesSentToTransportsListener.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Contracts\Service\ResetInterface;
+
+/*
+ * @author Marilena Ruffelaere <marilena.ruffelaere@gmail.com>
+ */
+
+class MessagesSentToTransportsListener implements EventSubscriberInterface, ResetInterface
+{
+    private array $sentMessages = [];
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SendMessageToTransportsEvent::class => ['onMessageSent', -255],
+        ];
+    }
+
+    public function onMessageSent(SendMessageToTransportsEvent $event): void
+    {
+        $envelope = $event->getEnvelope();
+        $this->sentMessages[] = [
+            'busName' => $envelope->last(BusNameStamp::class)->getBusName(),
+            'message' => $envelope->getMessage(),
+        ];
+    }
+
+    public function getSentMessages(): array
+    {
+        return $this->sentMessages;
+    }
+
+    public function getSentMessagesByBus(?string $busName): array
+    {
+        if (null === $busName) {
+            return $this->getSentMessages();
+        }
+
+        return array_filter($this->sentMessages, fn ($message) => $message['busName'] === $busName);
+    }
+
+    public function getSentMessagesByClassName(?string $className): array
+    {
+        if (null === $className) {
+            return $this->getSentMessages();
+        }
+
+        return array_filter($this->sentMessages, fn ($message) => $message['message']::class === $className);
+    }
+
+    public function reset(): void
+    {
+        $this->sentMessages = [];
+    }
+}

--- a/src/Symfony/Component/Messenger/Test/Constraint/MessageCount.php
+++ b/src/Symfony/Component/Messenger/Test/Constraint/MessageCount.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+/**
+ * @author Marilena Ruffelaere <marilena.ruffelaere@gmail.com>
+ */
+final class MessageCount extends Constraint
+{
+    public function __construct(private readonly int $expectedValue, private readonly ?string $bus = null)
+    {
+    }
+
+    public function toString(): string
+    {
+        return sprintf('%s has sent "%d" messages', $this->bus ? $this->bus.' ' : '', $this->expectedValue);
+    }
+
+
+    protected function matches($other): bool
+    {
+        return $this->expectedValue === \count($other);
+    }
+
+
+    protected function failureDescription($other): string
+    {
+        return sprintf('the Bus %s (%d sent)', $this->toString(), \count($other));
+    }
+}

--- a/src/Symfony/Component/Messenger/Test/Constraint/MessageCount.php
+++ b/src/Symfony/Component/Messenger/Test/Constraint/MessageCount.php
@@ -27,12 +27,10 @@ final class MessageCount extends Constraint
         return sprintf('%s has sent "%d" messages', $this->bus ? $this->bus.' ' : '', $this->expectedValue);
     }
 
-
     protected function matches($other): bool
     {
         return $this->expectedValue === \count($other);
     }
-
 
     protected function failureDescription($other): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT

Hello,
This MessengerAssertionTrait is a Helper for those who want to be able to test the dispatched messages while working with Messenger.

```php
$this->assertMessagesByBusCount(6);  //no busName = total count
$this->assertMessagesByBusCount(2, 'event.bus');
$this->assertMessagesByBusCount(4, 'query.bus');
$this->assertMessagesOfClassCount(2, DummyCommand::class);
$this->assertMessagesOfClassCount(3, DummyQuery::class);
$this->assertMessagesOfClassCount(1, DummyMessage::class);


/** @var DummyMessage[] $dummyMessages */
$dummyMessages = $this::getDispatchedMessagesByClassName(DummyMessage::class);
self::assertCount(1, $dummyMessages);
self::assertStringContainsString('dummy message text', $dummyMessages[0]->getMessage());

$messagesFromQueryBus = $this::getDispatchedMessagesByBusName('query.bus');
self::assertCount(4, $messagesFromQueryBus);

self::assertInstanceOf(DummyMessage::class, $messagesFromQueryBus[0]);

/** @var DummyQuery $firstQuery */
self::assertInstanceOf(DummyQuery::class, $firstQuery = $messagesFromQueryBus[1]);
self::assertStringContainsString('First Dummy Query message', $firstQuery->getMessage());
```

Hope this helps!
Regards,
Marilena Ruffelaere
