### PR TITLE
[Translation] Prevent creating empty keys when key ends with a period

### DIFF
--- a/src/Symfony/Component/Translation/Tests/Util/ArrayConverterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Util/ArrayConverterTest.php
@@ -69,6 +69,34 @@ class ArrayConverterTest extends TestCase
                     ],
                 ],
             ],
+            [
+                // input
+                [
+                    'foo.' => 'foo.',
+                    '.bar' => '.bar',
+                    'abc.abc' => 'value',
+                    'bcd.bcd.' => 'value',
+                    '.cde.cde.' => 'value',
+                    '.def.def' => 'value',
+                ],
+                // expected output
+                [
+                    'foo.' => 'foo.',
+                    '.bar' => '.bar',
+                    'abc' => [
+                        'abc' => 'value',
+                    ],
+                    'bcd' => [
+                        'bcd.' => 'value',
+                    ],
+                    '.cde' => [
+                        'cde.' => 'value',
+                    ],
+                    '.def' => [
+                        'def' => 'value',
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/src/Symfony/Component/Translation/Util/ArrayConverter.php
+++ b/src/Symfony/Component/Translation/Util/ArrayConverter.php
@@ -38,7 +38,7 @@ class ArrayConverter
         $tree = [];
 
         foreach ($messages as $id => $value) {
-            $referenceToElement = &self::getElementByPath($tree, explode('.', $id));
+            $referenceToElement = &self::getElementByPath($tree, self::getKeyParts($id));
 
             $referenceToElement = $value;
 
@@ -65,6 +65,7 @@ class ArrayConverter
                 $elem = &$elem[implode('.', \array_slice($parts, $i))];
                 break;
             }
+
             $parentOfElem = &$elem;
             $elem = &$elem[$part];
         }
@@ -95,5 +96,46 @@ class ArrayConverter
                 self::cancelExpand($tree, $prefix.$id, $value);
             }
         }
+    }
+
+    private static function getKeyParts(string $key)
+    {
+        $parts = explode('.', $key);
+        $partsCount = \count($parts);
+
+        $result = [];
+        $buffer = '';
+
+        foreach ($parts as $index => $part) {
+            if (0 === $index && '' === $part) {
+                $buffer = '.';
+
+                continue;
+            }
+
+            if ($index === $partsCount - 1 && '' === $part) {
+                $buffer .= '.';
+                $result[] = $buffer;
+
+                continue;
+            }
+
+            if (isset($parts[$index + 1]) && '' === $parts[$index + 1]) {
+                $buffer .= $part;
+
+                continue;
+            }
+
+            if ($buffer) {
+                $result[] = $buffer.$part;
+                $buffer = '';
+
+                continue;
+            }
+
+            $result[] = $part;
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51536 
| License       | MIT

Small fix that prevents creating empty keys on translations when the translation key ends with a period, example:
```php
'This is a validation.'
```

Before the fix, the yaml output was:
```yaml
'This is a validation':
         '': 'This is a validation.'
```

After the fix we got:
```yaml
'This is a validation.': 'This is a validation.'
```

This can be replicated by:
1. Create a new symfony project using the `--webapp` flag.
2. Execute the command to extract translations as yaml: `php bin/console translation:extract --force --format=yaml --as-tree=3 --prefix='' --clean en`


Results:
Before the fix:
<img width="1027" alt="image" src="https://github.com/symfony/symfony/assets/11241239/70ffbc54-30da-4f7e-88cc-e19bbd7980e1">

After the fix:
<img width="1229" alt="image" src="https://github.com/symfony/symfony/assets/11241239/6d26e701-80f9-4ac5-aff9-7e2c78c162f6">

