### PR TITLE
[Console] Strip tags before escaping text in `OutputFormatter`

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -40,7 +40,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
      */
     public static function escape(string $text): string
     {
-        $text = preg_replace('/([^\\\\]|^)([<>])/', '$1\\\\$2', $text);
+        $text = preg_replace('/([^\\\\]|^)([<>])/', '$1\\\\$2', strip_tags($text));
 
         return self::escapeTrailingBackslash($text);
     }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -115,6 +115,16 @@ class OutputFormatterTest extends TestCase
         );
     }
 
+    public function testTagEscaping()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $this->assertEquals(
+            'foo',
+            $formatter->escape('<info>foo</info>')
+        );
+    }
+
     public function testDeepNestedStyles()
     {
         $formatter = new OutputFormatter(true);

--- a/src/Symfony/Component/Console/Tests/Helper/FormatterHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FormatterHelperTest.php
@@ -83,9 +83,9 @@ class FormatterHelperTest extends TestCase
         $formatter = new FormatterHelper();
 
         $this->assertEquals(
-            '<error>                              </error>'."\n".
-            '<error>  \<info\>some info\</info\>  </error>'."\n".
-            '<error>                              </error>',
+            '<error>             </error>'."\n".
+            '<error>  some info  </error>'."\n".
+            '<error>             </error>',
             $formatter->formatBlock('<info>some info</info>', 'error', true),
             '::formatBlock() escapes \'<\' chars'
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50007
| License       | MIT

This fixes https://github.com/symfony/symfony/issues/50007 by adding a `strip_tags` call before running the `OutputFormatter::escape()` logic.