### PR TITLE
[MonologBridge][TwigBridge] Fix requiring symfony/deprecation-contracts

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.1",
         "monolog/monolog": "^1.25.1|^2|^3",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/http-kernel": "^5.4|^6.0|^7.0"
     },

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/translation-contracts": "^2.5|^3",
         "twig/twig": "^2.13|^3.0.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

Wherever we call trigger_deprecation we need the dep.