### PR TITLE
[Form] Fix merging params & files when "multiple" is enabled

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\RequestHandlerInterface;
+use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -95,7 +96,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             }
 
             if (\is_array($params) && \is_array($files)) {
-                $data = array_replace_recursive($params, $files);
+                $data = FormUtil::mergeParamsAndFiles($params, $files);
             } else {
                 $data = $params ?: $files;
             }

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\Util\ServerParams;
 
 /**
@@ -106,7 +107,7 @@ class NativeRequestHandler implements RequestHandlerInterface
             }
 
             if (\is_array($params) && \is_array($files)) {
-                $data = array_replace_recursive($params, $files);
+                $data = FormUtil::mergeParamsAndFiles($params, $files);
             } else {
                 $data = $params ?: $files;
             }

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -239,6 +239,42 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
     /**
      * @dataProvider methodExceptGetProvider
      */
+    public function testMergeParamsAndFilesMultiple($method)
+    {
+        $form = $this->createForm('param1', $method, true);
+        $form->add($this->createBuilder('field1', false, ['allow_file_upload' => true, 'multiple' => true])->getForm());
+        $file1 = $this->getUploadedFile();
+        $file2 = $this->getUploadedFile();
+
+        $this->setRequestData($method, [
+            'param1' => [
+                'field1' => [
+                    'foo',
+                    'bar',
+                    'baz',
+                ],
+            ],
+        ], [
+            'param1' => [
+                'field1' => [
+                    $file1,
+                    $file2,
+                ],
+            ],
+        ]);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+        $data = $form->get('field1')->getData();
+
+        $this->assertTrue($form->isSubmitted());
+        $this->assertIsArray($data);
+        $this->assertCount(5, $data);
+        $this->assertSame(['foo', 'bar', 'baz', $file1, $file2], $data);
+    }
+
+    /**
+     * @dataProvider methodExceptGetProvider
+     */
     public function testParamTakesPrecedenceOverFile($method)
     {
         $form = $this->createForm('param1', $method);

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -41,4 +41,29 @@ class FormUtil
         // not considered to be empty, ever.
         return null === $data || '' === $data;
     }
+
+    /**
+     * Recursively replaces or appends elements of the first array with elements
+     * of second array. If the key is an integer, the values will be appended to
+     * the new array; otherwise, the value from the second array will replace
+     * the one from the first array.
+     */
+    public static function mergeParamsAndFiles(array $params, array $files): array
+    {
+        $result = [];
+
+        foreach ($params as $key => $value) {
+            if (\is_array($value) && \is_array($files[$key] ?? null)) {
+                $value = self::mergeParamsAndFiles($value, $files[$key]);
+                unset($files[$key]);
+            }
+            if (\is_int($key)) {
+                $result[] = $value;
+            } else {
+                $result[$key] = $value;
+            }
+        }
+
+        return array_merge($result, $files);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

If a form field is configured with the "multiple" option, the request handler merges param values with uploaded files. However, it does not merge correctly if "multiple" is enabled.

Example:
```html
<input type="file" name="param[]" />
<input type="hidden" name="param[]" value="data1" />
<input type="hidden" name="param[]" value="data2" />
```

With the example, the file field will incorrectly replace the first hidden field, when they should be merged. This commit fixes the problem.