### PR TITLE
[Serializer] Add support for union collection value types in `ArrayDenormalizer`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+7.2
+---
+* Add support for union collection value types in `ArrayDenormalizer`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -462,7 +462,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $builtinType = $type->getBuiltinType();
                 if (\is_string($data) && (XmlEncoder::FORMAT === $format || CsvEncoder::FORMAT === $format)) {
                     if ('' === $data) {
-                        if (LegacyLegacyType::BUILTIN_TYPE_ARRAY === $builtinType) {
+                        if (LegacyType::BUILTIN_TYPE_ARRAY === $builtinType) {
                             return [];
                         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\Serializer\Exception\BadMethodCallException;
+use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\UnionType;
@@ -48,14 +50,19 @@ class ArrayDenormalizer implements DenormalizerInterface, DenormalizerAwareInter
             throw new BadMethodCallException('Please set a denormalizer before calling denormalize()!');
         }
         if (!\is_array($data)) {
-            throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Data expected to be "%s", "%s" given.', $type, get_debug_type($data)), $data, ['array'], $context['deserialization_path'] ?? null);
+            $valueType = $context['value_type'] ?? null;
+            $expected = $valueType ? 'array<'.implode('|', array_map(fn (Type $type) => $type->getClassName() ?? $type->getBuiltinType(), $valueType->getCollectionValueTypes())).'>' : $type;
+
+            throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Data expected to be "%s", "%s" given.', $expected, get_debug_type($data)), $data, ['array'], $context['deserialization_path'] ?? null);
         }
         if (!str_ends_with($type, '[]')) {
             throw new InvalidArgumentException('Unsupported class: '.$type);
         }
 
         $type = substr($type, 0, -2);
+        $valueType = $context['value_type'] ?? null;
 
+        # todo
         $typeIdentifiers = [];
         if (null !== $keyType = ($context['key_type'] ?? null)) {
             if ($keyType instanceof Type) {
@@ -65,13 +72,46 @@ class ArrayDenormalizer implements DenormalizerInterface, DenormalizerAwareInter
             }
         }
 
+        if ($valueType instanceof Type && \count($keyTypes = $valueType->getCollectionKeyTypes()) > 0) {
+            $builtinTypes = array_map(static fn (Type $keyType) => $keyType->getBuiltinType(), $keyTypes);
+        } else {
+            $builtinTypes = array_map(static fn (LegacyType $keyType) => $keyType->getBuiltinType(), \is_array($keyType = $context['key_type'] ?? []) ? $keyType : [$keyType]);
+        }
+
         foreach ($data as $key => $value) {
             $subContext = $context;
             $subContext['deserialization_path'] = ($context['deserialization_path'] ?? false) ? sprintf('%s[%s]', $context['deserialization_path'], $key) : "[$key]";
 
             $this->validateKeyType($typeIdentifiers, $key, $subContext['deserialization_path']);
 
-            $data[$key] = $this->denormalizer->denormalize($value, $type, $format, $subContext);
+            if ($valueType instanceof Type) {
+                foreach ($valueType->getCollectionValueTypes() as $subtype) {
+                    try {
+                        $subContext['value_type'] = $subtype;
+
+                        if ($subtype->isNullable() && null === $value) {
+                            $data[$key] = null;
+
+                            continue 2;
+                        }
+
+                        if (Type::BUILTIN_TYPE_ARRAY === $subtype->getBuiltinType()) {
+                            $class = $type;
+                        } else {
+                            $class = $subtype->getClassName() ?? $subtype->getBuiltinType();
+                        }
+
+                        $data[$key] = $this->denormalizer->denormalize($value, $class, $format, $subContext);
+
+                        continue 2;
+                    } catch (NotNormalizableValueException|InvalidArgumentException|ExtraAttributesException|MissingConstructorArgumentsException $e) {
+                    }
+                }
+
+                throw $e;
+            } else {
+                $data[$key] = $this->denormalizer->denormalize($value, $type, $format, $subContext);
+            }
         }
 
         return $data;
@@ -90,7 +130,7 @@ class ArrayDenormalizer implements DenormalizerInterface, DenormalizerAwareInter
     /**
      * @param list<string> $typeIdentifiers
      */
-    private function validateKeyType(array $typeIdentifiers, mixed $key, string $path): void
+    private function validateKeyType(array $builtinTypes, mixed $key, string $path): void
     {
         if (!$typeIdentifiers) {
             return;

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1214,7 +1214,7 @@ class SerializerTest extends TestCase
                 'useMessageForUser' => false,
                 'message' => 'The type of the "string" attribute for class "Symfony\\Component\\Serializer\\Tests\\Fixtures\\Php74Full" must be one of "string" ("null" given).',
             ],
-            ];
+        ];
 
         $this->assertSame($expected, $exceptionsAsArray);
     }
@@ -1464,8 +1464,8 @@ class SerializerTest extends TestCase
 
         try {
             $serializer->deserialize('{"get": "POST"}', DummyObjectWithEnumProperty::class, 'json', [
-                 DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
-             ]);
+                DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+            ]);
         } catch (\Throwable $e) {
             $this->assertInstanceOf(PartialDenormalizationException::class, $e);
         }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1141,7 +1141,7 @@ class SerializerTest extends TestCase
                 'expectedTypes' => ['array'],
                 'path' => 'anotherCollection',
                 'useMessageForUser' => false,
-                'message' => 'Data expected to be "Symfony\Component\Serializer\Tests\Fixtures\Php74Full[]", "null" given.',
+                'message' => 'Data expected to be "array<Symfony\Component\Serializer\Tests\Fixtures\Php74Full>", "null" given.',
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Currently only the following array types combination is supported: `array<MyObject>|array<Another>`. This results in arrays with only 1 type of objects.

This PR aims to add support for arrays where values can be either of those, like union types: `array<MyObject|Another>`.

I've currently tested is successfully against the following types:
- `DateTimeInterface[]`
- `array<array<DateTimeInterface|DateInterval|string>>`
- `array<DateTimeInterface>|array<DateInterval>`
- `array<DateTimeInterface|DateInterval>`
- `array<DateTimeInterface|null>`

See also https://github.com/Jeroeny/reproduce/blob/mixedarray/src/Test.php