### PR TITLE
[Notifier] [Brevo] Handle error responses without a message key

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -65,7 +65,7 @@ final class BrevoApiTransport extends AbstractApiTransport
         }
 
         if (201 !== $statusCode) {
-            throw new HttpTransportException('Unable to send an email: '.$result['message'].sprintf(' (code %d).', $statusCode), $response);
+            throw new HttpTransportException('Unable to send an email: '.($result['message'] ?? $response->getContent(false)).sprintf(' (code %d).', $statusCode), $response);
         }
 
         $sentMessage->setMessageId($result['messageId']);

--- a/src/Symfony/Component/Notifier/Bridge/Brevo/BrevoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Brevo/BrevoTransport.php
@@ -75,7 +75,7 @@ final class BrevoTransport extends AbstractTransport
         if (201 !== $statusCode) {
             $error = $response->toArray(false);
 
-            throw new TransportException('Unable to send the SMS: '.$error['message'], $response);
+            throw new TransportException('Unable to send the SMS: '.($error['message'] ?? $response->getContent(false)), $response);
         }
 
         $success = $response->toArray(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT

During their outage yesterday where the endpoint returned errors with status code 500, there was no message key in the json response.
This avoids a notice when the key does not exist. Instead, it uses the full response content, as done when the decoding fails.

This is the same change than https://github.com/symfony/symfony/pull/52095 but for the new Brevo bridge
