### PR TITLE
[TwigBridge] Fix Bootstrap 4 form errors rendered inside `<label>`

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -257,7 +257,8 @@
                 {{- label|trans(label_translation_parameters, translation_domain)|raw -}}
             {%- endif -%}
         {%- endif -%}
-        {% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}</{{ element|default('label') }}>
+        </{{ element|default('label') }}>
+        {% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}
     {%- else -%}
         {%- if errors|length > 0 -%}
         <div id="{{ id }}_errors" class="mb-2">
@@ -315,8 +316,8 @@
                     {%- endif -%}
                 {%- endif -%}
             {%- endif -%}
-            {{- form_errors(form) -}}
         </label>
+        {{- form_errors(form) -}}
     {%- endif -%}
 {%- endblock checkbox_radio_label %}
 
@@ -341,13 +342,13 @@
 
 {% block form_errors -%}
     {%- if errors|length > 0 -%}
-        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block">
+        <div class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block mb-1">
             {%- for error in errors -%}
                 <span class="d-block">
                     <span class="form-error-icon badge badge-danger text-uppercase">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span>
                 </span>
             {%- endfor -%}
-        </span>
+        </div>
     {%- endif %}
 {%- endblock form_errors %}
 

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -342,13 +342,13 @@
 
 {% block form_errors -%}
     {%- if errors|length > 0 -%}
-        <div class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block mb-1">
+        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block mb-1">
             {%- for error in errors -%}
                 <span class="d-block">
                     <span class="form-error-icon badge badge-danger text-uppercase">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span>
                 </span>
             {%- endfor -%}
-        </div>
+        </span>
     {%- endif %}
 {%- endblock form_errors %}
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
@@ -31,7 +31,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTestCase extends AbstractBootst
             '/div
     [
         ./label[@for="name"]
-        /following-sibling::div[@class="alert alert-danger d-block mb-1"]
+        /following-sibling::span[@class="alert alert-danger d-block mb-1"]
         [./span[@class="d-block"]
             [./span[.="[trans]Error[/trans]"]]
             [./span[.="[trans]Error![/trans]"]]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
@@ -31,14 +31,12 @@ abstract class AbstractBootstrap4HorizontalLayoutTestCase extends AbstractBootst
             '/div
     [
         ./label[@for="name"]
-        [
-            ./span[@class="alert alert-danger d-block"]
-                [./span[@class="d-block"]
-                    [./span[.="[trans]Error[/trans]"]]
-                    [./span[.="[trans]Error![/trans]"]]
-                ]
-                [count(./span)=1]
+        /following-sibling::div[@class="alert alert-danger d-block mb-1"]
+        [./span[@class="d-block"]
+            [./span[.="[trans]Error[/trans]"]]
+            [./span[.="[trans]Error![/trans]"]]
         ]
+        [count(./span)=1]
         /following-sibling::div[./input[@id="name"]]
     ]
 '

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
@@ -41,7 +41,7 @@ abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3Layout
             '/div
     [
         ./label[@for="name"]
-        /following-sibling::div[@class="alert alert-danger d-block mb-1"]
+        /following-sibling::span[@class="alert alert-danger d-block mb-1"]
         [./span[@class="d-block"]
             [./span[.="[trans]Error[/trans]"]]
             [./span[.="[trans]Error![/trans]"]]
@@ -321,7 +321,7 @@ abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3Layout
         $html = $this->renderErrors($view);
 
         $this->assertMatchesXpath($html,
-            '/div
+            '/span
     [@class="alert alert-danger d-block mb-1"]
     [
         ./span[@class="d-block"]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
@@ -41,14 +41,12 @@ abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3Layout
             '/div
     [
         ./label[@for="name"]
-        [
-            ./span[@class="alert alert-danger d-block"]
-                [./span[@class="d-block"]
-                    [./span[.="[trans]Error[/trans]"]]
-                    [./span[.="[trans]Error![/trans]"]]
-                ]
-                [count(./span)=1]
+        /following-sibling::div[@class="alert alert-danger d-block mb-1"]
+        [./span[@class="d-block"]
+            [./span[.="[trans]Error[/trans]"]]
+            [./span[.="[trans]Error![/trans]"]]
         ]
+        [count(./span)=1]
         /following-sibling::input[@id="name"]
     ]
 '
@@ -323,8 +321,8 @@ abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3Layout
         $html = $this->renderErrors($view);
 
         $this->assertMatchesXpath($html,
-            '/span
-    [@class="alert alert-danger d-block"]
+            '/div
+    [@class="alert alert-danger d-block mb-1"]
     [
         ./span[@class="d-block"]
             [./span[.="[trans]Error[/trans]"]]

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -60,10 +60,18 @@ class FormThemeTest extends TestCase
         $this->registerTwigRuntimeLoader($environment, $formRenderer);
         $compiler = new Compiler($environment);
 
+        // There's a different result when testing in Symfony 4 with PHP 8.2 + high-deps
+        // This workaround is used to deal with the difference.
+        $source = '[1 => "tpl1", 0 => "tpl2"]';
+        if ('["tpl1", "tpl2"]' === (new Compiler($environment))->subcompile($node->getNode('resources'))->getSource()) {
+            $source = '["tpl1", "tpl2"]';
+        }
+
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, [1 => "tpl1", 0 => "tpl2"], true);',
-                $this->getVariableGetter('form')
+                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, %s, true);',
+                $this->getVariableGetter('form'),
+                $source
             ),
             trim($compiler->compile($node)->getSource())
         );
@@ -72,8 +80,9 @@ class FormThemeTest extends TestCase
 
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, [1 => "tpl1", 0 => "tpl2"], false);',
-                $this->getVariableGetter('form')
+                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, %s, false);',
+                $this->getVariableGetter('form'),
+                $source
             ),
             trim($compiler->compile($node)->getSource())
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52352 
| License       | MIT

This PR will fix Bootstrap 4 form layout when using a required marker.