### PR TITLE
[HtmlSanitizer] Consider `width` attribute as safe

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Reference/W3CReference.php
+++ b/src/Symfony/Component/HtmlSanitizer/Reference/W3CReference.php
@@ -394,7 +394,7 @@ final class W3CReference
         'vlink' => false,
         'vspace' => true,
         'webkitdirectory' => true,
-        'width' => false,
+        'width' => true,
         'wrap' => true,
     ];
 }

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -427,8 +427,8 @@ class HtmlSanitizerAllTest extends TestCase
                 '<hr />',
             ],
             [
-                '<img src="/img/example.jpg" alt="Image alternative text" title="Image title">',
-                '<img src="/img/example.jpg" alt="Image alternative text" title="Image title" />',
+                '<img src="/img/example.jpg" alt="Image alternative text" title="Image title" height="150" width="300">',
+                '<img src="/img/example.jpg" alt="Image alternative text" title="Image title" height="150" width="300" />',
             ],
             [
                 '<img src="http://trusted.com/img/example.jpg" alt="Image alternative text" title="Image title" />',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50153
| License       | MIT

Consider the HTML attribute `width` to be safe, as attribute `height` already is.
