### PR TITLE
[Cache] Fix ArrayAdapter::freeze() return type

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -298,7 +298,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
         }
     }
 
-    private function freeze($value, string $key): string|int|float|bool|array|null
+    private function freeze($value, string $key): string|int|float|bool|array|\UnitEnum|null
     {
         if (null === $value) {
             return 'N;';

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Tests\Fixtures\TestEnum;
 
 /**
  * @group time-sensitive
@@ -90,5 +91,15 @@ class ArrayAdapterTest extends AdapterTestCase
         $this->assertFalse($cache->hasItem('bar'));
         $this->assertTrue($cache->hasItem('buz'));
         $this->assertTrue($cache->hasItem('foo'));
+    }
+
+    public function testEnum()
+    {
+        $cache = new ArrayAdapter();
+        $item = $cache->getItem('foo');
+        $item->set(TestEnum::Foo);
+        $cache->save($item);
+
+        $this->assertSame(TestEnum::Foo, $cache->getItem('foo')->get());
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Fixtures/TestEnum.php
+++ b/src/Symfony/Component/Cache/Tests/Fixtures/TestEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Fixtures;
+
+enum TestEnum
+{
+    case Foo;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/51867
| License       | MIT

Enums are not serialized and this is good: they don't need to be frozen since they are immutable.
The fix is to widen the return type.