### PR TITLE
Disable the "Copy as cURL" button when the debug info are disabled

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -230,6 +230,11 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
                 break;
             }
 
+            if (str_starts_with('Due to a bug in curl ', $line)) {
+                // When the curl client disables debug info due to a curl bug, we cannot build the command.
+                return null;
+            }
+
             if ('' === $line || preg_match('/^[*<]|(Host: )/', $line)) {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52441
| License       | MIT

Some versions of curl have a bug that prevents collecting the debug info. This is reported by writing an explanation message in the debug buffer.
When this is detecting, the "Copy as cURL" button is now skipped (like for other unsupported cases) instead of copying a broken command.
