### PR TITLE
[FrameworkBundle] Fix merge error with `ErrorLoggerCompilerPass`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ErrorLoggerCompilerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ErrorLoggerCompilerPass.php
@@ -22,11 +22,11 @@ class ErrorLoggerCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('debug.debug_handlers_listener')) {
+        if (!$container->hasDefinition('debug.error_handler_configurator')) {
             return;
         }
 
-        $definition = $container->getDefinition('debug.debug_handlers_listener');
+        $definition = $container->getDefinition('debug.error_handler_configurator');
         if ($container->hasDefinition('monolog.logger.php')) {
             $definition->replaceArgument(0, new Reference('monolog.logger.php'));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

@nicolas-grekas @MatTheCat does this make sense? If I change these 2 lines in 6.4 then my app loads fine. 

relates to https://github.com/symfony/symfony/pull/52009#issuecomment-1759977167

This comment from @HypeMC https://github.com/symfony/symfony/pull/52009#discussion_r1356574949 guided my debugging

or am I barking up the wrong tree?