### PR TITLE
[TwigBridge] Update UndefinedCallableHandler (importmap, form and worflow)

### DIFF
--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -24,6 +24,7 @@ class UndefinedCallableHandler
 {
     private const FILTER_COMPONENTS = [
         'humanize' => 'form',
+        'form_encode_currency' => 'form',
         'trans' => 'translation',
         'sanitize_html' => 'html-sanitizer',
         'yaml_encode' => 'yaml',
@@ -33,6 +34,7 @@ class UndefinedCallableHandler
     private const FUNCTION_COMPONENTS = [
         'asset' => 'asset',
         'asset_version' => 'asset',
+        'importmap' => 'asset-mapper',
         'dump' => 'debug-bundle',
         'encore_entry_link_tags' => 'webpack-encore-bundle',
         'encore_entry_script_tags' => 'webpack-encore-bundle',
@@ -47,6 +49,13 @@ class UndefinedCallableHandler
         'form_start' => 'form',
         'form_end' => 'form',
         'csrf_token' => 'form',
+        'form_parent' => 'form',
+        'field_name' => 'form',
+        'field_value' => 'form',
+        'field_label' => 'form',
+        'field_help' => 'form',
+        'field_errors' => 'form',
+        'field_choices' => 'form',
         'logout_url' => 'security-http',
         'logout_path' => 'security-http',
         'is_granted' => 'security-core',
@@ -58,8 +67,11 @@ class UndefinedCallableHandler
         'prerender' => 'web-link',
         'workflow_can' => 'workflow',
         'workflow_transitions' => 'workflow',
+        'workflow_transition' => 'workflow',
         'workflow_has_marked_place' => 'workflow',
         'workflow_marked_places' => 'workflow',
+        'workflow_metadata' => 'workflow',
+        'workflow_transition_blockers' => 'workflow',
     ];
 
     private const FULL_STACK_ENABLE = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| License       | MIT

The [UndefinedCallableHandler](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php) help DX by suggesting the missing packages to install when a Twig function / filter is used in template.

This PR updates the list of those callbacks with the recent additions in TwigBridge.

