### PR TITLE
[Messenger] Fix requiring `symfony/deprecation-contracts`

### DIFF
--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": ">=8.1",
         "psr/log": "^1|^2|^3",
-        "symfony/clock": "^6.3"
+        "symfony/clock": "^6.3",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "psr/cache": "^1.0|^2.0|^3.0",
         "symfony/console": "^6.3",
         "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/process": "^5.4|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

In https://github.com/symfony/symfony/pull/51174 I added it by mistake in require-dev instead of require :man_facepalming: