### PR TITLE
[AssetMapper] Normalizing path in test to fix / \ comparison in Windows

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/CompiledAssetMapperConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/CompiledAssetMapperConfigReaderTest.php
@@ -54,7 +54,7 @@ class CompiledAssetMapperConfigReaderTest extends TestCase
     public function testSaveConfig()
     {
         $reader = new CompiledAssetMapperConfigReader($this->writableRoot);
-        $this->assertEquals($this->writableRoot.'/foo.json', $reader->saveConfig('foo.json', ['foo' => 'bar']));
+        $this->assertEquals($this->writableRoot.\DIRECTORY_SEPARATOR.'foo.json', realpath($reader->saveConfig('foo.json', ['foo' => 'bar'])));
         $this->assertEquals(['foo' => 'bar'], json_decode(file_get_contents($this->writableRoot.'/foo.json'), true));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fixes the failing AppVeyor test
| License       | MIT

https://ci.appveyor.com/project/fabpot/symfony/builds/48330693#L1059