### PR TITLE
[Console] Allow setting a boolean default value on `InputOption::VALUE_NEGATABLE` options

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Add `TesterTrait::assertCommandIsInvalid()` to test command
  * Add a result-based testing API with `CommandTester::run()`, `ExecutionResult`, and `ConsoleAssertionsTrait` to assert output and error streams together
  * Add optional `$format` argument to `SymfonyStyle::createProgressBar()`, `SymfonyStyle::progressStart()`, and `SymfonyStyle::progressIterate()` to allow passing a custom `ProgressBar` format string
+ * Allow setting a boolean default value on `InputOption::VALUE_NEGATABLE` options
 
 8.0
 ---

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -190,8 +190,12 @@ class InputOption
      */
     public function setDefault(mixed $default): void
     {
-        if (self::VALUE_NONE === (self::VALUE_NONE & $this->mode) && null !== $default) {
+        if (self::VALUE_NONE === (self::VALUE_NONE & $this->mode) && !$this->isNegatable() && null !== $default) {
             throw new LogicException('Cannot set a default value when using InputOption::VALUE_NONE mode.');
+        }
+
+        if ($this->isNegatable() && null !== $default && !\is_bool($default)) {
+            throw new LogicException('A default value for a negatable option must be a boolean or null.');
         }
 
         if ($this->isArray()) {

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -228,6 +228,12 @@ class ArgvInputTest extends TestCase
                 ['foo' => false],
                 '->parse() parses long options without a value',
             ],
+            [
+                ['cli.php'],
+                [new InputOption('foo', null, InputOption::VALUE_NONE | InputOption::VALUE_NEGATABLE, '', false)],
+                ['foo' => false],
+                '->parse() parses long options without a value',
+            ],
         ];
     }
 

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -172,6 +172,24 @@ class InputOptionTest extends TestCase
         $option = new InputOption('foo', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
         $option->setDefault([1, 2]);
         $this->assertSame([1, 2], $option->getDefault(), '->setDefault() changes the default value');
+
+        $option = new InputOption('foo', null, InputOption::VALUE_NONE | InputOption::VALUE_NEGATABLE);
+        $option->setDefault(true);
+        $this->assertTrue($option->getDefault(), '->setDefault() changes the default value');
+
+        $option = new InputOption('foo', null, InputOption::VALUE_NEGATABLE);
+        $option->setDefault(false);
+        $this->assertFalse($option->getDefault(), '->setDefault() changes the default value');
+    }
+
+    public function testDefaultValueWithNegatableMode()
+    {
+        $option = new InputOption('foo', 'f', InputOption::VALUE_NEGATABLE);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A default value for a negatable option must be a boolean or null.');
+
+        $option->setDefault('default');
     }
 
     public function testSetDefaultWithObject()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  -
| License       | MIT

(Encountered on test run for #52055)

Currently, the following call/construction of an `InputOption` is valid:
```php
new InputOption('foo', null, InputOption::VALUE_NEGATABLE, '', false)
```
while the following call is not
```php
new InputOption('foo', null, InputOption::VALUE_NONE | InputOption::VALUE_NEGATABLE, '', false)
```

To me, this seems inconsistent, as I would expect both calls to behave in exactly the same manner. This PR ensures both calls are equally valid.

Note: a follow-up might be ensuring the passed default value is boolean when using `InputOption::VALUE_NEGATABLE`; I can add that to #52055 once this is merged.