### PR TITLE
[AssetMapper] Using ?specifier=* does not match unstable packages on jsdelivr

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -61,7 +61,7 @@ class JsDelivrEsmResolverTest extends TestCase
             'packages' => [new PackageRequireOptions('lodash')],
             'expectedRequests' => [
                 [
-                    'url' => '/v1/packages/npm/lodash/resolved?specifier=%2A',
+                    'url' => '/v1/packages/npm/lodash/resolved',
                     'response' => ['body' => ['version' => '1.2.3']],
                 ],
                 [
@@ -196,7 +196,7 @@ class JsDelivrEsmResolverTest extends TestCase
             'packages' => [new PackageRequireOptions('bootstrap/dist/css/bootstrap.min.css')],
             'expectedRequests' => [
                 [
-                    'url' => '/v1/packages/npm/bootstrap/resolved?specifier=%2A',
+                    'url' => '/v1/packages/npm/bootstrap/resolved',
                     'response' => ['body' => ['version' => '3.3.0']],
                 ],
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #52106
| License       | MIT

To find which version of a package to grab, we use this API endpoint - https://data.jsdelivr.com/v1/packages/npm/@tabler/core/resolved. If a version constraint is specified (e.g. `importmap:require 'bootstrap@^5'`), we add a `?specifier=5`. If no version is specified, previously we added `?specifier=*`. However, this seems to ignore beta releases (returning `null` for `@table/core`, whose only has a 1.0 beta). Omitting `?specifier` seems to grab the latest, no matter what it is.

Also, if for some reason, we still can't find a `version`, we know blow up with a much clearer exception.

Cheers!