### PR TITLE
[Config] Expose meta on `ResourceCheckerConfigCache` and `ConfigCacheInterface`

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Added method `getMeta()` to ResourceCheckerConfigCache and ConfigCacheInterface
+
 7.0
 ---
 

--- a/src/Symfony/Component/Config/ConfigCacheInterface.php
+++ b/src/Symfony/Component/Config/ConfigCacheInterface.php
@@ -42,4 +42,11 @@ interface ConfigCacheInterface
      * @throws \RuntimeException When the cache file cannot be written
      */
     public function write(string $content, array $metadata = null): void;
+
+    /*
+     * Returns the metadata stored for this cache.
+     *
+     * @return false|ResourceInterface[]
+     */
+    // public function getMeta() : false | array;
 }

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -68,13 +68,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
             return true; // shortcut - if we don't have any checkers we don't need to bother with the meta file at all
         }
 
-        $metadata = $this->getMetaFile();
-
-        if (!is_file($metadata)) {
-            return false;
-        }
-
-        $meta = $this->safelyUnserialize($metadata);
+        $meta = $this->getMeta();
 
         if (false === $meta) {
             return false;
@@ -131,6 +125,22 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
         if (\function_exists('opcache_invalidate') && filter_var(\ini_get('opcache.enable'), \FILTER_VALIDATE_BOOL)) {
             @opcache_invalidate($this->file, true);
         }
+    }
+
+    /**
+     * Returns the metadata stored for this cache.
+     *
+     * @return false|ResourceInterface[]
+     */
+    public function getMeta(): false|array
+    {
+        $metadata = $this->getMetaFile();
+
+        if (!is_file($metadata)) {
+            return false;
+        }
+
+        return $this->safelyUnserialize($metadata);
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -148,4 +148,14 @@ class ResourceCheckerConfigCacheTest extends TestCase
 
         $this->assertFalse($cache->isFresh());
     }
+
+    public function testGetMeta()
+    {
+        $checker = $this->createMock(ResourceCheckerInterface::class);
+        $cache = new ResourceCheckerConfigCache($this->cacheFile, [$checker]);
+        $cache->write('foo', [new FileResource(__FILE__)]);
+
+        $this->assertCount(1, $cache->getMeta());
+        $this->assertEquals(new FileResource(__FILE__), $cache->getMeta()[0]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT

When a developer adds meta to a config cache, it should also be possible to get back the meta.

I use these config caches for my own framework and want to retrieve a specific meta associated to the cache.