### PR TITLE
[Cache] Remove temporary cache item file on `rename()` failure

### DIFF
--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -90,6 +90,7 @@ trait FilesystemCommonTrait
 
     private function write(string $file, string $data, int $expiresAt = null)
     {
+        $unlink = false;
         set_error_handler(__CLASS__.'::throwError');
         try {
             if (null === $this->tmp) {
@@ -107,14 +108,22 @@ trait FilesystemCommonTrait
             }
             fwrite($h, $data);
             fclose($h);
+            $unlink = true;
 
             if (null !== $expiresAt) {
                 touch($this->tmp, $expiresAt ?: time() + 31556952); // 1 year in seconds
             }
 
-            return rename($this->tmp, $file);
+            $success = rename($this->tmp, $file);
+            $unlink = !$success;
+
+            return $success;
         } finally {
             restore_error_handler();
+
+            if ($unlink) {
+                @unlink($this->tmp);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #52092
| License       | MIT

The filesystem cache adapter creates a temporary file to store cache item data, then moves it to its target path using `rename()` function. If rename fails, for instance target path is not writable, the temporary file will remains.

To prevent filesystem saturation, the temporary files should be deleted if this operation is not done by the `rename()` function itself.