### PR TITLE
[Messenger] Dispatch events before & after each handler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -82,6 +82,8 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 abstract_arg('bus handler resolver'),
+                false,
+                service('event_dispatcher'),
             ])
             ->tag('monolog.logger', ['channel' => 'messenger'])
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -111,6 +111,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('bus handler resolver'),
                 false,
                 service('clock')->nullOnInvalid(),
+                service('event_dispatcher'),
             ])
             ->tag('monolog.logger', ['channel' => 'messenger'])
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+* New events: `HandlerStartingEvent`, `HandlerSuccessEvent`, `HandlerFailureEvent`
+
 7.0
 ---
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `HandlerStartingEvent`, `HandlerSuccessEvent` and `HandlerFailureEvent`, dispatched around each handler call
  * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
  * Add `--failed-after` and `--failed-before` options to the `messenger:failed:retry`, `messenger:failed:remove` and `messenger:failed:show` commands, and a `--class-filter` option to `messenger:failed:retry`
  * `RedispatchMessage` now dispatches to the senders configured for the message (routing config or `#[AsMessage]`) when `$transportNames` is empty, instead of sending to no sender at all

--- a/src/Symfony/Component/Messenger/Event/AbstractHandlerEvent.php
+++ b/src/Symfony/Component/Messenger/Event/AbstractHandlerEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+
+abstract class AbstractHandlerEvent
+{
+    public function __construct(
+        public readonly Envelope $envelope,
+        public readonly HandlerDescriptor $handlerDescriptor,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Messenger/Event/HandlerFailureEvent.php
+++ b/src/Symfony/Component/Messenger/Event/HandlerFailureEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+
+/**
+ * Event dispatched after a handler fails.
+ */
+final class HandlerFailureEvent extends AbstractHandlerEvent
+{
+    public function __construct(
+        Envelope $envelope,
+        HandlerDescriptor $handlerDescriptor,
+        public readonly \Throwable $exception,
+    ) {
+        parent::__construct($envelope, $handlerDescriptor);
+    }
+}

--- a/src/Symfony/Component/Messenger/Event/HandlerFailureEvent.php
+++ b/src/Symfony/Component/Messenger/Event/HandlerFailureEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+
+/**
+ * Event dispatched after a handler fails.
+ */
+final class HandlerFailureEvent
+{
+    public function __construct(
+        public readonly Envelope $envelope,
+        public readonly HandlerDescriptor $handlerDescriptor,
+        public readonly \Throwable $exception,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Messenger/Event/HandlerStartingEvent.php
+++ b/src/Symfony/Component/Messenger/Event/HandlerStartingEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+/**
+ * Event dispatched before a handler is called.
+ */
+final class HandlerStartingEvent extends AbstractHandlerEvent
+{
+}

--- a/src/Symfony/Component/Messenger/Event/HandlerStartingEvent.php
+++ b/src/Symfony/Component/Messenger/Event/HandlerStartingEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+
+/**
+ * Event dispatched before a handler is called.
+ */
+final class HandlerStartingEvent
+{
+    public function __construct(
+        public readonly Envelope $envelope,
+        public readonly HandlerDescriptor $handlerDescriptor,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Messenger/Event/HandlerSuccessEvent.php
+++ b/src/Symfony/Component/Messenger/Event/HandlerSuccessEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+/**
+ * Event dispatched after a handler succeeds.
+ */
+final class HandlerSuccessEvent extends AbstractHandlerEvent
+{
+}

--- a/src/Symfony/Component/Messenger/Event/HandlerSuccessEvent.php
+++ b/src/Symfony/Component/Messenger/Event/HandlerSuccessEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+
+/**
+ * Event dispatched after a handler succeeds.
+ */
+final class HandlerSuccessEvent
+{
+    public function __construct(
+        public readonly Envelope $envelope,
+        public readonly HandlerDescriptor $handlerDescriptor,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -12,8 +12,12 @@
 namespace Symfony\Component\Messenger\Middleware;
 
 use Psr\Clock\ClockInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\HandlerFailureEvent;
+use Symfony\Component\Messenger\Event\HandlerStartingEvent;
+use Symfony\Component\Messenger\Event\HandlerSuccessEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
@@ -37,6 +41,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
         private HandlersLocatorInterface $handlersLocator,
         private bool $allowNoHandlers = false,
         private ?ClockInterface $clock = null,
+        private ?EventDispatcherInterface $dispatcher = null,
     ) {
     }
 
@@ -60,16 +65,25 @@ class HandleMessageMiddleware implements MiddlewareInterface
                 continue;
             }
 
+            $this->dispatcher?->dispatch(new HandlerStartingEvent($envelope, $handlerDescriptor));
+
+            $e = null;
+            $ack = null;
+            $ackPending = false;
+
             try {
                 $handler = $handlerDescriptor->getHandler();
                 $batchHandler = $handlerDescriptor->getBatchHandler();
 
                 if ($batchHandler && $ackStamp = $envelope->last(AckStamp::class)) {
-                    $ack = new Acknowledger(get_debug_type($batchHandler), static function (?\Throwable $e = null, $result = null) use ($envelope, $ackStamp, $handlerDescriptor) {
+                    $dispatcher = $this->dispatcher;
+                    $ack = new Acknowledger(get_debug_type($batchHandler), static function (?\Throwable $e = null, $result = null) use ($envelope, $ackStamp, $handlerDescriptor, $dispatcher) {
                         if (null !== $e) {
+                            $dispatcher?->dispatch(new HandlerFailureEvent($envelope, $handlerDescriptor, $e));
                             $e = new HandlerFailedException($envelope, [$handlerDescriptor->getName() => $e]);
                         } else {
                             $envelope = $envelope->with(HandledStamp::fromDescriptor($handlerDescriptor, $result));
+                            $dispatcher?->dispatch(new HandlerSuccessEvent($envelope, $handlerDescriptor));
                         }
 
                         $ackStamp->ack($envelope, $e);
@@ -82,6 +96,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                     }
 
                     if (!$ack->isAcknowledged()) {
+                        $ackPending = true;
                         $envelope = $envelope->with(new NoAutoAckStamp($handlerDescriptor));
                     } elseif ($ack->getError()) {
                         throw $ack->getError();
@@ -97,6 +112,16 @@ class HandleMessageMiddleware implements MiddlewareInterface
                 $this->logger?->info('Message {class} handled by {handler}', $context + ['handler' => $handledStamp->getHandlerName()]);
             } catch (\Throwable $e) {
                 $exceptions[$handlerDescriptor->getName()] = $e;
+            }
+
+            // a batch handler resolves its outcome through the acknowledger, at flush time
+            // at the earliest, and the event is then dispatched by the callback above
+            if (null !== $this->dispatcher && !$ack?->isAcknowledged()) {
+                if (null !== $e) {
+                    $this->dispatcher->dispatch(new HandlerFailureEvent($envelope, $handlerDescriptor, $e));
+                } elseif (!$ackPending) {
+                    $this->dispatcher->dispatch(new HandlerSuccessEvent($envelope, $handlerDescriptor));
+                }
             }
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -12,7 +12,11 @@
 namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\HandlerFailureEvent;
+use Symfony\Component\Messenger\Event\HandlerStartingEvent;
+use Symfony\Component\Messenger\Event\HandlerSuccessEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
@@ -438,6 +442,195 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
 
         $middleware->handle($envelope, $this->getStackMock());
     }
+
+    public function testDispatchHandlerEvents()
+    {
+        $message = new DummyMessage('Hey');
+        $envelope = new Envelope($message);
+
+        $successHandler = $this->createMock(HandleMessageMiddlewareTestCallable::class);
+        $successHandler->expects($this->once())->method('__invoke');
+
+        $failureHandler = $this->createMock(HandleMessageMiddlewareTestCallable::class);
+        $failureHandler->expects($this->once())->method('__invoke')->willThrowException(
+            $exception = new \RuntimeException('Handler failed'),
+        );
+
+        $handlersLocator = new HandlersLocator([
+            DummyMessage::class => [
+                $successHandlerDescriptor = new HandlerDescriptor($successHandler, ['alias' => 'successHandler']),
+                $failureHandlerDescriptor = new HandlerDescriptor($failureHandler, ['alias' => 'failureHandler']),
+            ],
+        ]);
+
+        $dispatcher = new RecordingHandlerEventDispatcher();
+        $middleware = new HandleMessageMiddleware($handlersLocator, dispatcher: $dispatcher);
+
+        try {
+            $middleware->handle($envelope, new StackMiddleware());
+            $this->fail('The failing handler should bubble up as a HandlerFailedException.');
+        } catch (HandlerFailedException) {
+        }
+
+        $events = $dispatcher->events;
+        $this->assertCount(4, $events);
+
+        $this->assertInstanceOf(HandlerStartingEvent::class, $events[0]);
+        $this->assertSame($successHandlerDescriptor, $events[0]->handlerDescriptor);
+
+        $this->assertInstanceOf(HandlerSuccessEvent::class, $events[1]);
+        $this->assertSame($successHandlerDescriptor, $events[1]->handlerDescriptor);
+        $this->assertSame($successHandlerDescriptor->getName(), $events[1]->envelope->last(HandledStamp::class)->getHandlerName());
+
+        $this->assertInstanceOf(HandlerStartingEvent::class, $events[2]);
+        $this->assertSame($failureHandlerDescriptor, $events[2]->handlerDescriptor);
+
+        $this->assertInstanceOf(HandlerFailureEvent::class, $events[3]);
+        $this->assertSame($failureHandlerDescriptor, $events[3]->handlerDescriptor);
+        $this->assertSame($exception, $events[3]->exception);
+    }
+
+    public function testBatchHandlerOutcomeEventsAreDispatchedWhenTheBatchIsFlushed()
+    {
+        $handler = new class implements BatchHandlerInterface {
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function getBatchSize(): int
+            {
+                return 2;
+            }
+
+            private function process(array $jobs): void
+            {
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->ack($job);
+                }
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]), dispatcher: $dispatcher = new RecordingHandlerEventDispatcher());
+
+        $first = new DummyMessage('Hey');
+        $second = new DummyMessage('Bob');
+        $ack = static function () {};
+
+        $middleware->handle(new Envelope($first, [new AckStamp($ack)]), new StackMiddleware());
+
+        // the message is only queued at this point: no outcome yet
+        $this->assertCount(1, $dispatcher->events);
+        $this->assertInstanceOf(HandlerStartingEvent::class, $dispatcher->events[0]);
+
+        // the second message fills the batch, which flushes both
+        $middleware->handle(new Envelope($second, [new AckStamp($ack)]), new StackMiddleware());
+
+        $events = $dispatcher->events;
+        $this->assertCount(4, $events);
+        $this->assertInstanceOf(HandlerStartingEvent::class, $events[1]);
+        $this->assertInstanceOf(HandlerSuccessEvent::class, $events[2]);
+        $this->assertSame($first, $events[2]->envelope->getMessage());
+        $this->assertSame($first, $events[2]->envelope->last(HandledStamp::class)->getResult());
+        $this->assertInstanceOf(HandlerSuccessEvent::class, $events[3]);
+        $this->assertSame($second, $events[3]->envelope->getMessage());
+    }
+
+    public function testBatchHandlerFailureIsDispatchedOnceWithTheHandlerException()
+    {
+        $handler = new class implements BatchHandlerInterface {
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function getBatchSize(): int
+            {
+                return 1;
+            }
+
+            private function process(array $jobs): void
+            {
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->nack(new \RuntimeException('nacked'));
+                }
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]), dispatcher: $dispatcher = new RecordingHandlerEventDispatcher());
+
+        try {
+            $middleware->handle(new Envelope(new DummyMessage('Hey'), [new AckStamp(static function () {})]), new StackMiddleware());
+            $this->fail('The nacked batch should bubble up as a HandlerFailedException.');
+        } catch (HandlerFailedException) {
+        }
+
+        $events = $dispatcher->events;
+        $this->assertCount(2, $events);
+        $this->assertInstanceOf(HandlerStartingEvent::class, $events[0]);
+        $this->assertInstanceOf(HandlerFailureEvent::class, $events[1]);
+        $this->assertSame('nacked', $events[1]->exception->getMessage());
+    }
+
+    public function testHandlerOutcomeEventIsDispatchedWhenAPreviousBatchIsFlushedMeanwhile()
+    {
+        $batchHandler = new class implements BatchHandlerInterface {
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function getBatchSize(): int
+            {
+                return 2;
+            }
+
+            private function process(array $jobs): void
+            {
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->ack($job);
+                }
+            }
+        };
+
+        $flushingHandler = static function (DummyMessage $message) use ($batchHandler) {
+            $batchHandler->flush(true);
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [
+                $batchDescriptor = new HandlerDescriptor($batchHandler, ['alias' => 'batchHandler']),
+                $flushingDescriptor = new HandlerDescriptor($flushingHandler, ['alias' => 'flushingHandler']),
+            ],
+        ]), dispatcher: $dispatcher = new RecordingHandlerEventDispatcher());
+
+        $middleware->handle(new Envelope(new DummyMessage('Hey'), [new AckStamp(static function () {})]), new StackMiddleware());
+
+        $events = $dispatcher->events;
+        $this->assertCount(4, $events);
+
+        $this->assertInstanceOf(HandlerStartingEvent::class, $events[0]);
+        $this->assertSame($batchDescriptor, $events[0]->handlerDescriptor);
+
+        $this->assertInstanceOf(HandlerStartingEvent::class, $events[1]);
+        $this->assertSame($flushingDescriptor, $events[1]->handlerDescriptor);
+
+        $this->assertInstanceOf(HandlerSuccessEvent::class, $events[2]);
+        $this->assertSame($batchDescriptor, $events[2]->handlerDescriptor);
+
+        $this->assertInstanceOf(HandlerSuccessEvent::class, $events[3]);
+        $this->assertSame($flushingDescriptor, $events[3]->handlerDescriptor);
+    }
 }
 
 class HandleMessageMiddlewareTestCallable
@@ -451,5 +644,16 @@ class HandleMessageMiddlewareNamedArgumentTestCallable
 {
     public function __invoke(object $message, $namedArgument)
     {
+    }
+}
+
+class RecordingHandlerEventDispatcher implements EventDispatcherInterface
+{
+    /** @var list<object> */
+    public array $events = [];
+
+    public function dispatch(object $event): object
+    {
+        return $this->events[] = $event;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`HandleMessageMiddleware` now dispatches three events around each handler call:

- `HandlerStartingEvent`, right before the handler is invoked;
- `HandlerSuccessEvent`, once the handler succeeded;
- `HandlerFailureEvent`, once it failed, carrying the exception.

The worker events (`WorkerMessageHandledEvent`, `WorkerMessageFailedEvent`) are per message, only fire for messages consumed by a worker, and report several handlers as one aggregated outcome. These events are per handler, fire for sync and async dispatch alike, and carry the `HandlerDescriptor`, so auditing each handler run no longer requires diffing `HandledStamp`s and unwrapping `HandlerFailedException`.

For a **batch handler**, the outcome does not exist when the message is enqueued: it resolves through the `Acknowledger`, at flush time at the earliest. `HandlerStartingEvent` is dispatched when the handler is invoked, and the outcome event is dispatched by the acknowledger callback once the result or error is known, whether the handler acknowledges synchronously or at a later flush. Every handler run gets exactly one outcome event.

The events are dispatched on the `event_dispatcher` service wired by FrameworkBundle. Standalone users pass a `Psr\EventDispatcher\EventDispatcherInterface` as the fourth constructor argument of `HandleMessageMiddleware`; with none, no event is dispatched and nothing changes.

Documentation should cover: the three events and their properties, the per-handler versus per-message distinction with the worker events, that they fire for sync dispatch too, and the batch-handler timing (outcome at acknowledgment, not at enqueue).
