### PR TITLE
[HttpFoundation][Lock] Makes MongoDB adapters usable with `ext-mongodb` directly

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -159,7 +159,6 @@ jobs:
           echo COMPOSER_ROOT_VERSION=$COMPOSER_ROOT_VERSION >> $GITHUB_ENV
 
           echo "::group::composer update"
-          composer require --dev --no-update mongodb/mongodb
           composer update --no-progress --ansi
           echo "::endgroup::"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -190,9 +190,6 @@ jobs:
             exit 0
           fi
 
-          (cd src/Symfony/Component/HttpFoundation; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb)
-          (cd src/Symfony/Component/Lock; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb)
-
           # matrix.mode = high-deps
           echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} 'cd {} && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
 
@@ -211,8 +208,6 @@ jobs:
               git fetch --depth=2 origin $SYMFONY_VERSION
               git checkout -m FETCH_HEAD
               PATCHED_COMPONENTS=$(echo "$PATCHED_COMPONENTS" | xargs dirname | xargs -n1 -I{} bash -c "[ -e '{}/phpunit.xml.dist' ] && echo '{}'" | sort || true)
-              (cd src/Symfony/Component/HttpFoundation; composer require --dev --no-update mongodb/mongodb)
-              (cd src/Symfony/Component/Lock; composer require --dev --no-update mongodb/mongodb)
               if [[ $PATCHED_COMPONENTS ]]; then
                 echo "::group::install phpunit"
                 ./phpunit install

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `UriSigner` from the HttpKernel component
  * Add `partitioned` flag to `Cookie` (CHIPS Cookie)
  * Add argument `bool $flush = true` to `Response::send()`
+* Make `MongoDbSessionHandler` instantiable with the mongodb extension directly
 
 6.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -11,56 +11,98 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\UTCDateTime;
 use MongoDB\Client;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\SkippedTestSuiteError;
+use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\CommandException;
+use MongoDB\Driver\Exception\ConnectionException;
+use MongoDB\Driver\Manager;
+use MongoDB\Driver\Query;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
+
+require_once __DIR__.'/stubs/mongodb.php';
 
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *
+ * @group integration
  * @group time-sensitive
  *
  * @requires extension mongodb
  */
 class MongoDbSessionHandlerTest extends TestCase
 {
-    public array $options;
-    private MockObject&Client $mongo;
-    private MongoDbSessionHandler $storage;
+    private const DABASE_NAME = 'sf-test';
+    private const COLLECTION_NAME = 'session-test';
 
-    public static function setUpBeforeClass(): void
-    {
-        if (!class_exists(Client::class)) {
-            throw new SkippedTestSuiteError('The mongodb/mongodb package is required.');
-        }
-    }
+    public array $options;
+    private Manager $manager;
+    private MongoDbSessionHandler $storage;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->mongo = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->manager = new Manager('mongodb://'.getenv('MONGODB_HOST'));
+
+        try {
+            $this->manager->executeCommand(self::DABASE_NAME, new Command(['ping' => 1]));
+        } catch (ConnectionException $e) {
+            $this->markTestSkipped(sprintf('MongoDB Server "%s" not running: %s', getenv('MONGODB_HOST'), $e->getMessage()));
+        }
 
         $this->options = [
             'id_field' => '_id',
             'data_field' => 'data',
             'time_field' => 'time',
             'expiry_field' => 'expires_at',
-            'database' => 'sf-test',
-            'collection' => 'session-test',
+            'database' => self::DABASE_NAME,
+            'collection' => self::COLLECTION_NAME,
         ];
 
-        $this->storage = new MongoDbSessionHandler($this->mongo, $this->options);
+        $this->storage = new MongoDbSessionHandler($this->manager, $this->options);
     }
 
-    public function testConstructorShouldThrowExceptionForMissingOptions()
+    public function testCreateFromClient()
+    {
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('getManager')
+            ->willReturn($this->manager);
+
+        $this->storage = new MongoDbSessionHandler($client, $this->options);
+        $this->storage->write('foo', 'bar');
+
+        $this->assertCount(1, $this->getSessions());
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            $this->manager->executeCommand(self::DABASE_NAME, new Command(['drop' => self::COLLECTION_NAME]));
+        } catch (CommandException $e) {
+            // The server may return a NamespaceNotFound error if the collection does not exist
+            if (26 !== $e->getCode()) {
+                throw $e;
+            }
+        }
+    }
+
+    /** @dataProvider provideInvalidOptions */
+    public function testConstructorShouldThrowExceptionForMissingOptions(array $options)
     {
         $this->expectException(\InvalidArgumentException::class);
-        new MongoDbSessionHandler($this->mongo, []);
+        new MongoDbSessionHandler($this->manager, $options);
+    }
+
+    public function provideInvalidOptions()
+    {
+        yield 'empty' => [[]];
+        yield 'collection missing' => [['database' => 'foo']];
+        yield 'database missing' => [['collection' => 'foo']];
     }
 
     public function testOpenMethodAlwaysReturnTrue()
@@ -75,142 +117,93 @@ class MongoDbSessionHandlerTest extends TestCase
 
     public function testRead()
     {
-        $collection = $this->createMongoCollectionMock();
-
-        $this->mongo->expects($this->once())
-            ->method('selectCollection')
-            ->with($this->options['database'], $this->options['collection'])
-            ->willReturn($collection);
-
-        // defining the timeout before the actual method call
-        // allows to test for "greater than" values in the $criteria
-        $testTimeout = time() + 1;
-
-        $collection->expects($this->once())
-            ->method('findOne')
-            ->willReturnCallback(function ($criteria) use ($testTimeout) {
-                $this->assertArrayHasKey($this->options['id_field'], $criteria);
-                $this->assertEquals('foo', $criteria[$this->options['id_field']]);
-
-                $this->assertArrayHasKey($this->options['expiry_field'], $criteria);
-                $this->assertArrayHasKey('$gte', $criteria[$this->options['expiry_field']]);
-
-                $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, $criteria[$this->options['expiry_field']]['$gte']);
-                $this->assertGreaterThanOrEqual(round((string) $criteria[$this->options['expiry_field']]['$gte'] / 1000), $testTimeout);
-
-                return [
-                    $this->options['id_field'] => 'foo',
-                    $this->options['expiry_field'] => new \MongoDB\BSON\UTCDateTime(),
-                    $this->options['data_field'] => new \MongoDB\BSON\Binary('bar', \MongoDB\BSON\Binary::TYPE_OLD_BINARY),
-                ];
-            });
-
+        $this->insertSession('foo', 'bar', 0);
         $this->assertEquals('bar', $this->storage->read('foo'));
+    }
+
+    public function testReadNotFound()
+    {
+        $this->insertSession('foo', 'bar', 0);
+        $this->assertEquals('', $this->storage->read('foobar'));
+    }
+
+    public function testReadExpired()
+    {
+        $this->insertSession('foo', 'bar', -100_000);
+        $this->assertEquals('', $this->storage->read('foo'));
     }
 
     public function testWrite()
     {
-        $collection = $this->createMongoCollectionMock();
-
-        $this->mongo->expects($this->once())
-            ->method('selectCollection')
-            ->with($this->options['database'], $this->options['collection'])
-            ->willReturn($collection);
-
-        $collection->expects($this->once())
-            ->method('updateOne')
-            ->willReturnCallback(function ($criteria, $updateData, $options) {
-                $this->assertEquals([$this->options['id_field'] => 'foo'], $criteria);
-                $this->assertEquals(['upsert' => true], $options);
-
-                $data = $updateData['$set'];
-                $expectedExpiry = time() + (int) \ini_get('session.gc_maxlifetime');
-                $this->assertInstanceOf(\MongoDB\BSON\Binary::class, $data[$this->options['data_field']]);
-                $this->assertEquals('bar', $data[$this->options['data_field']]->getData());
-                $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, $data[$this->options['time_field']]);
-                $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, $data[$this->options['expiry_field']]);
-                $this->assertGreaterThanOrEqual($expectedExpiry, round((string) $data[$this->options['expiry_field']] / 1000));
-            });
-
+        $expectedTime = (new \DateTimeImmutable())->getTimestamp();
+        $expectedExpiry = $expectedTime + (int) \ini_get('session.gc_maxlifetime');
         $this->assertTrue($this->storage->write('foo', 'bar'));
+
+        $sessions = $this->getSessions();
+        $this->assertCount(1, $sessions);
+        $this->assertEquals('foo', $sessions[0]->_id);
+        $this->assertInstanceOf(Binary::class, $sessions[0]->data);
+        $this->assertEquals('bar', $sessions[0]->data->getData());
+        $this->assertInstanceOf(UTCDateTime::class, $sessions[0]->time);
+        $this->assertGreaterThanOrEqual($expectedTime, round((string) $sessions[0]->time / 1000));
+        $this->assertInstanceOf(UTCDateTime::class, $sessions[0]->expires_at);
+        $this->assertGreaterThanOrEqual($expectedExpiry, round((string) $sessions[0]->expires_at / 1000));
     }
 
     public function testReplaceSessionData()
     {
-        $collection = $this->createMongoCollectionMock();
-
-        $this->mongo->expects($this->once())
-            ->method('selectCollection')
-            ->with($this->options['database'], $this->options['collection'])
-            ->willReturn($collection);
-
-        $data = [];
-
-        $collection->expects($this->exactly(2))
-            ->method('updateOne')
-            ->willReturnCallback(function ($criteria, $updateData, $options) use (&$data) {
-                $data = $updateData;
-            });
-
         $this->storage->write('foo', 'bar');
+        $this->storage->write('baz', 'qux');
         $this->storage->write('foo', 'foobar');
 
-        $this->assertEquals('foobar', $data['$set'][$this->options['data_field']]->getData());
+        $sessions = $this->getSessions();
+        $this->assertCount(2, $sessions);
+        $this->assertEquals('foobar', $sessions[0]->data->getData());
     }
 
     public function testDestroy()
     {
-        $collection = $this->createMongoCollectionMock();
-
-        $this->mongo->expects($this->once())
-            ->method('selectCollection')
-            ->with($this->options['database'], $this->options['collection'])
-            ->willReturn($collection);
-
-        $collection->expects($this->once())
-            ->method('deleteOne')
-            ->with([$this->options['id_field'] => 'foo']);
+        $this->storage->write('foo', 'bar');
+        $this->storage->write('baz', 'qux');
 
         $this->assertTrue($this->storage->destroy('foo'));
+
+        $sessions = $this->getSessions();
+        $this->assertCount(1, $sessions);
+        $this->assertEquals('baz', $sessions[0]->_id);
     }
 
     public function testGc()
     {
-        $collection = $this->createMongoCollectionMock();
+        $this->insertSession('foo', 'bar', -100_000);
+        $this->insertSession('bar', 'bar', -100_000);
+        $this->insertSession('qux', 'bar', -300);
+        $this->insertSession('baz', 'bar', 0);
 
-        $this->mongo->expects($this->once())
-            ->method('selectCollection')
-            ->with($this->options['database'], $this->options['collection'])
-            ->willReturn($collection);
-
-        $collection->expects($this->once())
-            ->method('deleteMany')
-            ->willReturnCallback(function ($criteria) {
-                $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, $criteria[$this->options['expiry_field']]['$lt']);
-                $this->assertGreaterThanOrEqual(time() - 1, round((string) $criteria[$this->options['expiry_field']]['$lt'] / 1000));
-
-                $result = $this->createMock(\MongoDB\DeleteResult::class);
-                $result->method('getDeletedCount')->willReturn(42);
-
-                return $result;
-            });
-
-        $this->assertSame(42, $this->storage->gc(1));
+        $this->assertSame(2, $this->storage->gc(1));
+        $this->assertCount(2, $this->getSessions());
     }
 
-    public function testGetConnection()
+    /**
+     * @return list<object{_id:string,data:Binary,time:UTCDateTime,expires_at:UTCDateTime>
+     */
+    private function getSessions(): array
     {
-        $method = new \ReflectionMethod($this->storage, 'getMongo');
-
-        $this->assertInstanceOf(Client::class, $method->invoke($this->storage));
+        return $this->manager->executeQuery(self::DABASE_NAME.'.'.self::COLLECTION_NAME, new Query([]))->toArray();
     }
 
-    private function createMongoCollectionMock(): \MongoDB\Collection
+    private function insertSession(string $sessionId, string $data, int $timeDiff): void
     {
-        $collection = $this->getMockBuilder(\MongoDB\Collection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $time = time() + $timeDiff;
 
-        return $collection;
+        $write = new BulkWrite();
+        $write->insert([
+            '_id' => $sessionId,
+            'data' => new Binary($data, Binary::TYPE_GENERIC),
+            'time' => new UTCDateTime($time * 1000),
+            'expires_at' => new UTCDateTime(($time + (int) \ini_get('session.gc_maxlifetime')) * 1000),
+        ]);
+
+        $this->manager->executeBulkWrite(self::DABASE_NAME.'.'.self::COLLECTION_NAME, $write);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/stubs/mongodb.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/stubs/mongodb.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MongoDB;
+
+use MongoDB\Driver\Manager;
+
+/*
+ * Stubs for the mongodb/mongodb library version ~1.16
+ */
+if (!class_exists(Client::class, false)) {
+    abstract class Client
+    {
+        abstract public function getManager(): Manager;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
@@ -10,6 +10,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="MONGODB_HOST" value="localhost" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Make `MongoDbStore` instantiable with the mongodb extension directly
+
 6.3
 ---
 

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -14,8 +14,12 @@ namespace Symfony\Component\Lock\Store;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Client;
 use MongoDB\Collection;
+use MongoDB\Database;
+use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\Command;
 use MongoDB\Driver\Exception\WriteException;
-use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\Manager;
+use MongoDB\Driver\Query;
 use MongoDB\Exception\DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException as MongoInvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
@@ -44,21 +48,22 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
  *
  * @author Joe Bennett <joe@assimtech.com>
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
 class MongoDbStore implements PersistingStoreInterface
 {
     use ExpiringStoreTrait;
 
-    private Collection $collection;
-    private Client $client;
+    private Manager $manager;
+    private string $namespace;
     private string $uri;
     private array $options;
     private float $initialTtl;
 
     /**
-     * @param Collection|Client|string $mongo      An instance of a Collection or Client or URI @see https://docs.mongodb.com/manual/reference/connection-string/
-     * @param array                    $options    See below
-     * @param float                    $initialTtl The expiration delay of locks in seconds
+     * @param Collection|Client|Manager|string $mongo      An instance of a Collection or Client or URI @see https://docs.mongodb.com/manual/reference/connection-string/
+     * @param array                            $options    See below
+     * @param float                            $initialTtl The expiration delay of locks in seconds
      *
      * @throws InvalidArgumentException If required options are not provided
      * @throws InvalidTtlException      When the initial ttl is not valid
@@ -88,7 +93,7 @@ class MongoDbStore implements PersistingStoreInterface
      * readPreference is primary for all queries.
      * @see https://docs.mongodb.com/manual/applications/replication/
      */
-    public function __construct(Collection|Client|string $mongo, array $options = [], float $initialTtl = 300.0)
+    public function __construct(Collection|Database|Client|Manager|string $mongo, array $options = [], float $initialTtl = 300.0)
     {
         if (isset($options['gcProbablity'])) {
             trigger_deprecation('symfony/lock', '6.3', 'The "gcProbablity" option (notice the typo in its name) is deprecated in "%s"; use the "gcProbability" option instead.', __CLASS__);
@@ -108,21 +113,27 @@ class MongoDbStore implements PersistingStoreInterface
         $this->initialTtl = $initialTtl;
 
         if ($mongo instanceof Collection) {
-            $this->collection = $mongo;
+            $this->options['database'] ??= $mongo->getDatabaseName();
+            $this->options['collection'] ??= $mongo->getCollectionName();
+            $this->manager = $mongo->getManager();
+        } elseif ($mongo instanceof Database) {
+            $this->options['database'] ??= $mongo->getDatabaseName();
+            $this->manager = $mongo->getManager();
         } elseif ($mongo instanceof Client) {
-            $this->client = $mongo;
+            $this->manager = $mongo->getManager();
+        } elseif ($mongo instanceof Manager) {
+            $this->manager = $mongo;
         } else {
             $this->uri = $this->skimUri($mongo);
         }
 
-        if (!($mongo instanceof Collection)) {
-            if (null === $this->options['database']) {
-                throw new InvalidArgumentException(sprintf('"%s()" requires the "database" in the URI path or option.', __METHOD__));
-            }
-            if (null === $this->options['collection']) {
-                throw new InvalidArgumentException(sprintf('"%s()" requires the "collection" in the URI querystring or option.', __METHOD__));
-            }
+        if (null === $this->options['database']) {
+            throw new InvalidArgumentException(sprintf('"%s()" requires the "database" in the URI path or option.', __METHOD__));
         }
+        if (null === $this->options['collection']) {
+            throw new InvalidArgumentException(sprintf('"%s()" requires the "collection" in the URI querystring or option.', __METHOD__));
+        }
+        $this->namespace = $this->options['database'].'.'.$this->options['collection'];
 
         if ($this->options['gcProbability'] < 0.0 || $this->options['gcProbability'] > 1.0) {
             throw new InvalidArgumentException(sprintf('"%s()" gcProbability must be a float from 0.0 to 1.0, "%f" given.', __METHOD__, $this->options['gcProbability']));
@@ -142,6 +153,10 @@ class MongoDbStore implements PersistingStoreInterface
      */
     private function skimUri(string $uri): string
     {
+        if (!str_starts_with($uri, 'mongodb://') && !str_starts_with($uri, 'mongodb+srv://')) {
+            throw new InvalidArgumentException(sprintf('The given MongoDB Connection URI "%s" is invalid. Expecting "mongodb://" or "mongodb+srv://".', $uri));
+        }
+
         if (false === $parsedUrl = parse_url($uri)) {
             throw new InvalidArgumentException(sprintf('The given MongoDB Connection URI "%s" is invalid.', $uri));
         }
@@ -195,14 +210,19 @@ class MongoDbStore implements PersistingStoreInterface
      */
     public function createTtlIndex(int $expireAfterSeconds = 0)
     {
-        $this->getCollection()->createIndex(
-            [ // key
-                'expires_at' => 1,
+        $server = $this->getManager()->selectServer();
+        $server->executeCommand($this->options['database'], new Command([
+            'createIndexes' => $this->options['collection'],
+            'indexes' => [
+                [
+                    'key' => [
+                        'expires_at' => 1,
+                    ],
+                    'name' => 'expires_at_1',
+                    'expireAfterSeconds' => $expireAfterSeconds,
+                ],
             ],
-            [ // options
-                'expireAfterSeconds' => $expireAfterSeconds,
-            ]
-        );
+        ]));
     }
 
     /**
@@ -257,23 +277,35 @@ class MongoDbStore implements PersistingStoreInterface
      */
     public function delete(Key $key)
     {
-        $this->getCollection()->deleteOne([ // filter
-            '_id' => (string) $key,
-            'token' => $this->getUniqueToken($key),
-        ]);
+        $write = new BulkWrite();
+        $write->delete(
+            [
+                '_id' => (string) $key,
+                'token' => $this->getUniqueToken($key),
+            ],
+            ['limit' => 1]
+        );
+
+        $this->getManager()->executeBulkWrite($this->namespace, $write);
     }
 
     public function exists(Key $key): bool
     {
-        return null !== $this->getCollection()->findOne([ // filter
-            '_id' => (string) $key,
-            'token' => $this->getUniqueToken($key),
-            'expires_at' => [
-                '$gt' => $this->createMongoDateTime(microtime(true)),
+        $cursor = $this->manager->executeQuery($this->namespace, new Query(
+            [
+                '_id' => (string) $key,
+                'token' => $this->getUniqueToken($key),
+                'expires_at' => [
+                    '$gt' => $this->createMongoDateTime(microtime(true)),
+                ],
             ],
-        ], [
-            'readPreference' => new ReadPreference(\defined(ReadPreference::PRIMARY) ? ReadPreference::PRIMARY : ReadPreference::RP_PRIMARY),
-        ]);
+            [
+                'limit' => 1,
+                'projection' => ['_id' => 1],
+            ]
+        ));
+
+        return [] !== $cursor->toArray();
     }
 
     /**
@@ -286,8 +318,9 @@ class MongoDbStore implements PersistingStoreInterface
         $now = microtime(true);
         $token = $this->getUniqueToken($key);
 
-        $this->getCollection()->updateOne(
-            [ // filter
+        $write = new BulkWrite();
+        $write->update(
+            [
                 '_id' => (string) $key,
                 '$or' => [
                     [
@@ -300,17 +333,19 @@ class MongoDbStore implements PersistingStoreInterface
                     ],
                 ],
             ],
-            [ // update
+            [
                 '$set' => [
                     '_id' => (string) $key,
                     'token' => $token,
                     'expires_at' => $this->createMongoDateTime($now + $ttl),
                 ],
             ],
-            [ // options
+            [
                 'upsert' => true,
             ]
         );
+
+        $this->getManager()->executeBulkWrite($this->namespace, $write);
     }
 
     private function isDuplicateKeyException(WriteException $e): bool
@@ -326,20 +361,9 @@ class MongoDbStore implements PersistingStoreInterface
         return 11000 === $code;
     }
 
-    private function getCollection(): Collection
+    private function getManager(): Manager
     {
-        if (isset($this->collection)) {
-            return $this->collection;
-        }
-
-        $this->client ??= new Client($this->uri, $this->options['uriOptions'], $this->options['driverOptions']);
-
-        $this->collection = $this->client->selectCollection(
-            $this->options['database'],
-            $this->options['collection']
-        );
-
-        return $this->collection;
+        return $this->manager ??= new Manager($this->uri, $this->options['uriOptions'], $this->options['driverOptions']);
     }
 
     /**
@@ -351,7 +375,7 @@ class MongoDbStore implements PersistingStoreInterface
     }
 
     /**
-     * Retrieves an unique token for the given key namespaced to this store.
+     * Retrieves a unique token for the given key namespaced to this store.
      *
      * @param Key $key lock state container
      */

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreFactoryTest.php
@@ -12,11 +12,12 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use MongoDB\Collection;
-use MongoDB\Client;
-use PHPUnit\Framework\SkippedTestSuiteError;
+use MongoDB\Driver\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\Store\MongoDbStore;
 use Symfony\Component\Lock\Store\StoreFactory;
+
+require_once __DIR__.'/stubs/mongodb.php';
 
 /**
  * @author Alexandre Daubois <alex.daubois@gmail.com>
@@ -25,16 +26,20 @@ use Symfony\Component\Lock\Store\StoreFactory;
  */
 class MongoDbStoreFactoryTest extends TestCase
 {
-    public static function setupBeforeClass(): void
-    {
-        if (!class_exists(Client::class)) {
-            throw new SkippedTestSuiteError('The mongodb/mongodb package is required.');
-        }
-    }
-
     public function testCreateMongoDbCollectionStore()
     {
-        $store = StoreFactory::createStore($this->createMock(Collection::class));
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('getManager')
+            ->willReturn(new Manager());
+        $collection->expects($this->once())
+            ->method('getCollectionName')
+            ->willReturn('lock');
+        $collection->expects($this->once())
+            ->method('getDatabaseName')
+            ->willReturn('test');
+
+        $store = StoreFactory::createStore($collection);
 
         $this->assertInstanceOf(MongoDbStore::class, $store);
     }

--- a/src/Symfony/Component/Lock/Tests/Store/stubs/mongodb.php
+++ b/src/Symfony/Component/Lock/Tests/Store/stubs/mongodb.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MongoDB;
+
+use MongoDB\Driver\Manager;
+
+/*
+ * Stubs for the mongodb/mongodb library version ~1.16
+ */
+if (!class_exists(Client::class)) {
+    abstract class Client
+    {
+        abstract public function getManager(): Manager;
+    }
+}
+
+if (!class_exists(Database::class)) {
+    abstract class Database
+    {
+        abstract public function getManager(): Manager;
+
+        abstract public function getDatabaseName(): string;
+    }
+}
+
+if (!class_exists(Collection::class)) {
+    abstract class Collection
+    {
+        abstract public function getManager(): Manager;
+
+        abstract public function getCollectionName(): string;
+
+        abstract public function getDatabaseName(): string;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

[`mongodb/mongodb`](https://packagist.org/packages/mongodb/mongodb) is complex to handle for libraries with optional support of MongoDB, as it requires [`ext-mongodb`](https://www.php.net/manual/en/set.mongodb.php). In order to reduce complexity for maintainers, I reimplemented the session and lock adapters to use only the C driver classes.

Some features of `MongoDB\Client` are missing (server selection, session, transaction). But they are not necessary to store Sessions and Lock.

Changes:
- Lock & Session accept a `MongoDB\Driver\Manager`
- The lock uses exclusively UTC date. Before, there was a mix of `time()` and `UTCDatetime` objects.
- Session tests require a mongo server.
- `mongodb/mongodb` not needed in the CI

And of course also allows developers to use this adapters without installing `mongodb/mongodb` if they want, with the same features as before.