### PR TITLE
DX: PHP CS Fixer - drop explicit no_superfluous_phpdoc_tags config, as it's part of ruleset already

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,7 +31,6 @@ return (new PhpCsFixer\Config())
         'protected_to_private' => false,
         'native_constant_invocation' => ['strict' => false],
         'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => false],
-        'no_superfluous_phpdoc_tags' => ['remove_inheritdoc' => true],
         'header_comment' => ['header' => $fileHeaderComment],
         'modernize_strpos' => true,
         'get_class_to_class_keyword' => true,


### PR DESCRIPTION


https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/src/RuleSet/Sets/SymfonySet.php#L111