### PR TITLE
[HttpKernel] Fix `RequestPayloadValueResolver` handling error with no ExpectedTypes

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -108,11 +108,15 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 } catch (PartialDenormalizationException $e) {
                     $trans = $this->translator ? $this->translator->trans(...) : fn ($m, $p) => strtr($m, $p);
                     foreach ($e->getErrors() as $error) {
-                        $parameters = ['{{ type }}' => implode('|', $error->getExpectedTypes())];
+                        $parameters = [];
+                        $template = 'This value was of an unexpected type.';
+                        if ($expectedTypes = $error->getExpectedTypes()) {
+                            $template = 'This value should be of type {{ type }}.';
+                            $parameters['{{ type }}'] = implode('|', $expectedTypes);
+                        }
                         if ($error->canUseMessageForUser()) {
                             $parameters['hint'] = $error->getMessage();
                         }
-                        $template = 'This value should be of type {{ type }}.';
                         $message = $trans($template, $parameters, 'validators');
                         $violations->add(new ConstraintViolation($message, $template, $parameters, null, $error->getPath(), null));
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The `NotNormalizableValueException` errors in `PartialDenormalizationException->getErrors()` have a `->getExpectedTypes()` method that returns `array|null`.  The `RequestPayloadValueResolver` assumes this is always an array.

When the returned value is `null`, an Exception is thrown with `implode(): Argument #1 ($pieces) must be of type array, string given`. 

Also the exception message in case of an empty array was: `This value should be of type .`.

#SymfonyHackday
