### PR TITLE
[FrameworkBundle] Fix CommandDataCollector is always registered

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -861,6 +861,7 @@ class FrameworkExtension extends Extension
         $loader->load('profiling.php');
         $loader->load('collectors.php');
         $loader->load('cache_debug.php');
+        $loader->load('console_debug.php');
 
         if ($this->isInitializedConfigEnabled('form')) {
             $loader->load('form_debug.php');
@@ -922,7 +923,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('console_profiler_listener');
         }
 
-        if (!class_exists(CommandDataCollector::class)) {
+        if (!$container->getParameter('kernel.debug') || !class_exists(CliRequest::class) || !class_exists(CommandDataCollector::class)) {
             $container->removeDefinition('.data_collector.command');
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector;
-use Symfony\Component\Console\DataCollector\CommandDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\AjaxDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
@@ -75,8 +74,5 @@ return static function (ContainerConfigurator $container) {
         ->set('data_collector.router', RouterDataCollector::class)
             ->tag('kernel.event_listener', ['event' => KernelEvents::CONTROLLER, 'method' => 'onKernelController'])
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/router.html.twig', 'id' => 'router', 'priority' => 285])
-
-        ->set('.data_collector.command', CommandDataCollector::class)
-            ->tag('data_collector', ['template' => '@WebProfiler/Collector/command.html.twig', 'id' => 'command', 'priority' => 335])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console_debug.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Console\DataCollector\CommandDataCollector;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('.data_collector.command', CommandDataCollector::class)
+            ->tag('data_collector', ['template' => '@WebProfiler/Collector/command.html.twig', 'id' => 'command', 'priority' => 335])
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -101,7 +101,7 @@
         "symfony/twig-bridge": "<5.4",
         "symfony/twig-bundle": "<5.4",
         "symfony/validator": "<6.4",
-        "symfony/web-profiler-bundle": "<6.4",
+        "symfony/web-profiler-bundle": "<5.4",
         "symfony/workflow": "<6.4"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #52210 
| License       | MIT

Another attempt at fixing #52210, allowing to revert #52218 and leave the conflict constraints untouched

CommandDataCollector was always registered, and not always removed from the container when not needed/invalid.