### PR TITLE
[Config] Allow custom meta location in `ResourceCheckerConfigCache`

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Allow custom meta location in `ResourceCheckerConfigCache`
+
 7.0
 ---
 

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -21,14 +21,17 @@ class ResourceCheckerConfigCacheTest extends TestCase
 {
     private string $cacheFile;
 
+    private string $metaFile;
+
     protected function setUp(): void
     {
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'config_');
+        $this->metaFile = tempnam(sys_get_temp_dir(), 'config_');
     }
 
     protected function tearDown(): void
     {
-        $files = [$this->cacheFile, "{$this->cacheFile}.meta"];
+        $files = [$this->cacheFile, "{$this->cacheFile}.meta", $this->metaFile];
 
         foreach ($files as $file) {
             if (file_exists($file)) {
@@ -147,5 +150,16 @@ class ResourceCheckerConfigCacheTest extends TestCase
         unlink($metaFile);
 
         $this->assertFalse($cache->isFresh());
+    }
+
+    public function testCacheWithCustomMetaFile()
+    {
+        $this->assertStringEqualsFile($this->metaFile, '');
+
+        $checker = $this->createMock(ResourceCheckerInterface::class);
+        $cache = new ResourceCheckerConfigCache($this->cacheFile, [$checker], $this->metaFile);
+        $cache->write('foo', [new FileResource(__FILE__)]);
+
+        $this->assertStringNotEqualsFile($this->metaFile, '');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no 
| Tickets       |
| License       | MIT

This makes it possible to put the meta file in a different location.

One use case can be to write a file to `src` while keeping the meta file in `var`.