### PR TITLE
[Process] Fix memory limit in `PhpSubprocess` test

### DIFF
--- a/src/Symfony/Component/Process/Tests/PhpSubprocessTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpSubprocessTest.php
@@ -47,7 +47,7 @@ class PhpSubprocessTest extends TestCase
         yield 'Process does ignore dynamic memory_limit' => [
             'Process',
             self::getRandomMemoryLimit(),
-            self::getCurrentMemoryLimit(),
+            self::getDefaultMemoryLimit(),
         ];
 
         yield 'PhpSubprocess does not ignore dynamic memory_limit' => [
@@ -57,16 +57,16 @@ class PhpSubprocessTest extends TestCase
         ];
     }
 
-    private static function getCurrentMemoryLimit(): string
+    private static function getDefaultMemoryLimit(): string
     {
-        return trim(\ini_get('memory_limit'));
+        return trim(ini_get_all()['memory_limit']['global_value']);
     }
 
     private static function getRandomMemoryLimit(): string
     {
         $memoryLimit = 123; // Take something that's really unlikely to be configured on a user system.
 
-        while (($formatted = $memoryLimit.'M') === self::getCurrentMemoryLimit()) {
+        while (($formatted = $memoryLimit.'M') === self::getDefaultMemoryLimit()) {
             ++$memoryLimit;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

If your local `memory_limit` php configuration differs from the setting in the *phpunit.xml.dist* file https://github.com/symfony/symfony/blob/f46299957cd6d7f83e3ed62f890db20674f22ee0/phpunit.xml.dist#L15 the test always fails as the *src/Symfony/Component/Process/Tests/Fixtures/memory.php* file does not load the phpunit config.

/cc @Toflar 