### PR TITLE
DX: PHP CS Fixer - drop explicit nullable_type_declaration_for_default_null_value config, as it's part of ruleset anyway

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -30,7 +30,6 @@ return (new PhpCsFixer\Config())
         '@Symfony:risky' => true,
         'protected_to_private' => false,
         'native_constant_invocation' => ['strict' => false],
-        'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => false],
         'header_comment' => ['header' => $fileHeaderComment],
     ])
     ->setRiskyAllowed(true)


### PR DESCRIPTION
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/src/RuleSet/Sets/SymfonySet.php#L137