### PR TITLE
[Cache][VarExporter] Fix proxy generation to deal with edgy behaviors of internal classes

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -538,7 +538,7 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 
     public function hscan($key, &$iterator, $pattern = null, $count = 0): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, $pattern, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function incr($key, $by = 1): \Redis|false|int
@@ -888,7 +888,7 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 
     public function scan(&$iterator, $pattern = null, $count = 0, $type = null): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, $pattern, $count, $type, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, ...\array_slice(\func_get_args(), 1));
     }
 
     public function scard($key): \Redis|false|int
@@ -998,7 +998,7 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 
     public function sscan($key, &$iterator, $pattern = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, $pattern, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function ssubscribe($channels, $cb): bool
@@ -1278,7 +1278,7 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 
     public function zscan($key, &$iterator, $pattern = null, $count = 0): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, $pattern, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function zunion($keys, $weights = null, $options = null): \Redis|array|false

--- a/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
@@ -463,7 +463,7 @@ class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyOb
 
     public function hscan($key, &$iterator, $pattern = null, $count = 0): array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, $pattern, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function hrandfield($key, $options = null): \RedisCluster|array|string
@@ -738,7 +738,7 @@ class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyOb
 
     public function scan(&$iterator, $key_or_address, $pattern = null, $count = 0): array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, $key_or_address, $pattern, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, ...\array_slice(\func_get_args(), 1));
     }
 
     public function scard($key): \RedisCluster|false|int
@@ -858,7 +858,7 @@ class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyOb
 
     public function sscan($key, &$iterator, $pattern = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, $pattern, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function strlen($key): \RedisCluster|false|int
@@ -1103,7 +1103,7 @@ class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyOb
 
     public function zscan($key, &$iterator, $pattern = null, $count = 0): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, $pattern, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function zscore($key, $member): \RedisCluster|false|float

--- a/src/Symfony/Component/Cache/Traits/RelayProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RelayProxy.php
@@ -984,22 +984,22 @@ class RelayProxy extends Relay implements ResetInterface, LazyObjectInterface
 
     public function scan(&$iterator, $match = null, $count = 0, $type = null): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, $match, $count, $type, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, ...\array_slice(\func_get_args(), 1));
     }
 
     public function hscan($key, &$iterator, $match = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, $match, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function sscan($key, &$iterator, $match = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, $match, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function zscan($key, &$iterator, $match = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, $match, $count, ...\array_slice(\func_get_args(), 4));
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function keys($pattern): \Relay\Relay|array|false

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -26,7 +26,7 @@
         "psr/log": "^1.1|^2|^3",
         "symfony/cache-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3",
-        "symfony/var-exporter": "^6.2.10"
+        "symfony/var-exporter": "^6.3.6"
     },
     "require-dev": {
         "cache/integration-tests": "dev-master",

--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -215,7 +215,7 @@ final class ProxyHelper
 
     public static function exportSignature(\ReflectionFunctionAbstract $function, bool $withParameterTypes = true, string &$args = null): string
     {
-        $hasByRef = false;
+        $byRefIndex = 0;
         $args = '';
         $param = null;
         $parameters = [];
@@ -225,16 +225,20 @@ final class ProxyHelper
                 .($param->isPassedByReference() ? '&' : '')
                 .($param->isVariadic() ? '...' : '').'$'.$param->name
                 .($param->isOptional() && !$param->isVariadic() ? ' = '.self::exportDefault($param) : '');
-            $hasByRef = $hasByRef || $param->isPassedByReference();
+            if ($param->isPassedByReference()) {
+                $byRefIndex = 1 + $param->getPosition();
+            }
             $args .= ($param->isVariadic() ? '...$' : '$').$param->name.', ';
         }
 
-        if (!$param || !$hasByRef) {
+        if (!$param || !$byRefIndex) {
             $args = '...\func_get_args()';
         } elseif ($param->isVariadic()) {
             $args = substr($args, 0, -2);
         } else {
-            $args .= sprintf('...\array_slice(\func_get_args(), %d)', \count($parameters));
+            $args = explode(', ', $args, 1 + $byRefIndex);
+            $args[$byRefIndex] = sprintf('...\array_slice(\func_get_args(), %d)', $byRefIndex);
+            $args = implode(', ', $args);
         }
 
         $signature = 'function '.($function->returnsReference() ? '&' : '')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51770, #51679, #51700
| License       | MIT

Instead of #51838

This fixes the issue by not passing default values explicitly when they were not provided during the call to the method.