### PR TITLE
[Serializer] Fix issue related to handling namespace attributes in the `XmlEncoder` class

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -261,33 +261,31 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     /**
      * Parse the input DOMNode attributes into an array.
      */
-    private function parseXmlAttributes(\DOMNode $node, array $context = []): array
-    {
-        if (!$node->hasAttributes()) {
-            return [];
-        }
-
-        $data = [];
-        $typeCastAttributes = (bool) ($context[self::TYPE_CAST_ATTRIBUTES] ?? $this->defaultContext[self::TYPE_CAST_ATTRIBUTES]);
-
-        foreach ($node->attributes as $attr) {
-            if (!is_numeric($attr->nodeValue) || !$typeCastAttributes || (isset($attr->nodeValue[1]) && '0' === $attr->nodeValue[0] && '.' !== $attr->nodeValue[1])) {
-                $data['@'.$attr->nodeName] = $attr->nodeValue;
-
-                continue;
-            }
-
-            if (false !== $val = filter_var($attr->nodeValue, \FILTER_VALIDATE_INT)) {
-                $data['@'.$attr->nodeName] = $val;
-
-                continue;
-            }
-
-            $data['@'.$attr->nodeName] = (float) $attr->nodeValue;
-        }
-
-        return $data;
+   private function parseXmlAttributes(\DOMNode $node, array $context = []): array
+{
+    if (!$node->hasAttributes()) {
+        return [];
     }
+
+    $data = [];
+    $typeCastAttributes = (bool) ($context[self::TYPE_CAST_ATTRIBUTES] ?? $this->defaultContext[self::TYPE_CAST_ATTRIBUTES]);
+
+    foreach ($node->attributes as $attr) {
+        // Check if the attribute has a namespace
+        $name = $attr->prefix ? $attr->prefix . ':' . $attr->localName : $attr->localName;
+        if (!is_numeric($attr->nodeValue) || !$typeCastAttributes || (isset($attr->nodeValue[1]) && '0' === $attr->nodeValue[0] && '.' !== $attr->nodeValue[1])) {
+            $data['@' . $name] = $attr->nodeValue;
+        } else {
+            if (false !== $val = filter_var($attr->nodeValue, \FILTER_VALIDATE_INT)) {
+                $data['@' . $name] = $val;
+            } else {
+                $data['@' . $name] = (float) $attr->nodeValue;
+            }
+        }
+    }
+
+    return $data;
+}
 
     /**
      * Parse the input DOMNode value (content and children) into an array or a string.

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -400,6 +400,18 @@ XML;
 
         $this->assertEquals($source, $this->encoder->encode($array, 'xml'));
     }
+    public function testParseXmlAttributesWithNamespace()
+    {
+        $encoder = new XmlEncoder();
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+                <root xmlns:ns="http://example.com" ns:attribute="value"></root>';
+
+        $data = $encoder->decode($xml, 'xml');
+
+        $this->assertEquals(['@xmlns:ns' => 'http://example.com', '@ns:attribute' => 'value'], $data);
+    }
+
 
     public function testEncodeSerializerXmlRootNodeNameOption()
     {
@@ -473,6 +485,8 @@ XML;
 
         $this->assertEquals($array, $this->encoder->decode($source, 'xml'));
     }
+
+    
 
     public function testDecodeScalarWithAttribute()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

The XmlEncoder in Symfony does not parse the namespace for a node without children, resulting in invalid XML when encoding. The suggested solution is to modify the XmlEncoder::parseXmlAttributes method to fetch the namespace from the node if it has one.