### PR TITLE
[AssetMapper] Disable profiler when the "dev server" respond

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -38,7 +38,6 @@ use Symfony\Component\AssetMapper\ImportMap\RemotePackageDownloader;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\JsDelivrEsmResolver;
 use Symfony\Component\AssetMapper\MapperAwareAssetPackage;
 use Symfony\Component\AssetMapper\Path\PublicAssetsPathResolver;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -92,8 +91,9 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('asset public prefix'),
                 abstract_arg('extensions map'),
                 service('cache.asset_mapper'),
+                service('profiler')->nullOnInvalid(),
             ])
-            ->tag('kernel.event_subscriber', ['event' => RequestEvent::class])
+            ->tag('kernel.event_subscriber')
 
         ->set('asset_mapper.command.compile', AssetMapperCompileCommand::class)
             ->args([

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
@@ -30,6 +30,7 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
         EOF, $response->getContent());
         $this->assertSame('"b3445cb7a86a0795a7af7f2004498aef"', $response->headers->get('ETag'));
         $this->assertSame('immutable, max-age=604800, public', $response->headers->get('Cache-Control'));
+        $this->assertTrue($response->headers->has('X-Assets-Dev'));
     }
 
     public function test404OnUnknownAsset()
@@ -39,6 +40,7 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
         $client->request('GET', '/assets/unknown.css');
         $response = $client->getResponse();
         $this->assertSame(404, $response->getStatusCode());
+        $this->assertFalse($response->headers->has('X-Assets-Dev'));
     }
 
     public function test404OnInvalidDigest()

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/JavaScriptImportTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/JavaScriptImportTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\AssetMapper\Tests\ImportMap;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

In debug mode, the "dev server" send assets as if they were compiled in the public directory.

To improve the DX and not "pollute" too much the profiler (see capture below), this PR does two things : 
* disable the profiler for those requests 
* stop the request & response event propagation, to speed things a bit


<img width="800" alt="Capture d’écran 2023-10-17 à 10 57 44" src="https://github.com/symfony/symfony/assets/1359581/98eff6c5-2da4-46e3-9e7e-44b34ec38eef">

