### PR TITLE
[AssetMapper] Adding nopush to Link header

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -163,7 +163,7 @@ class ImportMapRenderer
 
     private function addWebLinkPreloads(Request $request, array $cssLinks): void
     {
-        $cssPreloadLinks = array_map(fn ($url) => (new Link('preload', $url))->withAttribute('as', 'style'), $cssLinks);
+        $cssPreloadLinks = array_map(fn ($url) => (new Link('preload', $url))->withAttribute('as', 'style')->withAttribute('nopush', true), $cssLinks);
 
         if (null === $linkProvider = $request->attributes->get('_links')) {
             $request->attributes->set('_links', new GenericLinkProvider($cssPreloadLinks));

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -195,7 +195,7 @@ class ImportMapRendererTest extends TestCase
         $this->assertInstanceOf(GenericLinkProvider::class, $linkProvider);
         $this->assertCount(1, $linkProvider->getLinks());
         $this->assertSame(['preload'], $linkProvider->getLinks()[0]->getRels());
-        $this->assertSame(['as' => 'style'], $linkProvider->getLinks()[0]->getAttributes());
+        $this->assertSame(['as' => 'style', 'nopush' => true], $linkProvider->getLinks()[0]->getAttributes());
         $this->assertSame('/assets/styles/app-preload-d1g35t.css', $linkProvider->getLinks()[0]->getHref());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None 
| License       | MIT

See conversation here - https://github.com/symfony/symfony/pull/51829#discussion_r1362689327

I am not 100% sure this is needed - I'd love an HTTP/2 expert (perhaps dunglas?) to weigh in on this. Notes:

A) The purpose of the `Link` header is to hint to the browser as early as possible that a CSS file is needed. However, a web server MAY see this and perform a server push. That is NOT desired, as it would push the asset on every request, even after it is cached.

B) So, adding `nopush` makes sense. But I'm not sure which web servers, in practice, are actually server-pushing at this time.

Note: HTTP/2 server push is removed from Chrome - https://developer.chrome.com/blog/removing-push/ - which means they send a `SETTINGS_ENABLE_PUSH=0` setting when establishing the connection to ask the server to NOT push.

So I think this is a good change... unless it's totally not needed because web servers aren't server-pushing already. And I don't know if that's the case.

Cheers!