### PR TITLE
[Form] Skip merging params & files if there are no files in the first place

### DIFF
--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormError;
@@ -234,6 +235,24 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
         $this->assertTrue($form->isSubmitted());
         $this->assertSame('DATA', $form->get('field1')->getData());
         $this->assertSame($file, $form->get('field2')->getData());
+    }
+
+    public function testIntegerChildren()
+    {
+        $form = $this->createForm('root', 'POST', true);
+        $form->add('0', TextType::class);
+        $form->add('1', TextType::class);
+
+        $this->setRequestData('POST', [
+            'root' => [
+                '1' => 'bar',
+            ],
+        ]);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $this->assertNull($form->get('0')->getData());
+        $this->assertSame('bar', $form->get('1')->getData());
     }
 
     /**

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -50,20 +50,21 @@ class FormUtil
      */
     public static function mergeParamsAndFiles(array $params, array $files): array
     {
-        $result = [];
+        if (array_is_list($files)) {
+            foreach ($files as $value) {
+                $params[] = $value;
+            }
+
+            return $params;
+        }
 
         foreach ($params as $key => $value) {
             if (\is_array($value) && \is_array($files[$key] ?? null)) {
-                $value = self::mergeParamsAndFiles($value, $files[$key]);
+                $params[$key] = self::mergeParamsAndFiles($value, $files[$key]);
                 unset($files[$key]);
-            }
-            if (\is_int($key)) {
-                $result[] = $value;
-            } else {
-                $result[$key] = $value;
             }
         }
 
-        return array_merge($result, $files);
+        return array_replace($params, $files);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52248
| License       | MIT

Skip merging params & files if there are no files in the first place. Works around problems with numeric field names.