### PR TITLE
[Yaml]  `Inline::parse(null)` not allowed

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -55,7 +55,7 @@ class Inline
      *
      * @throws ParseException
      */
-    public static function parse(string $value = null, int $flags = 0, array &$references = []): mixed
+    public static function parse(string $value, int $flags = 0, array &$references = []): mixed
     {
         self::initialize($flags);
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -29,7 +29,7 @@ class InlineTest extends TestCase
     /**
      * @dataProvider getTestsForParse
      */
-    public function testParse($yaml, $value, $flags = 0)
+    public function testParse(string $yaml, $value, $flags = 0)
     {
         $this->assertSame($value, Inline::parse($yaml, $flags), sprintf('::parse() converts an inline YAML to a PHP structure (%s)', $yaml));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52326
| License       | MIT

It's only called with string values in the Yaml component.

This class is internal. It allows to change the arg type.
The arg type was documented as `string`.
https://github.com/symfony/symfony/commit/7b1715b0782af05d5114cb5ad4433ac7e7e45e72#diff-1d97fcfb29e99f0200c3952e9a1a11c4b9f825c0f5ad4d4515b9b1805f8c988eR47