### PR TITLE
[Dotenv] Update README with variable override note

### DIFF
--- a/src/Symfony/Component/Dotenv/README.md
+++ b/src/Symfony/Component/Dotenv/README.md
@@ -27,6 +27,10 @@ $dotenv->overload(__DIR__.'/.env');
 $dotenv->loadEnv(__DIR__.'/.env');
 ```
 
+Note
+---
+Keep in mind that `$overrideExistingVars` work only with **existing** environment variables (defined before application) and not with `.env` file variables.
+
 Resources
 ---------
 


### PR DESCRIPTION
In the Dotenv README.md, a note has been added to clarify how the `$overrideExistingVars` flag behaves. This flag works only with existing environment variables (defined before application), and not with `.env` file variables. This change aims to prevent potential misunderstandings or misuse of the flag in the future.

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #52073
| License       | MIT