### PR TITLE
[TwigBridge] Mark CodeExtension as @internal

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -18,7 +18,12 @@ use Twig\TwigFilter;
 /**
  * Twig extension relate to PHP code and used by the profiler and the default exception templates.
  *
+ * This extension should only be used for debugging tools code
+ * that is never executed in a production environment.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
  */
 final class CodeExtension extends AbstractExtension
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

This is really just internal code used by our own tools. Let's make it clear that nobody should use it in production.
