### PR TITLE
[Validator] add missing catalan translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
@@ -402,6 +402,30 @@
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>El valor de la màscara de xarxa hauria d'estar entre {{ min }} i {{ max }}.</target>
             </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target>El nom del fitxer és massa llarg. Ha de tenir {{ filename_max_length }} caràcter o menys.|El nom del fitxer és massa llarg. Ha de tenir {{ filename_max_length }} caràcters o menys.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target>La contrasenya és massa feble. Si us plau, feu servir una contrasenya més segura.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target>Aquest valor conté caràcters que no estan permisos segons el nivell de restricció actual.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target>No es permet l'ús de caràcters invisibles.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target>No es permet barrejar números de diferents scripts.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target>No es permet l'ús de caràcters superposats ocults.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Solves #51932

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #51932 
| License       | MIT

This PR adds missing catalan translations for Validator component

