### PR TITLE
[Messenger] Fix graceful exit with ids

### DIFF
--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -124,7 +124,10 @@ EOF
         }
 
         $this->retrySpecificIds($failureTransportName, $ids, $io, $shouldForce);
-        $io->success('All done!');
+
+        if (!$this->shouldStop) {
+            $io->success('All done!');
+        }
 
         return 0;
     }
@@ -255,6 +258,10 @@ EOF
 
             $singleReceiver = new SingleMessageReceiver($receiver, $envelope);
             $this->runWorker($failureTransportName, $singleReceiver, $io, $shouldForce);
+
+            if ($this->shouldStop) {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

One last case I missed in #52080