### PR TITLE
[FrameworkBundle][Workflow] Add `WorflowGuardListenerPass` only if it exists

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -168,7 +168,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new CachePoolClearerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new CachePoolPrunerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $this->addCompilerPassIfExists($container, FormPass::class);
-        $container->addCompilerPass(new WorkflowGuardListenerPass());
+        $this->addCompilerPassIfExists($container, WorkflowGuardListenerPass::class);
         $container->addCompilerPass(new ResettableServicePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
         $container->addCompilerPass(new RegisterLocaleAwareServicesPass());
         $container->addCompilerPass(new TestServiceContainerWeakRefPass(), PassConfig::TYPE_BEFORE_REMOVING, -32);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #52187
| License       | MIT

As spotted by @PhilETaylor (in [this comment](https://github.com/symfony/symfony/pull/52032#issuecomment-1771431973)) the framework is broken in 6.4-dev when the worflow component is not installed.

This PR fixes that by registering the compiler pass only if available.
