### PR TITLE
[AssetMapper] Fixing memory bug where we stored way more file content than needed

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -104,11 +104,9 @@ EOT
 
     private function createManifestAndWriteFiles(SymfonyStyle $io): array
     {
-        $allAssets = $this->assetMapper->allAssets();
-
         $io->comment(sprintf('Compiling and writing asset files to <info>%s</info>', $this->shortenPath($this->assetsFilesystem->getDestinationPath())));
         $manifest = [];
-        foreach ($allAssets as $asset) {
+        foreach ($this->assetMapper->allAssets() as $asset) {
             if (null !== $asset->content) {
                 // The original content has been modified by the AssetMapperCompiler
                 $this->assetsFilesystem->write($asset->publicPath, $asset->content);

--- a/src/Symfony/Component/AssetMapper/MappedAsset.php
+++ b/src/Symfony/Component/AssetMapper/MappedAsset.php
@@ -26,7 +26,9 @@ final class MappedAsset
     public readonly string $publicExtension;
 
     /**
-     * The final content of this asset, if different from the source.
+     * The final content of this asset if different from the sourcePath.
+     *
+     * If null, the content should be read from the sourcePath.
      */
     public readonly ?string $content;
 

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\AssetMapper\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\AssetMapper\Tests\Fixtures\AssetMapperTestAppKernel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
 {
@@ -23,11 +24,12 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
         $client->request('GET', '/assets/file1-b3445cb7a86a0795a7af7f2004498aef.css');
         $response = $client->getResponse();
         $this->assertSame(200, $response->getStatusCode());
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(<<<EOF
         /* file1.css */
         body {}
 
-        EOF, $response->getContent());
+        EOF, $response->getFile()->getContent());
         $this->assertSame('"b3445cb7a86a0795a7af7f2004498aef"', $response->headers->get('ETag'));
         $this->assertSame('immutable, max-age=604800, public', $response->headers->get('Cache-Control'));
         $this->assertTrue($response->headers->has('X-Assets-Dev'));
@@ -59,11 +61,12 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
         $client->request('GET', '/assets/already-abcdefVWXYZ0123456789.digested.css');
         $response = $client->getResponse();
         $this->assertSame(200, $response->getStatusCode());
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(<<<EOF
         /* already-abcdefVWXYZ0123456789.digested.css */
         body {}
 
-        EOF, $response->getContent());
+        EOF, $response->getFile()->getContent());
     }
 
     protected static function getKernelClass(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes (on Symfonycasts, without this, `asset-map:compile` takes >500mb of memory)
| New feature?  | no
| Deprecations? | none
| Issues        | None
| License       | MIT

Hi!

This drastically improves the memory footprint when ALL assets are built, which happens in `asset-map:compile`, `debug:asset-map`, etc. Blackfire is a huge fan! https://blackfire.io/profiles/compare/4eb36732-8805-4c49-b636-d4bf8f9e2b27/graph

The MAIN optimization by far is to set `MappedAsset.content` to null if the final, compiled content matches the source file's content. This is the case for the vast-majority of mapped assets, and so the result is MUCH less content stored in memory for no reason.

Thanks to @smnandre and his earlier PR, which allows for the `null` content on mapped assets.

Cheers!