### PR TITLE
[DependencyInjection] Add `urlencode` function to `EnvVarProcessor`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate `ContainerAwareInterface` and `ContainerAwareTrait`, use dependency injection instead
  * Add `defined` env var processor that returns `true` for defined and neither null nor empty env vars
  * Add `#[AutowireLocator]` and `#[AutowireIterator]` attributes
+ * Add `urlencode` env var processor that url encodes a string value
 
 6.3
 ---

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -57,6 +57,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             'enum' => \BackedEnum::class,
             'shuffle' => 'array',
             'defined' => 'bool',
+            'urlencode' => 'string',
         ];
     }
 
@@ -342,6 +343,10 @@ class EnvVarProcessor implements EnvVarProcessorInterface
 
         if ('trim' === $prefix) {
             return trim($env);
+        }
+
+        if ('urlencode' === $prefix) {
+            return rawurlencode($env);
         }
 
         throw new RuntimeException(sprintf('Unsupported env var prefix "%s" for env name "%s".', $prefix, $name));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -51,6 +51,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'enum' => [\BackedEnum::class],
             'shuffle' => ['array'],
             'defined' => ['bool'],
+            'urlencode' => ['string'],
         ];
 
         $this->assertSame($expected, $container->getParameterBag()->getProvidedTypes());

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -948,6 +948,17 @@ CSV;
         $this->assertSame($expected, (new EnvVarProcessor(new Container()))->getEnv('defined', 'NO_SOMETHING', $callback));
     }
 
+    public function testGetEnvUrlencode()
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $result = $processor->getEnv('urlencode', 'URLENCODETEST', function () {
+            return 'foo: Data123!@-_ + bar: Not the same content as Data123!@-_ +';
+        });
+
+        $this->assertSame('foo%3A%20Data123%21%40-_%20%2B%20bar%3A%20Not%20the%20same%20content%20as%20Data123%21%40-_%20%2B', $result);
+    }
+
     public static function provideGetEnvDefined(): iterable
     {
         yield 'Defined' => [true, fn () => 'foo'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR adds `urlencode` to the default `EnvVarProcessor` to allow encoding environment variables in config files.
The comes handy when environment variables are provided by the OS and not through .env because those values are often not  compatible with DSN syntax for doctrine or mailer components.

In my case our app was deployed on an AWS stack and environment variables for SMPT and database where automatically provided in the deployment process and replaced in the respective .env files.
Because those values where not encoded they would cause issues with DSN format requireing me to commit them in my `.env.prod` which circumvents the purpose of the whole system.

Usage:
```yaml
# config/packages/mailer.yaml
framework:
    mailer:
        dsn: 'smtp://%env(urlencode:SMTP_USER)%:%env(urlencode:SMTP_PASSWORD)%@%env(urlencode:SMTP_HOST)%?encryption=%env(SMTP_ENCRYPTION)%&port=%env(SMTP_PORT)%&auth_mode=login'  
```