### PR TITLE
[HttpFoundation][Runtime] Add $flush parameter to Response::send()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Support root-level `Generator` in `StreamedJsonResponse`
  * Add `UriSigner` from the HttpKernel component
  * Add `partitioned` flag to `Cookie` (CHIPS Cookie)
+ * Add argument `bool $flush = true` to `Response::send()`
 
 6.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -415,12 +415,19 @@ class Response
     /**
      * Sends HTTP headers and content.
      *
+     * @param bool $flush Whether output buffers should be flushed
+     *
      * @return $this
      */
-    public function send(): static
+    public function send(/* bool $flush = true */): static
     {
         $this->sendHeaders();
         $this->sendContent();
+
+        $flush = 1 <= \func_num_args() ? func_get_arg(0) : true;
+        if (!$flush) {
+            return $this;
+        }
 
         if (\function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();

--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add argument `bool $debug = false` to `HttpKernelRunner::__construct()`
+
 5.4
 ---
 

--- a/src/Symfony/Component/Runtime/Runner/Symfony/HttpKernelRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/Symfony/HttpKernelRunner.php
@@ -24,13 +24,14 @@ class HttpKernelRunner implements RunnerInterface
     public function __construct(
         private readonly HttpKernelInterface $kernel,
         private readonly Request $request,
+        private readonly bool $debug = false,
     ) {
     }
 
     public function run(): int
     {
         $response = $this->kernel->handle($this->request);
-        $response->send();
+        $response->send(!$this->debug);
 
         if ($this->kernel instanceof TerminableInterface) {
             $this->kernel->terminate($this->request, $response);

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -131,7 +131,7 @@ class SymfonyRuntime extends GenericRuntime
     public function getRunner(?object $application): RunnerInterface
     {
         if ($application instanceof HttpKernelInterface) {
-            return new HttpKernelRunner($application, Request::createFromGlobals());
+            return new HttpKernelRunner($application, Request::createFromGlobals(), $this->options['debug'] ?? false);
         }
 
         if ($application instanceof Response) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT

Inspired by https://github.com/symfony/symfony/issues/51912 and https://github.com/symfony/symfony/issues/45205 subjects

Adds optional argument `$flush` to `Response::send()`. If `$flush === false`, output buffers are not flushed/`*_finish_request()` and alike functions are not called.

We leverage that in the Runtime component by not flushing the output buffers when debug mode is on in order to see exceptions thrown in listeners listening on the `TerminateEvent` and also to feel a more "real" processing time of things happening on terminate.