### PR TITLE
[HttpKernel] the debug log processor must be a callable

### DIFF
--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
@@ -18,12 +18,12 @@ use Monolog\Logger;
  */
 class DebugLoggerConfigurator
 {
-    private ?DebugLoggerInterface $processor = null;
+    private ?\Closure $processor = null;
 
-    public function __construct(DebugLoggerInterface $processor, bool $enable = null)
+    public function __construct(callable $processor, bool $enable = null)
     {
         if ($enable ?? !\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-            $this->processor = $processor;
+            $this->processor = $processor(...);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

A Monolog processor must be a callable, but a `DebugLoggerInterface` implementation is not necessarily a callable.
