### PR TITLE
Remove unused code from Process

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -77,7 +77,6 @@ class Process implements \IteratorAggregate
     private bool $pty;
     private array $options = ['suppress_errors' => true, 'bypass_shell' => true];
 
-    private bool $useFileHandles;
     private WindowsPipes|UnixPipes $processPipes;
 
     private ?int $latestSignal = null;
@@ -163,7 +162,6 @@ class Process implements \IteratorAggregate
 
         $this->setInput($input);
         $this->setTimeout($timeout);
-        $this->useFileHandles = '\\' === \DIRECTORY_SEPARATOR;
         $this->pty = false;
     }
 
@@ -325,7 +323,7 @@ class Process implements \IteratorAggregate
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $commandline = $this->prepareWindowsCommandLine($commandline, $env);
-        } elseif (!$this->useFileHandles && $this->isSigchildEnabled()) {
+        } elseif ($this->isSigchildEnabled()) {
             // last exit code is output on the fourth pipe and caught to work around --enable-sigchild
             $descriptors[3] = ['pipe', 'w'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

While trying to work on https://github.com/symfony/symfony/issues/43162#issuecomment-1787670224 I noticed that the private member `useFileHandles` is not used for anything anymore.
It is always set in the constructor to `'\\' === \DIRECTORY_SEPARATOR` so it basically has a constant value and its only usage is in an `elseif` after a check to the very same constant value: `if ('\\' === \DIRECTORY_SEPARATOR)`.
Therefore this code does nothing and can be removed.