### PR TITLE
[Doctrine] Allow DBAL 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
         "cache/integration-tests": "dev-master",
         "doctrine/collections": "^1.0|^2.0",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/dbal": "^3.6",
+        "doctrine/dbal": "^3.6|^4",
         "doctrine/orm": "^2.15|^3",
         "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^2.1.10|^3.1|^4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT

On the 6.x branches, we excluded DBAL 4 from the monorepo's composer.json in order to not lose DBAL 3 coverage in our test matrix. Since 7.0 dropped DBAL 2 support, we don't have this problem anymore on this branch.