### PR TITLE
[Yaml] Remove test on `Inline::parse(null)`

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -318,7 +318,6 @@ class InlineTest extends TestCase
     {
         return [
             ['', ''],
-            [null, ''],
             ['null', null],
             ['false', false],
             ['true', true],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52334
| License       | MIT

This test was added by https://github.com/symfony/symfony/pull/52332
It becomes wrong with https://github.com/symfony/symfony/pull/52334
It was not reverted by https://github.com/symfony/symfony/commit/eaff34a6591aac38324f5e630ec35fa1656fcd28