### PR TITLE
[FrameworkBundle][Scheduler] Add test for autoconfigured schedule

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/DummyTask.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/DummyTask.php
@@ -8,13 +8,13 @@ use Symfony\Component\Scheduler\Attribute\AsPeriodicTask;
 #[AsCronTask(expression: '* * * * *', arguments: [1], schedule: 'dummy_task')]
 #[AsCronTask(expression: '0 * * * *', timezone: 'Europe/Berlin', arguments: ['2'], schedule: 'dummy_task', method: 'method2')]
 #[AsPeriodicTask(frequency: 5, arguments: [3], schedule: 'dummy_task')]
-#[AsPeriodicTask(frequency: '1 day', from: '00:00:00', jitter: 60, arguments: ['4'], schedule: 'dummy_task', method: 'method4')]
+#[AsPeriodicTask(frequency: '1 day', from: '2023-10-25 09:59:00Z', jitter: 60, arguments: ['4'], schedule: 'dummy_task', method: 'method4')]
 class DummyTask
 {
     public static array $calls = [];
 
-    #[AsPeriodicTask(frequency: '1 hour', from: '09:00:00', until: '17:00:00', arguments: ['b' => 6, 'a' => '5'], schedule: 'dummy_task')]
-    #[AsCronTask(expression: '0 0 * * *', arguments: ['7', 8], schedule: 'dummy_task')]
+    #[AsPeriodicTask(frequency: '1 hour', from: '2023-10-26 09:00:00Z', until: '2023-10-26 17:00:00Z', arguments: ['b' => 6, 'a' => '5'], schedule: 'dummy_task')]
+    #[AsCronTask(expression: '0 10 * * *', arguments: ['7', 8], schedule: 'dummy_task')]
     public function attributesOnMethod(string $a, int $b): void
     {
         self::$calls[__FUNCTION__][] = [$a, $b];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SchedulerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SchedulerTest.php
@@ -13,9 +13,12 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummySchedule;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyTask;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Scheduler\Messenger\SchedulerTransport;
 use Symfony\Component\Scheduler\RecurringMessage;
 
@@ -52,6 +55,36 @@ class SchedulerTest extends AbstractWebTestCase
         $this->assertSame([], $fetchMessages(1.0));
         $this->assertSame([$bar], $fetchMessages(60.0));
         $this->assertSame([$foo, $bar, $foo, $bar], $fetchMessages(600.0));
+    }
+
+    public function testAutoconfiguredScheduler()
+    {
+        $container = self::getContainer();
+        $container->set('clock', $clock = new MockClock('2023-10-26T08:59:59Z'));
+
+        $this->assertTrue($container->get('receivers')->has('scheduler_dummy_task'));
+        $this->assertInstanceOf(SchedulerTransport::class, $cron = $container->get('receivers')->get('scheduler_dummy_task'));
+        $bus = $container->get(MessageBusInterface::class);
+
+        $getCalls = static function (float $sleep) use ($clock, $cron, $bus) {
+            DummyTask::$calls = [];
+            $clock->sleep($sleep);
+            foreach ($cron->get() as $message) {
+                $bus->dispatch($message->with(new ReceivedStamp('scheduler_dummy_task')));
+            }
+
+            return DummyTask::$calls;
+        };
+
+        $this->assertSame([], $getCalls(0));
+        $this->assertSame(['__invoke' => [[1]], 'method2' => [['2']], 'attributesOnMethod' => [['5', 6]]], $getCalls(1));
+        $this->assertSame(['__invoke' => [[3]]], $getCalls(5));
+        $this->assertSame(['__invoke' => [[3]]], $getCalls(5));
+        $calls = $getCalls(3595);
+        $this->assertCount(779, $calls['__invoke']);
+        $this->assertSame([['2']], $calls['method2']);
+        $this->assertSame([['4']], $calls['method4']);
+        $this->assertSame([['5', 6], ['7', 8]], $calls['attributesOnMethod']);
     }
 
     protected static function createKernel(array $options = []): KernelInterface

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -35,6 +35,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.13.1|^2",
         "doctrine/persistence": "^1.3|^2|^3",
+        "dragonmantank/cron-expression": "^3.1",
         "seld/jsonlint": "^1.10",
         "symfony/asset": "^5.4|^6.0|^7.0",
         "symfony/asset-mapper": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Add functional tests for autoconfigured schedules / tasks, as discussed in https://github.com/symfony/symfony/pull/51525#discussion_r1342467103.
