### PR TITLE
[AssetMapper] Adding import-parsing case where import contains a path

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -26,7 +26,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     public const URL_PATTERN_DIST = self::URL_PATTERN_DIST_CSS.'/+esm';
     public const URL_PATTERN_ENTRYPOINT = 'https://data.jsdelivr.com/v1/packages/npm/%s@%s/entrypoints';
 
-    public const IMPORT_REGEX = '{from"/npm/((?:@[^/]+/)?[^@]+)@([^/]+)/\+esm"}';
+    public const IMPORT_REGEX = '{from"/npm/((?:@[^/]+/)?[^@]+)@([^/]+)((?:/[^/]+)*?)/\+esm"}';
 
     private HttpClientInterface $httpClient;
 
@@ -223,6 +223,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         $dependencies = [];
         foreach ($matches[1] as $index => $packageName) {
             $version = $matches[2][$index];
+            $packageName .= $matches[3][$index]; // add the path if any
 
             $dependencies[] = new PackageRequireOptions($packageName, $version);
         }
@@ -238,7 +239,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     private function makeImportsBare(string $content, array &$dependencies): string
     {
         $content = preg_replace_callback(self::IMPORT_REGEX, function ($matches) use (&$dependencies) {
-            $packageName = $matches[1];
+            $packageName = $matches[1].$matches[3]; // add the path if any
             $dependencies[] = $packageName;
 
             return sprintf('from"%s"', $packageName);

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -393,6 +393,24 @@ class JsDelivrEsmResolverTest extends TestCase
             ],
         ];
 
+        yield 'make imports point to file and relative' => [
+            [
+                'twig' => self::createRemoteEntry('twig', version: '1.16.0'),
+            ],
+            [
+                [
+                    'url' => '/twig@1.16.0/+esm',
+                    'body' => 'import e from"/npm/locutus@2.0.16/php/strings/sprintf/+esm";console.log()',
+                ],
+            ],
+            [
+                'twig' => [
+                    'content' => 'import e from"locutus/php/strings/sprintf";console.log()',
+                    'dependencies' => ['locutus/php/strings/sprintf'],
+                ],
+            ],
+        ];
+
         yield 'js sourcemap is removed' => [
             [
                 '@chart.js/auto' => self::createRemoteEntry('chart.js/auto', version: '1.2.3'),
@@ -444,7 +462,12 @@ class JsDelivrEsmResolverTest extends TestCase
             $expectedNames[] = $packageData[0];
             $expectedVersions[] = $packageData[1];
         }
-        $this->assertSame($expectedNames, $matches[1]);
+        $actualNames = [];
+        foreach ($matches[1] as $i => $name) {
+            $actualNames[] = $name.$matches[3][$i];
+        }
+
+        $this->assertSame($expectedNames, $actualNames);
         $this->assertSame($expectedVersions, $matches[2]);
     }
 
@@ -480,6 +503,14 @@ class JsDelivrEsmResolverTest extends TestCase
             [
                 ['datatables.net', '2.1.1'],
                 ['datatables.net', '2.1.1'], // for the export syntax
+            ],
+        ];
+
+        yield 'import statements with paths' => [
+            'import e from"/npm/locutus@2.0.16/php/strings/sprintf/+esm";import t from"/npm/locutus@2.0.16/php/strings/vsprintf/+esm"',
+            [
+                ['locutus/php/strings/sprintf', '2.0.16'],
+                ['locutus/php/strings/vsprintf', '2.0.16'],
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | none
| Issues        | Fix https://github.com/symfony/symfony/discussions/52252
| License       | MIT

I feel like a broken record :). Hopefully the LAST unique import syntax that we find on jsdelivr. Reported, yet again, by @tacman who deserves some award for alpha & beta testing AssetMapper.

Thanks!