### PR TITLE
[WebProfilerBundle] Fix generated application link

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/_command_summary.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/_command_summary.html.twig
@@ -31,7 +31,7 @@
 
             <dt>Application</dt>
             <dd>
-                <a href="{{ path('_profiler_search_results', { token: token, limit: 10, ip: profile.ip }) }}">{{ profile.ip }}</a>
+                <a href="{{ path('_profiler_search_results', { token: token, limit: 10, ip: profile.ip, type: 'command' }) }}">{{ profile.ip }}</a>
             </dd>
 
             <dt>Profiled on</dt>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I played a little bit with the new Profiling command https://github.com/symfony/symfony/pull/47416 (I love it !), and found that `type=command` is missing in one URL

![image](https://github.com/symfony/symfony/assets/9253091/c0ba0a81-e906-4223-b91d-7b91ceac2309)

