### PR TITLE
[Process] Pass the commandline as array to `proc_open()`

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -327,7 +327,12 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
             'KEY_FILE' => __DIR__.'/Fixtures/tls/server.key',
             'CERT_FILE' => __DIR__.'/Fixtures/tls/server.crt',
         ]);
-        $process->start();
+
+        try {
+            $process->start();
+        } catch (ProcessFailedException $e) {
+            self::markTestSkipped('vulcain failed: '.$e->getMessage());
+        }
 
         register_shutdown_function($process->stop(...));
         sleep('\\' === \DIRECTORY_SEPARATOR ? 10 : 1);

--- a/src/Symfony/Component/Process/Exception/ProcessStartFailedException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessStartFailedException.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Exception;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Exception for processes failed during startup.
+ */
+class ProcessStartFailedException extends ProcessFailedException
+{
+    private Process $process;
+
+    public function __construct(Process $process, ?string $message)
+    {
+        if ($process->isStarted()) {
+            throw new InvalidArgumentException('Expected a process that failed during startup, but the given process was started successfully.');
+        }
+
+        $error = sprintf('The command "%s" failed.'."\n\nWorking directory: %s\n\nError: %s",
+            $process->getCommandLine(),
+            $process->getWorkingDirectory(),
+            $message ?? 'unknown'
+        );
+
+        // Skip parent constructor
+        RuntimeException::__construct($error);
+
+        $this->process = $process;
+    }
+
+    public function getProcess(): Process
+    {
+        return $this->process;
+    }
+}

--- a/src/Symfony/Component/Process/Messenger/RunProcessContext.php
+++ b/src/Symfony/Component/Process/Messenger/RunProcessContext.php
@@ -27,7 +27,7 @@ final class RunProcessContext
         Process $process,
     ) {
         $this->exitCode = $process->getExitCode();
-        $this->output = $process->isOutputDisabled() ? null : $process->getOutput();
-        $this->errorOutput = $process->isOutputDisabled() ? null : $process->getErrorOutput();
+        $this->output = !$process->isStarted() || $process->isOutputDisabled() ? null : $process->getOutput();
+        $this->errorOutput = !$process->isStarted() || $process->isOutputDisabled() ? null : $process->getErrorOutput();
     }
 }

--- a/src/Symfony/Component/Process/Tests/Messenger/RunProcessMessageHandlerTest.php
+++ b/src/Symfony/Component/Process/Tests/Messenger/RunProcessMessageHandlerTest.php
@@ -33,7 +33,11 @@ class RunProcessMessageHandlerTest extends TestCase
             (new RunProcessMessageHandler())(new RunProcessMessage(['invalid']));
         } catch (RunProcessFailedException $e) {
             $this->assertSame(['invalid'], $e->context->message->command);
-            $this->assertSame('\\' === \DIRECTORY_SEPARATOR ? 1 : 127, $e->context->exitCode);
+            $this->assertContains(
+                $e->context->exitCode,
+                [null, '\\' === \DIRECTORY_SEPARATOR ? 1 : 127],
+                'Exit code should be 1 on Windows, 127 on other systems, or null',
+            );
 
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/43162#issuecomment-931145776
| License       | MIT

Since PHP 7.4, `proc_open()` accepts an array which makes it twice as fast (4x as fast with PHP 8.3), see https://github.com/symfony/symfony/issues/43162#issuecomment-1787670224

This pull request enables calling `proc_open()` with an array if:

1. `$this->commandline` is an array
2. and we are not on Windows
3. and PHP was compiled without `--enable-sigchild`