### PR TITLE
[HttpKernel] Fix missing argument `$statusCode` in `ProfilerStorageInterface::find()`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
@@ -29,12 +29,13 @@ interface ProfilerStorageInterface
     /**
      * Finds profiler tokens for the given criteria.
      *
-     * @param int|null      $limit  The maximum number of tokens to return
-     * @param int|null      $start  The start date to search from
-     * @param int|null      $end    The end date to search to
-     * @param \Closure|null $filter A filter to apply on the list of tokens
+     * @param int|null      $limit      The maximum number of tokens to return
+     * @param int|null      $start      The start date to search from
+     * @param int|null      $end        The end date to search to
+     * @param string|null   $statusCode The response status code
+     * @param \Closure|null $filter     A filter to apply on the list of tokens
      */
-    public function find(?string $ip, ?string $url, ?int $limit, ?string $method, int $start = null, int $end = null/* , \Closure $filter = null */): array;
+    public function find(?string $ip, ?string $url, ?int $limit, ?string $method, int $start = null, int $end = null/* , string $statusCode = null, \Closure $filter = null */): array;
 
     /**
      * Reads data associated with the given token.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT

It seems the argument has never been added to the internal interface since its introduction in `FileProfilerStorage::find()` in 3.1 (ref https://github.com/symfony/symfony/commit/7d3700a48f840706613857aff7311e150ab1cc59#diff-da2e8209f32b7918b8869eaa8d63c28e63b6e6a9b68f43eb26745d038100418f).