### PR TITLE
[HttpKernel] Introduce `ExceptionEvent::isKernelTerminating()` to skip error rendering when kernel is terminating

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 7.0 to 7.1
+=======================
+
+HttpKernel
+----------
+
+ * `ExceptionEvent` now takes an optional `$isKernelTerminating` parameter

--- a/src/Symfony/Component/HttpKernel/Event/ExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ExceptionEvent.php
@@ -31,12 +31,14 @@ final class ExceptionEvent extends RequestEvent
 {
     private \Throwable $throwable;
     private bool $allowCustomResponseCode = false;
+    private bool $isKernelTerminating = false;
 
-    public function __construct(HttpKernelInterface $kernel, Request $request, int $requestType, \Throwable $e)
+    public function __construct(HttpKernelInterface $kernel, Request $request, int $requestType, \Throwable $e, bool $isKernelTerminating = false)
     {
         parent::__construct($kernel, $request, $requestType);
 
         $this->setThrowable($e);
+        $this->isKernelTerminating = $isKernelTerminating;
     }
 
     public function getThrowable(): \Throwable
@@ -68,5 +70,10 @@ final class ExceptionEvent extends RequestEvent
     public function isAllowingCustomResponseCode(): bool
     {
         return $this->allowCustomResponseCode;
+    }
+
+    public function isKernelTerminating(): bool
+    {
+        return $this->isKernelTerminating;
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -102,6 +102,10 @@ class ErrorListener implements EventSubscriberInterface
             return;
         }
 
+        if (!$this->debug && $event->isKernelTerminating()) {
+            return;
+        }
+
         $throwable = $event->getThrowable();
 
         if ($exceptionHandler = set_exception_handler(var_dump(...))) {

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -244,6 +244,19 @@ class ErrorListenerTest extends TestCase
         $this->assertFalse($response->headers->has('content-security-policy'), 'CSP header has been removed');
     }
 
+    public function testTerminating()
+    {
+        $listener = new ErrorListener('foo', $this->createMock(LoggerInterface::class));
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel->expects($this->never())->method('handle');
+
+        $request = Request::create('/');
+
+        $event = new ExceptionEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, new \Exception('foo'), true);
+        $listener->onKernelException($event);
+    }
+
     /**
      * @dataProvider controllerProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #51912
| License       | MIT