### PR TITLE
[Console] Deprecate combining incompatible mode flags in `InputArgument` and `InputOption`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -13,6 +13,8 @@ Console
 
  * [BC BREAK] Add `object` support to input options and arguments' default by changing the `$default` type to `mixed` in `InputArgument`, `InputOption`, `#[Argument]` and `#[Option]`
  * Add optional `$format` argument to `SymfonyStyle::createProgressBar()`, `SymfonyStyle::progressStart()`, and `SymfonyStyle::progressIterate()` to allow passing a custom `ProgressBar` format string
+ * Deprecate passing both `InputArgument::REQUIRED` and `InputArgument::OPTIONAL` modes to `InputArgument` constructor
+ * Deprecate passing more than one out of `InputOption::VALUE_NONE`, `InputOption::VALUE_REQUIRED` and `InputOption::VALUE_OPTIONAL` modes to `InputOption` constructor
 
 DependencyInjection
 -------------------

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -17,6 +17,8 @@ CHANGELOG
  * Add a result-based testing API with `CommandTester::run()`, `ExecutionResult`, and `ConsoleAssertionsTrait` to assert output and error streams together
  * Add optional `$format` argument to `SymfonyStyle::createProgressBar()`, `SymfonyStyle::progressStart()`, and `SymfonyStyle::progressIterate()` to allow passing a custom `ProgressBar` format string
  * Allow setting a boolean default value on `InputOption::VALUE_NEGATABLE` options
+ * Deprecate passing both `InputArgument::REQUIRED` and `InputArgument::OPTIONAL` modes to `InputArgument` constructor
+ * Deprecate passing more than one out of `InputOption::VALUE_NONE`, `InputOption::VALUE_REQUIRED` and `InputOption::VALUE_OPTIONAL` modes to `InputOption` constructor
 
 8.0
 ---

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -59,10 +59,14 @@ class InputArgument
         mixed $default = null,
         private \Closure|array $suggestedValues = [],
     ) {
-        if (null === $mode) {
-            $mode = self::OPTIONAL;
-        } elseif ($mode >= (self::IS_ARRAY << 1) || $mode < 1) {
+        // If not explicitly marked as required, we assume the value to be optional
+        $mode = self::REQUIRED === (self::REQUIRED & $mode) ? $mode : (self::OPTIONAL | $mode);
+        if ($mode >= (self::IS_ARRAY << 1) || $mode < 1) {
             throw new InvalidArgumentException(\sprintf('Argument mode "%s" is not valid.', $mode));
+        }
+
+        if ((self::REQUIRED | self::OPTIONAL) === ((self::REQUIRED | self::OPTIONAL) & $mode)) {
+            trigger_deprecation('symfony/console', '8.1', 'Argument "%s" mode should specify either required or optional.', $name);
         }
 
         $this->mode = $mode;

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -96,10 +96,14 @@ class InputOption
             }
         }
 
-        if (null === $mode) {
-            $mode = self::VALUE_NONE;
-        } elseif ($mode >= (self::VALUE_NEGATABLE << 1) || $mode < 1) {
+        // If not explicitly marked as required or optional, we assume the value accepts no input
+        $mode = self::VALUE_REQUIRED === (self::VALUE_REQUIRED & $mode) || self::VALUE_OPTIONAL === (self::VALUE_OPTIONAL & $mode) ? $mode : (self::VALUE_NONE | $mode);
+        if ($mode >= (self::VALUE_NEGATABLE << 1) || $mode < 1) {
             throw new InvalidArgumentException(\sprintf('Option mode "%s" is not valid.', $mode));
+        }
+
+        if (!\in_array($mode & (self::VALUE_NONE | self::VALUE_REQUIRED | self::VALUE_OPTIONAL), [self::VALUE_NONE, self::VALUE_REQUIRED, self::VALUE_OPTIONAL], true)) {
+            trigger_deprecation('symfony/console', '8.1', 'Option "%s" mode should be either none, required or optional.', $name);
         }
 
         $this->name = $name;

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Tests\Input;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -32,7 +34,7 @@ class InputArgumentTest extends TestCase
         $this->assertFalse($argument->isRequired(), '__construct() gives a "InputArgument::OPTIONAL" mode by default');
 
         $argument = new InputArgument('foo', null);
-        $this->assertFalse($argument->isRequired(), '__construct() can take "InputArgument::OPTIONAL" as its mode');
+        $this->assertFalse($argument->isRequired(), '__construct() gives a "InputArgument::OPTIONAL" mode by default');
 
         $argument = new InputArgument('foo', InputArgument::OPTIONAL);
         $this->assertFalse($argument->isRequired(), '__construct() can take "InputArgument::OPTIONAL" as its mode');
@@ -47,6 +49,15 @@ class InputArgumentTest extends TestCase
         $this->expectExceptionMessage('Argument mode "-1" is not valid.');
 
         new InputArgument('foo', '-1');
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testAmbiguousRequirementSpecifierMode()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/console 8.1: Argument "foo" mode should specify either required or optional.');
+
+        new InputArgument('foo', InputArgument::OPTIONAL | InputArgument::REQUIRED);
     }
 
     public function testIsArray()

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Console\Tests\Input;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -83,9 +86,9 @@ class InputOptionTest extends TestCase
         $this->assertFalse($option->isValueOptional(), '__construct() gives a "InputOption::VALUE_NONE" mode by default');
 
         $option = new InputOption('foo', 'f', null);
-        $this->assertFalse($option->acceptValue(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
-        $this->assertFalse($option->isValueRequired(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
-        $this->assertFalse($option->isValueOptional(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
+        $this->assertFalse($option->acceptValue(), '__construct() gives a "InputOption::VALUE_NONE" mode by default');
+        $this->assertFalse($option->isValueRequired(), '__construct() gives a "InputOption::VALUE_NONE" mode by default');
+        $this->assertFalse($option->isValueOptional(), '__construct() gives a "InputOption::VALUE_NONE" mode by default');
 
         $option = new InputOption('foo', 'f', InputOption::VALUE_NONE);
         $this->assertFalse($option->acceptValue(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
@@ -109,6 +112,24 @@ class InputOptionTest extends TestCase
         $this->expectExceptionMessage('Option mode "-1" is not valid.');
 
         new InputOption('foo', 'f', '-1');
+    }
+
+    #[DataProvider('provideCombiningInvalidModes')]
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testCombiningInvalidModesIsDeprecated(int $mode)
+    {
+        $this->expectUserDeprecationMessage('Since symfony/console 8.1: Option "foo" mode should be either none, required or optional.');
+
+        new InputOption('foo', 'f', $mode);
+    }
+
+    public static function provideCombiningInvalidModes(): iterable
+    {
+        yield [InputOption::VALUE_NONE | InputOption::VALUE_REQUIRED];
+        yield [InputOption::VALUE_NONE | InputOption::VALUE_OPTIONAL];
+        yield [InputOption::VALUE_REQUIRED | InputOption::VALUE_OPTIONAL];
+        yield [InputOption::VALUE_NONE | InputOption::VALUE_REQUIRED | InputOption::VALUE_OPTIONAL];
     }
 
     public function testEmptyNameIsInvalid()

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/string": "^7.4|^8.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | n/a
| License       | MIT

Currently it is allowed to to combine various combinations of input value requirement specifiers, which are logically exclusive behavior-wise. To prevent mistakes or possibly ambiguous behavior, this PR adds additional validation to ensure there's always exactly one specifier part of the mode after finishing the constructor.

This is done by adding a deprecation message for these cases, which can be replaced with an `InvalidArgumentException` in a future major version. The tests added are currently checking for the deprecation message and could be updated to check for this exception instead.