### PR TITLE
Fix tests

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
@@ -18,8 +18,8 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToValueTransform
 
 class ChoiceToValueTransformerTest extends TestCase
 {
-    protected ChoiceToValueTransformer $transformer;
-    protected ChoiceToValueTransformer $transformerWithNull;
+    protected ?ChoiceToValueTransformer $transformer;
+    protected ?ChoiceToValueTransformer $transformerWithNull;
 
     protected function setUp(): void
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -20,8 +20,8 @@ class DateTimeToRfc3339TransformerTest extends BaseDateTimeTransformerTestCase
 {
     use DateTimeEqualsTrait;
 
-    protected \DateTime $dateTime;
-    protected \DateTime $dateTimeWithoutSeconds;
+    protected ?\DateTime $dateTime;
+    protected ?\DateTime $dateTimeWithoutSeconds;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

It looks like `tearDown()` methods sets properties null, which aren't nullable. 