### PR TITLE
[WebProfilerBundle] Rewrite to avoid using request word when nothing found

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -38,7 +38,7 @@
                                                 <strong>There are no uncalled listeners</strong>.
                                             </p>
                                             <p>
-                                                All listeners were called for this request or an error occurred
+                                                All listeners were called or an error occurred
                                                 when trying to collect uncalled listeners (in which case check the
                                                 logs to get more information).
                                             </p>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -35,7 +35,7 @@
 
     {% if not collector.hasexception %}
         <div class="empty empty-panel">
-            <p>No exception was thrown and caught during the request.</p>
+            <p>No exception was thrown and caught.</p>
         </div>
     {% else %}
         <div class="sf-reset">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -394,7 +394,7 @@
         </div>
     {% else %}
         <div class="empty empty-panel">
-            <p>No forms were submitted for this request.</p>
+            <p>No forms were submitted.</p>
         </div>
     {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -99,7 +99,7 @@
     <div class="sf-serializer sf-reset">
         {% if not collector.handledCount %}
             <div class="empty empty-panel">
-                <p>Nothing was handled by the serializer for this request.</p>
+                <p>Nothing was handled by the serializer.</p>
             </div>
         {% else %}
             <div class="metrics">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -94,7 +94,7 @@
         <h2>Twig</h2>
 
         <div class="empty empty-panel">
-            <p>No Twig templates were rendered for this request.</p>
+            <p>No Twig templates were rendered.</p>
         </div>
     {% else %}
         <h2>Twig Metrics</h2>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
@@ -126,7 +126,7 @@
         </div>
     {% else %}
         <div class="empty empty-panel">
-            <p>No calls to the validator were collected during this request.</p>
+            <p>No calls to the validator were collected.</p>
         </div>
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

When profiling commands, we don't have request.

![image](https://github.com/symfony/symfony/assets/9253091/93c2ea02-dfdb-4f5f-9c21-cfe32ec45f76)

Others collectors templates don't use "Request" when there is no item
