### PR TITLE
[FrameworkBundle] Fix calling `Kernel::warmUp()` when running `cache:warmup`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Dumper\Preloader;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 
 /**
  * Warmup the cache.
@@ -73,8 +74,13 @@ EOF
         if (!$input->getOption('no-optional-warmers')) {
             $this->cacheWarmer->enableOptionalWarmers();
         }
+        $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
 
-        $preload = $this->cacheWarmer->warmUp($cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir'));
+        if ($kernel instanceof WarmableInterface) {
+            $kernel->warmUp($cacheDir);
+        }
+
+        $preload = $this->cacheWarmer->warmUp($cacheDir);
 
         if ($preload && file_exists($preloadFile = $cacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
             Preloader::append($preloadFile, $preload);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

Maps to https://github.com/symfony/symfony/blob/e86d26abd07187d5ec5b2d780cfd1d872d57fe2a/src/Symfony/Component/HttpKernel/Kernel.php#L581-L587