### PR TITLE
[HttpFoundation] initialize protected callback property with null

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -26,7 +26,7 @@ namespace Symfony\Component\HttpFoundation;
  */
 class StreamedResponse extends Response
 {
-    protected \Closure $callback;
+    protected ?\Closure $callback = null;
     protected bool $streamed = false;
 
     private bool $headersSent = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/51972#discussion_r1356871038
| License       | MIT