### PR TITLE
[Translation] Add translation provider events

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+* Add `TranslationPullEvent` and `TranslationPushEvent`
+
 7.0
 ---
 

--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -44,7 +44,7 @@ final class TranslationPullCommand extends Command
     private array $enabledLocales;
     private ?EventDispatcherInterface $eventDispatcher;
 
-    public function __construct(TranslationProviderCollection $providerCollection, TranslationWriterInterface $writer, TranslationReaderInterface $reader, string $defaultLocale, array $transPaths = [], array $enabledLocales = [], ?EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(TranslationProviderCollection $providerCollection, TranslationWriterInterface $writer, TranslationReaderInterface $reader, string $defaultLocale, array $transPaths = [], array $enabledLocales = [], EventDispatcherInterface $eventDispatcher = null)
     {
         $this->providerCollection = $providerCollection;
         $this->writer = $writer;

--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation\Command;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
@@ -26,7 +27,6 @@ use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 use Symfony\Component\Translation\Reader\TranslationReaderInterface;
 use Symfony\Component\Translation\Writer\TranslationWriterInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -40,15 +40,15 @@ final class TranslationPushCommand extends Command
     private TranslationReaderInterface $reader;
     private array $transPaths;
     private array $enabledLocales;
-    private ?EventDispatcherInterface $eventDispatcher;
+    private ?EventDispatcherInterface $dispatcher;
 
-    public function __construct(TranslationProviderCollection $providers, TranslationReaderInterface $reader, array $transPaths = [], array $enabledLocales = [], ?EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(TranslationProviderCollection $providers, TranslationReaderInterface $reader, array $transPaths = [], array $enabledLocales = [], ?EventDispatcherInterface $dispatcher = null)
     {
         $this->providers = $providers;
         $this->reader = $reader;
         $this->transPaths = $transPaths;
         $this->enabledLocales = $enabledLocales;
-        $this->eventDispatcher = $eventDispatcher;
+        $this->dispatcher = $dispatcher;
 
         parent::__construct();
     }
@@ -141,7 +141,7 @@ EOF
         }
 
         if (!$deleteMissing && $force) {
-            $this->eventDispatcher?->dispatch(new TranslationPushEvent($localTranslations));
+            $this->dispatcher?->dispatch(new TranslationPushEvent($localTranslations));
 
             $provider->write($localTranslations);
 
@@ -168,7 +168,7 @@ EOF
             $translationsToWrite->addBag($localTranslations->intersect($providerTranslations));
         }
 
-        $this->eventDispatcher?->dispatch(new TranslationPushEvent($translationsToWrite));
+        $this->dispatcher?->dispatch(new TranslationPushEvent($translationsToWrite));
 
         $provider->write($translationsToWrite);
 

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation\Command;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
@@ -26,7 +27,6 @@ use Symfony\Component\Translation\Provider\FilteringProvider;
 use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 use Symfony\Component\Translation\Reader\TranslationReaderInterface;
 use Symfony\Component\Translation\TranslatorBag;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -42,7 +42,7 @@ final class TranslationPushCommand extends Command
     private array $enabledLocales;
     private ?EventDispatcherInterface $dispatcher;
 
-    public function __construct(TranslationProviderCollection $providers, TranslationReaderInterface $reader, array $transPaths = [], array $enabledLocales = [], ?EventDispatcherInterface $dispatcher = null)
+    public function __construct(TranslationProviderCollection $providers, TranslationReaderInterface $reader, array $transPaths = [], array $enabledLocales = [], EventDispatcherInterface $dispatcher = null)
     {
         $this->providers = $providers;
         $this->reader = $reader;

--- a/src/Symfony/Component/Translation/Event/AbstractTranslationEvent.php
+++ b/src/Symfony/Component/Translation/Event/AbstractTranslationEvent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Symfony/Component/Translation/Event/AbstractTranslationEvent.php
+++ b/src/Symfony/Component/Translation/Event/AbstractTranslationEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Event;
+
+use Symfony\Component\Translation\TranslatorBag;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+abstract class AbstractTranslationEvent extends Event
+{
+    public function __construct(
+        public readonly TranslatorBag $translatorBag,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Translation/Event/TranslationPullEvent.php
+++ b/src/Symfony/Component/Translation/Event/TranslationPullEvent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Symfony/Component/Translation/Event/TranslationPullEvent.php
+++ b/src/Symfony/Component/Translation/Event/TranslationPullEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Event;
+
+/**
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class TranslationPullEvent extends AbstractTranslationEvent
+{
+}

--- a/src/Symfony/Component/Translation/Event/TranslationPullEvent.php
+++ b/src/Symfony/Component/Translation/Event/TranslationPullEvent.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Symfony\Component\Translation\Event;
 
 /**
+ * This event will be dispatched by the translation:pull command just before the translations pulled from the provider
+ * are written to the filesystem.
+ *
  * @author wicliff <wicliff.wolda@gmail.com>
  */
 class TranslationPullEvent extends AbstractTranslationEvent

--- a/src/Symfony/Component/Translation/Event/TranslationPushEvent.php
+++ b/src/Symfony/Component/Translation/Event/TranslationPushEvent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Symfony/Component/Translation/Event/TranslationPushEvent.php
+++ b/src/Symfony/Component/Translation/Event/TranslationPushEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Event;
+
+/**
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class TranslationPushEvent extends AbstractTranslationEvent
+{
+}

--- a/src/Symfony/Component/Translation/Event/TranslationPushEvent.php
+++ b/src/Symfony/Component/Translation/Event/TranslationPushEvent.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Symfony\Component\Translation\Event;
 
 /**
+ * This event will be dispatched by the translation:push command just before the translations from the filesystem are
+ * pushed to the provider.
+ *
  * @author wicliff <wicliff.wolda@gmail.com>
  */
 class TranslationPushEvent extends AbstractTranslationEvent

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -731,12 +731,10 @@ XLIFF
         $dispatcher->expects(self::once())
             ->method('dispatch')->with(self::callback(static fn (TranslationPullEvent $event): bool => true));
 
-        $providerReadTranslatorBag = new TranslatorBag();
-
         $provider = $this->createMock(ProviderInterface::class);
         $provider->expects($this->once())
             ->method('read')
-            ->willReturn($providerReadTranslatorBag);
+            ->willReturn(new TranslatorBag());
 
         $tester = $this->createCommandTester(provider: $provider, dispatcher: $dispatcher);
 
@@ -763,7 +761,13 @@ XLIFF
 
     private function createCommandTester(ProviderInterface $provider, array $locales = ['en'], array $domains = ['messages'], $defaultLocale = 'en', EventDispatcherInterface $dispatcher = null): CommandTester
     {
-        $command = $this->createCommand(provider: $provider, locales: $locales, domains: $domains, defaultLocale: $defaultLocale, dispatcher: $dispatcher);
+        $command = $this->createCommand(
+            provider: $provider,
+            locales: $locales,
+            domains: $domains,
+            defaultLocale: $defaultLocale,
+            dispatcher: $dispatcher
+        );
         $application = new Application();
         $application->add($command);
 

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -761,13 +761,7 @@ XLIFF
 
     private function createCommandTester(ProviderInterface $provider, array $locales = ['en'], array $domains = ['messages'], $defaultLocale = 'en', EventDispatcherInterface $dispatcher = null): CommandTester
     {
-        $command = $this->createCommand(
-            provider: $provider,
-            locales: $locales,
-            domains: $domains,
-            defaultLocale: $defaultLocale,
-            dispatcher: $dispatcher
-        );
+        $command = $this->createCommand($provider, $locales, $domains, $defaultLocale, ['loco'], $dispatcher);
         $application = new Application();
         $application->add($command);
 
@@ -785,13 +779,13 @@ XLIFF
         $reader->addLoader('yml', new YamlFileLoader());
 
         return new TranslationPullCommand(
-            providerCollection: $this->getProviderCollection($provider, $providerNames, $locales, $domains),
-            writer: $writer,
-            reader: $reader,
-            defaultLocale: $defaultLocale,
-            transPaths: [$this->translationAppDir.'/translations'],
-            enabledLocales: $locales,
-            eventDispatcher: $dispatcher
+            $this->getProviderCollection($provider, $providerNames, $locales, $domains),
+            $writer,
+            $reader,
+            $defaultLocale,
+            [$this->translationAppDir.'/translations'],
+            $locales,
+            $dispatcher
         );
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -455,12 +455,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
     private function createCommandTester(ProviderInterface $provider, array $locales = ['en'], array $domains = ['messages'], EventDispatcherInterface $dispatcher = null): CommandTester
     {
-        $command = $this->createCommand(
-            provider: $provider,
-            locales: $locales,
-            domains: $domains,
-            dispatcher: $dispatcher
-        );
+        $command = $this->createCommand($provider, $locales, $domains, ['loco'], $dispatcher);
         $application = new Application();
         $application->add($command);
 

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -416,9 +416,12 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         $provider = $this->createMock(ProviderInterface::class);
         $provider->expects($this->once())
             ->method('read')
-            ->willReturn($providerReadTranslatorBag);
+            ->willReturn(new TranslatorBag());
 
-        $tester = $this->createCommandTester(provider: $provider, dispatcher: $dispatcher);
+        $tester = $this->createCommandTester(
+            provider: $provider,
+            dispatcher: $dispatcher
+        );
 
         $tester->execute($command);
     }
@@ -452,7 +455,12 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
     private function createCommandTester(ProviderInterface $provider, array $locales = ['en'], array $domains = ['messages'], EventDispatcherInterface $dispatcher = null): CommandTester
     {
-        $command = $this->createCommand(provider: $provider, locales: $locales, domains: $domains, dispatcher: $dispatcher);
+        $command = $this->createCommand(
+            provider: $provider,
+            locales: $locales,
+            domains: $domains,
+            dispatcher: $dispatcher
+        );
         $application = new Application();
         $application->add($command);
 

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -18,13 +18,15 @@
     "require": {
         "php": ">=8.2",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^2.5|^3.0"
+        "symfony/translation-contracts": "^2.5|^3.0",
+        "symfony/event-dispatcher-contracts": "^2.5|^3.0"
     },
     "require-dev": {
         "nikic/php-parser": "^4.13",
         "symfony/config": "^6.4|^7.0",
         "symfony/console": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
+        "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-client-contracts": "^2.5|^3.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/intl": "^6.4|^7.0",

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/event-dispatcher-contracts": "^2.5|^3.0",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^2.5|^3.0",
-        "symfony/event-dispatcher-contracts": "^2.5|^3.0"
+        "symfony/translation-contracts": "^2.5|^3.0"
     },
     "require-dev": {
         "nikic/php-parser": "^4.13",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49520
| License       | MIT

two new events to allow mutation of the translator bag just before it's send to the provider or written to the filesystem.
briefly discussed over here: https://github.com/symfony/symfony/pull/49231#discussion_r1113623448