### PR TITLE
[HttpKernel] Fix BC with FWB v5.3

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -37,10 +38,15 @@ class DebugHandlersListener implements EventSubscriberInterface
     private bool $hasTerminatedWithException = false;
 
     /**
+     * @param bool          $webMode
      * @param callable|null $exceptionHandler A handler that must support \Throwable instances that will be called on Exception
      */
-    public function __construct(callable $exceptionHandler = null, bool $webMode = null)
+    public function __construct(callable $exceptionHandler = null, bool|LoggerInterface $webMode = null)
     {
+        if ($webMode instanceof LoggerInterface) {
+            // BC with Symfony 5
+            $webMode = null;
+        }
         $handler = set_exception_handler('is_int');
         $this->earlyHandler = \is_array($handler) ? $handler[0] : null;
         restore_exception_handler();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The class in `@internal` but we reference it in FWB. In 5.4, it has an incompatible signature. This fixes the issue with accepting the previous type.