### PR TITLE
[Security] Update `InteractiveAuthenticatorInterface` description

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/InteractiveAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/InteractiveAuthenticatorInterface.php
@@ -16,8 +16,8 @@ namespace Symfony\Component\Security\Http\Authenticator;
  * be used by interactive authenticators.
  *
  * Interactive login requires explicit user action (e.g. a login
- * form or HTTP basic authentication). Implementing this interface
- * will dispatch the InteractiveLoginEvent upon successful login.
+ * form). Implementing this interface will dispatch the InteractiveLoginEvent
+ * upon successful login.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

`SecurityEvents` phpdoc and `InteractiveAuthenticatorInterface` are contradictory, this PR try to fix it

https://github.com/symfony/symfony/blob/d28330faaadb68f59e0d93da101741979db51df0/src/Symfony/Component/Security/Http/SecurityEvents.php#L20-L27


Found it when documenting InteractiveLoginEvent https://github.com/symfony/symfony-docs/pull/19029
