### PR TITLE
[HttpClient] Replace `escapeshellarg` to prevent overpassing `ARG_MAX`

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Symfony\Component\Process\Process;
 use Symfony\Component\VarDumper\Caster\ImgStub;
 
 /**
@@ -193,27 +194,14 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
         $dataArg = [];
 
         if ($json = $trace['options']['json'] ?? null) {
-            if (!$this->argMaxLengthIsSafe($payload = self::jsonEncode($json))) {
-                return null;
-            }
-            $dataArg[] = '--data '.escapeshellarg($payload);
+            $dataArg[] = '--data-raw '.$this->escapePayload(self::jsonEncode($json));
         } elseif ($body = $trace['options']['body'] ?? null) {
             if (\is_string($body)) {
-                if (!$this->argMaxLengthIsSafe($body)) {
-                    return null;
-                }
-                try {
-                    $dataArg[] = '--data '.escapeshellarg($body);
-                } catch (\ValueError) {
-                    return null;
-                }
+                $dataArg[] = '--data-raw '.$this->escapePayload($body);
             } elseif (\is_array($body)) {
                 $body = explode('&', self::normalizeBody($body));
                 foreach ($body as $value) {
-                    if (!$this->argMaxLengthIsSafe($payload = urldecode($value))) {
-                        return null;
-                    }
-                    $dataArg[] = '--data '.escapeshellarg($payload);
+                    $dataArg[] = '--data-raw '.$this->escapePayload(urldecode($value));
                 }
             } else {
                 return null;
@@ -250,13 +238,18 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
         return implode(" \\\n  ", $command);
     }
 
-    /**
-     * Let's be defensive : we authorize only size of 8kio on Windows for escapeshellarg() argument to avoid a fatal error.
-     *
-     * @see https://github.com/php/php-src/blob/9458f5f2c8a8e3d6c65cc181747a5a75654b7c6e/ext/standard/exec.c#L397
-     */
-    private function argMaxLengthIsSafe(string $payload): bool
+    private function escapePayload(string $payload): string
     {
-        return \strlen($payload) < ('\\' === \DIRECTORY_SEPARATOR ? 8100 : 256000);
+        static $useProcess;
+
+        if ($useProcess ??= class_exists(Process::class)) {
+            return (new Process([$payload]))->getCommandLine();
+        }
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            return '"'.str_replace('"', '""', $payload).'"';
+        }
+
+        return "'".str_replace("'", "'\\''", $payload)."'";
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49693
| License       | MIT

I'm not 100% sure if it is a bugfix or a feature.

I used Nicolas' suggestion in the issue to sanitize the input and used `--data-raw` to avoid any automatic formatting.

Removing the use of `escapeshellarg()` also allows to remove `HttpClientDataCollectorTest::testItDoesNotGeneratesCurlCommandsForNotEncodableBody()`. Indeed, the body can now be encoded and will result on the following cURL command:

```
curl \\n
      --compressed \\n
      --request POST \\n
      --url 'http://localhost:8057/json' \\n
      --header 'Accept: */*' \\n
      --header 'Content-Length: 1' \\n
      --header 'Content-Type: application/x-www-form-urlencoded' \\n
      --header 'Accept-Encoding: gzip' \\n
      --header 'User-Agent: Symfony HttpClient (Native)' \\n
      --data-raw '\x00'

```