### PR TITLE
[Mailer][Notifier] Update Sendinblue / Brevo API host

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
@@ -37,7 +37,7 @@ class SendinblueApiTransportTest extends TestCase
     {
         yield [
             new SendinblueApiTransport('ACCESS_KEY'),
-            'sendinblue+api://api.sendinblue.com',
+            'sendinblue+api://api.brevo.com',
         ];
 
         yield [
@@ -89,7 +89,7 @@ class SendinblueApiTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.sendinblue.com:8984/v3/smtp/email', $url);
+            $this->assertSame('https://api.brevo.com:8984/v3/smtp/email', $url);
             $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
 
             return new MockResponse(json_encode(['message' => 'i\'m a teapot']), [
@@ -119,7 +119,7 @@ class SendinblueApiTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.sendinblue.com:8984/v3/smtp/email', $url);
+            $this->assertSame('https://api.brevo.com:8984/v3/smtp/email', $url);
             $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
 
             return new MockResponse(json_encode(['messageId' => 'foobar']), [

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueApiTransport.php
@@ -180,6 +180,6 @@ final class SendinblueApiTransport extends AbstractApiTransport
 
     private function getEndpoint(): ?string
     {
-        return ($this->host ?: 'api.sendinblue.com').($this->port ? ':'.$this->port : '');
+        return ($this->host ?: 'api.brevo.com').($this->port ? ':'.$this->port : '');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class SendinblueTransport extends AbstractTransport
 {
-    protected const HOST = 'api.sendinblue.com';
+    protected const HOST = 'api.brevo.com';
 
     private $apiKey;
     private $sender;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #52264
| License       | MIT

Sendinblue rebrands to Brevo, and it simultaneously upgrade smtp and API servers.
There are 2 distincts API currently : api.sendinblue.com (deprecated but still running) and api.brevo.com (the one to use)
Unlike SMTP host, API host is not changed on LTS 5.4 and are still set to api.sendinblue.com. 
