### PR TITLE
[AssetMapper] Link needs as="style"

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -163,7 +163,7 @@ class ImportMapRenderer
 
     private function addWebLinkPreloads(Request $request, array $cssLinks): void
     {
-        $cssPreloadLinks = array_map(fn ($url) => new Link('preload', $url), $cssLinks);
+        $cssPreloadLinks = array_map(fn ($url) => (new Link('preload', $url))->withAttribute('as', 'style'), $cssLinks);
 
         if (null === $linkProvider = $request->attributes->get('_links')) {
             $request->attributes->set('_links', new GenericLinkProvider($cssPreloadLinks));

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -195,6 +195,7 @@ class ImportMapRendererTest extends TestCase
         $this->assertInstanceOf(GenericLinkProvider::class, $linkProvider);
         $this->assertCount(1, $linkProvider->getLinks());
         $this->assertSame(['preload'], $linkProvider->getLinks()[0]->getRels());
+        $this->assertSame(['as' => 'style'], $linkProvider->getLinks()[0]->getAttributes());
         $this->assertSame('/assets/styles/app-preload-d1g35t.css', $linkProvider->getLinks()[0]->getHref());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Mentioned on https://github.com/symfony/recipes/pull/1245#issuecomment-1766106851
| License       | MIT

Hi!

The `as="style"` is required. It was missing from the docs (I'll make a PR there) and so I forgot it :). Tested on a real project to verify the warning was gone.

Cheers!