### PR TITLE
[Serializer] Fix using `DateIntervalNormalizer` with union types

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 
 /**
  * Normalizes an instance of {@see \DateInterval} to an interval string.
@@ -70,17 +70,16 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
      *
      * @return \DateInterval
      *
-     * @throws InvalidArgumentException
-     * @throws UnexpectedValueException
+     * @throws NotNormalizableValueException
      */
     public function denormalize($data, string $type, string $format = null, array $context = [])
     {
         if (!\is_string($data)) {
-            throw new InvalidArgumentException(sprintf('Data expected to be a string, "%s" given.', get_debug_type($data)));
+            throw NotNormalizableValueException::createForUnexpectedDataType('Data expected to be a string.', $data, ['string'], $context['deserialization_path'] ?? null, true);
         }
 
         if (!$this->isISO8601($data)) {
-            throw new UnexpectedValueException('Expected a valid ISO 8601 interval string.');
+            throw NotNormalizableValueException::createForUnexpectedDataType('Expected a valid ISO 8601 interval string.', $data, ['string'], $context['deserialization_path'] ?? null, true);
         }
 
         $dateIntervalFormat = $context[self::FORMAT_KEY] ?? $this->defaultContext[self::FORMAT_KEY];
@@ -98,7 +97,7 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
         }
         $valuePattern = '/^'.$signPattern.preg_replace('/%([yYmMdDhHiIsSwW])(\w)/', '(?:(?P<$1>\d+)$2)?', preg_replace('/(T.*)$/', '($1)?', $dateIntervalFormat)).'$/';
         if (!preg_match($valuePattern, $data)) {
-            throw new UnexpectedValueException(sprintf('Value "%s" contains intervals not accepted by format "%s".', $data, $dateIntervalFormat));
+            throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Value "%s" contains intervals not accepted by format "%s".', $data, $dateIntervalFormat), $data, ['string'], $context['deserialization_path'] ?? null, false);
         }
 
         try {
@@ -115,7 +114,7 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
 
             return new \DateInterval($data);
         } catch (\Exception $e) {
-            throw new UnexpectedValueException($e->getMessage(), $e->getCode(), $e);
+            throw NotNormalizableValueException::createForUnexpectedDataType($e->getMessage(), $data, ['string'], $context['deserialization_path'] ?? null, false, $e->getCode(), $e);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
 
 /**
@@ -123,26 +123,26 @@ class DateIntervalNormalizerTest extends TestCase
 
     public function testDenormalizeExpectsString()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(NotNormalizableValueException::class);
         $this->normalizer->denormalize(1234, \DateInterval::class);
     }
 
     public function testDenormalizeNonISO8601IntervalStringThrowsException()
     {
-        $this->expectException(UnexpectedValueException::class);
+        $this->expectException(NotNormalizableValueException::class);
         $this->expectExceptionMessage('Expected a valid ISO 8601 interval string.');
         $this->normalizer->denormalize('10 years 2 months 3 days', \DateInterval::class, null);
     }
 
     public function testDenormalizeInvalidDataThrowsException()
     {
-        $this->expectException(UnexpectedValueException::class);
+        $this->expectException(NotNormalizableValueException::class);
         $this->normalizer->denormalize('invalid interval', \DateInterval::class);
     }
 
     public function testDenormalizeFormatMismatchThrowsException()
     {
-        $this->expectException(UnexpectedValueException::class);
+        $this->expectException(NotNormalizableValueException::class);
         $this->normalizer->denormalize('P00Y00M00DT00H00M00S', \DateInterval::class, null, [DateIntervalNormalizer::FORMAT_KEY => 'P%yY%mM%dD']);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The union logic of `AbstractObjectNormalizer` tries to denormalize each union type and catches `NotNormalizableValueException` (among some other exceptions). If a non-catching exception is thrown, denormalization fails on that first type, while a later type might have succeeded. 

If I try to denormalize a `DateTimeInterface` value into a `DateInterval|DateTimeInterface`  type, it will fail because the `DateIntervalNormalizer` throws `UnexpectedValueException` instead of `NotNormalizableValueException`.   
Denormalizing a `DateInterval` into `DateTimeInterface|DateInterval` does work, because `DateTimeNormalizer` throws `NotNormalizableValueException`. I also checked some other Object-specific normalizers like `Uid`, `Problem`, `DateTimeZone`, `DataUri`, `BackedEnum`, they are using `NotNormalizableValueException`. 

See reproducer: https://github.com/Jeroeny/reproduce/tree/union/src
