### PR TITLE
[HttpKernel] Preventing error 500 when function putenv is disabled

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -778,7 +778,9 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             $this->startTime = microtime(true);
         }
         if ($this->debug && !isset($_ENV['SHELL_VERBOSITY']) && !isset($_SERVER['SHELL_VERBOSITY'])) {
-            putenv('SHELL_VERBOSITY=3');
+            if (\function_exists('putenv')) {
+                putenv('SHELL_VERBOSITY=3');
+            }
             $_ENV['SHELL_VERBOSITY'] = 3;
             $_SERVER['SHELL_VERBOSITY'] = 3;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

**Description:**
Some webhostings are blocking function "**putenv**". So, it will show error 500 Error (UndefinedFunction) with text:
Attempted to call function "putenv" from namespace "Symfony\Component\HttpKernel

This PR is checking callability of putenv first, so preventing error 500.

**How to test?**
  -> php.ini - disabled_functions=putenv
  -> enable debug
  - >Then you will see error 500
  -> After this PR/commit, it's without problem.

For example it's very common problem for PrestaShop users. (PrestaShop is using Symfony)
