### PR TITLE
[Validator] Updated missing Latvian translation keys

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
@@ -402,6 +402,30 @@
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>Tīkla maskas (netmask) vērtībai jābūt starp {{ min }} un {{ max }}.</target>
             </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target>Faila nosaukums ir pārāk garš. Tas var būt {{ filename_max_length }} rakstzīme vai īsāks.|Faila nosaukums ir pārāk garš. Tas var būt {{ filename_max_length }} rakstzīmes vai īsāks.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target>Paroles stiprums ir pārāk zems. Lūdzu, izmantojiet spēcīgāku paroli.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target>Šī vērtība satur rakstzīmes, kuras nav atļautas pašreizējā ierobežojuma līmenī.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target>Neredzamu rakstzīmju izmantošana nav atļauta.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target>Nav atļauts sajaukt numurus no dažādiem skriptiem.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target>Slēptu pārklājuma rakstzīmju izmantošana nav atļauta.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | #51946 
| License       | MIT

Updated missing Latvian translations with help from a Latvian.