### PR TITLE
[Serializer] Fix denormalizing empty string into `object|null` parameter

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyString.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyString.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @author Jeroen <github.com/Jeroeny>
+ */
+class DummyString implements DenormalizableInterface
+{
+    /** @var string $value */
+    public $value;
+
+    public function denormalize(DenormalizerInterface $denormalizer, $data, string $format = null, array $context = [])
+    {
+        $this->value = $data;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithNotNormalizable.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithNotNormalizable.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Jeroen <github.com/Jeroeny>
+ */
+class DummyWithNotNormalizable
+{
+    public function __construct(public NotNormalizableDummy|null $value)
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithObjectOrBool.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithObjectOrBool.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Jeroen <github.com/Jeroeny>
+ */
+class DummyWithObjectOrBool
+{
+    public function __construct(public Php80WithPromotedTypedConstructor|bool $value)
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithObjectOrNull.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithObjectOrNull.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Jeroen <github.com/Jeroeny>
+ */
+class DummyWithObjectOrNull
+{
+    public function __construct(public Php80WithPromotedTypedConstructor|null $value)
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithStringObject.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithStringObject.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Jeroen <github.com/Jeroeny>
+ */
+class DummyWithStringObject
+{
+    public function __construct(public DummyString|null $value)
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NotNormalizableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NotNormalizableDummy.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\DenormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @author Jeroen <github.com/Jeroeny>
+ */
+class NotNormalizableDummy implements DenormalizableInterface
+{
+    public function __construct()
+    {
+    }
+
+    public function denormalize(DenormalizerInterface $denormalizer, $data, string $format = null, array $context = [])
+    {
+        throw new NotNormalizableValueException();
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -62,6 +63,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberThree;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumConstructor;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumProperty;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyWithObjectOrNull;
 use Symfony\Component\Serializer\Tests\Fixtures\FalseBuiltInDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Full;
@@ -816,6 +818,17 @@ class SerializerTest extends TestCase
         $actual = $serializer->deserialize('{"false":false}', FalseBuiltInDummy::class, 'json');
 
         $this->assertEquals(new FalseBuiltInDummy(), $actual);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testDeserializeUntypedFormat()
+    {
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]))], ['csv' => new CsvEncoder()]);
+        $actual = $serializer->deserialize('value'.\PHP_EOL.',', DummyWithObjectOrNull::class, 'csv', [CsvEncoder::AS_COLLECTION_KEY => false]);
+
+        $this->assertEquals(new DummyWithObjectOrNull(null), $actual);
     }
 
     private function serializerWithClassDiscriminator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

> In XML and CSV all basic datatypes are represented as strings

The `AbstractObjectNormalizer` handles this for bool, int and float types. But if a parameter is typed `Object|null`, a serialization and then deserialization will fail. 

This will throw: 

```php
final class Xml
{
    public function __construct(public Uuid|null $element = null)
    {
    }
}

$test = new Xml(null);
$serialized = $this->serializer->serialize($test, XmlEncoder::FORMAT);
$deserialized = $this->serializer->deserialize($serialized, Xml::class, XmlEncoder::FORMAT);
```

```
  [Symfony\Component\Serializer\Exception\NotNormalizableValueException]       
  The data is not a valid "Symfony\Component\Uid\Uuid" string representation.  
```

Reproducer: https://github.com/Jeroeny/reproduce/blob/xmlnull/src/Test.php
