### PR TITLE
Fix missing dispatch `WorkerStoppedEvent` after `SIGINT` or `SIGTERM`

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnFailureLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMemoryLimitListener;
@@ -270,6 +271,8 @@ EOF
         $this->logger?->info('Received signal {signal}.', ['signal' => $signal, 'transport_names' => $this->worker->getMetadata()->getTransportNames()]);
 
         $this->worker->stop();
+
+        $this->eventDispatcher?->dispatch(new WorkerStoppedEvent($this->worker));
 
         return false;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes?
| New feature?  | no 
| Deprecations? | no
| License       | MIT

Related to https://github.com/symfony/symfony/issues/52077

In my point of view this Event should be dispatched here.
But maybe there are reasons for not doing this in the past.

I am not sure if bugfix or new feature.
