### PR TITLE
[Messenger] declare constructor argument as optional for backwards compatibility

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/DelayedMessageHandlingException.php
+++ b/src/Symfony/Component/Messenger/Exception/DelayedMessageHandlingException.php
@@ -22,9 +22,9 @@ use Symfony\Component\Messenger\Envelope;
 class DelayedMessageHandlingException extends RuntimeException
 {
     private array $exceptions;
-    private Envelope $envelope;
+    private ?Envelope $envelope;
 
-    public function __construct(array $exceptions, Envelope $envelope)
+    public function __construct(array $exceptions, Envelope $envelope = null)
     {
         $this->envelope = $envelope;
 
@@ -49,7 +49,7 @@ class DelayedMessageHandlingException extends RuntimeException
         return $this->exceptions;
     }
 
-    public function getEnvelope(): Envelope
+    public function getEnvelope(): ?Envelope
     {
         return $this->envelope;
     }

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -187,7 +187,7 @@ class Worker
                     $receiver->reject($envelope);
                 }
 
-                if ($e instanceof HandlerFailedException || $e instanceof DelayedMessageHandlingException) {
+                if ($e instanceof HandlerFailedException || ($e instanceof DelayedMessageHandlingException && null !== $e->getEnvelope())) {
                     $envelope = $e->getEnvelope();
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/51468#issuecomment-1746200733
| License       | MIT