### PR TITLE
[Mailer] Capitalize sender header for Mailgun

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -62,7 +62,7 @@ class MailgunApiTransportTest extends TestCase
 
         $email = new Email();
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
-        $email->getHeaders()->addTextHeader('h:sender', $envelope->getSender()->toString());
+        $email->getHeaders()->addTextHeader('h:Sender', $envelope->getSender()->toString());
         $email->getHeaders()->addTextHeader('h:X-Mailgun-Variables', $json);
         $email->getHeaders()->addTextHeader('h:foo', 'foo-value');
         $email->getHeaders()->addTextHeader('t:text', 'text-value');
@@ -79,8 +79,8 @@ class MailgunApiTransportTest extends TestCase
         $this->assertArrayHasKey('h:X-Mailgun-Variables', $payload);
         $this->assertEquals($json, $payload['h:X-Mailgun-Variables']);
 
-        $this->assertArrayHasKey('h:sender', $payload);
-        $this->assertEquals($envelope->getSender()->toString(), $payload['h:sender']);
+        $this->assertArrayHasKey('h:Sender', $payload);
+        $this->assertEquals($envelope->getSender()->toString(), $payload['h:Sender']);
         $this->assertArrayHasKey('h:foo', $payload);
         $this->assertEquals('foo-value', $payload['h:foo']);
         $this->assertArrayHasKey('t:text', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
@@ -69,8 +69,6 @@ class MailgunHttpTransportTest extends TestCase
             $this->assertStringContainsString('Subject: Hello!', $content);
             $this->assertStringContainsString('To: Saif Eddin <saif.gmati@symfony.com>', $content);
             $this->assertStringContainsString('From: Fabien <fabpot@symfony.com>', $content);
-            $this->assertStringContainsString('Sender: Senior Fabien Eddin <fabpot@symfony.com>', $content);
-            $this->assertStringContainsString('h:sender: "Senior Fabien Eddin" <fabpot@symfony.com>', $content);
             $this->assertStringContainsString('Hello There!', $content);
 
             return new MockResponse(json_encode(['id' => 'foobar']), [
@@ -81,16 +79,10 @@ class MailgunHttpTransportTest extends TestCase
         $transport->setPort(8984);
 
         $mail = new Email();
-        $toAddress = new Address('saif.gmati@symfony.com', 'Saif Eddin');
-        $fromAddress = new Address('fabpot@symfony.com', 'Fabien');
-        $senderAddress = new Address('fabpot@symfony.com', 'Senior Fabien Eddin');
         $mail->subject('Hello!')
-            ->to($toAddress)
-            ->from($fromAddress)
-            ->sender($senderAddress)
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
             ->text('Hello There!');
-
-        $mail->getHeaders()->addHeader('h:sender', $mail->getSender()->toString());
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -87,7 +87,7 @@ class MailgunApiTransport extends AbstractApiTransport
     private function getPayload(Email $email, Envelope $envelope): array
     {
         $headers = $email->getHeaders();
-        $headers->addHeader('h:sender', $envelope->getSender()->toString());
+        $headers->addHeader('h:Sender', $envelope->getSender()->toString());
         $html = $email->getHtmlBody();
         if (null !== $html && \is_resource($html)) {
             if (stream_get_meta_data($html)['seekable'] ?? false) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
@@ -53,7 +53,6 @@ class MailgunHttpTransport extends AbstractHttpTransport
     protected function doSendHttp(SentMessage $message): ResponseInterface
     {
         $body = new FormDataPart([
-            'h:sender' => $message->getEnvelope()->getSender()->toString(),
             'to' => implode(',', $this->stringifyAddresses($message->getEnvelope()->getRecipients())),
             'message' => new DataPart($message->toString(), 'message.mime'),
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/51773#issuecomment-1759392593
| License       | MIT

This fix resolves the duplicate header issue.
Without a fix, using API & HTTP transport type, emails could leave with double headers, causing problems for some email providers, for example, the problem was reproduced with Gmail:
`5.7.1 This message is not RFC 5322 compliant. There are multiple Sender 5.7.1 headers. To reduce the amount of spam sent to Gmail, this message has 5.7.1 been blocked.`

Moreover, I found that changes to HTTP transport type were not necessary since this problem could be solved by simply adding a sender, so I reverted everything for HTTP transport type.
