### PR TITLE
[VarDump] Fix order of dumped properties - parent goes first

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -177,6 +177,10 @@ class Caster
         $classProperties = [];
         $className = $class->name;
 
+        if ($parent = $class->getParentClass()) {
+            $classProperties += self::$classProperties[$parent->name] ??= self::getClassProperties($parent);
+        }
+
         foreach ($class->getProperties() as $p) {
             if ($p->isStatic()) {
                 continue;
@@ -187,10 +191,6 @@ class Caster
                 $p->isProtected() => self::PREFIX_PROTECTED.$p->name,
                 default => "\0".$className."\0".$p->name,
             }] = new UninitializedStub($p);
-        }
-
-        if ($parent = $class->getParentClass()) {
-            $classProperties += self::$classProperties[$parent->name] ??= self::getClassProperties($parent);
         }
 
         return $classProperties;

--- a/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
@@ -185,4 +185,29 @@ EOTXT
             }
         });
     }
+
+    public function testClassHierarchy()
+    {
+        $this->assertDumpMatchesFormat(<<<'DUMP'
+            Symfony\Component\VarDumper\Tests\Caster\B {
+              +a: "a"
+              #b: "b"
+              -c: "c"
+              +d: "d"
+              #e: "e"
+              -f: "f"
+            }
+            DUMP, new B());
+    }
+}
+
+class A {
+    public $a = 'a';
+    protected $b = 'b';
+    private $c = 'c';
+}
+class B extends A {
+    public $d = 'd';
+    protected $e = 'e';
+    private $f = 'f';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |
| Issues        |
| License       | MIT
