### PR TITLE
Add "ext-pcntl" as suggested dependency for "console" and "messenger" components

### DIFF
--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -42,6 +42,9 @@
         "symfony/lock": "<5.4",
         "symfony/process": "<5.4"
     },
+    "suggest": {
+        "ext-pcntl": "Take advantage of PHP's process control (PCNTL)"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Console\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -44,6 +44,9 @@
         "symfony/http-kernel": "<5.4",
         "symfony/serializer": "<5.4"
     },
+    "suggest": {
+        "ext-pcntl": "Take advantage of PHP's process control (PCNTL)"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Messenger\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Follows symfony/symfony-docs#19006. 
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

I'm open to update the suggestion message based on a better explanation regarding the purpose of the extension in each component.
