### PR TITLE
[AssetMapper] [Bugfix] Added packageName and filePath to ImportMapEntry when requiring package

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -295,13 +295,15 @@ class ImportMapManager
         $resolvedPackages = $this->resolver->resolvePackages($packagesToRequire);
         foreach ($resolvedPackages as $resolvedPackage) {
             $importName = $resolvedPackage->requireOptions->importName ?: $resolvedPackage->requireOptions->packageName;
-
+            [$packageName, $filePath] = ImportMapConfigReader::splitPackageNameAndFilePath($importName);
             $newEntry = new ImportMapEntry(
                 $importName,
                 path: $resolvedPackage->requireOptions->path,
                 version: $resolvedPackage->version,
                 type: $resolvedPackage->type,
                 isEntrypoint: $resolvedPackage->requireOptions->entrypoint,
+                packageName: $packageName,
+                filePath: $filePath,
             );
             $importMapEntries->add($newEntry);
             $addedEntries[] = $newEntry;

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -162,7 +162,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         foreach ($importMapEntries as $package => $entry) {
             $pattern = ImportMapType::CSS === $entry->type ? $this->distUrlCssPattern : $this->distUrlPattern;
             if (null === $entry->packageName || null === $entry->version || null === $entry->filePath) {
-                throw new RuntimeException(sprintf('The package %s cannot be downloaded. "packageName", "version" or "filePath" must be defined.', $entry->importName));
+                throw new RuntimeException(sprintf('The package "%s" cannot be downloaded. "packageName", "version" and "filePath" must be defined.', $entry->importName));
             }
             $url = sprintf($pattern, $entry->packageName, $entry->version, $entry->filePath);
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -161,6 +161,9 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
 
         foreach ($importMapEntries as $package => $entry) {
             $pattern = ImportMapType::CSS === $entry->type ? $this->distUrlCssPattern : $this->distUrlPattern;
+            if (null === $entry->packageName || null === $entry->version || null === $entry->filePath) {
+                throw new RuntimeException(sprintf('The package %s cannot be downloaded. "packageName", "version" or "filePath" must be defined.', $entry->importName));
+            }
             $url = sprintf($pattern, $entry->packageName, $entry->version, $entry->filePath);
 
             $responses[$package] = $this->httpClient->request('GET', $url);

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -293,7 +293,7 @@ class JsDelivrEsmResolverTest extends TestCase
     public static function provideDownloadPackagesTests()
     {
         yield 'single package' => [
-            ['lodash' => new ImportMapEntry('lodash', version: '1.2.3', packageName: 'lodash')],
+            ['lodash' => new ImportMapEntry('lodash', version: '1.2.3', packageName: 'lodash', filePath: '')],
             [
                 [
                     'url' => '/lodash@1.2.3/+esm',
@@ -333,7 +333,7 @@ class JsDelivrEsmResolverTest extends TestCase
 
         yield 'multiple files' => [
             [
-                'lodash' => new ImportMapEntry('lodash', version: '1.2.3', packageName: 'lodash'),
+                'lodash' => new ImportMapEntry('lodash', version: '1.2.3', packageName: 'lodash', filePath: ''),
                 'chart.js/auto' => new ImportMapEntry('chart.js/auto', version: '4.5.6', packageName: 'chart.js', filePath: '/auto'),
                 'bootstrap/dist/bootstrap.css' => new ImportMapEntry('bootstrap/dist/bootstrap.css', version: '5.0.6', type: ImportMapType::CSS, packageName: 'bootstrap', filePath: '/dist/bootstrap.css'),
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

In #51845, 2 new properties have been added to `ImportMapEntry` that are not initialized in `ImportMapManager` when calling `importmap:require a_package`.
This PR fixes this.