### PR TITLE
[Lock] Fix mongodb extension requirement in tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use MongoDB\Client;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
@@ -32,13 +33,16 @@ class MongoDbSessionHandlerTest extends TestCase
     private $storage;
     public $options;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(Client::class)) {
+            throw new SkippedTestSuiteError('The mongodb/mongodb package is required.');
+        }
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
-
-        if (!class_exists(Client::class)) {
-            $this->markTestSkipped('The mongodb/mongodb package is required.');
-        }
 
         $this->mongo = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreFactoryTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use MongoDB\Collection;
+use MongoDB\Client;
+use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\Store\MongoDbStore;
 use Symfony\Component\Lock\Store\StoreFactory;
@@ -18,13 +21,20 @@ use Symfony\Component\Lock\Store\StoreFactory;
 /**
  * @author Alexandre Daubois <alex.daubois@gmail.com>
  *
- * @requires extension mongo
+ * @requires extension mongodb
  */
 class MongoDbStoreFactoryTest extends TestCase
 {
+    public static function setupBeforeClass(): void
+    {
+        if (!class_exists(Client::class)) {
+            throw new SkippedTestSuiteError('The mongodb/mongodb package is required.');
+        }
+    }
+
     public function testCreateMongoDbCollectionStore()
     {
-        $store = StoreFactory::createStore($this->createMock(\MongoDB\Collection::class));
+        $store = StoreFactory::createStore($this->createMock(Collection::class));
 
         $this->assertInstanceOf(MongoDbStore::class, $store);
     }

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
@@ -32,7 +32,7 @@ class MongoDbStoreTest extends AbstractStoreTestCase
 
     public static function setupBeforeClass(): void
     {
-        if (!class_exists(\MongoDB\Client::class)) {
+        if (!class_exists(Client::class)) {
             throw new SkippedTestSuiteError('The mongodb/mongodb package is required.');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The MongoDB session store relies on `ext-mongodb`, not the legacy `ext-mongo`. Fix the PhpUnit requirement so the tests are not skipped: https://github.com/symfony/symfony/actions/runs/6668689428/job/18124800680#step:7:559