### PR TITLE
[Console][FrameworkBundle] Fix missing `profile` option for console commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
@@ -59,7 +59,8 @@ final class ConsoleProfilerListener implements EventSubscriberInterface
 
     public function initialize(ConsoleCommandEvent $event): void
     {
-        if (!$event->getInput()->getOption('profile')) {
+        $input = $event->getInput();
+        if (!$input->hasOption('profile') || !$input->getOption('profile')) {
             $this->profiler->disable();
 
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix https://github.com/symfony/symfony/issues/52433
| License       | MIT
