### PR TITLE
[Tests] Use `unset()` instead of nullable properties

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
@@ -18,8 +18,8 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToValueTransform
 
 class ChoiceToValueTransformerTest extends TestCase
 {
-    protected ?ChoiceToValueTransformer $transformer;
-    protected ?ChoiceToValueTransformer $transformerWithNull;
+    protected ChoiceToValueTransformer $transformer;
+    protected ChoiceToValueTransformer $transformerWithNull;
 
     protected function setUp(): void
     {
@@ -32,8 +32,8 @@ class ChoiceToValueTransformerTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->transformer = null;
-        $this->transformerWithNull = null;
+        unset($this->transformer);
+        unset($this->transformerWithNull);
     }
 
     public static function transformProvider(): array

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -20,8 +20,8 @@ class DateTimeToRfc3339TransformerTest extends BaseDateTimeTransformerTestCase
 {
     use DateTimeEqualsTrait;
 
-    protected ?\DateTime $dateTime;
-    protected ?\DateTime $dateTimeWithoutSeconds;
+    protected \DateTime $dateTime;
+    protected \DateTime $dateTimeWithoutSeconds;
 
     protected function setUp(): void
     {
@@ -33,8 +33,8 @@ class DateTimeToRfc3339TransformerTest extends BaseDateTimeTransformerTestCase
 
     protected function tearDown(): void
     {
-        $this->dateTime = null;
-        $this->dateTimeWithoutSeconds = null;
+        unset($this->dateTime);
+        unset($this->dateTimeWithoutSeconds);
     }
 
     public static function allProvider(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

Follows
* #52374