### PR TITLE
[AssetMapper] Fixing bug where JSCompiler used non-absolute importmap entry path

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -153,7 +153,7 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
                 return $asset;
             }
 
-            return $assetMapper->getAssetFromSourcePath($importMapEntry->path);
+            return $assetMapper->getAssetFromSourcePath($this->importMapConfigReader->convertPathToFilesystemPath($importMapEntry->path));
         } catch (CircularAssetsException $exception) {
             return $exception->getIncompleteMappedAsset();
         }

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
@@ -209,11 +209,7 @@ class ImportMapGenerator
             return $asset;
         }
 
-        if (str_starts_with($path, '.')) {
-            $path = $this->importMapConfigReader->getRootDirectory().'/'.$path;
-        }
-
-        return $this->assetMapper->getAssetFromSourcePath($path);
+        return $this->assetMapper->getAssetFromSourcePath($this->importMapConfigReader->convertPathToFilesystemPath($path));
     }
 
     private function findEagerImports(MappedAsset $asset): array

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -152,11 +152,10 @@ class ImportMapManager
                 throw new \LogicException(sprintf('The path "%s" of the package "%s" cannot be found: either pass the logical name of the asset or a relative path starting with "./".', $requireOptions->path, $requireOptions->importName));
             }
 
-            $rootImportMapDir = $this->importMapConfigReader->getRootDirectory();
             // convert to a relative path (or fallback to the logical path)
             $path = $asset->logicalPath;
-            if ($rootImportMapDir && str_starts_with(realpath($asset->sourcePath), realpath($rootImportMapDir))) {
-                $path = './'.substr(realpath($asset->sourcePath), \strlen(realpath($rootImportMapDir)) + 1);
+            if (null !== $relativePath = $this->importMapConfigReader->convertFilesystemPathToPath($asset->sourcePath)) {
+                $path = $relativePath;
             }
 
             $newEntry = ImportMapEntry::createLocal(
@@ -213,10 +212,6 @@ class ImportMapManager
             return $asset;
         }
 
-        if (str_starts_with($path, '.')) {
-            $path = $this->importMapConfigReader->getRootDirectory().'/'.$path;
-        }
-
-        return $this->assetMapper->getAssetFromSourcePath($path);
+        return $this->assetMapper->getAssetFromSourcePath($this->importMapConfigReader->convertPathToFilesystemPath($path));
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
 use Symfony\Component\AssetMapper\ImportMap\JavaScriptImport;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 class ImportMapGeneratorTest extends TestCase
 {
@@ -252,8 +253,14 @@ class ImportMapGeneratorTest extends TestCase
         $this->mockImportMap($importMapEntries);
         $this->mockAssetMapper($mappedAssets);
         $this->configReader->expects($this->any())
-            ->method('getRootDirectory')
-            ->willReturn('/fake/root');
+            ->method('convertPathToFilesystemPath')
+            ->willReturnCallback(function (string $path) {
+                if (!str_starts_with($path, '.')) {
+                    return $path;
+                }
+
+                return Path::join('/fake/root', $path);
+            });
 
         $this->assertEquals($expectedData, $manager->getRawImportMapData());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

Introduced over the weekend in #52349.

The `path` key inside `importmap.php` can be a full filesystem path or it can start with `./` to indicate a relative path to the root directory. That has been the case for weeks. In #52349, when start using the `path` of an importmap entry to find the `MappedAsset`. When doing that, I didn't consider the case where `path` is a relative path.

This PR fixes that and moves the code handling this into `ImportMapConfigReader` so that we're not repeating it in several places.

Cheers!
