### PR TITLE
[FrameworkBundle] Remove mailer and notification traits from KernelTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -24,9 +24,6 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 abstract class KernelTestCase extends TestCase
 {
-    use MailerAssertionsTrait;
-    use NotificationAssertionsTrait;
-
     protected static ?string $class = null;
     protected static ?KernelInterface $kernel = null;
     protected static bool $booted = false;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Mailer;
@@ -20,8 +21,10 @@ use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 
-class MailerTest extends AbstractWebTestCase
+final class MailerTest extends AbstractWebTestCase
 {
+    use MailerAssertionsTrait;
+
     public function testEnvelopeListener()
     {
         self::bootKernel(['test_case' => 'Mailer']);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/NotificationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/NotificationTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-use use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Bundle\FrameworkBundle\Test\NotificationAssertionsTrait;
 
 final class NotificationTest extends AbstractWebTestCase
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/NotificationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/NotificationTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+
 final class NotificationTest extends AbstractWebTestCase
 {
+    use NotificationAssertionsTrait;
+
     /**
      * @requires function \Symfony\Bundle\MercureBundle\MercureBundle::build
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | not exactly (BC)
| Issues        | -
| License       | MIT

I propose to remove `MailerAssertionsTrait` and `NotificationAssertionsTrait` from the KernelTestCase;

 - It bloats the class for no reason
 - Mailer and notification components may not be used at all in an app, it's confusing to have asserts available that will not work
 - It's not possible to remove a trait from a class, yet it's easy to add it in a subclass if needed
 - It's not exactly composition over inheritance but the idea is similar (a better way would be to use `MailerAssert::*` to use composition instead of `self::*` with traits but that's another story)

Because of that we have our own implementation of KernelTestCase (just to remove those traits) which is a pity.

It's a BC BREAK and I'm not sure if I should target v6.4 or not. Let me know and if it's accepted I can update the correct CHANGELOG too.