### PR TITLE
[AssetMapper] Optimize memory usage (load only "compilable" assets)

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapperCompiler.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperCompiler.php
@@ -42,4 +42,15 @@ class AssetMapperCompiler
 
         return $content;
     }
+
+    public function supports(MappedAsset $asset): bool
+    {
+        foreach ($this->assetCompilers as $compiler) {
+            if ($compiler->supports($asset)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -139,12 +139,13 @@ EOT
         foreach ($allAssets as $asset) {
             // $asset->getPublicPath() will start with a "/"
             $targetPath = $publicDir.$asset->publicPath;
-
-            if (!is_dir($dir = \dirname($targetPath))) {
-                $this->filesystem->mkdir($dir);
+            if (null !== $asset->content) {
+                // The original content has been modified by the AssetMapperCompiler
+                $this->filesystem->dumpFile($targetPath, $asset->content);
+            } else {
+                $this->filesystem->copy($asset->sourcePath, $targetPath, true);
             }
 
-            $this->filesystem->dumpFile($targetPath, $asset->content);
             $manifest[$asset->logicalPath] = $asset->publicPath;
         }
         ksort($manifest);

--- a/src/Symfony/Component/AssetMapper/MappedAsset.php
+++ b/src/Symfony/Component/AssetMapper/MappedAsset.php
@@ -24,7 +24,12 @@ final class MappedAsset
     public readonly string $publicPath;
     public readonly string $publicPathWithoutDigest;
     public readonly string $publicExtension;
-    public readonly string $content;
+
+    /**
+     * The final content of this asset, if different from the source.
+     */
+    public readonly ?string $content;
+
     public readonly string $digest;
     public readonly bool $isPredigested;
     public readonly bool $isVendor;
@@ -73,9 +78,7 @@ final class MappedAsset
             $this->publicPathWithoutDigest = $publicPathWithoutDigest;
             $this->publicExtension = pathinfo($publicPathWithoutDigest, \PATHINFO_EXTENSION);
         }
-        if (null !== $content) {
-            $this->content = $content;
-        }
+        $this->content = $content;
         if (null !== $digest) {
             $this->digest = $digest;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

A bit late for 6.4... but this PR will have a sensible impact on performances.

Currently if the assets directory contains 500 images, they are all loaded in memory during the compile command. 
Their contents are also serialized/unserialized and stored in cache.

This PR allow to load/store in memory/cache only the assets supported by the compilers (JS/CSS files today)