### PR TITLE
[Notifier] [Telegram] Fix version and exception signature

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -36,7 +36,7 @@ final class TelegramTransport extends AbstractTransport
     private string $token;
     private ?string $chatChannel;
 
-    public const EXCLUSIVE_OPTIONS = [
+    private const EXCLUSIVE_OPTIONS = [
         'message_id',
         'callback_query_id',
         'photo',

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -1242,6 +1242,6 @@ JSON;
         $transport = self::createTransport($client, 'testChannel');
 
         $this->expectException(MultipleExclusiveOptionsUsedException::class);
-        $sentMessage = $transport->send(new ChatMessage('', $messageOptions));
+        $transport->send(new ChatMessage('', $messageOptions));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
@@ -17,8 +17,9 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/http-client": "^5.4|^6.0|^7.0",
-        "symfony/notifier": "^6.2.7|^7.0"
+        "symfony/http-client": "^6.3|^7.0",
+        "symfony/mime": "^5.4|^6.3|^7.0",
+        "symfony/notifier": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Telegram\\": "" },

--- a/src/Symfony/Component/Notifier/Exception/MultipleExclusiveOptionsUsedException.php
+++ b/src/Symfony/Component/Notifier/Exception/MultipleExclusiveOptionsUsedException.php
@@ -17,15 +17,16 @@ namespace Symfony\Component\Notifier\Exception;
 class MultipleExclusiveOptionsUsedException extends InvalidArgumentException
 {
     /**
-     * @param string[]      $usedExclusiveOptions
-     * @param string[]|null $exclusiveOptions
+     * @param string[] $usedExclusiveOptions
+     * @param string[] $exclusiveOptions
      */
-    public function __construct(array $usedExclusiveOptions, array $exclusiveOptions = null, \Throwable $previous = null)
+    public function __construct(array $usedExclusiveOptions, array $exclusiveOptions, \Throwable $previous = null)
     {
-        $message = sprintf('Multiple exclusive options have been used "%s".', implode('", "', $usedExclusiveOptions));
-        if (null !== $exclusiveOptions) {
-            $message .= sprintf(' Only one of %s can be used.', implode('", "', $exclusiveOptions));
-        }
+        $message = sprintf(
+            'Multiple exclusive options have been used "%s". Only one of "%s" can be used.',
+            implode('", "', $usedExclusiveOptions),
+            implode('", "', $exclusiveOptions)
+        );
 
         parent::__construct($message, 0, $previous);
     }

--- a/src/Symfony/Component/Notifier/Tests/Exception/MultipleExclusiveOptionsUsedExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/MultipleExclusiveOptionsUsedExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Exception\MultipleExclusiveOptionsUsedException;
+
+class MultipleExclusiveOptionsUsedExceptionTest extends TestCase
+{
+    public function testMessage()
+    {
+        $exception = new MultipleExclusiveOptionsUsedException(['foo', 'bar'], ['foo', 'bar', 'baz']);
+
+        $this->assertSame(
+            'Multiple exclusive options have been used "foo", "bar". Only one of "foo", "bar", "baz" can be used.',
+            $exception->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | --
| License       | MIT

The PR
* https://github.com/symfony/symfony/pull/51717

introduced a new exception in the Notifier component. I tested this locally and faced the following error:
```
Class "Symfony\Component\Notifier\Exception\MultipleExclusiveOptionsUsedException" not found
```

The version bump of the notifier was missing.
I also added tests for the exception class.

I am wondering about the parameter signature, and I am not sure if the second parameter should be nullable:
https://github.com/symfony/symfony/blob/c868be44ab61ac02e978dd18438915bcaed1aa8d/src/Symfony/Component/Notifier/Exception/MultipleExclusiveOptionsUsedException.php#L17-L31

@igrizzli is there anything I am missing or can e adjust the signature:
```diff
- public function __construct(array $usedExclusiveOptions, array $exclusiveOptions = null, \Throwable $previous = null)
+ public function __construct(array $usedExclusiveOptions, array $exclusiveOptions, \Throwable $previous = null)
``