### PR TITLE
Revert "dev" keyword on PhpUnitBridge

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/phpunit-bridge",
     "type": "symfony-bridge",
     "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
-    "keywords": ["dev"],
+    "keywords": [],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT

This PR revert #51925

The issue with the `dev` key word, is: Composer ask to re-run command with the `--dev` flag

Which makes `simple-phpunit` stuck when running in a CI

For the recall:
- simple-phpunit run `composer require --no-update symfony/phpunit-bridge "*@dev"` https://github.com/symfony/symfony/blob/5f77c3fb3e5b95b577b1fd17cb03c12be568c70d/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php#L256
- composer ask for re-running the command in `--dev`
https://github.com/composer/composer/blob/c827c93b62186488dbffdf4b614413ae7a785607/src/Composer/Command/RequireCommand.php#L235-L261