### PR TITLE
symfony-52273 [doctrine-messenger] DB table locks on messenger_messag…

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -345,13 +345,13 @@ class Connection implements ResetInterface
         $redeliverLimit = (clone $now)->modify(sprintf('-%d seconds', $this->configuration['redeliver_timeout']));
 
         return $this->createQueryBuilder()
-            ->where('m.delivered_at is null OR m.delivered_at < ?')
-            ->andWhere('m.available_at <= ?')
             ->andWhere('m.queue_name = ?')
+            ->andWhere('m.delivered_at is null OR m.delivered_at < ?')
+            ->andWhere('m.available_at <= ?')
             ->setParameters([
+                $this->configuration['queue_name'],
                 $redeliverLimit,
                 $now,
-                $this->configuration['queue_name'],
             ], [
                 Types::DATETIME_MUTABLE,
                 Types::DATETIME_MUTABLE,


### PR DESCRIPTION
…es with many failures

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52273 
| License       | MIT

Reorder Query for doctrine-messenger to limit on `queue_name` first.