### PR TITLE
DX: PHP CS Fixer - keep Annotation,NamedArgumentConstructor,Target annotations as single group

### DIFF
--- a/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
+++ b/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
@@ -27,7 +27,7 @@ interface SignalableCommandInterface
      * The method will be called when the application is signaled.
      *
      * @param int|false $previousExitCode
-
+     *
      * @return int|false The exit code to return or false to continue the normal execution
      */
     public function handleSignal(int $signal, /* int|false $previousExitCode = 0 */);

--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -45,7 +45,6 @@ namespace Symfony\Component\Validator\Constraints;
  *     $validator->validate($address, null, "Address")
  *
  * @Annotation
- *
  * @Target({"CLASS", "ANNOTATION"})
  *
  * @author Bernhard Schussek <bschussek@gmail.com>

--- a/src/Symfony/Component/Validator/Constraints/GroupSequenceProvider.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequenceProvider.php
@@ -18,9 +18,7 @@ use Symfony\Component\Validator\Attribute\HasNamedArguments;
  * Attribute to define a group sequence provider.
  *
  * @Annotation
- *
  * @NamedArgumentConstructor
- *
  * @Target({"CLASS", "ANNOTATION"})
  *
  * @author Bernhard Schussek <bschussek@gmail.com>

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
@@ -16,7 +16,6 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @Annotation
- *
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Florent Morselli <florent.morselli@spomky-labs.com>

--- a/src/Symfony/Component/Validator/Constraints/When.php
+++ b/src/Symfony/Component/Validator/Constraints/When.php
@@ -18,7 +18,6 @@ use Symfony\Component\Validator\Exception\LogicException;
 
 /**
  * @Annotation
- *
  * @Target({"CLASS", "PROPERTY", "METHOD", "ANNOTATION"})
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix CS <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

it's already there for majority of files, except those few