### PR TITLE
[Routing] Fix requiring symfony/deprecation-contracts

### DIFF
--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "symfony/config": "^6.4|^7.0",
@@ -24,7 +25,6 @@
         "symfony/yaml": "^6.4|^7.0",
         "symfony/expression-language": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/deprecation-contracts": "^2.5|^3",
         "psr/log": "^1|^2|^3"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

In https://github.com/symfony/symfony/pull/51177 I added it by mistake in require-dev instead of require :man_facepalming:

It's always needed for the deprecated routes feature.