### PR TITLE
[HttpKernel] Handle nullable callback of `StreamedResponse`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -56,8 +56,12 @@ class StreamedResponse extends Response
         return $this;
     }
 
-    public function getCallback(): \Closure
+    public function getCallback(): ?\Closure
     {
+        if (!isset($this->callback)) {
+            return null;
+        }
+
         return ($this->callback)(...);
     }
 

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -92,8 +92,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         } finally {
             $this->requestStack->pop();
 
-            if ($response instanceof StreamedResponse) {
-                $callback = $response->getCallback();
+            if ($response instanceof StreamedResponse && $callback = $response->getCallback()) {
                 $requestStack = $this->requestStack;
 
                 $response->setCallback(static function () use ($request, $callback, $requestStack) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |  -
| License       | MIT

This PR fixes a bug introduced by #51396. Having a callback in `StreamResponsed` is not a mandatory by design. 

So the method `getCallback` must check it like `sendContent` does.

When we are dealing with cacheable ressource, only headers are sent from `StreamResponsed`, for example:

```php
#[Route(path: '/download')]
public function download(Request $request): StreamedResponse
{
    // Get the last modified of a file.
    $lastModified = \DateTime::createFromFormat('d/m/Y H:i:s', '10/10/2023 13:22:00');

    $response = (new StreamedResponse())->setLastModified($lastModified);

    if ($response->isNotModified($request)) {
        return $response;
    }

    // Get the stream of a file and attach it to the callback.
    // ...

    return $response;
}
```

`HttpKernel` class have to handle it else if you obtain `HTTP 500` with message `Value of type null is not callable`.

cc @nicolas-grekas 

EDIT: found by @alexismarquis 