### PR TITLE
[Form] Fix merging form data and files (ter)

### DIFF
--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
@@ -23,6 +24,7 @@ use Symfony\Component\Form\FormRegistry;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\RequestHandlerInterface;
 use Symfony\Component\Form\ResolvedFormTypeFactory;
+use Symfony\Component\Form\Tests\Extension\Type\ItemFileType;
 use Symfony\Component\Form\Util\ServerParams;
 
 /**
@@ -309,6 +311,48 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
 
         $this->assertTrue($form->isSubmitted());
         $this->assertSame('DATA', $form->getData());
+    }
+
+    public function testMergeZeroIndexedCollection()
+    {
+        $form = $this->createForm('root', 'POST', true);
+        $form->add('items', CollectionType::class, [
+            'entry_type' => ItemFileType::class,
+            'allow_add' => true,
+        ]);
+
+        $file = $this->getUploadedFile();
+
+        $this->setRequestData('POST', [
+            'root' => [
+                'items' => [
+                    0 => [
+                        'item' => 'test',
+                    ],
+                ],
+            ],
+        ], [
+            'root' => [
+                'items' => [
+                    0 => [
+                        'file' => $file,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $itemsForm = $form->get('items');
+
+        $this->assertTrue($form->isSubmitted());
+        $this->assertTrue($form->isValid());
+
+        $this->assertTrue($itemsForm->has('0'));
+        $this->assertFalse($itemsForm->has('1'));
+
+        $this->assertEquals('test', $itemsForm->get('0')->get('item')->getData());
+        $this->assertNotNull($itemsForm->get('0')->get('file'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Type/ItemFileType.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Type/ItemFileType.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ItemFileType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('item', TextType::class);
+        $builder->add('file', FileType::class);
+    }
+}

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -50,13 +50,7 @@ class FormUtil
      */
     public static function mergeParamsAndFiles(array $params, array $files): array
     {
-        if (array_is_list($files)) {
-            foreach ($files as $value) {
-                $params[] = $value;
-            }
-
-            return $params;
-        }
+        $isFilesList = array_is_list($files);
 
         foreach ($params as $key => $value) {
             if (\is_array($value) && \is_array($files[$key] ?? null)) {
@@ -65,6 +59,14 @@ class FormUtil
             }
         }
 
-        return array_replace($params, $files);
+        if (!$isFilesList) {
+            return array_replace($params, $files);
+        }
+
+        foreach ($files as $value) {
+            $params[] = $value;
+        }
+
+        return $params;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52318
| License       | MIT

Adapted from a patch provided by @jan-pintr

The original was like below but this one looks more appropriate to me.

<details>

```diff
--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -47,8 +47,12 @@ public static function isEmpty(mixed $data): bool
     public static function mergeParamsAndFiles(array $params, array $files): array
     {
         if (array_is_list($files)) {
-            foreach ($files as $value) {
-                $params[] = $value;
+            foreach ($files as $key => $value) {
+                if (is_array($params[$key])) {
+                    $params[$key] = array_merge($params[$key], $value);
+                } else {
+                    $params[] = $value;
+                }
             }
 
             return $params;
@@ -61,6 +65,6 @@ public static function mergeParamsAndFiles(array $params, array $files): array
             }
         }
 
-        return array_replace($params, $files);
+        return array_merge($params, $files);
     }```

</details>