### PR TITLE
[HttpKernel] Fix CacheWarmerAggregateTest

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
@@ -98,10 +98,6 @@ class CacheWarmerAggregateTest extends TestCase
         $warmer = $this->createMock(CacheWarmerInterface::class);
         $warmer
             ->expects($this->once())
-            ->method('isOptional')
-            ->willReturn(false);
-        $warmer
-            ->expects($this->once())
             ->method('warmUp')
             ->with('cache_dir', 'build_dir');
 
@@ -110,7 +106,7 @@ class CacheWarmerAggregateTest extends TestCase
         $aggregate->warmUp('cache_dir', 'build_dir');
     }
 
-    public function testWarmupOnOptionalWarmerDoNotPassBuildDir()
+    public function testWarmupOnOptionalWarmerPassBuildDir()
     {
         $warmer = $this->createMock(CacheWarmerInterface::class);
         $warmer
@@ -120,10 +116,10 @@ class CacheWarmerAggregateTest extends TestCase
         $warmer
             ->expects($this->once())
             ->method('warmUp')
-            ->with('cache_dir', null);
+            ->with('cache_dir', 'build_dir');
 
         $aggregate = new CacheWarmerAggregate([$warmer]);
-        $aggregate->enableOptionalWarmers();
+        $aggregate->enableOnlyOptionalWarmers();
         $aggregate->warmUp('cache_dir', 'build_dir');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

https://github.com/symfony/symfony/pull/50391 seems to bring broken tests. Particularly, the `testWarmupOnOptionalWarmerPassBuildDir` test doesn't seem relevant given the actual code of `CacheWarmerAggregate`. Indeed, nothing in the code is setting `buildDir` to null when using an optional warmer. I suggest a changes to fix this test on 6.4.

Also for the first one, given `optionalsEnabled` is enabled, `isOptional` is never called. I suggest to remove this expectation.