### PR TITLE
[Validator] Fix `Constraints\Email::ERROR_NAMES`

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -32,7 +32,7 @@ class Email extends Constraint
     public const INVALID_FORMAT_ERROR = 'bd79c0ab-ddba-46cc-a703-a7a4b08de310';
 
     protected static $errorNames = [
-        self::INVALID_FORMAT_ERROR => 'STRICT_CHECK_FAILED_ERROR',
+        self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',
     ];
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

`Constraint\Email::ERROR_NAMES` contains `"STRICT_CHECK_FAILED_ERROR"` but there's no constant with that name, it's `"INVALID_FORMAT_ERROR"`
