### PR TITLE
[Scheduler] Add `FailureEvent`

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Add `MessageProviderInterface` to trigger unique messages at runtime
  * Add `PreRunEvent` and `PostRunEvent` events
  * Add `DispatchSchedulerEventListener`
+ * Add `FailureEvent` event
 
 6.3
 ---

--- a/src/Symfony/Component/Scheduler/Event/FailureEvent.php
+++ b/src/Symfony/Component/Scheduler/Event/FailureEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Event;
+
+use Symfony\Component\Scheduler\Generator\MessageContext;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+
+class FailureEvent
+{
+    private bool $shouldIgnore = false;
+
+    public function __construct(
+        private readonly ScheduleProviderInterface $schedule,
+        private readonly MessageContext $messageContext,
+        private readonly object $message,
+        private readonly \Throwable $error,
+    ) {
+    }
+
+    public function getMessageContext(): MessageContext
+    {
+        return $this->messageContext;
+    }
+
+    public function getSchedule(): ScheduleProviderInterface
+    {
+        return $this->schedule;
+    }
+
+    public function getMessage(): object
+    {
+        return $this->message;
+    }
+
+    public function getError(): \Throwable
+    {
+        return $this->error;
+    }
+
+    public function shouldIgnore(bool $shouldIgnore = null): bool
+    {
+        if (null !== $shouldIgnore) {
+            $this->shouldIgnore = $shouldIgnore;
+        }
+
+        return $this->shouldIgnore;
+    }
+}

--- a/src/Symfony/Component/Scheduler/Schedule.php
+++ b/src/Symfony/Component/Scheduler/Schedule.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Scheduler;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Scheduler\Event\FailureEvent;
 use Symfony\Component\Scheduler\Event\PostRunEvent;
 use Symfony\Component\Scheduler\Event\PreRunEvent;
 use Symfony\Component\Scheduler\Exception\LogicException;
@@ -148,6 +149,13 @@ final class Schedule implements ScheduleProviderInterface
     public function after(callable $listener, int $priority = 0): static
     {
         $this->dispatcher->addListener(PostRunEvent::class, $listener, $priority);
+
+        return $this;
+    }
+
+    public function onFailure(callable $listener, int $priority = 0): static
+    {
+        $this->dispatcher->addListener(FailureEvent::class, $listener, $priority);
 
         return $this;
     }

--- a/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
@@ -15,8 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Scheduler\Event\FailureEvent;
 use Symfony\Component\Scheduler\Event\PostRunEvent;
 use Symfony\Component\Scheduler\Event\PreRunEvent;
 use Symfony\Component\Scheduler\EventListener\DispatchSchedulerEventListener;
@@ -45,15 +47,19 @@ class DispatchSchedulerEventListenerTest extends TestCase
         $listener = new DispatchSchedulerEventListener($scheduleProviderLocator, $eventDispatcher = new EventDispatcher());
         $workerReceivedEvent = new WorkerMessageReceivedEvent($envelope, 'default');
         $workerHandledEvent = new WorkerMessageHandledEvent($envelope, 'default');
+        $workerFailedEvent = new WorkerMessageFailedEvent($envelope, 'default', new \Exception());
         $secondListener = new TestEventListener();
 
         $eventDispatcher->addListener(PreRunEvent::class, [$secondListener, 'preRun']);
         $eventDispatcher->addListener(PostRunEvent::class, [$secondListener, 'postRun']);
+        $eventDispatcher->addListener(FailureEvent::class, [$secondListener, 'onFailure']);
         $listener->onMessageReceived($workerReceivedEvent);
         $listener->onMessageHandled($workerHandledEvent);
+        $listener->onMessageFailed($workerFailedEvent);
 
         $this->assertTrue($secondListener->preInvoked);
         $this->assertTrue($secondListener->postInvoked);
+        $this->assertTrue($secondListener->failureInvoked);
     }
 }
 
@@ -62,6 +68,7 @@ class TestEventListener
     public string $name;
     public bool $preInvoked = false;
     public bool $postInvoked = false;
+    public bool $failureInvoked = false;
 
     /* Listener methods */
 
@@ -73,5 +80,10 @@ class TestEventListener
     public function postRun($e)
     {
         $this->postInvoked = true;
+    }
+
+    public function onFailure($e)
+    {
+        $this->failureInvoked = true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT

Following PR #51805, It would be interesting to add a `failureEvent` allowing you, for instance, to remove the recurring message, depending on the error caught. 