### PR TITLE
[Cache] Add support for `prefix` for `\RedisCluster`

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -333,6 +333,10 @@ trait RedisTrait
                     case 'slaves': $redis->setOption(\RedisCluster::OPT_SLAVE_FAILOVER, \RedisCluster::FAILOVER_DISTRIBUTE_SLAVES); break;
                 }
 
+                if (isset($params['prefix']) && is_string($params['prefix'])) {
+                    $redis->setOption(\Redis::OPT_PREFIX, $params['prefix']);
+                }
+
                 return $redis;
             };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?   |    5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I noticed that the prefix for `\RedisCluster` is not used.

The `RedisCluster::OPT_PREFIX` option does not exist.
However, `\Redis::OPT_PREFIX` works fine. Moreover, `\Redis::OPT_PREFIX` is even used in the RedisClusterAdapterTest tests https://github.com/symfony/symfony/blob/b1ec74b3041d11580f7c1d7e04bbe69cb8292c25/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php#L35

If you can tell me how I can supplement existing tests to check the use of the prefix, I would be grateful.
