### PR TITLE
[String] New locale aware casing methods

### DIFF
--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `localeLower()`, `localeUpper()`, `localeTitle()` methods to `AbstractUnicodeString`
+
 6.2
 ---
 

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -50,6 +50,48 @@ END'],
         $this->assertSame('Dieser Wert sollte grOEsser oder gleich', (string) $s->ascii([$rule]));
     }
 
+    /**
+     * @dataProvider provideLocaleLower
+     *
+     * @requires extension intl
+     */
+    public function testLocaleLower(string $locale, string $expected, string $origin)
+    {
+        $instance = static::createFromString($origin)->localeLower($locale);
+
+        $this->assertNotSame(static::createFromString($origin), $instance);
+        $this->assertEquals(static::createFromString($expected), $instance);
+        $this->assertSame($expected, (string) $instance);
+    }
+
+    /**
+     * @dataProvider provideLocaleUpper
+     *
+     * @requires extension intl
+     */
+    public function testLocaleUpper(string $locale, string $expected, string $origin)
+    {
+        $instance = static::createFromString($origin)->localeUpper($locale);
+
+        $this->assertNotSame(static::createFromString($origin), $instance);
+        $this->assertEquals(static::createFromString($expected), $instance);
+        $this->assertSame($expected, (string) $instance);
+    }
+
+    /**
+     * @dataProvider provideLocaleTitle
+     *
+     * @requires extension intl
+     */
+    public function testLocaleTitle(string $locale, string $expected, string $origin)
+    {
+        $instance = static::createFromString($origin)->localeTitle($locale);
+
+        $this->assertNotSame(static::createFromString($origin), $instance);
+        $this->assertEquals(static::createFromString($expected), $instance);
+        $this->assertSame($expected, (string) $instance);
+    }
+
     public function provideCreateFromCodePoint(): array
     {
         return [
@@ -289,6 +331,78 @@ END'],
                 ['déjà σσς i̇iıi', 'DÉJÀ Σσς İIıi'],
             ]
         );
+    }
+
+    public static function provideLocaleLower(): array
+    {
+        return [
+            // Lithuanian
+            // Introduce an explicit dot above when lowercasing capital I's and J's
+            // whenever there are more accents above.
+            // LATIN CAPITAL LETTER I WITH OGONEK -> LATIN SMALL LETTER I WITH OGONEK
+            ['lt', 'į', 'Į'],
+            // LATIN CAPITAL LETTER I WITH GRAVE -> LATIN SMALL LETTER I COMBINING DOT ABOVE
+            ['lt', 'i̇̀', 'Ì'],
+            // LATIN CAPITAL LETTER I WITH ACUTE -> LATIN SMALL LETTER I COMBINING DOT ABOVE COMBINING ACUTE ACCENT
+            ['lt', 'i̇́', 'Í'],
+            // LATIN CAPITAL LETTER I WITH TILDE -> LATIN SMALL LETTER I COMBINING DOT ABOVE COMBINING TILDE
+            ['lt', 'i̇̃', 'Ĩ'],
+
+            // Turkish and Azeri
+            // When lowercasing, remove dot_above in the sequence I + dot_above, which will turn into 'i'.
+            // LATIN CAPITAL LETTER I WITH DOT ABOVE -> LATIN SMALL LETTER I
+            ['tr', 'i', 'İ'],
+            ['tr_TR', 'i', 'İ'],
+            ['az', 'i', 'İ'],
+
+            // Default casing rules
+            // LATIN CAPITAL LETTER I WITH DOT ABOVE -> LATIN SMALL LETTER I COMBINING DOT ABOVE
+            ['en_US', 'i̇', 'İ'],
+            ['en', 'i̇', 'İ'],
+        ];
+    }
+
+    public static function provideLocaleUpper(): array
+    {
+        return [
+            // Turkish and Azeri
+            // When uppercasing, i turns into a dotted capital I
+            // LATIN SMALL LETTER I -> LATIN CAPITAL LETTER I WITH DOT ABOVE
+            ['tr', 'İ', 'i'],
+            ['tr_TR', 'İ', 'i'],
+            ['az', 'İ', 'i'],
+
+            // Greek
+            // Remove accents when uppercasing
+            // GREEK SMALL LETTER ALPHA WITH TONOS -> GREEK CAPITAL LETTER ALPHA
+            ['el', 'Α', 'ά'],
+            ['el_GR', 'Α', 'ά'],
+
+            // Default casing rules
+            // GREEK SMALL LETTER ALPHA WITH TONOS -> GREEK CAPITAL LETTER ALPHA WITH TONOS
+            ['en_US', 'Ά', 'ά'],
+            ['en', 'Ά', 'ά'],
+        ];
+    }
+
+    public static function provideLocaleTitle(): array
+    {
+        return [
+            // Greek
+            // Titlecasing words, should keep the accents on the first letter
+            ['el', 'Άδικος', 'άδικος'],
+            ['el_GR', 'Άδικος', 'άδικος'],
+            ['en', 'Άδικος', 'άδικος'],
+
+            // Dutch
+            // Title casing should treat 'ij' as one character
+            ['nl_NL', 'IJssel', 'ijssel'],
+            ['nl_BE', 'IJssel', 'ijssel'],
+            ['nl', 'IJssel', 'ijssel'],
+
+            // Default casing rules
+            ['en', 'Ijssel', 'ijssel'],
+        ];
     }
 
     public static function provideUpper(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix #52161
| License       | MIT

Adds new localeUpper/localeLower/localeTitle methods to the AbstractUnicodeString class
- To change the string case according to locale-specific case mappings

Code examples:
```php
$string = new UnicodeString('άδικος');
echo $string->upper(), PHP_EOL; // ΆΔΙΚΟΣ
echo $string->localeUpper('el'), PHP_EOL; // ΑΔΙΚΟΣ

$string = new UnicodeString('ijssel');
echo $string->title(), PHP_EOL; // Ijssel
echo $string->localeTitle('nl'), PHP_EOL; // IJssel

$string = new UnicodeString('İSTANBUL');
echo $string->lower(), PHP_EOL; // i̇stanbul (LATIN SMALL LETTER I COMBINING DOT ABOVE)
echo $string->localeLower('tr'), PHP_EOL; // istanbul (LATIN SMALL LETTER I)
```
