### PR TITLE
[AssetMapper] Fixing bug of bad parsing of imports when an import then export are adjacent

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -26,7 +26,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     public const URL_PATTERN_DIST = self::URL_PATTERN_DIST_CSS.'/+esm';
     public const URL_PATTERN_ENTRYPOINT = 'https://data.jsdelivr.com/v1/packages/npm/%s@%s/entrypoints';
 
-    public const IMPORT_REGEX = '{from"/npm/([^@]*@?\S+?)@([^/]+)/\+esm"}';
+    public const IMPORT_REGEX = '{from"/npm/((?:@[^/]+/)?[^@]+)@([^/]+)/\+esm"}';
 
     private HttpClientInterface $httpClient;
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -474,6 +474,14 @@ class JsDelivrEsmResolverTest extends TestCase
                 ['@vue/shared', '3.3.4'],
             ],
         ];
+
+        yield 'adjacent import and export statements' => [
+            'import e from"/npm/datatables.net@2.1.1/+esm";export{default}from"/npm/datatables.net@2.1.1/+esm";',
+            [
+                ['datatables.net', '2.1.1'],
+                ['datatables.net', '2.1.1'], // for the export syntax
+            ],
+        ];
     }
 
     private static function createRemoteEntry(string $importName, string $version, ImportMapType $type = ImportMapType::JS, string $packageSpecifier = null): ImportMapEntry


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | See https://github.com/symfony/symfony/pull/52119#issuecomment-1772497622 though this appears to be unrelated to that PR
| License       | MIT

There should be a finite number of import statement formats. @tacman found a new one! :) 

Cheers!