### PR TITLE
[Mime] Throw InvalidArgumentException on invalid form field type inside array

### DIFF
--- a/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
+++ b/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
@@ -32,13 +32,8 @@ final class FormDataPart extends AbstractMultipartPart
     {
         parent::__construct();
 
-        foreach ($fields as $name => $value) {
-            if (!\is_string($value) && !\is_array($value) && !$value instanceof TextPart) {
-                throw new InvalidArgumentException(sprintf('The value of the form field "%s" can only be a string, an array, or an instance of TextPart ("%s" given).', $name, get_debug_type($value)));
-            }
+        $this->fields = $fields;
 
-            $this->fields[$name] = $value;
-        }
         // HTTP does not support \r\n in header values
         $this->getHeaders()->setMaxLineLength(\PHP_INT_MAX);
     }
@@ -73,6 +68,10 @@ final class FormDataPart extends AbstractMultipartPart
                 array_walk($item, $prepare, $fieldName);
 
                 return;
+            }
+
+            if (!\is_string($item) && !$item instanceof TextPart) {
+                throw new InvalidArgumentException(sprintf('The value of the form field "%s" can only be a string, an array, or an instance of TextPart, "%s" given.', $fieldName, get_debug_type($item)));
             }
 
             $values[] = $this->preparePart($fieldName, $item);

--- a/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
@@ -199,6 +199,22 @@ class FormDataPartTest extends TestCase
         $f->getParts();
     }
 
+    public function testExceptionOnFormFieldsWithDisallowedTypesInsideArray()
+    {
+        $f = new FormDataPart([
+            'foo' => [
+                'bar' => 'baz',
+                'qux' => [
+                    'quux' => 1,
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value of the form field "foo[qux][quux]" can only be a string, an array, or an instance of TextPart, "int" given.');
+        $f->getParts();
+    }
+
     public function testToString()
     {
         $p = DataPart::fromPath($file = __DIR__.'/../../Fixtures/mimetypes/test.gif');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT

Example code:
```php
$f = new FormDataPart([
            'foo' => [
                'bar' => 'baz',
                'qux' => [
                    'quux' => 1,
                ],
            ],
        ]);
$f->getParts();
```

Currently, when you use a disallowed type inside an array, a TypeError is thrown:
` Symfony\Component\Mime\Part\Multipart\FormDataPart::configurePart(): Argument #2 ($part) must be of type Symfony\Component\Mime\Part\TextPart, int given`

This change adds a clearly understandable error message:
`The value of the form field "foo[qux][quux]" can only be a string, an array, or an instance of TextPart ("int" given).`