### PR TITLE
[Translation][Validator] Add missing translations for Croatian (hr)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
@@ -402,6 +402,30 @@
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>Vrijednost mrežne maske trebala bi biti između {{ min }} i {{ max }}.</target>
             </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target>Naziv datoteke je predug. Treba imati {{ filename_max_length }} znak ili manje.|Naziv datoteke je predug. Treba imati {{ filename_max_length }} znaka ili manje.|Naziv datoteke je predug. Treba imati {{ filename_max_length }} znakova ili manje.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target>Jačina lozinke je preniska. Molim koristite jaču lozinku.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target>Ova vrijednost sadrži znakove koji nisu dopušteni prema trenutnoj razini ograničenja.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target>Korištenje nevidljivih znakova nije dopušteno.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target>Miješanje brojeva iz različitih pisama nije dopušteno.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target>Korištenje skrivenih preklapajućih znakova nije dopušteno.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51935 
| License      | MIT

This pull request adds a few missing translations (104 - 109) for Validator Component for Croatian (hr) language.