### PR TITLE
[Tests] Move `expectException` closer to the place of the expectation to avoid false positives

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -27,7 +27,6 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
 
     public function testExceptionOnAbstractTaggedSubscriber()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $container = $this->createBuilder();
 
         $abstractDefinition = new Definition('stdClass');
@@ -36,12 +35,13 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
 
         $container->setDefinition('a', $abstractDefinition);
 
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->process($container);
     }
 
     public function testExceptionOnAbstractTaggedListener()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $container = $this->createBuilder();
 
         $abstractDefinition = new Definition('stdClass');
@@ -49,6 +49,8 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
         $abstractDefinition->addTag('doctrine.event_listener', ['event' => 'test']);
 
         $container->setDefinition('a', $abstractDefinition);
+
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->process($container);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterMappingsPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterMappingsPassTest.php
@@ -20,9 +20,11 @@ class RegisterMappingsPassTest extends TestCase
 {
     public function testNoDriverParmeterException()
     {
+        $container = $this->createBuilder();
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Could not find the manager name parameter in the container. Tried the following parameter names: "manager.param.one", "manager.param.two"');
-        $container = $this->createBuilder();
+
         $this->process($container, [
             'manager.param.one',
             'manager.param.two',

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -58,7 +58,6 @@ class DoctrineExtensionTest extends TestCase
 
     public function testFixManagersAutoMappingsWithTwoAutomappings()
     {
-        $this->expectException(\LogicException::class);
         $emConfigs = [
             'em1' => [
                 'auto_mapping' => true,
@@ -75,6 +74,8 @@ class DoctrineExtensionTest extends TestCase
 
         $reflection = new \ReflectionClass($this->extension);
         $method = $reflection->getMethod('fixManagersAutoMappings');
+
+        $this->expectException(\LogicException::class);
 
         $method->invoke($this->extension, $emConfigs, $bundles);
     }
@@ -255,8 +256,6 @@ class DoctrineExtensionTest extends TestCase
 
     public function testUnrecognizedCacheDriverException()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('"unrecognized_type" is an unrecognized Doctrine cache driver.');
         $cacheName = 'metadata_cache';
         $container = $this->createContainer();
         $objectManager = [
@@ -265,6 +264,9 @@ class DoctrineExtensionTest extends TestCase
                 'type' => 'unrecognized_type',
             ],
         ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"unrecognized_type" is an unrecognized Doctrine cache driver.');
 
         $this->invokeLoadCacheDriver($objectManager, $container, $cacheName);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
@@ -152,9 +152,6 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     public function testLoadValuesForChoicesDoesNotLoadIfSingleIntId()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Not defining the IdReader explicitly as a value callback when the query can be optimized is not supported.');
-
         $loader = new DoctrineChoiceLoader(
             $this->om,
             $this->class,
@@ -169,7 +166,10 @@ class DoctrineChoiceLoaderTest extends TestCase
             ->with($this->obj2)
             ->willReturn('2');
 
-        $this->assertSame(['2'], $loader->loadValuesForChoices([$this->obj2]));
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Not defining the IdReader explicitly as a value callback when the query can be optimized is not supported.');
+
+        $loader->loadValuesForChoices([$this->obj2]);
     }
 
     public function testLoadValuesForChoicesDoesNotLoadIfSingleIntIdAndValueGiven()
@@ -253,17 +253,12 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     public function testLegacyLoadChoicesForValuesLoadsOnlyChoicesIfValueUseIdReader()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Not defining the IdReader explicitly as a value callback when the query can be optimized is not supported.');
-
         $loader = new DoctrineChoiceLoader(
             $this->om,
             $this->class,
             $this->idReader,
             $this->objectLoader
         );
-
-        $choices = [$this->obj2, $this->obj3];
 
         $this->idReader->expects($this->any())
             ->method('getIdField')
@@ -275,10 +270,10 @@ class DoctrineChoiceLoaderTest extends TestCase
         $this->objectLoader->expects($this->never())
             ->method('getEntitiesByIds');
 
-        $this->assertSame(
-            [4 => $this->obj3, 7 => $this->obj2],
-            $loader->loadChoicesForValues([4 => '3', 7 => '2'])
-        );
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Not defining the IdReader explicitly as a value callback when the query can be optimized is not supported.');
+
+        $loader->loadChoicesForValues([4 => '3', 7 => '2']);
     }
 
     public function testLoadChoicesForValuesLoadsOnlyChoicesIfValueUseIdReader()
@@ -374,14 +369,14 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     public function testPassingIdReaderWithoutSingleIdEntity()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "$idReader" argument of "Symfony\\Bridge\\Doctrine\\Form\\ChoiceList\\DoctrineChoiceLoader::__construct" must be null when the query cannot be optimized because of composite id fields.');
-
         $idReader = $this->createMock(IdReader::class);
         $idReader->expects($this->once())
             ->method('isSingleId')
             ->willReturn(false)
         ;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "$idReader" argument of "Symfony\\Bridge\\Doctrine\\Form\\ChoiceList\\DoctrineChoiceLoader::__construct" must be null when the query cannot be optimized because of composite id fields.');
 
         new DoctrineChoiceLoader($this->om, $this->class, $idReader, $this->objectLoader);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -218,7 +218,7 @@ class EntityTypeTest extends BaseTypeTestCase
     public function testConfigureQueryBuilderWithClosureReturningNonQueryBuilder()
     {
         $this->expectException(UnexpectedTypeException::class);
-        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+        $this->factory->createNamed('name', static::TESTED_TYPE, null, [
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => fn () => new \stdClass(),

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineTransactionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineTransactionMiddlewareTest.php
@@ -56,14 +56,15 @@ class DoctrineTransactionMiddlewareTest extends MiddlewareTestCase
 
     public function testTransactionIsRolledBackOnException()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Thrown from next middleware.');
         $this->connection->expects($this->once())
             ->method('beginTransaction')
         ;
         $this->connection->expects($this->once())
             ->method('rollBack')
         ;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Thrown from next middleware.');
 
         $this->middleware->handle(new Envelope(new \stdClass()), $this->getThrowingStackMock());
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -89,8 +89,6 @@ class EntityUserProviderTest extends TestCase
 
     public function testLoadUserByIdentifierWithNonUserLoaderRepositoryAndWithoutProperty()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('You must either make the "Symfony\Bridge\Doctrine\Tests\Fixtures\User" entity Doctrine Repository ("Doctrine\ORM\EntityRepository") implement "Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.');
         $em = DoctrineTestHelper::createTestEntityManager();
         $this->createSchema($em);
 
@@ -100,6 +98,10 @@ class EntityUserProviderTest extends TestCase
         $em->flush();
 
         $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Bridge\Doctrine\Tests\Fixtures\User');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You must either make the "Symfony\Bridge\Doctrine\Tests\Fixtures\User" entity Doctrine Repository ("Doctrine\ORM\EntityRepository") implement "Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.');
+
         $provider->loadUserByIdentifier('user1');
     }
 
@@ -171,13 +173,14 @@ class EntityUserProviderTest extends TestCase
 
     public function testLoadUserByIdentifierShouldDeclineInvalidInterface()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $repository = $this->createMock(ObjectRepository::class);
 
         $provider = new EntityUserProvider(
             $this->getManager($this->getObjectManager($repository)),
             'Symfony\Bridge\Doctrine\Tests\Fixtures\User'
         );
+
+        $this->expectException(\InvalidArgumentException::class);
 
         $provider->loadUserByIdentifier('name');
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -617,8 +617,6 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testDedicatedEntityManagerNullObject()
     {
-        $this->expectException(ConstraintDefinitionException::class);
-        $this->expectExceptionMessage('Object manager "foo" does not exist.');
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
@@ -632,13 +630,14 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $entity = new SingleIntIdEntity(1, null);
 
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Object manager "foo" does not exist.');
+
         $this->validator->validate($entity, $constraint);
     }
 
     public function testEntityManagerNullObject()
     {
-        $this->expectException(ConstraintDefinitionException::class);
-        $this->expectExceptionMessage('Unable to find the object manager associated with an entity of class "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity"');
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
@@ -651,6 +650,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->initialize($this->context);
 
         $entity = new SingleIntIdEntity(1, null);
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Unable to find the object manager associated with an entity of class "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity"');
 
         $this->validator->validate($entity, $constraint);
     }
@@ -719,8 +721,6 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidateRepositoryForInheritance()
     {
-        $this->expectException(ConstraintDefinitionException::class);
-        $this->expectExceptionMessage('The "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity" entity repository does not support the "Symfony\Bridge\Doctrine\Tests\Fixtures\Person" entity. The entity should be an instance of or extend "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity".');
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
@@ -729,6 +729,10 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         ]);
 
         $entity = new Person(1, 'Foo');
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity" entity repository does not support the "Symfony\Bridge\Doctrine\Tests\Fixtures\Person" entity. The entity should be an instance of or extend "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity".');
+
         $this->validator->validate($entity, $constraint);
     }
 

--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/HttpFoundationFactoryTest.php
@@ -185,13 +185,13 @@ class HttpFoundationFactoryTest extends TestCase
 
     public function testCreateUploadedFileWithError()
     {
-        $this->expectException(FileException::class);
-        $this->expectExceptionMessage('The file "e" could not be written on disk.');
-
         $uploadedFile = $this->createUploadedFile('Error.', \UPLOAD_ERR_CANT_WRITE, 'e', 'text/plain');
         $symfonyUploadedFile = $this->callCreateUploadedFile($uploadedFile);
 
         $this->assertEquals(\UPLOAD_ERR_CANT_WRITE, $symfonyUploadedFile->getError());
+
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('The file "e" could not be written on disk.');
 
         $symfonyUploadedFile->move($this->tmpDir, 'shouldFail.txt');
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -30,8 +30,9 @@ class HttpKernelExtensionTest extends TestCase
 {
     public function testFragmentWithError()
     {
-        $this->expectException(\Twig\Error\RuntimeError::class);
         $renderer = $this->getFragmentHandler($this->throwException(new \Exception('foo')));
+
+        $this->expectException(\Twig\Error\RuntimeError::class);
 
         $this->renderTemplate($renderer);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -118,7 +118,6 @@ class TranslationDebugCommandTest extends TestCase
 
     public function testDebugInvalidDirectory()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $kernel = $this->createMock(KernelInterface::class);
         $kernel->expects($this->once())
             ->method('getBundle')
@@ -126,6 +125,9 @@ class TranslationDebugCommandTest extends TestCase
             ->willThrowException(new \InvalidArgumentException());
 
         $tester = $this->createCommandTester([], [], $kernel);
+
+        $this->expectException(\InvalidArgumentException::class);
+
         $tester->execute(['locale' => 'en', 'bundle' => 'dir']);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -60,10 +60,11 @@ bar';
 
     public function testLintFileNotReadable()
     {
-        $this->expectException(\RuntimeException::class);
         $tester = $this->createCommandTester();
         $filename = $this->createFile('');
         unlink($filename);
+
+        $this->expectException(\RuntimeException::class);
 
         $tester->execute(['filename' => $filename], ['decorated' => false]);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -92,12 +92,13 @@ class AbstractControllerTest extends TestCase
 
     public function testMissingParameterBag()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('TestAbstractController::getParameter()" method is missing a parameter bag');
         $container = new Container();
 
         $controller = $this->createController();
         $controller->setContainer($container);
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('TestAbstractController::getParameter()" method is missing a parameter bag');
 
         $controller->getParameter('foo');
     }
@@ -146,11 +147,11 @@ class AbstractControllerTest extends TestCase
 
     public function testGetUserWithEmptyContainer()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The SecurityBundle is not registered in your application.');
-
         $controller = $this->createController();
         $controller->setContainer(new Container());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The SecurityBundle is not registered in your application.');
 
         $controller->getUser();
     }
@@ -327,9 +328,9 @@ class AbstractControllerTest extends TestCase
 
     public function testFileWhichDoesNotExist()
     {
-        $this->expectException(FileNotFoundException::class);
-
         $controller = $this->createController();
+
+        $this->expectException(FileNotFoundException::class);
 
         $controller->file('some-file.txt', 'test.php');
     }
@@ -350,8 +351,6 @@ class AbstractControllerTest extends TestCase
 
     public function testdenyAccessUnlessGranted()
     {
-        $this->expectException(AccessDeniedException::class);
-
         $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $authorizationChecker->expects($this->once())->method('isGranted')->willReturn(false);
 
@@ -360,6 +359,8 @@ class AbstractControllerTest extends TestCase
 
         $controller = $this->createController();
         $controller->setContainer($container);
+
+        $this->expectException(AccessDeniedException::class);
 
         $controller->denyAccessUnlessGranted('foo');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -47,7 +47,7 @@ class TemplateControllerTest extends TestCase
         $controller = new TemplateController();
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('You cannot use the TemplateController if the Twig Bundle is not available.');
+        $this->expectExceptionMessage('You cannot use the TemplateController if the Twig Bundle is not available. Try running "composer require symfony/twig-bundle".');
 
         $controller('mytemplate')->getContent();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -34,13 +34,15 @@ class ProfilerPassTest extends TestCase
      */
     public function testTemplateNoIdThrowsException()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $builder = new ContainerBuilder();
         $builder->register('profiler', 'ProfilerClass');
         $builder->register('my_collector_service')
             ->addTag('data_collector', ['template' => 'foo']);
 
         $profilerPass = new ProfilerPass();
+
+        $this->expectException(\InvalidArgumentException::class);
+
         $profilerPass->process($builder);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
@@ -58,48 +58,52 @@ class WorkflowGuardListenerPassTest extends TestCase
 
     public function testExceptionIfTheTokenStorageServiceIsNotPresent()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('The "security.token_storage" service is needed to be able to use the workflow guard listener.');
         $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);
         $this->container->register('security.role_hierarchy', RoleHierarchy::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "security.token_storage" service is needed to be able to use the workflow guard listener.');
 
         $this->compilerPass->process($this->container);
     }
 
     public function testExceptionIfTheAuthorizationCheckerServiceIsNotPresent()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('The "security.authorization_checker" service is needed to be able to use the workflow guard listener.');
         $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);
         $this->container->register('security.role_hierarchy', RoleHierarchy::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "security.authorization_checker" service is needed to be able to use the workflow guard listener.');
 
         $this->compilerPass->process($this->container);
     }
 
     public function testExceptionIfTheAuthenticationTrustResolverServiceIsNotPresent()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('The "security.authentication.trust_resolver" service is needed to be able to use the workflow guard listener.');
         $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
         $this->container->register('security.role_hierarchy', RoleHierarchy::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "security.authentication.trust_resolver" service is needed to be able to use the workflow guard listener.');
 
         $this->compilerPass->process($this->container);
     }
 
     public function testExceptionIfTheRoleHierarchyServiceIsNotPresent()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('The "security.role_hierarchy" service is needed to be able to use the workflow guard listener.');
         $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "security.role_hierarchy" service is needed to be able to use the workflow guard listener.');
 
         $this->compilerPass->process($this->container);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -61,8 +61,10 @@ class ConfigurationTest extends TestCase
      */
     public function testInvalidSessionName($sessionName)
     {
-        $this->expectException(InvalidConfigurationException::class);
         $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+
         $processor->processConfiguration(
             new Configuration(true),
             [[
@@ -177,11 +179,12 @@ class ConfigurationTest extends TestCase
      */
     public function testInvalidAssetsConfiguration(array $assetConfig, $expectedMessage)
     {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        $processor = new Processor();
-        $configuration = new Configuration(true);
         $processor->processConfiguration($configuration, [
                 [
                     'http_method_override' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -634,9 +634,11 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testRouterRequiresResourceOption()
     {
-        $this->expectException(InvalidConfigurationException::class);
         $container = $this->createContainer();
         $loader = new FrameworkExtension();
+
+        $this->expectException(InvalidConfigurationException::class);
+
         $loader->load([['http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true], 'router' => true]], $container);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -81,9 +81,11 @@ class RouterDebugCommandTest extends AbstractWebTestCase
 
     public function testSearchWithThrow()
     {
+        $tester = $this->createCommandTester();
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The route "gerard" does not exist.');
-        $tester = $this->createCommandTester();
+
         $tester->execute(['name' => 'gerard'], ['interactive' => true]);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -299,25 +299,29 @@ class RouterTest extends TestCase
 
     public function testEnvPlaceholders()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Using "%env(FOO)%" is not allowed in routing configuration.');
         $routes = new RouteCollection();
 
         $routes->add('foo', new Route('/%env(FOO)%'));
 
         $router = new Router($this->getPsr11ServiceContainer($routes), 'foo', [], null, $this->getParameterBag());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Using "%env(FOO)%" is not allowed in routing configuration.');
+
         $router->getRouteCollection();
     }
 
     public function testEnvPlaceholdersWithSfContainer()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Using "%env(FOO)%" is not allowed in routing configuration.');
         $routes = new RouteCollection();
 
         $routes->add('foo', new Route('/%env(FOO)%'));
 
         $router = new Router($this->getServiceContainer($routes), 'foo');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Using "%env(FOO)%" is not allowed in routing configuration.');
+
         $router->getRouteCollection();
     }
 
@@ -381,8 +385,6 @@ class RouterTest extends TestCase
 
     public function testExceptionOnNonExistentParameterWithSfContainer()
     {
-        $this->expectException(ParameterNotFoundException::class);
-        $this->expectExceptionMessage('You have requested a non-existent parameter "nope".');
         $routes = new RouteCollection();
 
         $routes->add('foo', new Route('/%nope%'));
@@ -390,13 +392,15 @@ class RouterTest extends TestCase
         $sc = $this->getServiceContainer($routes);
 
         $router = new Router($sc, 'foo');
+
+        $this->expectException(ParameterNotFoundException::class);
+        $this->expectExceptionMessage('You have requested a non-existent parameter "nope".');
+
         $router->getRouteCollection()->get('foo');
     }
 
     public function testExceptionOnNonStringParameter()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The container parameter "object", used in the route configuration value "/%object%", must be a string or numeric, but it is of type "stdClass".');
         $routes = new RouteCollection();
 
         $routes->add('foo', new Route('/%object%'));
@@ -405,6 +409,10 @@ class RouterTest extends TestCase
         $parameters = $this->getParameterBag(['object' => new \stdClass()]);
 
         $router = new Router($sc, 'foo', [], null, $parameters);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The container parameter "object", used in the route configuration value "/%object%", must be a string or numeric, but it is of type "stdClass".');
+
         $router->getRouteCollection()->get('foo');
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -24,8 +24,6 @@ class AddSecurityVotersPassTest extends TestCase
 {
     public function testNoVoters()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('No security voters found. You need to tag at least one with "security.voter".');
         $container = new ContainerBuilder();
         $container
             ->register('security.access.decision_manager', AccessDecisionManager::class)
@@ -33,6 +31,10 @@ class AddSecurityVotersPassTest extends TestCase
         ;
 
         $compilerPass = new AddSecurityVotersPass();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('No security voters found. You need to tag at least one with "security.voter".');
+
         $compilerPass->process($container);
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -36,7 +36,6 @@ class MainConfigurationTest extends TestCase
 
     public function testNoConfigForProvider()
     {
-        $this->expectException(InvalidConfigurationException::class);
         $config = [
             'providers' => [
                 'stub' => [],
@@ -45,12 +44,14 @@ class MainConfigurationTest extends TestCase
 
         $processor = new Processor();
         $configuration = new MainConfiguration([], []);
+
+        $this->expectException(InvalidConfigurationException::class);
+
         $processor->processConfiguration($configuration, [$config]);
     }
 
     public function testManyConfigForProvider()
     {
-        $this->expectException(InvalidConfigurationException::class);
         $config = [
             'providers' => [
                 'stub' => [
@@ -62,6 +63,9 @@ class MainConfigurationTest extends TestCase
 
         $processor = new Processor();
         $configuration = new MainConfiguration([], []);
+
+        $this->expectException(InvalidConfigurationException::class);
+
         $processor->processConfiguration($configuration, [$config]);
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -145,9 +145,6 @@ class AccessTokenFactoryTest extends TestCase
 
     public function testMultipleTokenHandlersSet()
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('You cannot configure multiple token handlers.');
-
         $config = [
             'token_handler' => [
                 'id' => 'in_memory_token_handler_service_id',
@@ -156,6 +153,10 @@ class AccessTokenFactoryTest extends TestCase
         ];
 
         $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You cannot configure multiple token handlers.');
+
         $this->processConfig($config, $factory);
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -45,8 +45,6 @@ class SecurityExtensionTest extends TestCase
 
     public function testInvalidCheckPath()
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The check_path "/some_area/login_check" for login method "form_login" is not matched by the firewall pattern "/secured_area/.*".');
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
@@ -64,13 +62,14 @@ class SecurityExtensionTest extends TestCase
             ],
         ]);
 
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The check_path "/some_area/login_check" for login method "form_login" is not matched by the firewall pattern "/secured_area/.*".');
+
         $container->compile();
     }
 
     public function testFirewallWithInvalidUserProvider()
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Unable to create definition for "security.user.provider.concrete.my_foo" user provider');
         $container = $this->getRawContainer();
 
         $extension = $container->getExtension('security');
@@ -88,6 +87,9 @@ class SecurityExtensionTest extends TestCase
                 ],
             ],
         ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Unable to create definition for "security.user.provider.concrete.my_foo" user provider');
 
         $container->compile();
     }
@@ -161,8 +163,6 @@ class SecurityExtensionTest extends TestCase
 
     public function testMissingProviderForListener()
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Not configuring explicitly the provider for the "http_basic" authenticator on "ambiguous" firewall is ambiguous as there is more than one registered provider.');
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
             'providers' => [
@@ -177,6 +177,9 @@ class SecurityExtensionTest extends TestCase
                 ],
             ],
         ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Not configuring explicitly the provider for the "http_basic" authenticator on "ambiguous" firewall is ambiguous as there is more than one registered provider.');
 
         $container->compile();
     }
@@ -712,9 +715,6 @@ class SecurityExtensionTest extends TestCase
      */
     public function testEntryPointRequired(array $firewall, string $messageRegex)
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches($messageRegex);
-
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
             'providers' => [
@@ -725,6 +725,9 @@ class SecurityExtensionTest extends TestCase
                 'main' => $firewall,
             ],
         ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches($messageRegex);
 
         $container->compile();
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -34,13 +34,14 @@ class ProfilerControllerTest extends WebTestCase
 {
     public function testHomeActionWithProfilerDisabled()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('The profiler must be enabled.');
-
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $twig = $this->createMock(Environment::class);
 
         $controller = new ProfilerController($urlGenerator, null, $twig, []);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The profiler must be enabled.');
+
         $controller->homeAction();
     }
 
@@ -110,13 +111,14 @@ class ProfilerControllerTest extends WebTestCase
 
     public function testToolbarActionWithProfilerDisabled()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('The profiler must be enabled.');
-
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $twig = $this->createMock(Environment::class);
 
         $controller = new ProfilerController($urlGenerator, null, $twig, []);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The profiler must be enabled.');
+
         $controller->toolbarAction(Request::create('/_wdt/foo-token'), null);
     }
 
@@ -202,13 +204,14 @@ class ProfilerControllerTest extends WebTestCase
 
     public function testSearchBarActionWithProfilerDisabled()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('The profiler must be enabled.');
-
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $twig = $this->createMock(Environment::class);
 
         $controller = new ProfilerController($urlGenerator, null, $twig, []);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The profiler must be enabled.');
+
         $controller->searchBarAction(Request::create('/_profiler/search_bar'));
     }
 
@@ -296,13 +299,14 @@ class ProfilerControllerTest extends WebTestCase
 
     public function testSearchActionWithProfilerDisabled()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('The profiler must be enabled.');
-
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $twig = $this->createMock(Environment::class);
 
         $controller = new ProfilerController($urlGenerator, null, $twig, []);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The profiler must be enabled.');
+
         $controller->searchBarAction(Request::create('/_profiler/search'));
     }
 
@@ -335,13 +339,14 @@ class ProfilerControllerTest extends WebTestCase
 
     public function testPhpinfoActionWithProfilerDisabled()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('The profiler must be enabled.');
-
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $twig = $this->createMock(Environment::class);
 
         $controller = new ProfilerController($urlGenerator, null, $twig, []);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The profiler must be enabled.');
+
         $controller->phpinfoAction();
     }
 
@@ -357,26 +362,28 @@ class ProfilerControllerTest extends WebTestCase
 
     public function testFontActionWithProfilerDisabled()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('The profiler must be enabled.');
-
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $twig = $this->createMock(Environment::class);
 
         $controller = new ProfilerController($urlGenerator, null, $twig, []);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The profiler must be enabled.');
+
         $controller->fontAction('JetBrainsMono');
     }
 
     public function testFontActionWithInvalidFontName()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('Font file "InvalidFontName.woff2" not found.');
-
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $profiler = $this->createMock(Profiler::class);
         $twig = $this->createMock(Environment::class);
 
         $controller = new ProfilerController($urlGenerator, $profiler, $twig, []);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Font file "InvalidFontName.woff2" not found.');
+
         $controller->fontAction('InvalidFontName');
     }
 

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -61,14 +61,12 @@ class PackagesTest extends TestCase
     public function testNoDefaultPackage()
     {
         $this->expectException(LogicException::class);
-        $packages = new Packages();
-        $packages->getPackage();
+        (new Packages())->getPackage();
     }
 
     public function testUndefinedPackage()
     {
         $this->expectException(InvalidArgumentException::class);
-        $packages = new Packages();
-        $packages->getPackage('a');
+        (new Packages())->getPackage('a');
     }
 }

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -110,7 +110,7 @@ class UrlPackageTest extends TestCase
     /**
      * @dataProvider getWrongBaseUrlConfig
      */
-    public function testWrongBaseUrl($baseUrls)
+    public function testWrongBaseUrl(string $baseUrls)
     {
         $this->expectException(InvalidArgumentException::class);
         new UrlPackage($baseUrls, new EmptyVersionStrategy());

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -101,11 +101,12 @@ class MemcachedAdapterTest extends AdapterTestCase
 
     public function testOptionSerializer()
     {
-        $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('MemcachedAdapter: "serializer" option must be "php" or "igbinary".');
         if (!\Memcached::HAVE_JSON) {
             $this->markTestSkipped('Memcached::HAVE_JSON required');
         }
+
+        $this->expectException(CacheException::class);
+        $this->expectExceptionMessage('MemcachedAdapter: "serializer" option must be "php" or "igbinary".');
 
         new MemcachedAdapter(MemcachedAdapter::createConnection([], ['serializer' => 'json']));
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
@@ -40,14 +40,16 @@ class ProxyAdapterTest extends AdapterTestCase
 
     public function testProxyfiedItem()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('OK bar');
         $item = new CacheItem();
         $pool = new ProxyAdapter(new TestingArrayAdapter($item));
 
         $proxyItem = $pool->getItem('foo');
 
         $this->assertNotSame($item, $proxyItem);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('OK bar');
+
         $pool->save($proxyItem->set('bar'));
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
@@ -37,9 +37,11 @@ class RedisAdapterSentinelTest extends AbstractRedisAdapterTestCase
 
     public function testInvalidDSNHasBothClusterAndSentinel()
     {
+        $dsn = 'redis:?host[redis1]&host[redis2]&host[redis3]&redis_cluster=1&redis_sentinel=mymaster';
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot use both "redis_cluster" and "redis_sentinel" at the same time.');
-        $dsn = 'redis:?host[redis1]&host[redis2]&host[redis3]&redis_cluster=1&redis_sentinel=mymaster';
+
         RedisAdapter::createConnection($dsn);
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareTestTrait.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareTestTrait.php
@@ -22,9 +22,11 @@ trait TagAwareTestTrait
 {
     public function testInvalidTag()
     {
-        $this->expectException(\Psr\Cache\InvalidArgumentException::class);
         $pool = $this->createCachePool();
         $item = $pool->getItem('foo');
+
+        $this->expectException(\Psr\Cache\InvalidArgumentException::class);
+
         $item->tag(':');
     }
 

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -76,22 +76,24 @@ class CacheItemTest extends TestCase
      */
     public function testInvalidTag($tag)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache tag');
         $item = new CacheItem();
         $r = new \ReflectionProperty($item, 'isTaggable');
         $r->setValue($item, true);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cache tag');
 
         $item->tag($tag);
     }
 
     public function testNonTaggableItem()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Cache item "foo" comes from a non tag-aware pool: you cannot tag it.');
         $item = new CacheItem();
         $r = new \ReflectionProperty($item, 'key');
         $r->setValue($item, 'foo');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cache item "foo" comes from a non tag-aware pool: you cannot tag it.');
 
         $item->tag([]);
     }

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
@@ -179,8 +179,6 @@ class CachePoolPassTest extends TestCase
 
     public function testThrowsExceptionWhenCachePoolTagHasUnknownAttributes()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid "cache.pool" tag for service "app.cache_pool": accepted attributes are');
         $container = new ContainerBuilder();
         $container->setParameter('kernel.container_class', 'app');
         $container->setParameter('kernel.project_dir', 'foo');
@@ -191,6 +189,9 @@ class CachePoolPassTest extends TestCase
         $cachePool = new ChildDefinition('app.cache_adapter');
         $cachePool->addTag('cache.pool', ['foobar' => 123]);
         $container->setDefinition('app.cache_pool', $cachePool);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "cache.pool" tag for service "app.cache_pool": accepted attributes are');
 
         $this->cachePoolPass->process($container);
     }

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPrunerPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPrunerPassTest.php
@@ -59,13 +59,15 @@ class CachePoolPrunerPassTest extends TestCase
 
     public function testCompilerPassThrowsOnInvalidDefinitionClass()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Class "Symfony\Component\Cache\Tests\DependencyInjection\NotFound" used for service "pool.not-found" cannot be found.');
         $container = new ContainerBuilder();
         $container->register('console.command.cache_pool_prune')->addArgument([]);
         $container->register('pool.not-found', NotFound::class)->addTag('cache.pool');
 
         $pass = new CachePoolPrunerPass();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Class "Symfony\Component\Cache\Tests\DependencyInjection\NotFound" used for service "pool.not-found" cannot be found.');
+
         $pass->process($container);
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
@@ -58,8 +58,7 @@ class DefaultMarshallerTest extends TestCase
     {
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessage('Class not found: NotExistingClass');
-        $marshaller = new DefaultMarshaller();
-        $marshaller->unmarshall('O:16:"NotExistingClass":0:{}');
+        (new DefaultMarshaller())->unmarshall('O:16:"NotExistingClass":0:{}');
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/ConfigCacheFactoryTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheFactoryTest.php
@@ -18,8 +18,9 @@ class ConfigCacheFactoryTest extends TestCase
 {
     public function testCacheWithInvalidCallback()
     {
-        $this->expectException(\TypeError::class);
         $cacheFactory = new ConfigCacheFactory(true);
+
+        $this->expectException(\TypeError::class);
 
         $cacheFactory->cache('file', new \stdClass());
     }

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -21,37 +21,45 @@ class ArrayNodeTest extends TestCase
 {
     public function testNormalizeThrowsExceptionWhenFalseIsNotAllowed()
     {
-        $this->expectException(InvalidTypeException::class);
         $node = new ArrayNode('root');
+
+        $this->expectException(InvalidTypeException::class);
+
         $node->normalize(false);
     }
 
     public function testExceptionThrownOnUnrecognizedChild()
     {
+        $node = new ArrayNode('root');
+
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Unrecognized option "foo" under "root"');
-        $node = new ArrayNode('root');
+
         $node->normalize(['foo' => 'bar']);
     }
 
     public function testNormalizeWithProposals()
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Did you mean "alpha1", "alpha2"?');
         $node = new ArrayNode('root');
         $node->addChild(new ArrayNode('alpha1'));
         $node->addChild(new ArrayNode('alpha2'));
         $node->addChild(new ArrayNode('beta'));
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Did you mean "alpha1", "alpha2"?');
+
         $node->normalize(['alpha3' => 'foo']);
     }
 
     public function testNormalizeWithoutProposals()
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Available options are "alpha1", "alpha2".');
         $node = new ArrayNode('root');
         $node->addChild(new ArrayNode('alpha1'));
         $node->addChild(new ArrayNode('alpha2'));
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Available options are "alpha1", "alpha2".');
+
         $node->normalize(['beta' => 'foo']);
     }
 
@@ -193,32 +201,38 @@ class ArrayNodeTest extends TestCase
 
     public function testAddChildEmptyName()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Child nodes must be named.');
         $node = new ArrayNode('root');
 
         $childNode = new ArrayNode('');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Child nodes must be named.');
+
         $node->addChild($childNode);
     }
 
     public function testAddChildNameAlreadyExists()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('A child node named "foo" already exists.');
         $node = new ArrayNode('root');
 
         $childNode = new ArrayNode('foo');
         $node->addChild($childNode);
 
         $childNodeWithSameName = new ArrayNode('foo');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('A child node named "foo" already exists.');
+
         $node->addChild($childNodeWithSameName);
     }
 
     public function testGetDefaultValueWithoutDefaultValue()
     {
+        $node = new ArrayNode('foo');
+
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The node at path "foo" has no default value.');
-        $node = new ArrayNode('foo');
+
         $node->getDefaultValue();
     }
 
@@ -267,14 +281,15 @@ class ArrayNodeTest extends TestCase
      */
     public function testMergeWithoutIgnoringExtraKeys(array $prenormalizeds)
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('merge() expects a normalized config array.');
         $node = new ArrayNode('root');
         $node->addChild(new ScalarNode('foo'));
         $node->addChild(new ScalarNode('bar'));
         $node->setIgnoreExtraKeys(false);
 
         $r = new \ReflectionMethod($node, 'mergeValues');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('merge() expects a normalized config array.');
 
         $r->invoke($node, ...$prenormalizeds);
     }
@@ -284,14 +299,15 @@ class ArrayNodeTest extends TestCase
      */
     public function testMergeWithIgnoringAndRemovingExtraKeys(array $prenormalizeds)
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('merge() expects a normalized config array.');
         $node = new ArrayNode('root');
         $node->addChild(new ScalarNode('foo'));
         $node->addChild(new ScalarNode('bar'));
         $node->setIgnoreExtraKeys(true);
 
         $r = new \ReflectionMethod($node, 'mergeValues');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('merge() expects a normalized config array.');
 
         $r->invoke($node, ...$prenormalizeds);
     }

--- a/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
@@ -50,8 +50,11 @@ class BooleanNodeTest extends TestCase
      */
     public function testNormalizeThrowsExceptionOnInvalidValues($value)
     {
-        $this->expectException(InvalidTypeException::class);
+
         $node = new BooleanNode('test');
+
+        $this->expectException(InvalidTypeException::class);
+
         $node->normalize($value);
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
@@ -21,71 +21,85 @@ class NumericNodeDefinitionTest extends TestCase
 {
     public function testIncoherentMinAssertion()
     {
+        $node = new IntegerNodeDefinition('foo');
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('You cannot define a min(4) as you already have a max(3)');
-        $def = new IntegerNodeDefinition('foo');
-        $def->max(3)->min(4);
+
+        $node->max(3)->min(4);
     }
 
     public function testIncoherentMaxAssertion()
     {
+        $node = new IntegerNodeDefinition('foo');
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('You cannot define a max(2) as you already have a min(3)');
-        $node = new IntegerNodeDefinition('foo');
+
         $node->min(3)->max(2);
     }
 
     public function testIntegerMinAssertion()
     {
+        $node = new IntegerNodeDefinition('foo');
+
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The value 4 is too small for path "foo". Should be greater than or equal to 5');
-        $def = new IntegerNodeDefinition('foo');
-        $def->min(5)->getNode()->finalize(4);
+
+        $node->min(5)->getNode()->finalize(4);
     }
 
     public function testIntegerMaxAssertion()
     {
+        $node = new IntegerNodeDefinition('foo');
+
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The value 4 is too big for path "foo". Should be less than or equal to 3');
-        $def = new IntegerNodeDefinition('foo');
-        $def->max(3)->getNode()->finalize(4);
+
+        $node->max(3)->getNode()->finalize(4);
     }
 
     public function testIntegerValidMinMaxAssertion()
     {
-        $def = new IntegerNodeDefinition('foo');
-        $node = $def->min(3)->max(7)->getNode();
+        $node = new IntegerNodeDefinition('foo');
+        $node = $node->min(3)->max(7)->getNode();
         $this->assertEquals(4, $node->finalize(4));
     }
 
     public function testFloatMinAssertion()
     {
+        $node = new FloatNodeDefinition('foo');
+
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The value 400 is too small for path "foo". Should be greater than or equal to 500');
-        $def = new FloatNodeDefinition('foo');
-        $def->min(5E2)->getNode()->finalize(4e2);
+
+        $node->min(5E2)->getNode()->finalize(4e2);
     }
 
     public function testFloatMaxAssertion()
     {
+        $node = new FloatNodeDefinition('foo');
+
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The value 4.3 is too big for path "foo". Should be less than or equal to 0.3');
-        $def = new FloatNodeDefinition('foo');
-        $def->max(0.3)->getNode()->finalize(4.3);
+
+        $node->max(0.3)->getNode()->finalize(4.3);
     }
 
     public function testFloatValidMinMaxAssertion()
     {
-        $def = new FloatNodeDefinition('foo');
-        $node = $def->min(3.0)->max(7e2)->getNode();
+        $node = new FloatNodeDefinition('foo');
+        $node = $node->min(3.0)->max(7e2)->getNode();
         $this->assertEquals(4.5, $node->finalize(4.5));
     }
 
     public function testCannotBeEmptyThrowsAnException()
     {
+        $node = new IntegerNodeDefinition('foo');
+
         $this->expectException(InvalidDefinitionException::class);
         $this->expectExceptionMessage('->cannotBeEmpty() is not applicable to NumericNodeDefinition.');
-        $def = new IntegerNodeDefinition('foo');
-        $def->cannotBeEmpty();
+
+        $node->cannotBeEmpty();
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -53,9 +53,11 @@ class EnumNodeTest extends TestCase
 
     public function testFinalizeWithInvalidValue()
     {
+        $node = new EnumNode('foo', null, ['foo', 'bar', TestEnum::Foo]);
+
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The value "foobar" is not allowed for path "foo". Permissible values: "foo", "bar", Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo');
-        $node = new EnumNode('foo', null, ['foo', 'bar', TestEnum::Foo]);
+
         $node->finalize('foobar');
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
@@ -56,8 +56,10 @@ class FloatNodeTest extends TestCase
      */
     public function testNormalizeThrowsExceptionOnInvalidValues($value)
     {
-        $this->expectException(InvalidTypeException::class);
         $node = new FloatNode('test');
+
+        $this->expectException(InvalidTypeException::class);
+
         $node->normalize($value);
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
@@ -51,8 +51,10 @@ class IntegerNodeTest extends TestCase
      */
     public function testNormalizeThrowsExceptionOnInvalidValues($value)
     {
-        $this->expectException(InvalidTypeException::class);
         $node = new IntegerNode('test');
+
+        $this->expectException(InvalidTypeException::class);
+
         $node->normalize($value);
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/MergeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/MergeTest.php
@@ -20,7 +20,6 @@ class MergeTest extends TestCase
 {
     public function testForbiddenOverwrite()
     {
-        $this->expectException(ForbiddenOverwriteException::class);
         $tb = new TreeBuilder('root', 'array');
         $tree = $tb
             ->getRootNode()
@@ -40,6 +39,8 @@ class MergeTest extends TestCase
         $b = [
             'foo' => 'moo',
         ];
+
+        $this->expectException(ForbiddenOverwriteException::class);
 
         $tree->merge($a, $b);
     }
@@ -94,7 +95,6 @@ class MergeTest extends TestCase
 
     public function testDoesNotAllowNewKeysInSubsequentConfigs()
     {
-        $this->expectException(InvalidConfigurationException::class);
         $tb = new TreeBuilder('root', 'array');
         $tree = $tb
             ->getRootNode()
@@ -123,6 +123,8 @@ class MergeTest extends TestCase
                 'b' => ['value' => 'foo'],
             ],
         ];
+
+        $this->expectException(InvalidConfigurationException::class);
 
         $tree->merge($a, $b);
     }

--- a/src/Symfony/Component/Config/Tests/Definition/NormalizationTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/NormalizationTest.php
@@ -170,13 +170,14 @@ class NormalizationTest extends TestCase
 
     public function testNonAssociativeArrayThrowsExceptionIfAttributeNotSet()
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The attribute "id" must be set for path "root.thing".');
         $denormalized = [
             'thing' => [
                 ['foo', 'bar'], ['baz', 'qux'],
             ],
         ];
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The attribute "id" must be set for path "root.thing".');
 
         $this->assertNormalized($this->getNumericKeysTestTree(), $denormalized, []);
     }

--- a/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
@@ -88,8 +88,10 @@ class ScalarNodeTest extends TestCase
      */
     public function testNormalizeThrowsExceptionOnInvalidValues($value)
     {
-        $this->expectException(InvalidTypeException::class);
         $node = new ScalarNode('test');
+
+        $this->expectException(InvalidTypeException::class);
+
         $node->normalize($value);
     }
 
@@ -156,9 +158,11 @@ class ScalarNodeTest extends TestCase
      */
     public function testNotAllowedEmptyValuesThrowException($value)
     {
-        $this->expectException(InvalidConfigurationException::class);
         $node = new ScalarNode('test');
         $node->setAllowEmptyValue(false);
+
+        $this->expectException(InvalidConfigurationException::class);
+
         $node->finalize($value);
     }
 

--- a/src/Symfony/Component/Config/Tests/FileLocatorTest.php
+++ b/src/Symfony/Component/Config/Tests/FileLocatorTest.php
@@ -88,26 +88,29 @@ class FileLocatorTest extends TestCase
 
     public function testLocateThrowsAnExceptionIfTheFileDoesNotExists()
     {
+        $loader = new FileLocator([__DIR__.'/Fixtures']);
+
         $this->expectException(FileLocatorFileNotFoundException::class);
         $this->expectExceptionMessage('The file "foobar.xml" does not exist');
-        $loader = new FileLocator([__DIR__.'/Fixtures']);
 
         $loader->locate('foobar.xml', __DIR__);
     }
 
     public function testLocateThrowsAnExceptionIfTheFileDoesNotExistsInAbsolutePath()
     {
-        $this->expectException(FileLocatorFileNotFoundException::class);
         $loader = new FileLocator([__DIR__.'/Fixtures']);
+
+        $this->expectException(FileLocatorFileNotFoundException::class);
 
         $loader->locate(__DIR__.'/Fixtures/foobar.xml', __DIR__);
     }
 
     public function testLocateEmpty()
     {
+        $loader = new FileLocator([__DIR__.'/Fixtures']);
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('An empty file name is not valid to be located.');
-        $loader = new FileLocator([__DIR__.'/Fixtures']);
 
         $loader->locate('', __DIR__);
     }

--- a/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
@@ -60,11 +60,12 @@ class DelegatingLoaderTest extends TestCase
 
     public function testLoadThrowsAnExceptionIfTheResourceCannotBeLoaded()
     {
-        $this->expectException(LoaderLoadException::class);
         $loader = $this->createMock(LoaderInterface::class);
         $loader->expects($this->once())->method('supports')->willReturn(false);
         $resolver = new LoaderResolver([$loader]);
         $loader = new DelegatingLoader($resolver);
+
+        $this->expectException(LoaderLoadException::class);
 
         $loader->load('foo');
     }

--- a/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
@@ -48,7 +48,6 @@ class LoaderTest extends TestCase
 
     public function testResolveWhenResolverCannotFindLoader()
     {
-        $this->expectException(LoaderLoadException::class);
         $resolver = $this->createMock(LoaderResolverInterface::class);
         $resolver->expects($this->once())
             ->method('resolve')
@@ -57,6 +56,8 @@ class LoaderTest extends TestCase
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);
+
+        $this->expectException(LoaderLoadException::class);
 
         $loader->resolve('FOOBAR');
     }

--- a/src/Symfony/Component/Config/Tests/Resource/ClassExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ClassExistenceResourceTest.php
@@ -85,28 +85,31 @@ EOF
 
     public function testBadParentWithNoTimestamp()
     {
+        $res = new ClassExistenceResource(BadParent::class, false);
+
         $this->expectException(\ReflectionException::class);
         $this->expectExceptionMessage('Class "Symfony\Component\Config\Tests\Fixtures\MissingParent" not found while loading "Symfony\Component\Config\Tests\Fixtures\BadParent".');
 
-        $res = new ClassExistenceResource(BadParent::class, false);
         $res->isFresh(0);
     }
 
     public function testBadFileName()
     {
+        $res = new ClassExistenceResource(BadFileName::class, false);
+
         $this->expectException(\ReflectionException::class);
         $this->expectExceptionMessage('Mismatch between file name and class name.');
 
-        $res = new ClassExistenceResource(BadFileName::class, false);
         $res->isFresh(0);
     }
 
     public function testBadFileNameBis()
     {
+        $res = new ClassExistenceResource(BadFileName::class, false);
+
         $this->expectException(\ReflectionException::class);
         $this->expectExceptionMessage('Mismatch between file name and class name.');
 
-        $res = new ClassExistenceResource(BadFileName::class, false);
         $res->isFresh(0);
     }
 
@@ -119,9 +122,10 @@ EOF
 
     public function testParseError()
     {
+        $res = new ClassExistenceResource(ParseError::class, false);
+
         $this->expectException(\ParseError::class);
 
-        $res = new ClassExistenceResource(ParseError::class, false);
         $res->isFresh(0);
     }
 }

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -91,12 +91,13 @@ class XmlUtilsTest extends TestCase
 
     public function testParseWithInvalidValidatorCallable()
     {
-        $this->expectException(InvalidXmlException::class);
-        $this->expectExceptionMessage('The XML is not valid');
         $fixtures = __DIR__.'/../Fixtures/Util/';
 
         $mock = $this->createMock(Validator::class);
         $mock->expects($this->once())->method('validate')->willReturn(false);
+
+        $this->expectException(InvalidXmlException::class);
+        $this->expectExceptionMessage('The XML is not valid');
 
         XmlUtils::parse(file_get_contents($fixtures.'valid.xml'), [$mock, 'validate']);
     }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -229,8 +229,8 @@ class ApplicationTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Command class "Foo5Command" is not correctly initialized. You probably forgot to call the parent constructor.');
-        $application = new Application();
-        $application->add(new \Foo5Command());
+
+        (new Application())->add(new \Foo5Command());
     }
 
     public function testHasGet()
@@ -294,8 +294,8 @@ class ApplicationTest extends TestCase
     {
         $this->expectException(CommandNotFoundException::class);
         $this->expectExceptionMessage('The command "foofoo" does not exist.');
-        $application = new Application();
-        $application->get('foofoo');
+
+        (new Application())->get('foofoo');
     }
 
     public function testGetNamespaces()
@@ -351,20 +351,21 @@ class ApplicationTest extends TestCase
     {
         $this->expectException(NamespaceNotFoundException::class);
         $this->expectExceptionMessage('There are no commands defined in the "bar" namespace.');
-        $application = new Application();
-        $application->findNamespace('bar');
+
+        (new Application)->findNamespace('bar');
     }
 
     public function testFindUniqueNameButNamespaceName()
     {
-        $this->expectException(CommandNotFoundException::class);
-        $this->expectExceptionMessage('Command "foo1" is not defined');
         $application = new Application();
         $application->add(new \FooCommand());
         $application->add(new \Foo1Command());
         $application->add(new \Foo2Command());
 
-        $application->find($commandName = 'foo1');
+        $this->expectException(CommandNotFoundException::class);
+        $this->expectExceptionMessage('Command "foo1" is not defined');
+
+        $application->find('foo1');
     }
 
     public function testFind()
@@ -403,13 +404,14 @@ class ApplicationTest extends TestCase
 
     public function testFindCaseInsensitiveSuggestions()
     {
-        $this->expectException(CommandNotFoundException::class);
-        $this->expectExceptionMessage('Command "FoO:BaR" is ambiguous');
         $application = new Application();
         $application->add(new \FooSameCaseLowercaseCommand());
         $application->add(new \FooSameCaseUppercaseCommand());
 
-        $this->assertInstanceOf(\FooSameCaseLowercaseCommand::class, $application->find('FoO:BaR'), '->find() will find two suggestions with case insensitivity');
+        $this->expectException(CommandNotFoundException::class);
+        $this->expectExceptionMessage('Command "FoO:BaR" is ambiguous');
+
+        $application->find('FoO:BaR');
     }
 
     public function testFindWithCommandLoader()
@@ -506,10 +508,12 @@ class ApplicationTest extends TestCase
      */
     public function testFindAlternativeExceptionMessageSingle($name)
     {
-        $this->expectException(CommandNotFoundException::class);
-        $this->expectExceptionMessage('Did you mean this');
         $application = new Application();
         $application->add(new \Foo3Command());
+
+        $this->expectException(CommandNotFoundException::class);
+        $this->expectExceptionMessage('Did you mean this');
+
         $application->find($name);
     }
 
@@ -744,11 +748,13 @@ class ApplicationTest extends TestCase
 
     public function testFindWithDoubleColonInNameThrowsException()
     {
-        $this->expectException(CommandNotFoundException::class);
-        $this->expectExceptionMessage('Command "foo::bar" is not defined.');
         $application = new Application();
         $application->add(new \FooCommand());
         $application->add(new \Foo4Command());
+
+        $this->expectException(CommandNotFoundException::class);
+        $this->expectExceptionMessage('Command "foo::bar" is not defined.');
+
         $application->find('foo::bar');
     }
 
@@ -1248,8 +1254,6 @@ class ApplicationTest extends TestCase
 
     public function testAddingOptionWithDuplicateShortcut()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('An option with shortcut "e" already exists.');
         $dispatcher = new EventDispatcher();
         $application = new Application();
         $application->setAutoExit(false);
@@ -1268,6 +1272,9 @@ class ApplicationTest extends TestCase
         $input = new ArrayInput(['command' => 'foo']);
         $output = new NullOutput();
 
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An option with shortcut "e" already exists.');
+
         $application->run($input, $output);
     }
 
@@ -1276,7 +1283,6 @@ class ApplicationTest extends TestCase
      */
     public function testAddingAlreadySetDefinitionElementData($def)
     {
-        $this->expectException(\LogicException::class);
         $application = new Application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
@@ -1288,10 +1294,13 @@ class ApplicationTest extends TestCase
 
         $input = new ArrayInput(['command' => 'foo']);
         $output = new NullOutput();
+
+        $this->expectException(\LogicException::class);
+
         $application->run($input, $output);
     }
 
-    public static function getAddingAlreadySetDefinitionElementData()
+    public static function getAddingAlreadySetDefinitionElementData(): array
     {
         return [
             [new InputArgument('command', InputArgument::REQUIRED)],
@@ -1428,8 +1437,6 @@ class ApplicationTest extends TestCase
 
     public function testRunWithExceptionAndDispatcher()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('error');
         $application = new Application();
         $application->setDispatcher($this->getDispatcher());
         $application->setAutoExit(false);
@@ -1440,6 +1447,10 @@ class ApplicationTest extends TestCase
         });
 
         $tester = new ApplicationTester($application);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('error');
+
         $tester->run(['command' => 'foo']);
     }
 
@@ -1504,9 +1515,6 @@ class ApplicationTest extends TestCase
 
     public function testRunWithFindError()
     {
-        $this->expectException(\Error::class);
-        $this->expectExceptionMessage('Find exception');
-
         $application = new Application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
@@ -1518,6 +1526,10 @@ class ApplicationTest extends TestCase
 
         // The exception should not be ignored
         $tester = new ApplicationTester($application);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Find exception');
+
         $tester->run(['command' => 'foo']);
     }
 
@@ -1590,8 +1602,6 @@ class ApplicationTest extends TestCase
 
     public function testRunWithErrorAndDispatcher()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('error');
         $application = new Application();
         $application->setDispatcher($this->getDispatcher());
         $application->setAutoExit(false);
@@ -1604,6 +1614,10 @@ class ApplicationTest extends TestCase
         });
 
         $tester = new ApplicationTester($application);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('error');
+
         $tester->run(['command' => 'dym']);
         $this->assertStringContainsString('before.dym.error.after.', $tester->getDisplay(), 'The PHP error did not dispatch events');
     }
@@ -1802,9 +1816,11 @@ class ApplicationTest extends TestCase
 
     public function testGetDisabledLazyCommand()
     {
-        $this->expectException(CommandNotFoundException::class);
         $application = new Application();
         $application->setCommandLoader(new FactoryCommandLoader(['disabled' => fn () => new DisabledCommand()]));
+
+        $this->expectException(CommandNotFoundException::class);
+
         $application->get('disabled');
     }
 
@@ -1895,8 +1911,6 @@ class ApplicationTest extends TestCase
 
     public function testThrowingErrorListener()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('foo');
         $dispatcher = $this->getDispatcher();
         $dispatcher->addListener('console.error', function (ConsoleErrorEvent $event) {
             throw new \RuntimeException('foo');
@@ -1916,20 +1930,25 @@ class ApplicationTest extends TestCase
         });
 
         $tester = new ApplicationTester($application);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('foo');
+
         $tester->run(['command' => 'foo']);
     }
 
     public function testCommandNameMismatchWithCommandLoaderKeyThrows()
     {
-        $this->expectException(CommandNotFoundException::class);
-        $this->expectExceptionMessage('The "test" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".');
-
         $app = new Application();
         $loader = new FactoryCommandLoader([
             'test' => static fn () => new Command('test-command'),
         ]);
 
         $app->setCommandLoader($loader);
+
+        $this->expectException(CommandNotFoundException::class);
+        $this->expectExceptionMessage('The "test" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".');
+
         $app->get('test');
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -144,11 +144,10 @@ class CommandTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf('Command name "%s" is invalid.', $name));
 
-        $command = new \TestCommand();
-        $command->setName($name);
+        (new \TestCommand())->setName($name);
     }
 
-    public static function provideInvalidCommandNames()
+    public static function provideInvalidCommandNames(): array
     {
         return [
             [''],
@@ -236,8 +235,7 @@ class CommandTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot retrieve helper "formatter" because there is no HelperSet defined.');
-        $command = new \TestCommand();
-        $command->getHelper('formatter');
+        (new \TestCommand())->getHelper('formatter');
     }
 
     public function testMergeApplicationDefinition()
@@ -305,16 +303,17 @@ class CommandTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('You must override the execute() method in the concrete command class.');
-        $command = new Command('foo');
-        $command->run(new StringInput(''), new NullOutput());
+        (new Command('foo'))->run(new StringInput(''), new NullOutput());
     }
 
     public function testRunWithInvalidOption()
     {
-        $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "--bar" option does not exist.');
         $command = new \TestCommand();
         $tester = new CommandTester($command);
+
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "--bar" option does not exist.');
+
         $tester->execute(['--bar' => true]);
     }
 

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -180,8 +180,6 @@ class AddConsoleCommandPassTest extends TestCase
 
     public function testProcessThrowAnExceptionIfTheServiceIsAbstract()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must not be abstract.');
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->addCompilerPass(new AddConsoleCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
@@ -191,13 +189,14 @@ class AddConsoleCommandPassTest extends TestCase
         $definition->setAbstract(true);
         $container->setDefinition('my-command', $definition);
 
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must not be abstract.');
+
         $container->compile();
     }
 
     public function testProcessThrowAnExceptionIfTheServiceIsNotASubclassOfCommand()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must be a subclass of "Symfony\Component\Console\Command\Command".');
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->addCompilerPass(new AddConsoleCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
@@ -205,6 +204,9 @@ class AddConsoleCommandPassTest extends TestCase
         $definition = new Definition('SplObjectStorage');
         $definition->addTag('console.command');
         $container->setDefinition('my-command', $definition);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must be a subclass of "Symfony\Component\Console\Command\Command".');
 
         $container->compile();
     }
@@ -281,8 +283,6 @@ class AddConsoleCommandPassTest extends TestCase
 
     public function testProcessOnChildDefinitionWithoutClass()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The definition for "my-child-command" has no class.');
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddConsoleCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
 
@@ -297,6 +297,9 @@ class AddConsoleCommandPassTest extends TestCase
 
         $container->setDefinition($parentId, $parentDefinition);
         $container->setDefinition($childId, $childDefinition);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The definition for "my-child-command" has no class.');
 
         $container->compile();
     }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleStackTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleStackTest.php
@@ -61,9 +61,11 @@ class OutputFormatterStyleStackTest extends TestCase
 
     public function testInvalidPop()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $stack = new OutputFormatterStyleStack();
         $stack->push(new OutputFormatterStyle('white', 'black'));
+
+        $this->expectException(\InvalidArgumentException::class);
+
         $stack->pop(new OutputFormatterStyle('yellow', 'blue'));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -118,10 +118,12 @@ class ProgressIndicatorTest extends TestCase
 
     public function testCannotStartAlreadyStartedIndicator()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Progress indicator already started.');
         $bar = new ProgressIndicator($this->getOutputStream());
         $bar->start('Starting...');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Progress indicator already started.');
+
         $bar->start('Starting Again.');
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -677,8 +677,6 @@ EOD;
 
     public function testAmbiguousChoiceFromChoicelist()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided answer is ambiguous. Value should be one of "env_2" or "env_3".');
         $possibleChoices = [
             'env_1' => 'My first environment',
             'env_2' => 'My environment',
@@ -692,10 +690,13 @@ EOD;
         $question = new ChoiceQuestion('Please select the environment to load', $possibleChoices);
         $question->setMaxAttempts(1);
 
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided answer is ambiguous. Value should be one of "env_2" or "env_3".');
+
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream("My environment\n")), $this->createOutputInterface(), $question);
     }
 
-    public static function answerProvider()
+    public static function answerProvider(): array
     {
         return [
             ['env_1', 'env_1'],
@@ -743,22 +744,18 @@ EOD;
     {
         $this->expectException(MissingInputException::class);
         $this->expectExceptionMessage('Aborted.');
-        $dialog = new QuestionHelper();
-        $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new Question('What\'s your name?'));
+        (new QuestionHelper())->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new Question('What\'s your name?'));
     }
 
     public function testAskThrowsExceptionOnMissingInputForChoiceQuestion()
     {
         $this->expectException(MissingInputException::class);
         $this->expectExceptionMessage('Aborted.');
-        $dialog = new QuestionHelper();
-        $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new ChoiceQuestion('Choice', ['a', 'b']));
+        (new QuestionHelper())->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new ChoiceQuestion('Choice', ['a', 'b']));
     }
 
     public function testAskThrowsExceptionOnMissingInputWithValidator()
     {
-        $this->expectException(MissingInputException::class);
-        $this->expectExceptionMessage('Aborted.');
         $dialog = new QuestionHelper();
 
         $question = new Question('What\'s your name?');
@@ -767,6 +764,9 @@ EOD;
                 throw new \Exception('A value is required.');
             }
         });
+
+        $this->expectException(MissingInputException::class);
+        $this->expectExceptionMessage('Aborted.');
 
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), $question);
     }

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -137,8 +137,7 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Aborted.');
-        $dialog = new SymfonyQuestionHelper();
-        $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new Question('What\'s your name?'));
+        (new SymfonyQuestionHelper())->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new Question('What\'s your name?'));
     }
 
     public function testChoiceQuestionPadding()

--- a/src/Symfony/Component/Console/Tests/Helper/TableStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableStyleTest.php
@@ -20,7 +20,6 @@ class TableStyleTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid padding type. Expected one of (STR_PAD_LEFT, STR_PAD_RIGHT, STR_PAD_BOTH).');
-        $style = new TableStyle();
-        $style->setPadType(31);
+        (new TableStyle())->setPadType(31);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -1017,15 +1017,14 @@ TABLE;
 
     public function testThrowsWhenTheCellInAnArray()
     {
-        $table = new Table($this->getOutputStream());
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cell must be a TableCell, a scalar or an object implementing "__toString()", "array" given.');
+        $table = new Table($output = $this->getOutputStream());
         $table
             ->setHeaders(['ISBN', 'Title', 'Author', 'Price'])
             ->setRows([
                 ['99921-58-10-7', [], 'Dante Alighieri', '9.95'],
             ]);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A cell must be a TableCell, a scalar or an object implementing "__toString()", "array" given.');
 
         $table->render();
     }

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -242,8 +242,7 @@ class ArgvInputTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
-        $input = new ArgvInput($argv);
-        $input->bind($definition);
+        (new ArgvInput($argv))->bind($definition);
     }
 
     /**
@@ -254,11 +253,10 @@ class ArgvInputTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
-        $input = new ArgvInput($argv);
-        $input->bind($definition);
+        (new ArgvInput($argv))->bind($definition);
     }
 
-    public static function provideInvalidInput()
+    public static function provideInvalidInput(): array
     {
         return [
             [
@@ -329,7 +327,7 @@ class ArgvInputTest extends TestCase
         ];
     }
 
-    public static function provideInvalidNegatableInput()
+    public static function provideInvalidNegatableInput(): array
     {
         return [
             [

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -74,7 +74,7 @@ class ArrayInputTest extends TestCase
         $this->assertEquals($expectedOptions, $input->getOptions(), $message);
     }
 
-    public static function provideOptions()
+    public static function provideOptions(): array
     {
         return [
             [
@@ -133,7 +133,7 @@ class ArrayInputTest extends TestCase
         new ArrayInput($parameters, $definition);
     }
 
-    public static function provideInvalidInput()
+    public static function provideInvalidInput(): array
     {
         return [
             [

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -86,25 +86,31 @@ class InputArgumentTest extends TestCase
 
     public function testSetDefaultWithRequiredArgument()
     {
+        $argument = new InputArgument('foo', InputArgument::REQUIRED);
+
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot set a default value except for InputArgument::OPTIONAL mode.');
-        $argument = new InputArgument('foo', InputArgument::REQUIRED);
+
         $argument->setDefault('default');
     }
 
     public function testSetDefaultWithRequiredArrayArgument()
     {
+        $argument = new InputArgument('foo', InputArgument::REQUIRED | InputArgument::IS_ARRAY);
+
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot set a default value except for InputArgument::OPTIONAL mode.');
-        $argument = new InputArgument('foo', InputArgument::REQUIRED | InputArgument::IS_ARRAY);
+
         $argument->setDefault([]);
     }
 
     public function testSetDefaultWithArrayArgument()
     {
+        $argument = new InputArgument('foo', InputArgument::IS_ARRAY);
+
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('A default value for an array argument must be an array.');
-        $argument = new InputArgument('foo', InputArgument::IS_ARRAY);
+
         $argument->setDefault('default');
     }
 
@@ -130,10 +136,11 @@ class InputArgumentTest extends TestCase
 
     public function testCompleteClosureReturnIncorrectType()
     {
+        $argument = new InputArgument('foo', InputArgument::OPTIONAL, '', null, fn (CompletionInput $input) => 'invalid');
+
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Closure for argument "foo" must return an array. Got "string".');
 
-        $argument = new InputArgument('foo', InputArgument::OPTIONAL, '', null, fn (CompletionInput $input) => 'invalid');
         $argument->complete(new CompletionInput(), new CompletionSuggestions());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -162,17 +162,21 @@ class InputOptionTest extends TestCase
 
     public function testDefaultValueWithValueNoneMode()
     {
+        $option = new InputOption('foo', 'f', InputOption::VALUE_NONE);
+
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot set a default value when using InputOption::VALUE_NONE mode.');
-        $option = new InputOption('foo', 'f', InputOption::VALUE_NONE);
+
         $option->setDefault('default');
     }
 
     public function testDefaultValueWithIsArrayMode()
     {
+        $option = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY);
+
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('A default value for an array option must be an array.');
-        $option = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY);
+
         $option->setDefault('default');
     }
 
@@ -229,10 +233,11 @@ class InputOptionTest extends TestCase
 
     public function testCompleteClosureReturnIncorrectType()
     {
+        $option = new InputOption('foo', null, InputOption::VALUE_OPTIONAL, '', null, fn (CompletionInput $input) => 'invalid');
+
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Closure for option "foo" must return an array. Got "string".');
 
-        $option = new InputOption('foo', null, InputOption::VALUE_OPTIONAL, '', null, fn (CompletionInput $input) => 'invalid');
         $option->complete(new CompletionInput(), new CompletionSuggestions());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -63,17 +63,21 @@ class InputTest extends TestCase
 
     public function testSetInvalidOption()
     {
+        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" option does not exist.');
-        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+
         $input->setOption('foo', 'bar');
     }
 
     public function testGetInvalidOption()
     {
+        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" option does not exist.');
-        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+
         $input->getOption('foo');
     }
 
@@ -93,35 +97,43 @@ class InputTest extends TestCase
 
     public function testSetInvalidArgument()
     {
+        $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" argument does not exist.');
-        $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
+
         $input->setArgument('foo', 'bar');
     }
 
     public function testGetInvalidArgument()
     {
+        $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" argument does not exist.');
-        $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
+
         $input->getArgument('foo');
     }
 
     public function testValidateWithMissingArguments()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
         $input = new ArrayInput([]);
         $input->bind(new InputDefinition([new InputArgument('name', InputArgument::REQUIRED)]));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
+
         $input->validate();
     }
 
     public function testValidateWithMissingRequiredArguments()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
         $input = new ArrayInput(['bar' => 'baz']);
         $input->bind(new InputDefinition([new InputArgument('name', InputArgument::REQUIRED), new InputArgument('bar', InputArgument::OPTIONAL)]));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
+
         $input->validate();
     }
 

--- a/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
+++ b/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
@@ -137,8 +137,7 @@ class ConsoleLoggerTest extends TestCase
     public function testThrowsOnInvalidLevel()
     {
         $this->expectException(InvalidArgumentException::class);
-        $logger = $this->getLogger();
-        $logger->log('invalid level', 'Foo');
+        $this->getLogger()->log('invalid level', 'Foo');
     }
 
     public function testContextReplacement()

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -154,8 +154,6 @@ class CommandTesterTest extends TestCase
 
     public function testCommandWithWrongInputsNumber()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Aborted.');
         $questions = [
             'What\'s your name?',
             'How are you?',
@@ -174,13 +172,15 @@ class CommandTesterTest extends TestCase
 
         $tester = new CommandTester($command);
         $tester->setInputs(['a', 'Bobby', 'Fine']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Aborted.');
+
         $tester->execute([]);
     }
 
     public function testCommandWithQuestionsButNoInputs()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Aborted.');
         $questions = [
             'What\'s your name?',
             'How are you?',
@@ -198,6 +198,10 @@ class CommandTesterTest extends TestCase
         });
 
         $tester = new CommandTester($command);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Aborted.');
+
         $tester->execute([]);
     }
 

--- a/src/Symfony/Component/CssSelector/Tests/CssSelectorConverterTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/CssSelectorConverterTest.php
@@ -48,8 +48,7 @@ class CssSelectorConverterTest extends TestCase
     {
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('Expected identifier, but <eof at 3> found.');
-        $converter = new CssSelectorConverter();
-        $converter->toXPath('h1:');
+        (new CssSelectorConverter())->toXPath('h1:');
     }
 
     /** @dataProvider getCssToXPathWithoutPrefixTestData */
@@ -60,7 +59,7 @@ class CssSelectorConverterTest extends TestCase
         $this->assertEquals($xpath, $converter->toXPath($css, ''), '->parse() parses an input string and returns a node');
     }
 
-    public static function getCssToXPathWithoutPrefixTestData()
+    public static function getCssToXPathWithoutPrefixTestData(): array
     {
         return [
             ['h1', 'h1'],

--- a/src/Symfony/Component/CssSelector/Tests/Parser/TokenStreamTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/TokenStreamTest.php
@@ -54,10 +54,11 @@ class TokenStreamTest extends TestCase
 
     public function testFailToGetNextIdentifier()
     {
-        $this->expectException(SyntaxErrorException::class);
-
         $stream = new TokenStream();
         $stream->push(new Token(Token::TYPE_DELIMITER, '.', 2));
+
+        $this->expectException(SyntaxErrorException::class);
+
         $stream->getNextIdentifier();
     }
 
@@ -74,10 +75,11 @@ class TokenStreamTest extends TestCase
 
     public function testFailToGetNextIdentifierOrStar()
     {
-        $this->expectException(SyntaxErrorException::class);
-
         $stream = new TokenStream();
         $stream->push(new Token(Token::TYPE_DELIMITER, '.', 2));
+
+        $this->expectException(SyntaxErrorException::class);
+
         $stream->getNextIdentifierOrStar();
     }
 

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -38,56 +38,68 @@ class TranslatorTest extends TestCase
 
     public function testCssToXPathPseudoElement()
     {
-        $this->expectException(ExpressionErrorException::class);
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
+
+        $this->expectException(ExpressionErrorException::class);
+
         $translator->cssToXPath('e::first-line');
     }
 
     public function testGetExtensionNotExistsExtension()
     {
-        $this->expectException(ExpressionErrorException::class);
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
+
+        $this->expectException(ExpressionErrorException::class);
+
         $translator->getExtension('fake');
     }
 
     public function testAddCombinationNotExistsExtension()
     {
-        $this->expectException(ExpressionErrorException::class);
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $parser = new Parser();
         $xpath = $parser->parse('*')[0];
         $combinedXpath = $parser->parse('*')[0];
+
+        $this->expectException(ExpressionErrorException::class);
+
         $translator->addCombination('fake', $xpath, $combinedXpath);
     }
 
     public function testAddFunctionNotExistsFunction()
     {
-        $this->expectException(ExpressionErrorException::class);
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $xpath = new XPathExpr();
         $function = new FunctionNode(new ElementNode(), 'fake');
+
+        $this->expectException(ExpressionErrorException::class);
+
         $translator->addFunction($xpath, $function);
     }
 
     public function testAddPseudoClassNotExistsClass()
     {
-        $this->expectException(ExpressionErrorException::class);
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $xpath = new XPathExpr();
+
+        $this->expectException(ExpressionErrorException::class);
+
         $translator->addPseudoClass($xpath, 'fake');
     }
 
     public function testAddAttributeMatchingClassNotExistsClass()
     {
-        $this->expectException(ExpressionErrorException::class);
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $xpath = new XPathExpr();
+
+        $this->expectException(ExpressionErrorException::class);
+
         $translator->addAttributeMatching($xpath, '', '', '');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/AliasTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/AliasTest.php
@@ -74,12 +74,14 @@ class AliasTest extends TestCase
      */
     public function testCannotDeprecateWithAnInvalidTemplate($message)
     {
-        $this->expectException(InvalidArgumentException::class);
         $def = new Alias('foo');
+
+        $this->expectException(InvalidArgumentException::class);
+
         $def->setDeprecated('package', '1.1', $message);
     }
 
-    public static function invalidDeprecationMessageProvider()
+    public static function invalidDeprecationMessageProvider(): array
     {
         return [
             "With \rs" => ["invalid \r message %alias_id%"],

--- a/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
@@ -91,8 +91,9 @@ class ChildDefinitionTest extends TestCase
 
     public function testReplaceArgumentShouldRequireIntegerIndex()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $def = new ChildDefinition('foo');
+
+        $this->expectException(\InvalidArgumentException::class);
 
         $def->replaceArgument('0', 'foo');
     }
@@ -118,11 +119,12 @@ class ChildDefinitionTest extends TestCase
 
     public function testGetArgumentShouldCheckBounds()
     {
-        $this->expectException(\OutOfBoundsException::class);
         $def = new ChildDefinition('foo');
 
         $def->setArguments([0 => 'foo']);
         $def->replaceArgument(0, 'foo');
+
+        $this->expectException(\OutOfBoundsException::class);
 
         $def->getArgument(1);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AbstractRecursivePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AbstractRecursivePassTest.php
@@ -107,11 +107,11 @@ class AbstractRecursivePassTest extends TestCase
 
     public function testGetConstructorDefinitionNoClass()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid service "foo": the class is not set.');
-
         $container = new ContainerBuilder();
         $container->register('foo');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid service "foo": the class is not set.');
 
         (new class() extends AbstractRecursivePass {
             protected function processValue($value, $isRoot = false): mixed

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AliasDeprecatedPublicServicesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AliasDeprecatedPublicServicesPassTest.php
@@ -47,13 +47,13 @@ final class AliasDeprecatedPublicServicesPassTest extends TestCase
      */
     public function testProcessWithMissingAttribute(string $attribute, array $attributes)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('The "%s" attribute is mandatory for the "container.private" tag on the "foo" service.', $attribute));
-
         $container = new ContainerBuilder();
         $container
             ->register('foo')
             ->addTag('container.private', $attributes);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The "%s" attribute is mandatory for the "container.private" tag on the "foo" service.', $attribute));
 
         (new AliasDeprecatedPublicServicesPass())->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoAliasServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoAliasServicePassTest.php
@@ -21,19 +21,20 @@ class AutoAliasServicePassTest extends TestCase
 {
     public function testProcessWithMissingParameter()
     {
-        $this->expectException(ParameterNotFoundException::class);
         $container = new ContainerBuilder();
 
         $container->register('example')
             ->addTag('auto_alias', ['format' => '%non_existing%.example']);
 
         $pass = new AutoAliasServicePass();
+
+        $this->expectException(ParameterNotFoundException::class);
+
         $pass->process($container);
     }
 
     public function testProcessWithMissingFormat()
     {
-        $this->expectException(InvalidArgumentException::class);
         $container = new ContainerBuilder();
 
         $container->register('example')
@@ -41,6 +42,9 @@ class AutoAliasServicePassTest extends TestCase
         $container->setParameter('existing', 'mysql');
 
         $pass = new AutoAliasServicePass();
+
+        $this->expectException(InvalidArgumentException::class);
+
         $pass->process($container);
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -609,12 +609,13 @@ class AutowirePassTest extends TestCase
 
     public function testUnionScalarArgsCannotBeAutowired()
     {
-        $this->expectException(AutowiringFailedException::class);
-        $this->expectExceptionMessage('Cannot autowire service "union_scalars": argument "$timeout" of method "Symfony\Component\DependencyInjection\Tests\Compiler\UnionScalars::__construct()" is type-hinted "float|int", you should configure its value explicitly.');
         $container = new ContainerBuilder();
 
         $container->register('union_scalars', UnionScalars::class)
             ->setAutowired(true);
+
+        $this->expectException(AutowiringFailedException::class);
+        $this->expectExceptionMessage('Cannot autowire service "union_scalars": argument "$timeout" of method "Symfony\Component\DependencyInjection\Tests\Compiler\UnionScalars::__construct()" is type-hinted "float|int", you should configure its value explicitly.');
 
         (new AutowirePass())->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
@@ -24,28 +24,29 @@ class CheckCircularReferencesPassTest extends TestCase
 {
     public function testProcess()
     {
-        $this->expectException(ServiceCircularReferenceException::class);
         $container = new ContainerBuilder();
         $container->register('a')->addArgument(new Reference('b'));
         $container->register('b')->addArgument(new Reference('a'));
+
+        $this->expectException(ServiceCircularReferenceException::class);
 
         $this->process($container);
     }
 
     public function testProcessWithAliases()
     {
-        $this->expectException(ServiceCircularReferenceException::class);
         $container = new ContainerBuilder();
         $container->register('a')->addArgument(new Reference('b'));
         $container->setAlias('b', 'c');
         $container->setAlias('c', 'a');
+
+        $this->expectException(ServiceCircularReferenceException::class);
 
         $this->process($container);
     }
 
     public function testProcessWithFactory()
     {
-        $this->expectException(ServiceCircularReferenceException::class);
         $container = new ContainerBuilder();
 
         $container
@@ -56,23 +57,25 @@ class CheckCircularReferencesPassTest extends TestCase
             ->register('b', 'stdClass')
             ->setFactory([new Reference('a'), 'getInstance']);
 
+        $this->expectException(ServiceCircularReferenceException::class);
+
         $this->process($container);
     }
 
     public function testProcessDetectsIndirectCircularReference()
     {
-        $this->expectException(ServiceCircularReferenceException::class);
         $container = new ContainerBuilder();
         $container->register('a')->addArgument(new Reference('b'));
         $container->register('b')->addArgument(new Reference('c'));
         $container->register('c')->addArgument(new Reference('a'));
+
+        $this->expectException(ServiceCircularReferenceException::class);
 
         $this->process($container);
     }
 
     public function testProcessDetectsIndirectCircularReferenceWithFactory()
     {
-        $this->expectException(ServiceCircularReferenceException::class);
         $container = new ContainerBuilder();
 
         $container->register('a')->addArgument(new Reference('b'));
@@ -83,16 +86,19 @@ class CheckCircularReferencesPassTest extends TestCase
 
         $container->register('c')->addArgument(new Reference('a'));
 
+        $this->expectException(ServiceCircularReferenceException::class);
+
         $this->process($container);
     }
 
     public function testDeepCircularReference()
     {
-        $this->expectException(ServiceCircularReferenceException::class);
         $container = new ContainerBuilder();
         $container->register('a')->addArgument(new Reference('b'));
         $container->register('b')->addArgument(new Reference('c'));
         $container->register('c')->addArgument(new Reference('b'));
+
+        $this->expectException(ServiceCircularReferenceException::class);
 
         $this->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -21,18 +21,20 @@ class CheckDefinitionValidityPassTest extends TestCase
 {
     public function testProcessDetectsSyntheticNonPublicDefinitions()
     {
-        $this->expectException(RuntimeException::class);
         $container = new ContainerBuilder();
         $container->register('a')->setSynthetic(true)->setPublic(false);
+
+        $this->expectException(RuntimeException::class);
 
         $this->process($container);
     }
 
     public function testProcessDetectsNonSyntheticNonAbstractDefinitionWithoutClass()
     {
-        $this->expectException(RuntimeException::class);
         $container = new ContainerBuilder();
         $container->register('a')->setSynthetic(false)->setAbstract(false);
+
+        $this->expectException(RuntimeException::class);
 
         $this->process($container);
     }
@@ -92,10 +94,12 @@ class CheckDefinitionValidityPassTest extends TestCase
      */
     public function testInvalidTags(string $name, array $attributes, string $message)
     {
-        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($message);
         $container = new ContainerBuilder();
         $container->register('a', 'class')->addTag($name, $attributes);
+
+        $this->expectException(RuntimeException::class);
+
         $this->process($container);
     }
 
@@ -121,20 +125,22 @@ class CheckDefinitionValidityPassTest extends TestCase
 
     public function testDynamicPublicServiceName()
     {
-        $this->expectException(EnvParameterException::class);
         $container = new ContainerBuilder();
         $env = $container->getParameterBag()->get('env(BAR)');
         $container->register("foo.$env", 'class')->setPublic(true);
+
+        $this->expectException(EnvParameterException::class);
 
         $this->process($container);
     }
 
     public function testDynamicPublicAliasName()
     {
-        $this->expectException(EnvParameterException::class);
         $container = new ContainerBuilder();
         $env = $container->getParameterBag()->get('env(BAR)');
         $container->setAlias("foo.$env", 'class')->setPublic(true);
+
+        $this->expectException(EnvParameterException::class);
 
         $this->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
@@ -41,7 +41,6 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
 
     public function testProcessThrowsExceptionOnInvalidReference()
     {
-        $this->expectException(ServiceNotFoundException::class);
         $container = new ContainerBuilder();
 
         $container
@@ -49,12 +48,13 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
             ->addArgument(new Reference('b'))
         ;
 
+        $this->expectException(ServiceNotFoundException::class);
+
         $this->process($container);
     }
 
     public function testProcessThrowsExceptionOnInvalidReferenceFromInlinedDefinition()
     {
-        $this->expectException(ServiceNotFoundException::class);
         $container = new ContainerBuilder();
 
         $def = new Definition();
@@ -64,6 +64,8 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
             ->register('a', '\stdClass')
             ->addArgument($def)
         ;
+
+        $this->expectException(ServiceNotFoundException::class);
 
         $this->process($container);
     }
@@ -84,34 +86,36 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
 
     public function testWithErroredServiceLocator()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('The service "foo" in the container provided to "bar" has a dependency on a non-existent service "baz".');
         $container = new ContainerBuilder();
 
         ServiceLocatorTagPass::register($container, ['foo' => new Reference('baz')], 'bar');
 
         (new AnalyzeServiceReferencesPass())->process($container);
         (new InlineServiceDefinitionsPass())->process($container);
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "foo" in the container provided to "bar" has a dependency on a non-existent service "baz".');
+
         $this->process($container);
     }
 
     public function testWithErroredHiddenService()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('The service "bar" has a dependency on a non-existent service "foo".');
         $container = new ContainerBuilder();
 
         ServiceLocatorTagPass::register($container, ['foo' => new Reference('foo')], 'bar');
 
         (new AnalyzeServiceReferencesPass())->process($container);
         (new InlineServiceDefinitionsPass())->process($container);
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "bar" has a dependency on a non-existent service "foo".');
+
         $this->process($container);
     }
 
     public function testProcessThrowsExceptionOnInvalidReferenceWithAlternatives()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('The service "a" has a dependency on a non-existent service "@ccc". Did you mean this: "ccc"?');
         $container = new ContainerBuilder();
 
         $container
@@ -121,18 +125,21 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
         $container
             ->register('ccc', '\stdClass');
 
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "a" has a dependency on a non-existent service "@ccc". Did you mean this: "ccc"?');
+
         $this->process($container);
     }
 
     public function testCurrentIdIsExcludedFromAlternatives()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('The service "app.my_service" has a dependency on a non-existent service "app.my_service2".');
-
         $container = new ContainerBuilder();
         $container
             ->register('app.my_service', \stdClass::class)
             ->addArgument(new Reference('app.my_service2'));
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "app.my_service" has a dependency on a non-existent service "app.my_service2".');
 
         $this->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckReferenceValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckReferenceValidityPassTest.php
@@ -20,11 +20,12 @@ class CheckReferenceValidityPassTest extends TestCase
 {
     public function testProcessDetectsReferenceToAbstractDefinition()
     {
-        $this->expectException(\RuntimeException::class);
         $container = new ContainerBuilder();
 
         $container->register('a')->setAbstract(true);
         $container->register('b')->addArgument(new Reference('a'));
+
+        $this->expectException(\RuntimeException::class);
 
         $this->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -46,53 +46,53 @@ class CheckTypeDeclarationsPassTest extends TestCase
 {
     public function testProcessThrowsExceptionOnInvalidTypesConstructorArguments()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Bar::__construct()" accepts "stdClass", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('foo', Foo::class);
         $container->register('bar', Bar::class)
             ->addArgument(new Reference('foo'));
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Bar::__construct()" accepts "stdClass", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
+
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessThrowsExceptionOnInvalidTypesMethodCallArguments()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoo()" accepts "stdClass", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('foo', Foo::class);
         $container->register('bar', BarMethodCall::class)
             ->addMethodCall('setFoo', [new Reference('foo')]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoo()" accepts "stdClass", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
+
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessFailsWhenPassingNullToRequiredArgument()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Bar::__construct()" accepts "stdClass", "null" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('bar', Bar::class)
             ->addArgument(null);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Bar::__construct()" accepts "stdClass", "null" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessThrowsExceptionWhenMissingArgumentsInConstructor()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Bar::__construct()" requires 1 arguments, 0 passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('bar', Bar::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Bar::__construct()" requires 1 arguments, 0 passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
@@ -124,9 +124,6 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
     public function testProcessThrowsExceptionWhenMissingArgumentsInMethodCall()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoo()" requires 1 arguments, 0 passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('foo', \stdClass::class);
@@ -134,14 +131,14 @@ class CheckTypeDeclarationsPassTest extends TestCase
             ->addArgument(new Reference('foo'))
             ->addMethodCall('setFoo', []);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoo()" requires 1 arguments, 0 passed.');
+
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessVariadicFails()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 2 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoosVariadic()" accepts "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo", "stdClass" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('stdClass', \stdClass::class);
@@ -153,14 +150,14 @@ class CheckTypeDeclarationsPassTest extends TestCase
                 new Reference('stdClass'),
             ]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 2 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoosVariadic()" accepts "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo", "stdClass" passed.');
+
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessVariadicFailsOnPassingBadTypeOnAnotherArgument()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoosVariadic()" accepts "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo", "stdClass" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('stdClass', \stdClass::class);
@@ -168,6 +165,9 @@ class CheckTypeDeclarationsPassTest extends TestCase
             ->addMethodCall('setFoosVariadic', [
                 new Reference('stdClass'),
             ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoosVariadic()" accepts "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo", "stdClass" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
@@ -222,9 +222,6 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
     public function testProcessFailsWhenUsingOptionalArgumentWithBadType()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 2 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoosOptional()" accepts "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo", "stdClass" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('stdClass', \stdClass::class);
@@ -234,6 +231,9 @@ class CheckTypeDeclarationsPassTest extends TestCase
                 new Reference('foo'),
                 new Reference('stdClass'),
             ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 2 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoosOptional()" accepts "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo", "stdClass" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
@@ -252,13 +252,13 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
     public function testProcessSuccessWhenPassingNullToOptionalThatDoesNotAcceptNull()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarOptionalArgumentNotNull::__construct()" accepts "int", "null" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('bar', BarOptionalArgumentNotNull::class)
             ->addArgument(null);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarOptionalArgumentNotNull::__construct()" accepts "int", "null" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
@@ -293,22 +293,19 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
     public function testProcessFailsOnPassingScalarTypeToConstructorTypedWithClass()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Bar::__construct()" accepts "stdClass", "int" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('bar', Bar::class)
             ->addArgument(1);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Bar::__construct()" accepts "stdClass", "int" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessFailsOnPassingScalarTypeToMethodTypedWithClass()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoo()" accepts "stdClass", "string" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('bar', BarMethodCall::class)
@@ -316,14 +313,14 @@ class CheckTypeDeclarationsPassTest extends TestCase
                 'builtin type instead of class',
             ]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setFoo()" accepts "stdClass", "string" passed.');
+
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessFailsOnPassingClassToScalarTypedParameter()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setScalars()" accepts "int", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('foo', Foo::class);
@@ -332,6 +329,9 @@ class CheckTypeDeclarationsPassTest extends TestCase
                 new Reference('foo'),
                 new Reference('foo'),
             ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\BarMethodCall::setScalars()" accepts "int", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
@@ -381,13 +381,13 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
     public function testProcessSuccessWhenPassingIntegerToArrayTypedParameter()
     {
-        $this->expectException(InvalidParameterTypeException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\BarMethodCall::setArray()" accepts "array", "int" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('bar', BarMethodCall::class)
             ->addMethodCall('setArray', [1]);
+
+        $this->expectException(InvalidParameterTypeException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\BarMethodCall::setArray()" accepts "array", "int" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
@@ -438,9 +438,6 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
     public function testProcessFactoryFailsOnInvalidParameterType()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo::createBarArguments()" accepts "stdClass", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('foo', Foo::class);
@@ -451,14 +448,14 @@ class CheckTypeDeclarationsPassTest extends TestCase
                 'createBarArguments',
             ]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo::createBarArguments()" accepts "stdClass", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
+
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessFactoryFailsOnInvalidParameterTypeOptional()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "bar": argument 2 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo::createBarArguments()" accepts "stdClass", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
-
         $container = new ContainerBuilder();
 
         $container->register('stdClass', \stdClass::class);
@@ -470,6 +467,9 @@ class CheckTypeDeclarationsPassTest extends TestCase
                 new Reference('foo'),
                 'createBarArguments',
             ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "bar": argument 2 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo::createBarArguments()" accepts "stdClass", "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\Foo" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
@@ -644,9 +644,6 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
     public function testProcessHandleMixedEnvPlaceholder()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "foobar": argument 1 of "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\BarMethodCall::setArray()" accepts "array", "string" passed.');
-
         $container = new ContainerBuilder(new EnvPlaceholderParameterBag([
             'ccc' => '%env(FOO)%',
         ]));
@@ -655,14 +652,14 @@ class CheckTypeDeclarationsPassTest extends TestCase
             ->register('foobar', BarMethodCall::class)
             ->addMethodCall('setArray', ['foo%ccc%']);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "foobar": argument 1 of "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\BarMethodCall::setArray()" accepts "array", "string" passed.');
+
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
 
     public function testProcessHandleMultipleEnvPlaceholder()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "foobar": argument 1 of "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\BarMethodCall::setArray()" accepts "array", "string" passed.');
-
         $container = new ContainerBuilder(new EnvPlaceholderParameterBag([
             'ccc' => '%env(FOO)%',
             'fcy' => '%env(int:BAR)%',
@@ -671,6 +668,9 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $container
             ->register('foobar', BarMethodCall::class)
             ->addMethodCall('setArray', ['%ccc%%fcy%']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "foobar": argument 1 of "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\BarMethodCall::setArray()" accepts "array", "string" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -241,8 +241,7 @@ class ContainerBuilderTest extends TestCase
     {
         $this->expectException(ServiceNotFoundException::class);
         $this->expectExceptionMessage('You have requested a non-existent service "foo".');
-        $builder = new ContainerBuilder();
-        $builder->get('foo');
+        (new ContainerBuilder())->get('foo');
     }
 
     public function testGetReturnsNullIfServiceDoesNotExistAndInvalidReferenceIsUsed()
@@ -254,9 +253,11 @@ class ContainerBuilderTest extends TestCase
 
     public function testGetThrowsCircularReferenceExceptionIfServiceHasReferenceToItself()
     {
-        $this->expectException(ServiceCircularReferenceException::class);
         $builder = new ContainerBuilder();
         $builder->register('baz', 'stdClass')->setArguments([new Reference('baz')]);
+
+        $this->expectException(ServiceCircularReferenceException::class);
+
         $builder->get('baz');
     }
 
@@ -307,8 +308,7 @@ class ContainerBuilderTest extends TestCase
     public function testBadAliasId($id)
     {
         $this->expectException(InvalidArgumentException::class);
-        $builder = new ContainerBuilder();
-        $builder->setAlias($id, 'foo');
+        (new ContainerBuilder())->setAlias($id, 'foo');
     }
 
     /**
@@ -317,11 +317,10 @@ class ContainerBuilderTest extends TestCase
     public function testBadDefinitionId($id)
     {
         $this->expectException(InvalidArgumentException::class);
-        $builder = new ContainerBuilder();
-        $builder->setDefinition($id, new Definition('Foo'));
+        (new ContainerBuilder())->setDefinition($id, new Definition('Foo'));
     }
 
-    public static function provideBadId()
+    public static function provideBadId(): array
     {
         return [
             [''],
@@ -643,9 +642,11 @@ class ContainerBuilderTest extends TestCase
 
     public function testCreateSyntheticService()
     {
-        $this->expectException(\RuntimeException::class);
         $builder = new ContainerBuilder();
         $builder->register('foo', 'Bar\FooClass')->setSynthetic(true);
+
+        $this->expectException(\RuntimeException::class);
+
         $builder->get('foo');
     }
 
@@ -690,15 +691,15 @@ class ContainerBuilderTest extends TestCase
 
     public function testCreateServiceWithAbstractArgument()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Argument "$baz" of service "foo" is abstract: should be defined by Pass.');
-
         $builder = new ContainerBuilder();
         $builder->register('foo', FooWithAbstractArgument::class)
             ->setArgument('$baz', new AbstractArgument('should be defined by Pass'))
             ->setPublic(true);
 
         $builder->compile();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Argument "$baz" of service "foo" is abstract: should be defined by Pass.');
 
         $builder->get('foo');
     }
@@ -714,12 +715,13 @@ class ContainerBuilderTest extends TestCase
 
     public function testResolveServicesWithDecoratedDefinition()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Constructing service "foo" from a parent definition is not supported at build time.');
         $builder = new ContainerBuilder();
         $builder->setDefinition('grandpa', new Definition('stdClass'));
         $builder->setDefinition('parent', new ChildDefinition('grandpa'));
         $builder->setDefinition('foo', new ChildDefinition('parent'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Constructing service "foo" from a parent definition is not supported at build time.');
 
         $builder->get('foo');
     }
@@ -808,12 +810,14 @@ class ContainerBuilderTest extends TestCase
 
     public function testMergeThrowsExceptionForDuplicateAutomaticInstanceofDefinitions()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('"AInterface" has already been autoconfigured and merge() does not support merging autoconfiguration for the same class/interface.');
         $container = new ContainerBuilder();
         $config = new ContainerBuilder();
         $container->registerForAutoconfiguration('AInterface');
         $config->registerForAutoconfiguration('AInterface');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"AInterface" has already been autoconfigured and merge() does not support merging autoconfiguration for the same class/interface.');
+
         $container->merge($config);
     }
 
@@ -913,12 +917,14 @@ class ContainerBuilderTest extends TestCase
 
     public function testCompileWithArrayInStringResolveEnv()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('A string value must be composed of strings and/or numbers, but found parameter "env(json:ARRAY)" of type "array" inside string value "ABC %env(json:ARRAY)%".');
         putenv('ARRAY={"foo":"bar"}');
 
         $container = new ContainerBuilder();
         $container->setParameter('foo', 'ABC %env(json:ARRAY)%');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('A string value must be composed of strings and/or numbers, but found parameter "env(json:ARRAY)" of type "array" inside string value "ABC %env(json:ARRAY)%".');
+
         $container->compile(true);
 
         putenv('ARRAY');
@@ -926,10 +932,12 @@ class ContainerBuilderTest extends TestCase
 
     public function testCompileWithResolveMissingEnv()
     {
-        $this->expectException(EnvNotFoundException::class);
-        $this->expectExceptionMessage('Environment variable not found: "FOO".');
         $container = new ContainerBuilder();
         $container->setParameter('foo', '%env(FOO)%');
+
+        $this->expectException(EnvNotFoundException::class);
+        $this->expectExceptionMessage('Environment variable not found: "FOO".');
+
         $container->compile(true);
     }
 
@@ -1037,10 +1045,12 @@ class ContainerBuilderTest extends TestCase
 
     public function testMergeLogicException()
     {
-        $this->expectException(\LogicException::class);
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->compile();
+
+        $this->expectException(\LogicException::class);
+
         $container->merge(new ContainerBuilder());
     }
 
@@ -1272,11 +1282,13 @@ class ContainerBuilderTest extends TestCase
 
     public function testThrowsExceptionWhenSetServiceOnACompiledContainer()
     {
-        $this->expectException(\BadMethodCallException::class);
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->register('a', 'stdClass')->setPublic(true);
         $container->compile();
+
+        $this->expectException(\BadMethodCallException::class);
+
         $container->set('a', new \stdClass());
     }
 
@@ -1301,10 +1313,12 @@ class ContainerBuilderTest extends TestCase
 
     public function testThrowsExceptionWhenSetDefinitionOnACompiledContainer()
     {
-        $this->expectException(\BadMethodCallException::class);
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->compile();
+
+        $this->expectException(\BadMethodCallException::class);
+
         $container->setDefinition('a', new Definition());
     }
 
@@ -1394,8 +1408,6 @@ class ContainerBuilderTest extends TestCase
 
     public function testThrowsCircularExceptionForCircularAliases()
     {
-        $this->expectException(ServiceCircularReferenceException::class);
-        $this->expectExceptionMessage('Circular reference detected for service "app.test_class", path: "app.test_class -> App\TestClass -> app.test_class".');
         $builder = new ContainerBuilder();
 
         $builder->setAliases([
@@ -1403,6 +1415,9 @@ class ContainerBuilderTest extends TestCase
             'app.test_class' => new Alias('App\\TestClass'),
             'App\\TestClass' => new Alias('app.test_class'),
         ]);
+
+        $this->expectException(ServiceCircularReferenceException::class);
+        $this->expectExceptionMessage('Circular reference detected for service "app.test_class", path: "app.test_class -> App\TestClass -> app.test_class".');
 
         $builder->findDefinition('foo');
     }
@@ -1450,59 +1465,64 @@ class ContainerBuilderTest extends TestCase
 
     public function testNoClassFromGlobalNamespaceClassId()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The definition for "DateTimeImmutable" has no class attribute, and appears to reference a class or interface in the global namespace.');
         $container = new ContainerBuilder();
 
         $container->register(\DateTimeImmutable::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The definition for "DateTimeImmutable" has no class attribute, and appears to reference a class or interface in the global namespace.');
+
         $container->compile();
     }
 
     public function testNoClassFromGlobalNamespaceClassIdWithLeadingSlash()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The definition for "\DateTimeImmutable" has no class attribute, and appears to reference a class or interface in the global namespace.');
         $container = new ContainerBuilder();
 
         $container->register('\\'.\DateTimeImmutable::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The definition for "\DateTimeImmutable" has no class attribute, and appears to reference a class or interface in the global namespace.');
+
         $container->compile();
     }
 
     public function testNoClassFromNamespaceClassIdWithLeadingSlash()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The definition for "\Symfony\Component\DependencyInjection\Tests\FooClass" has no class attribute, and appears to reference a class or interface. Please specify the class attribute explicitly or remove the leading backslash by renaming the service to "Symfony\Component\DependencyInjection\Tests\FooClass" to get rid of this error.');
         $container = new ContainerBuilder();
 
         $container->register('\\'.FooClass::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The definition for "\Symfony\Component\DependencyInjection\Tests\FooClass" has no class attribute, and appears to reference a class or interface. Please specify the class attribute explicitly or remove the leading backslash by renaming the service to "Symfony\Component\DependencyInjection\Tests\FooClass" to get rid of this error.');
+
         $container->compile();
     }
 
     public function testNoClassFromNonClassId()
     {
+        $container = new ContainerBuilder();
+        $container->register('123_abc');
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The definition for "123_abc" has no class.');
-        $container = new ContainerBuilder();
 
-        $container->register('123_abc');
         $container->compile();
     }
 
     public function testNoClassFromNsSeparatorId()
     {
+        $container = new ContainerBuilder();
+        $container->register('\\foo');
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The definition for "\foo" has no class.');
-        $container = new ContainerBuilder();
 
-        $container->register('\\foo');
         $container->compile();
     }
 
     public function testGetThrownServiceNotFoundExceptionWithCorrectServiceId()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('The service "child_service" has a dependency on a non-existent service "non_existent_service".');
-
         $container = new ContainerBuilder();
         $container->register('child_service', \stdClass::class)
             ->addArgument([
@@ -1515,6 +1535,9 @@ class ContainerBuilderTest extends TestCase
                 'child_service' => new Reference('child_service'),
             ])
         ;
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "child_service" has a dependency on a non-existent service "non_existent_service".');
 
         $container->compile();
     }
@@ -1753,13 +1776,14 @@ class ContainerBuilderTest extends TestCase
 
     public function testErroredDefinition()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Service "errored_definition" is broken.');
         $container = new ContainerBuilder();
 
         $container->register('errored_definition', 'stdClass')
             ->addError('Service "errored_definition" is broken.')
             ->setPublic(true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Service "errored_definition" is broken.');
 
         $container->get('errored_definition');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -264,21 +264,25 @@ class ContainerTest extends TestCase
 
     public function testGetSyntheticServiceThrows()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('The "request" service is synthetic, it needs to be set at boot time before it can be used.');
         require_once __DIR__.'/Fixtures/php/services9_compiled.php';
 
         $container = new \ProjectServiceContainer();
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The "request" service is synthetic, it needs to be set at boot time before it can be used.');
+
         $container->get('request');
     }
 
     public function testGetRemovedServiceThrows()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('The "inlined" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.');
         require_once __DIR__.'/Fixtures/php/services9_compiled.php';
 
         $container = new \ProjectServiceContainer();
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The "inlined" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.');
+
         $container->get('inlined');
     }
 
@@ -400,10 +404,12 @@ class ContainerTest extends TestCase
 
     public function testRequestAnInternalSharedPrivateService()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('You have requested a non-existent service "internal".');
         $c = new ProjectServiceContainer();
         $c->get('internal_dependency');
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('You have requested a non-existent service "internal".');
+
         $c->get('internal');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -118,9 +118,11 @@ class DefinitionTest extends TestCase
 
     public function testExceptionOnEmptyMethodCall()
     {
+        $def = new Definition('stdClass');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Method name cannot be empty.');
-        $def = new Definition('stdClass');
+
         $def->addMethodCall('');
     }
 
@@ -189,12 +191,14 @@ class DefinitionTest extends TestCase
      */
     public function testSetDeprecatedWithInvalidDeprecationTemplate($message)
     {
-        $this->expectException(InvalidArgumentException::class);
         $def = new Definition('stdClass');
+
+        $this->expectException(InvalidArgumentException::class);
+
         $def->setDeprecated('vendor/package', '1.1', $message);
     }
 
-    public static function invalidDeprecationMessageProvider()
+    public static function invalidDeprecationMessageProvider(): array
     {
         return [
             "With \rs" => ["invalid \r message %service_id%"],
@@ -274,28 +278,32 @@ class DefinitionTest extends TestCase
 
     public function testGetArgumentShouldCheckBounds()
     {
-        $this->expectException(\OutOfBoundsException::class);
         $def = new Definition('stdClass');
-
         $def->addArgument('foo');
+
+        $this->expectException(\OutOfBoundsException::class);
+
         $def->getArgument(1);
     }
 
     public function testReplaceArgumentShouldCheckBounds()
     {
+        $def = new Definition('stdClass');
+        $def->addArgument('foo');
+
         $this->expectException(\OutOfBoundsException::class);
         $this->expectExceptionMessage('The index "1" is not in the range [0, 0] of the arguments of class "stdClass".');
-        $def = new Definition('stdClass');
 
-        $def->addArgument('foo');
         $def->replaceArgument(1, 'bar');
     }
 
     public function testReplaceArgumentWithoutExistingArgumentsShouldCheckBounds()
     {
+        $def = new Definition('stdClass');
+
         $this->expectException(\OutOfBoundsException::class);
         $this->expectExceptionMessage('Cannot replace arguments for class "stdClass" if none have been configured yet.');
-        $def = new Definition('stdClass');
+
         $def->replaceArgument(0, 'bar');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -196,9 +196,10 @@ class EnvVarProcessorTest extends TestCase
      */
     public function testGetEnvIntInvalid($value)
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Non-numeric env var');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('int', 'foo', function ($name) use ($value) {
             $this->assertSame('foo', $name);
@@ -246,9 +247,10 @@ class EnvVarProcessorTest extends TestCase
      */
     public function testGetEnvFloatInvalid($value)
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Non-numeric env var');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('float', 'foo', function ($name) use ($value) {
             $this->assertSame('foo', $name);
@@ -295,9 +297,10 @@ class EnvVarProcessorTest extends TestCase
      */
     public function testGetEnvConstInvalid($value)
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('undefined constant');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('const', 'foo', function ($name) use ($value) {
             $this->assertSame('foo', $name);
@@ -373,9 +376,10 @@ class EnvVarProcessorTest extends TestCase
 
     public function testGetEnvInvalidJson()
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Syntax error');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('json', 'foo', function ($name) {
             $this->assertSame('foo', $name);
@@ -389,9 +393,10 @@ class EnvVarProcessorTest extends TestCase
      */
     public function testGetEnvJsonOther($value)
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid JSON env var');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('json', 'foo', function ($name) use ($value) {
             $this->assertSame('foo', $name);
@@ -413,9 +418,10 @@ class EnvVarProcessorTest extends TestCase
 
     public function testGetEnvUnknown()
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unsupported env var prefix');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('unknown', 'foo', function ($name) {
             $this->assertSame('foo', $name);
@@ -426,9 +432,10 @@ class EnvVarProcessorTest extends TestCase
 
     public function testGetEnvKeyInvalidKey()
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid env "key:foo": a key specifier should be provided.');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('key', 'foo', function ($name) {
             $this->fail('Should not get here');
@@ -440,9 +447,10 @@ class EnvVarProcessorTest extends TestCase
      */
     public function testGetEnvKeyNoArrayResult($value)
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Resolved value of "foo" did not result in an array value.');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('key', 'index:foo', function ($name) use ($value) {
             $this->assertSame('foo', $name);
@@ -466,9 +474,10 @@ class EnvVarProcessorTest extends TestCase
      */
     public function testGetEnvKeyArrayKeyNotFound($value)
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(EnvNotFoundException::class);
         $this->expectExceptionMessage('Key "index" not found in');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('key', 'index:foo', function ($name) use ($value) {
             $this->assertSame('foo', $name);
@@ -621,9 +630,10 @@ class EnvVarProcessorTest extends TestCase
 
     public function testRequireMissingFile()
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(EnvNotFoundException::class);
         $this->expectExceptionMessage('missing-file');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('require', '/missing-file', fn ($name) => $name);
     }
@@ -684,14 +694,14 @@ class EnvVarProcessorTest extends TestCase
      */
     public function testGetEnvResolveNotScalar($value)
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Parameter "bar" found when resolving env var "foo" must be scalar');
-
         $container = new ContainerBuilder();
         $container->setParameter('bar', $value);
         $container->compile();
 
         $processor = new EnvVarProcessor($container);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Parameter "bar" found when resolving env var "foo" must be scalar');
 
         $processor->getEnv('resolve', 'foo', fn () => '%bar%');
     }
@@ -877,9 +887,10 @@ CSV;
 
     public function testGetEnvInvalidPrefixWithDefault()
     {
+        $processor = new EnvVarProcessor(new Container());
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unsupported env var prefix');
-        $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('unknown', 'default::FAKE', function ($name) {
             $this->assertSame('default::FAKE', $name);

--- a/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
@@ -34,12 +34,13 @@ class ServiceLocatorTest extends ServiceLocatorTestCase
 
     public function testGetThrowsOnUndefinedService()
     {
-        $this->expectException(NotFoundExceptionInterface::class);
-        $this->expectExceptionMessage('Service "dummy" not found: the container inside "Symfony\Component\DependencyInjection\Tests\ServiceLocatorTest" is a smaller service locator that only knows about the "foo" and "bar" services.');
         $locator = $this->getServiceLocator([
             'foo' => fn () => 'bar',
             'bar' => fn () => 'baz',
         ]);
+
+        $this->expectException(NotFoundExceptionInterface::class);
+        $this->expectExceptionMessage('Service "dummy" not found: the container inside "Symfony\Component\DependencyInjection\Tests\ServiceLocatorTest" is a smaller service locator that only knows about the "foo" and "bar" services.');
 
         $locator->get('dummy');
     }
@@ -53,26 +54,29 @@ class ServiceLocatorTest extends ServiceLocatorTestCase
 
     public function testThrowsInServiceSubscriber()
     {
-        $this->expectException(NotFoundExceptionInterface::class);
-        $this->expectExceptionMessage('Service "foo" not found: even though it exists in the app\'s container, the container inside "caller" is a smaller service locator that only knows about the "bar" service. Unless you need extra laziness, try using dependency injection instead. Otherwise, you need to declare it using "SomeServiceSubscriber::getSubscribedServices()".');
         $container = new Container();
         $container->set('foo', new \stdClass());
         $subscriber = new SomeServiceSubscriber();
         $subscriber->container = $this->getServiceLocator(['bar' => function () {}]);
         $subscriber->container = $subscriber->container->withContext('caller', $container);
 
+        $this->expectException(NotFoundExceptionInterface::class);
+        $this->expectExceptionMessage('Service "foo" not found: even though it exists in the app\'s container, the container inside "caller" is a smaller service locator that only knows about the "bar" service. Unless you need extra laziness, try using dependency injection instead. Otherwise, you need to declare it using "SomeServiceSubscriber::getSubscribedServices()".');
+
         $subscriber->getFoo();
     }
 
     public function testGetThrowsServiceNotFoundException()
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('Service "foo" not found: even though it exists in the app\'s container, the container inside "foo" is a smaller service locator that is empty... Try using dependency injection instead.');
         $container = new Container();
         $container->set('foo', new \stdClass());
 
         $locator = new ServiceLocator([]);
         $locator = $locator->withContext('foo', $container);
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('Service "foo" not found: even though it exists in the app\'s container, the container inside "foo" is a smaller service locator that is empty... Try using dependency injection instead.');
+
         $locator->get('foo');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | --
| License       | MIT

If you guys like this PR, I will fix the other places as well

Should be merged after merge & upmerge of:
* #52365 