### PR TITLE
[FrameworkBundle] Add conflict with `WebProfilerBundle` < 6.4

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -100,7 +100,7 @@
         "symfony/twig-bridge": "<5.4",
         "symfony/twig-bundle": "<5.4",
         "symfony/validator": "<6.4",
-        "symfony/web-profiler-bundle": "<5.4",
+        "symfony/web-profiler-bundle": "<6.4",
         "symfony/workflow": "<6.4"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #52210
| License       | MIT