### PR TITLE
DX: nullable_type_declaration

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -37,6 +37,7 @@ return (new PhpCsFixer\Config())
         'header_comment' => ['header' => $fileHeaderComment],
         'modernize_strpos' => true,
         'get_class_to_class_keyword' => true,
+        'nullable_type_declaration' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -29,7 +29,7 @@ class Autoconfigure
         public ?bool $autowire = null,
         public ?array $properties = null,
         public array|string|null $configurator = null,
-        public string|null $constructor = null,
+        public ?string $constructor = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -30,7 +30,7 @@ use Symfony\Component\Dotenv\Dotenv;
 final class DotenvDumpCommand extends Command
 {
     private string $projectDir;
-    private string|null $defaultEnv;
+    private ?string $defaultEnv;
 
     public function __construct(string $projectDir, string $defaultEnv = null)
     {

--- a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
@@ -32,7 +32,7 @@ class OrderedHashMapIterator implements \Iterator
     private int $cursorId;
     /** @var array<int, int> */
     private array $managedCursors;
-    private string|null $key = null;
+    private ?string $key = null;
     /** @var TValue|null */
     private mixed $current = null;
 

--- a/src/Symfony/Component/Notifier/Bridge/Novu/NovuOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/NovuOptions.php
@@ -19,13 +19,13 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 class NovuOptions implements MessageOptionsInterface
 {
     public function __construct(
-        private readonly string|null $subscriberId = null,
-        private readonly string|null $firstName = null,
-        private readonly string|null $lastName = null,
-        private readonly string|null $email = null,
-        private readonly string|null $phone = null,
-        private readonly string|null $avatar = null,
-        private readonly string|null $locale = null,
+        private readonly ?string $subscriberId = null,
+        private readonly ?string $firstName = null,
+        private readonly ?string $lastName = null,
+        private readonly ?string $email = null,
+        private readonly ?string $phone = null,
+        private readonly ?string $avatar = null,
+        private readonly ?string $locale = null,
         private readonly array $options = [],
     ) {
     }

--- a/src/Symfony/Component/Notifier/Bridge/Novu/NovuSubscriberRecipient.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/NovuSubscriberRecipient.php
@@ -20,12 +20,12 @@ class NovuSubscriberRecipient implements RecipientInterface
 {
     public function __construct(
         private readonly string $subscriberId,
-        private readonly string|null $firstName = null,
-        private readonly string|null $lastName = null,
-        private readonly string|null $email = null,
-        private readonly string|null $phone = null,
-        private readonly string|null $avatar = null,
-        private readonly string|null $locale = null,
+        private readonly ?string $firstName = null,
+        private readonly ?string $lastName = null,
+        private readonly ?string $email = null,
+        private readonly ?string $phone = null,
+        private readonly ?string $avatar = null,
+        private readonly ?string $locale = null,
     ) {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT

https://cs.symfony.com/doc/rules/language_construct/nullable_type_declaration.html#example-1

requested in https://github.com/symfony/symfony/pull/48095#discussion_r1365500259

I do not put this rule in ruleset, as it requires PHP 8 - if you want to move it to `@Symfony` ruleset, let me know

There is concern how to have this rule configured and have PHPUnit bridge supporting 7.4, but I think I will leave it unresolved for now.