### PR TITLE
[MonologBridge] Fix support for monolog 3.0

### DIFF
--- a/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
+++ b/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
@@ -13,7 +13,9 @@ namespace Symfony\Bridge\Monolog\Command;
 
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\HandlerInterface;
+use Monolog\Level;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
 use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -155,6 +157,16 @@ EOF
         }
         $logBlock = sprintf('<bg=%s> </>', self::BG_COLOR[$clientId % 8]);
         $output->write($logBlock);
+
+        if (Logger::API >= 3) {
+            $record = new LogRecord(
+                $record['datetime'],
+                $record['channel'],
+                Level::fromValue($record['level']),
+                $record['message'],
+                $record['context']->getContext(),
+            );
+        }
 
         $this->handler->handle($record);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | 
| License       | MIT

`handle` function in HandlerInterface supports only LogRecord argument in monolog 3.0.