### PR TITLE
[RateLimiter] Fix reservations outside the second fixed window

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -77,7 +77,9 @@ final class Window implements LimiterStateInterface
             return 0;
         }
 
-        return (int) ceil($this->timer + $this->intervalInSeconds - $now);
+        $inWindow = (int) ceil(($this->hitCount + $tokens) / $this->maxSize) - 1;
+
+        return (int) ceil($this->timer + ($this->intervalInSeconds * $inWindow) - $now);
     }
 
     public function __serialize(): array

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -76,6 +76,39 @@ class FixedWindowLimiterTest extends TestCase
         $this->assertTrue($rateLimit->isAccepted());
     }
 
+    public function testReserveOutsideWindow()
+    {
+        $limiter = $this->createLimiter();
+
+        // initial reserve
+        $limiter->reserve(10);
+
+        // Reserve the first window and the second window
+        $firstReservation = $limiter->reserve(10);
+        $secondReservation = $limiter->reserve(10);
+
+        $this->assertFalse($firstReservation->getRateLimit()->isAccepted());
+        $this->assertFalse($secondReservation->getRateLimit()->isAccepted());
+        $this->assertEquals(60, ceil($firstReservation->getWaitDuration()));
+        $this->assertEquals(120, ceil($secondReservation->getWaitDuration()));
+    }
+
+    public function testReservePartiallyFilledWindow()
+    {
+        $limiter = $this->createLimiter();
+
+        $limiter->reserve(10);
+        $first = $limiter->reserve(5);
+        $second = $limiter->reserve(3);
+        $third = $limiter->reserve(5);
+
+        $this->assertEquals(60, ceil($first->getWaitDuration()));
+        // 3 more tokens still fit in the second window (5 + 3 = 8 <= 10)
+        $this->assertEquals(60, ceil($second->getWaitDuration()));
+        // these 5 tokens overflow into the third window (8 + 5 = 13 > 10)
+        $this->assertEquals(120, ceil($third->getWaitDuration()));
+    }
+
     public function testWaitIntervalOnConsumeOverLimit()
     {
         $limiter = $this->createLimiter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using `FixedWindowLimiter::reserve()` to reserve more tokens than the current window has available, `Window::calculateTimeForTokens()` must tell the caller how long to wait before a window with enough capacity opens.

The original formula (`$this->timer + $this->intervalInSeconds - $now`) always returned the time until the end of the *first* window, regardless of how far ahead the reservations overflow. Reserving 3× the window size would give the same wait time for the 2nd and 3rd batch.

Using `$this->hitCount + $tokens` (not just `$this->hitCount`) ensures that tokens which still fit within a partially-filled overflow window don't get pushed to the next one.

**Example** (limit=10, interval=60s, all reserves at t=0):

| Action | hitCount after | Wait (old) | Wait (fixed) |
|---|---|---|---|
| `reserve(10)` | 10 | 0 | 0 |
| `reserve(10)` | 20 | 60 | 60 |
| `reserve(10)` | 30 | 60 ❌ | 120 ✅ |
| `reserve(5)` then `reserve(3)` | 18 | 60, 60 | 60, 60 ✅ (both fit in window 2) |
| `reserve(5)` then `reserve(3)` then `reserve(5)` | 23 | 60, 60, 60 | 60, 60, 120 ✅ (last overflows to window 3) |