### PR TITLE
[HttpFoundation] Cookies Having Independent Partitioned State (CHIPS)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Make `HeaderBag::getDate()`, `Response::getDate()`, `getExpires()` and `getLastModified()` return a `DateTimeImmutable`
  * Support root-level `Generator` in `StreamedJsonResponse`
  * Add `UriSigner` from the HttpKernel component
+ * Add `partitioned` flag to `Cookie` (CHIPS Cookie)
 
 6.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -87,6 +87,19 @@ class CookieTest extends TestCase
         $this->assertSame(0, $cookie->getExpiresTime());
     }
 
+    public function testMinimalParameters()
+    {
+        $constructedCookie = new Cookie('foo');
+
+        $createdCookie = Cookie::create('foo');
+
+        $cookie = new Cookie('foo', null, 0, '/', null, null, true, false, 'lax');
+
+        $this->assertEquals($constructedCookie, $cookie);
+
+        $this->assertEquals($createdCookie, $cookie);
+    }
+
     public function testGetValue()
     {
         $value = 'MyValue';
@@ -187,6 +200,17 @@ class CookieTest extends TestCase
         $this->assertTrue($cookie->isHttpOnly(), '->isHttpOnly() returns whether the cookie is only transmitted over HTTP');
     }
 
+    public function testIsPartitioned()
+    {
+        $cookie = new Cookie('foo', 'bar', 0, '/', '.myfoodomain.com', true, true, false, 'Lax', true);
+
+        $this->assertTrue($cookie->isPartitioned());
+
+        $cookie = Cookie::create('foo')->withPartitioned(true);
+
+        $this->assertTrue($cookie->isPartitioned());
+    }
+
     public function testCookieIsNotCleared()
     {
         $cookie = Cookie::create('foo', 'bar', time() + 3600 * 24);
@@ -262,6 +286,20 @@ class CookieTest extends TestCase
             ->withSameSite(null);
         $this->assertEquals($expected, (string) $cookie, '->__toString() returns string representation of a cleared cookie if value is NULL');
 
+        $expected = 'foo=deleted; expires='.gmdate('D, d M Y H:i:s T', $expire = time() - 31536001).'; Max-Age=0; path=/admin/; domain=.myfoodomain.com; secure; httponly; samesite=none; partitioned';
+        $cookie = new Cookie('foo', null, 1, '/admin/', '.myfoodomain.com', true, true, false, 'none', true);
+        $this->assertEquals($expected, (string) $cookie, '->__toString() returns string representation of a cleared cookie if value is NULL');
+
+        $cookie = Cookie::create('foo')
+            ->withExpires(1)
+            ->withPath('/admin/')
+            ->withDomain('.myfoodomain.com')
+            ->withSecure(true)
+            ->withHttpOnly(true)
+            ->withSameSite('none')
+            ->withPartitioned(true);
+        $this->assertEquals($expected, (string) $cookie, '->__toString() returns string representation of a cleared cookie if value is NULL');
+
         $expected = 'foo=bar; path=/; httponly; samesite=lax';
         $cookie = Cookie::create('foo', 'bar');
         $this->assertEquals($expected, (string) $cookie);
@@ -321,6 +359,9 @@ class CookieTest extends TestCase
 
         $cookie = Cookie::fromString('foo_cookie=foo==; expires=Tue, 22 Sep 2020 06:27:09 GMT; path=/');
         $this->assertEquals(Cookie::create('foo_cookie', 'foo==', strtotime('Tue, 22 Sep 2020 06:27:09 GMT'), '/', null, false, false, true, null), $cookie);
+
+        $cookie = Cookie::fromString('foo_cookie=foo==; expires=Tue, 22 Sep 2020 06:27:09 GMT; path=/; secure; httponly; samesite=none; partitioned');
+        $this->assertEquals(new Cookie('foo_cookie', 'foo==', strtotime('Tue, 22 Sep 2020 06:27:09 GMT'), '/', null, true, true, true, 'none', true), $cookie);
     }
 
     public function testFromStringWithHttpOnly()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT

Due to [Chrome's roadmap](https://developer.chrome.com/docs/privacy-sandbox/third-party-cookie-phase-out/) (and all other major browsers) to phase out third-party cookies starting from midway through 2024, "partitioned" cookies were introduced. If a cookie is flagged as `partitioned`, its cross-site boundry is tied to the top-level site.

Considerations: According to current security design, browser will only accept partitioned cookies with the `secure` flag and `SameSite` attribute `none` (otherwise it isn't a third-party cookie...). I classified this as an implementation topic and therefore omitted this validation in the Cookie class itself.

Further information:
- [Chrome for Developers](https://developer.chrome.com/docs/privacy-sandbox/chips/)
- [Mozilla Dev](https://developer.mozilla.org/en-US/docs/Web/Privacy/Partitioned_cookies)
- [CHIPS](https://github.com/privacycg/CHIPS)