### PR TITLE
[Process] remove fixing of legacy bug, when PTS functionality is enabled

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -332,10 +332,6 @@ class Process implements \IteratorAggregate
             // See https://unix.stackexchange.com/questions/71205/background-process-pipe-input
             $commandline = '{ ('.$commandline.') <&3 3<&- 3>/dev/null & } 3<&0;';
             $commandline .= 'pid=$!; echo $pid >&3; wait $pid 2>/dev/null; code=$?; echo $code >&3; exit $code';
-
-            // Workaround for the bug, when PTS functionality is enabled.
-            // @see : https://bugs.php.net/69442
-            $ptsWorkaround = fopen(__FILE__, 'r');
         }
 
         $envPairs = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

The PR drop fixing PHP bug, that was closed in PHP 7.0

Original issues:
https://github.com/php/php-src/pull/1588
https://github.com/symfony/symfony/pull/16574

Original commit:
https://github.com/php/php-src/commit/ff6b309c6f4c26ffedd5fc9e4cd021b7300617a3