### PR TITLE
[Validator] #51928 Missing translations for Belarusian (be)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
@@ -402,6 +402,30 @@
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>Значэнне сеткавай маскі павінна быць ад {{min}} да {{max}}.</target>
             </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target>Назва файла занадта доўгая. Ён павінен мець {{ filename_max_length }} сімвал або менш.|Назва файла занадта доўгая. Ён павінен мець {{ filename_max_length }} сімвалы або менш.|Назва файла занадта доўгая. Ён павінен мець {{ filename_max_length }} сімвалаў або менш.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target>Надзейнасць пароля занадта нізкая. Выкарыстоўвайце больш надзейны пароль.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target>Гэта значэнне змяшчае сімвалы, якія не дазволены цяперашнім узроўнем абмежаванняў.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target>Выкарыстанне нябачных сімвалаў не дазваляецца.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target>Змешванне лікаў з розных алфавітаў не дапускаецца.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target>Выкарыстанне схаваных накладзеных сімвалаў не дазваляецца.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
- Added missing translations for Belarusian (be);

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51928
| License       | MIT

- Added missing translations for Belarusian (be);
