### PR TITLE
[Console] `InputArgument` and `InputOption` code cleanup

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -283,7 +283,7 @@ class Command
     }
 
     /**
-     * Adds suggestions to $suggestions for the current completion input (e.g. option or argument).
+     * Supplies suggestions when resolving possible completion options for input (e.g. option or argument).
      */
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
@@ -401,8 +401,8 @@ class Command
     /**
      * Adds an argument.
      *
-     * @param $mode    The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
-     * @param $default The default value (for InputArgument::OPTIONAL mode only)
+     * @param                                                                               $mode            The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
+     * @param                                                                               $default         The default value (for InputArgument::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @return $this
@@ -420,9 +420,9 @@ class Command
     /**
      * Adds an option.
      *
-     * @param $shortcut The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param $mode     The option mode: One of the InputOption::VALUE_* constants
-     * @param $default  The default value (must be null for InputOption::VALUE_NONE)
+     * @param                                                                               $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param                                                                               $mode            The option mode: One of the InputOption::VALUE_* constants
+     * @param                                                                               $default         The default value (must be null for InputOption::VALUE_NONE)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @return $this

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -25,16 +25,26 @@ use Symfony\Component\Console\Exception\LogicException;
  */
 class InputArgument
 {
+    /**
+     * Providing an argument is required (e.g. just 'app:foo' is not allowed).
+     */
     public const REQUIRED = 1;
+
+    /**
+     * Providing an argument is optional (e.g. 'app:foo' and 'app:foo bar' are both allowed). This is the default behavior of arguments.
+     */
     public const OPTIONAL = 2;
+
+    /**
+     * The argument accepts multiple values and turn them into an array (e.g. 'app:foo bar baz' will result in value ['bar', 'baz']).
+     */
     public const IS_ARRAY = 4;
 
     private int $mode;
-    private string|int|bool|array|float|null $default;
 
     /**
      * @param string                                                                        $name            The argument name
-     * @param int|null                                                                      $mode            The argument mode: a bit mask of self::REQUIRED, self::OPTIONAL and self::IS_ARRAY
+     * @param int-mask-of<InputArgument::*>|null                                            $mode            The argument mode: a bit mask of self::REQUIRED, self::OPTIONAL and self::IS_ARRAY
      * @param string                                                                        $description     A description text
      * @param string|bool|int|float|array|null                                              $default         The default value (for self::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
@@ -50,7 +60,7 @@ class InputArgument
     ) {
         if (null === $mode) {
             $mode = self::OPTIONAL;
-        } elseif ($mode > 7 || $mode < 1) {
+        } elseif ($mode >= (self::IS_ARRAY << 1) || $mode < 1) {
             throw new InvalidArgumentException(sprintf('Argument mode "%s" is not valid.', $mode));
         }
 
@@ -89,8 +99,6 @@ class InputArgument
 
     /**
      * Sets the default value.
-     *
-     * @throws LogicException When incorrect default value is given
      */
     public function setDefault(string|bool|int|float|array|null $default): void
     {
@@ -117,13 +125,16 @@ class InputArgument
         return $this->default;
     }
 
+    /**
+     * Returns true if the argument has values for input completion.
+     */
     public function hasCompletion(): bool
     {
         return [] !== $this->suggestedValues;
     }
 
     /**
-     * Adds suggestions to $suggestions for the current completion input.
+     * Supplies suggestions when command resolves possible completion options for input.
      *
      * @see Command::complete()
      */

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -46,18 +46,18 @@ class InputOption
     public const VALUE_IS_ARRAY = 8;
 
     /**
-     * The option may have either positive or negative value (e.g. --ansi or --no-ansi).
+     * The option allows passing a negated variant (e.g. --ansi or --no-ansi).
      */
     public const VALUE_NEGATABLE = 16;
 
     private string $name;
-    private string|array|null $shortcut;
+    private ?string $shortcut;
     private int $mode;
     private string|int|bool|array|float|null $default;
 
     /**
      * @param string|array|null                                                             $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param int|null                                                                      $mode            The option mode: One of the VALUE_* constants
+     * @param int-mask-of<InputOption::*>|null                                              $mode            The option mode: One of the VALUE_* constants
      * @param string|bool|int|float|array|null                                              $default         The default value (must be null for self::VALUE_NONE)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
@@ -175,11 +175,19 @@ class InputOption
         return self::VALUE_IS_ARRAY === (self::VALUE_IS_ARRAY & $this->mode);
     }
 
+    /**
+     * Returns true if the option allows passing a negated variant.
+     *
+     * @return bool true if mode is self::VALUE_NEGATABLE, false otherwise
+     */
     public function isNegatable(): bool
     {
         return self::VALUE_NEGATABLE === (self::VALUE_NEGATABLE & $this->mode);
     }
 
+    /**
+     * Sets the default value.
+     */
     public function setDefault(string|bool|int|float|array|null $default): void
     {
         if (self::VALUE_NONE === (self::VALUE_NONE & $this->mode) && null !== $default) {
@@ -213,13 +221,16 @@ class InputOption
         return $this->description;
     }
 
+    /**
+     * Returns true if the option has values for input completion.
+     */
     public function hasCompletion(): bool
     {
         return [] !== $this->suggestedValues;
     }
 
     /**
-     * Adds suggestions to $suggestions for the current completion input.
+     * Supplies suggestions when command resolves possible completion options for input.
      *
      * @see Command::complete()
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT

This updates the `InputOption` and `InputArgument` classes to be slightly more consistent. Moreover it adds some additional dockblocks that were not present yet.
