### PR TITLE
[AssetMapper] Allowing circular references in JavaScriptImportPathCompiler

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -148,11 +148,15 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
             return null;
         }
 
-        if ($asset = $assetMapper->getAsset($importMapEntry->path)) {
-            return $asset;
-        }
+        try {
+            if ($asset = $assetMapper->getAsset($importMapEntry->path)) {
+                return $asset;
+            }
 
-        return $assetMapper->getAssetFromSourcePath($importMapEntry->path);
+            return $assetMapper->getAssetFromSourcePath($importMapEntry->path);
+        } catch (CircularAssetsException $exception) {
+            return $exception->getIncompleteMappedAsset();
+        }
     }
 
     private function findAssetForRelativeImport(string $importedModule, MappedAsset $asset, AssetMapperInterface $assetMapper): ?MappedAsset
@@ -168,8 +172,7 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
             return null;
         }
 
-        $dependentAsset = $assetMapper->getAssetFromSourcePath($resolvedSourcePath);
-
+        $dependentAsset = $assetMapper->getAsset($resolvedSourcePath);
         if ($dependentAsset) {
             return $dependentAsset;
         }

--- a/src/Symfony/Component/AssetMapper/Exception/CircularAssetsException.php
+++ b/src/Symfony/Component/AssetMapper/Exception/CircularAssetsException.php
@@ -11,9 +11,26 @@
 
 namespace Symfony\Component\AssetMapper\Exception;
 
+use Symfony\Component\AssetMapper\MappedAsset;
+
 /**
  * Thrown when a circular reference is detected while creating an asset.
  */
 class CircularAssetsException extends RuntimeException
 {
+    public function __construct(private MappedAsset $mappedAsset, string $message = '', int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Returns the asset that was being created when the circular reference was detected.
+     *
+     * This asset will not be fully initialized: it will be missing some
+     * properties like digest and content.
+     */
+    public function getIncompleteMappedAsset(): MappedAsset
+    {
+        return $this->mappedAsset;
+    }
 }

--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -37,13 +37,14 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
     public function createMappedAsset(string $logicalPath, string $sourcePath): ?MappedAsset
     {
         if (isset($this->assetsBeingCreated[$logicalPath])) {
-            throw new CircularAssetsException(sprintf('Circular reference detected while creating asset for "%s": "%s".', $logicalPath, implode(' -> ', $this->assetsBeingCreated).' -> '.$logicalPath));
+            throw new CircularAssetsException($this->assetsCache[$logicalPath], sprintf('Circular reference detected while creating asset for "%s": "%s".', $logicalPath, implode(' -> ', $this->assetsBeingCreated).' -> '.$logicalPath));
         }
         $this->assetsBeingCreated[$logicalPath] = $logicalPath;
 
         if (!isset($this->assetsCache[$logicalPath])) {
             $isVendor = $this->isVendor($sourcePath);
             $asset = new MappedAsset($logicalPath, $sourcePath, $this->assetsPathResolver->resolvePublicPath($logicalPath), isVendor: $isVendor);
+            $this->assetsCache[$logicalPath] = $asset;
 
             $content = $this->compileContent($asset);
             [$digest, $isPredigested] = $this->getDigest($asset, $content);

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\Compiler\AssetCompilerInterface;
 use Symfony\Component\AssetMapper\Compiler\CssAssetUrlCompiler;
 use Symfony\Component\AssetMapper\Compiler\JavaScriptImportPathCompiler;
-use Symfony\Component\AssetMapper\Exception\RuntimeException;
+use Symfony\Component\AssetMapper\Exception\CircularAssetsException;
 use Symfony\Component\AssetMapper\Factory\MappedAssetFactory;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
 use Symfony\Component\AssetMapper\MappedAsset;
@@ -85,7 +85,7 @@ class MappedAssetFactoryTest extends TestCase
     {
         $factory = $this->createFactory();
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CircularAssetsException::class);
         $this->expectExceptionMessage('Circular reference detected while creating asset for "circular1.css": "circular1.css -> circular2.css -> circular1.css".');
         $factory->createMappedAsset('circular1.css', __DIR__.'/../Fixtures/circular_dir/circular1.css');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

Hi!

In AssetMapper, we throw a `CircularAssetsException` if you ask for the `app.js` asset, but it's still being created. This circular situation only happens via asset compilers: if, while compiling `app.js`, we ask for `other.js`... and then while compiling that, we ask for `app.js`.

However, JS modules *do* allow for circular references - e.g. `app.js` imports `other.js` which imports `app.js`. Before this PR, this situation would trigger the `CircularAssetsException`. After, it is handled correctly. `JavaScriptImportPathCompiler` calls `$assetMapper->getAsset()` only to populate the `MappedAsset.javaScriptImports` property. So, allowing for the half-created `MappedAsset` is safe here: we do not use any of the not-yet-populated properties.

Cheers!
