### PR TITLE
[Scheduler] Save checkpoint in a finally block

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -72,8 +72,11 @@ final class MessageGenerator implements MessageGeneratorInterface
             }
 
             if ($yield) {
-                yield (new MessageContext($this->name, $id, $trigger, $time, $nextTime)) => $message;
-                $checkpoint->save($time, $index);
+                try {
+                    yield (new MessageContext($this->name, $id, $trigger, $time, $nextTime)) => $message;
+                } finally {
+                    $checkpoint->save($time, $index);
+                }
             }
         }
 

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Scheduler\Tests\Generator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Scheduler\Generator\Checkpoint;
 use Symfony\Component\Scheduler\Generator\MessageContext;
 use Symfony\Component\Scheduler\Generator\MessageGenerator;
 use Symfony\Component\Scheduler\RecurringMessage;
@@ -126,6 +128,32 @@ class MessageGeneratorTest extends TestCase
         $this->assertSame($message->getTrigger(), $context->trigger);
         $this->assertEquals(self::makeDateTime('22:14:00'), $context->triggeredAt);
         $this->assertEquals(self::makeDateTime('22:16:00'), $context->nextTriggerAt);
+    }
+
+    public function testCheckpointSavedInBrokenLoop()
+    {
+        $clock = new MockClock(self::makeDateTime('22:12:00'));
+
+        $message = $this->createMessage((object) ['id' => 'message'], '22:13:00', '22:14:00', '22:16:00');
+        $schedule = (new Schedule())->add($message);
+
+        $cache = new ArrayAdapter();
+        $schedule->stateful($cache);
+        $checkpoint = new Checkpoint('dummy', cache: $cache);
+
+        $scheduler = new MessageGenerator($schedule, 'dummy', clock: $clock, checkpoint: $checkpoint);
+
+        // Warmup. The first run is always returns nothing.
+        $this->assertSame([], iterator_to_array($scheduler->getMessages(), false));
+
+        $clock->sleep(60 + 10); // 22:13:10
+
+        foreach ($scheduler->getMessages() as $message) {
+            // Message is handled but loop is broken just after
+            break;
+        }
+
+        $this->assertEquals(self::makeDateTime('22:13:00'), $checkpoint->time());
     }
 
     public static function messagesProvider(): \Generator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3  <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #52288 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

As described in the linked issue : 
> The message generator appears to store stateful data by loading and saving the checkpoint with the cache.
> 
> But if the worker is configured to stop after X message(s), once the last message is handled, the (messenger) worker will break its loop and stop. In this case, the execution stop and the stateful data of the message (time of last execution for example) will not be saved.
> 
> So when the consumer restarts it will re-handle the message because the last execution was not stored.
> 

So the solution here is to put the code that save the checkpoint in a `finally` block. 
Thanks [maelanleborgne](https://github.com/maelanleborgne).

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
