### PR TITLE
add ext-pcntl as dependency

### DIFF
--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "ext-pcntl": "*",
         "psr/log": "^1|^2|^3",
         "symfony/clock": "^6.3|^7.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| Tickets       | -
| License       | MIT

If PCNTL is not available on the system an exception will be htrown in ConsumeMessagesCommand.php, because it requires SIGTERM and SIGINT
Adding the dependency makes it clearer and more understandable which requirements are needed.