### PR TITLE
[AssetMapper] jsdelivr "no version" import syntax

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/VersionProblemCommandTrait.php
+++ b/src/Symfony/Component/AssetMapper/Command/VersionProblemCommandTrait.php
@@ -29,12 +29,6 @@ trait VersionProblemCommandTrait
                 continue;
             }
 
-            if (null === $problem->requiredVersionConstraint) {
-                $output->writeln(sprintf('[warning] <info>%s</info> appears to import <info>%s</info> but this is not listed as a dependency of <info>%s</info>. This is odd and could be a misconfiguration of that package.', $problem->packageName, $problem->dependencyPackageName, $problem->packageName));
-
-                continue;
-            }
-
             $output->writeln(sprintf('[warning] <info>%s</info> requires <info>%s</info>@<comment>%s</comment> but version <comment>%s</comment> is installed.', $problem->packageName, $problem->dependencyPackageName, $problem->requiredVersionConstraint, $problem->installedVersion));
         }
     }

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapVersionChecker.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapVersionChecker.php
@@ -87,13 +87,12 @@ class ImportMapVersionChecker
                 }
 
                 $dependencyPackageName = $entries->get($dependencyName)->getPackageName();
-                $dependencyVersionConstraint = $packageDependencies[$dependencyPackageName] ?? null;
 
-                if (null === $dependencyVersionConstraint) {
-                    $problems[] = new PackageVersionProblem($packageName, $dependencyPackageName, $dependencyVersionConstraint, $entries->get($dependencyName)->version);
-
+                if (!isset($packageDependencies[$dependencyPackageName])) {
                     continue;
                 }
+
+                $dependencyVersionConstraint = $packageDependencies[$dependencyPackageName];
 
                 if (!$this->isVersionSatisfied($dependencyVersionConstraint, $entries->get($dependencyName)->version)) {
                     $problems[] = new PackageVersionProblem($packageName, $dependencyPackageName, $dependencyVersionConstraint, $entries->get($dependencyName)->version);

--- a/src/Symfony/Component/AssetMapper/ImportMap/PackageVersionProblem.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/PackageVersionProblem.php
@@ -16,7 +16,7 @@ final class PackageVersionProblem
     public function __construct(
         public readonly string $packageName,
         public readonly string $dependencyPackageName,
-        public readonly ?string $requiredVersionConstraint,
+        public readonly string $requiredVersionConstraint,
         public readonly ?string $installedVersion
     ) {
     }

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -26,7 +26,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     public const URL_PATTERN_DIST = self::URL_PATTERN_DIST_CSS.'/+esm';
     public const URL_PATTERN_ENTRYPOINT = 'https://data.jsdelivr.com/v1/packages/npm/%s@%s/entrypoints';
 
-    public const IMPORT_REGEX = '{from"/npm/((?:@[^/]+/)?[^@]+)@([^/]+)((?:/[^/]+)*?)/\+esm"}';
+    public const IMPORT_REGEX = '{from"/npm/((?:@[^/]+/)?[^@]+?)(?:@([^/]+))?((?:/[^/]+)*?)/\+esm"}';
 
     private HttpClientInterface $httpClient;
 
@@ -222,7 +222,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         preg_match_all(self::IMPORT_REGEX, $content, $matches);
         $dependencies = [];
         foreach ($matches[1] as $index => $packageName) {
-            $version = $matches[2][$index];
+            $version = $matches[2][$index] ?: null;
             $packageName .= $matches[3][$index]; // add the path if any
 
             $dependencies[] = new PackageRequireOptions($packageName, $version);

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapVersionCheckerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapVersionCheckerTest.php
@@ -220,28 +220,6 @@ class ImportMapVersionCheckerTest extends TestCase
             ],
         ];
 
-        yield 'single that imports something that is not required by the package' => [
-            [
-                self::createRemoteEntry('foo', version: '1.0.0'),
-                self::createRemoteEntry('bar', version: '1.5.0'),
-            ],
-            [
-                'foo' => ['bar'],
-                'bar' => [],
-            ],
-            [
-                [
-                    'url' => '/foo/1.0.0',
-                    'response' => [
-                        'dependencies' => [],
-                    ],
-                ],
-            ],
-            [
-                new PackageVersionProblem('foo', 'bar', null, '1.5.0'),
-            ],
-        ];
-
         yield 'single with npm-style constraint' => [
             [
                 self::createRemoteEntry('foo', version: '1.0.0'),

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -513,6 +513,22 @@ class JsDelivrEsmResolverTest extends TestCase
                 ['locutus/php/strings/vsprintf', '2.0.16'],
             ],
         ];
+
+        yield 'import statements without a version' => [
+            'import{ReplaceAroundStep as c,canSplit as d,StepMap as p,liftTarget as f}from"/npm/prosemirror-transform/+esm";import{PluginKey as h,EditorState as m,TextSelection as v,Plugin as g,AllSelection as y,Selection as b,NodeSelection as w,SelectionRange as k}from"/npm/prosemirror-state@1.4.3/+esm";',
+            [
+                ['prosemirror-transform', ''],
+                ['prosemirror-state', '1.4.3'],
+            ],
+        ];
+
+        yield 'import statements without a version and with paths' => [
+            'import{ReplaceAroundStep as c,canSplit as d,StepMap as p,liftTarget as f}from"/npm/prosemirror-transform/php/strings/vsprintf/+esm";import{PluginKey as h,EditorState as m,TextSelection as v,Plugin as g,AllSelection as y,Selection as b,NodeSelection as w,SelectionRange as k}from"/npm/prosemirror-state@1.4.3/php/strings/sprintf/+esm";',
+            [
+                ['prosemirror-transform/php/strings/vsprintf', ''],
+                ['prosemirror-state/php/strings/sprintf', '1.4.3'],
+            ],
+        ];
     }
 
     private static function createRemoteEntry(string $importName, string $version, ImportMapType $type = ImportMapType::JS, string $packageSpecifier = null): ImportMapEntry


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

Hi!

Another new import case from jsdelivr - found in a real project. The module in question - https://cdn.jsdelivr.net/npm/@toast-ui/editor@3.2.2/+esm

This is, I believe, a misconfiguration in that package (PR opened) where they `import` `prosemirror-transform` but do not list this as a dependency in their `package.json`. 

Regardless, we now handle this. And i've removed a warning about this... as the user has done nothing wrong.

Cheers!
