### PR TITLE
[Serializer] Add `AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION` for scalar type transformation

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Improve `NotNormalizableValueException` exception messages in `BackedEnumNormalizer` to contain more useful information
  * Trigger a deprecation when a date could not be parsed using the default format
+ * Add `AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION` for scalar type transformation
 
 8.0
 ---

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractObjectNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractObjectNormalizerContextBuilder.php
@@ -62,6 +62,14 @@ abstract class AbstractObjectNormalizerContextBuilder extends AbstractNormalizer
     }
 
     /**
+     * Configures whether to convert scalar types to the expected type, if their value is compatible.
+     */
+    public function withEnableTypeConversion(?bool $enableTypeConversion): static
+    {
+        return $this->with(AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION, $enableTypeConversion);
+    }
+
+    /**
      * Configures whether fields with the value `null` should be output during normalization.
      */
     public function withSkipNullValues(?bool $skipNullValues): static

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -69,6 +69,13 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     public const DISABLE_TYPE_ENFORCEMENT = 'disable_type_enforcement';
 
     /**
+     * While denormalizing, convert scalar types to the expected type.
+     *
+     * If not defined, it will be enabled for XML and CSV format, because all basic datatypes are represented as strings.
+     */
+    public const ENABLE_TYPE_CONVERSION = 'enable_type_conversion';
+
+    /**
      * Flag to control whether fields with the value `null` should be output
      * when normalizing or omitted.
      */
@@ -317,6 +324,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             $data = ['#' => $data];
         }
 
+        $context[self::ENABLE_TYPE_CONVERSION] ??= XmlEncoder::FORMAT === $format || CsvEncoder::FORMAT === $format;
+
         $allowedAttributes = $this->getAllowedAttributes($type, $context, true);
         $normalizedData = $this->prepareForDenormalization($data);
         $extraAttributes = [];
@@ -476,7 +485,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 // if a value is meant to be a string, float, int or a boolean value from the serialized representation.
                 // That's why we have to transform the values, if one of these non-string basic datatypes is expected.
                 $typeIdentifier = $t->getTypeIdentifier();
-                if (\is_string($data) && (XmlEncoder::FORMAT === $format || CsvEncoder::FORMAT === $format)) {
+                if (\is_string($data) && ($context[self::ENABLE_TYPE_CONVERSION] ?? $this->defaultContext[self::ENABLE_TYPE_CONVERSION] ?? false)) {
                     if ('' === $data) {
                         if (TypeIdentifier::ARRAY === $typeIdentifier) {
                             return [];

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractObjectNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractObjectNormalizerContextBuilderTest.php
@@ -39,6 +39,7 @@ class AbstractObjectNormalizerContextBuilderTest extends TestCase
             ->withEnableMaxDepth($values[AbstractObjectNormalizer::ENABLE_MAX_DEPTH])
             ->withDepthKeyPattern($values[AbstractObjectNormalizer::DEPTH_KEY_PATTERN])
             ->withDisableTypeEnforcement($values[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT])
+            ->withEnableTypeConversion($values[AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION])
             ->withSkipNullValues($values[AbstractObjectNormalizer::SKIP_NULL_VALUES])
             ->withSkipUninitializedValues($values[AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES])
             ->withMaxDepthHandler($values[AbstractObjectNormalizer::MAX_DEPTH_HANDLER])
@@ -59,6 +60,7 @@ class AbstractObjectNormalizerContextBuilderTest extends TestCase
             AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true,
             AbstractObjectNormalizer::DEPTH_KEY_PATTERN => '%s_%s',
             AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => false,
+            AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => false,
             AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
             AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => false,
             AbstractObjectNormalizer::MAX_DEPTH_HANDLER => static function (): void {},
@@ -71,6 +73,7 @@ class AbstractObjectNormalizerContextBuilderTest extends TestCase
             AbstractObjectNormalizer::ENABLE_MAX_DEPTH => null,
             AbstractObjectNormalizer::DEPTH_KEY_PATTERN => null,
             AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => null,
+            AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => null,
             AbstractObjectNormalizer::SKIP_NULL_VALUES => null,
             AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => null,
             AbstractObjectNormalizer::MAX_DEPTH_HANDLER => null,

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -726,7 +726,8 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertInstanceOf(AbstractDummySecondChild::class, $denormalizedData);
     }
 
-    public function testDenormalizeBasicTypePropertiesFromXml()
+    #[DataProvider('denormalizeBasicTypePropertiesConversionDataProvider')]
+    public function testDenormalizeBasicTypePropertiesConversion(string $format, array $context = [])
     {
         $denormalizer = $this->getDenormalizerForObjectWithBasicProperties();
 
@@ -747,7 +748,8 @@ class AbstractObjectNormalizerTest extends TestCase
                 'floatNegInf' => '-INF',
             ],
             ObjectWithBasicProperties::class,
-            'xml'
+            $format,
+            $context
         );
 
         $this->assertInstanceOf(ObjectWithBasicProperties::class, $objectWithBooleanProperties);
@@ -769,6 +771,30 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertNan($objectWithBooleanProperties->floatNaN);
         $this->assertInfinite($objectWithBooleanProperties->floatInf);
         $this->assertEquals(-\INF, $objectWithBooleanProperties->floatNegInf);
+    }
+
+    public function testDenormalizeBasicTypePropertiesThrowsWithoutTypeConversion()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessageMatches('/must be one of "bool" \("string" given\)/');
+        $denormalizer = $this->getDenormalizerForObjectWithBasicProperties();
+        $denormalizer->denormalize(
+            [
+                'boolTrue1' => 'true',
+            ],
+            ObjectWithBasicProperties::class,
+            'other',
+            [AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => false]
+        );
+    }
+
+    public static function denormalizeBasicTypePropertiesConversionDataProvider(): array
+    {
+        return [
+            ['xml', []],
+            ['csv', []],
+            ['other', [AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => true]],
+        ];
     }
 
     private function getDenormalizerForObjectWithBasicProperties()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

The `AbstractObjectNormalizer` converts string types to other scalar types for the Xml and Csv format. 
This logic is quite useful for other untyped formats as well. Like data coming from a Http query. 

It'd nice if the logic can be exposed via this new constant to be set in the `$context`. 