### PR TITLE
[HttpKernel] Update AbstractBundle.php, use !isset($this->path)

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/AbstractBundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/AbstractBundle.php
@@ -50,7 +50,7 @@ abstract class AbstractBundle extends Bundle implements ConfigurableExtensionInt
 
     public function getPath(): string
     {
-        if (null === $this->path) {
+        if (!isset($this->path)) {
             $reflected = new \ReflectionObject($this);
             // assume the modern directory structure by default
             $this->path = \dirname($reflected->getFileName(), 2);


### PR DESCRIPTION
Fixes issue #52292

| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  no
| Deprecations?no
| Issues        | Fix #52292
| License       | MIT


Check for isset rather than accessing the property before initialization.
```
!! Error {https://github.com/symfony/symfony/pull/111
!! #message: "Typed property Symfony\Component\HttpKernel\Bundle\Bundle::$path must not be accessed before initialization"
!! #code: 0
!! #file: "./vendor/symfony/http-kernel/Bundle/AbstractBundle.php"
!! #line: 53
!! trace: {
```