### PR TITLE
[Translation] add bundles trans paths into commands (extract/pull/push)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1342,7 +1342,7 @@ class FrameworkExtension extends Extension
         $defaultDir = $container->getParameterBag()->resolveValue($config['default_path']);
         foreach ($container->getParameter('kernel.bundles_metadata') as $name => $bundle) {
             if ($container->fileExists($dir = $bundle['path'].'/Resources/translations') || $container->fileExists($dir = $bundle['path'].'/translations')) {
-                $dirs[] = $dir;
+                $dirs[] = $transPaths[] = $dir;
             } else {
                 $nonExistingDirs[] = $dir;
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1130,7 +1130,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertContains(
             strtr(__DIR__.'/Fixtures/TestBundle/Resources/translations/messages.en.yaml', '/', \DIRECTORY_SEPARATOR),
             $files,
-            '->registerTranslatorConfiguration() finds translation resources with in bundles'
+            '->registerTranslatorConfiguration() finds translation resources within bundles'
         );
 
         $positionOverridingTranslationFile = array_search(strtr(realpath(__DIR__.'/translations/security.en.yaml'), '/', \DIRECTORY_SEPARATOR), $files);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Hello ! 

While playing with `translation:extract` command to trying to gather all sylius translation in one file in order to send them to a translation provider, I found that although translation file are correctly loaded from a bundle while browsing the application, it was mandatory to launch the `translation:extract` for EACH bundle, and in a Sylius App, there is a lot :sweat_smile: 

This fix pass all $transPaths discovered during compilation into that command (and also push/pull commands). 

In my mind, it's a bugfix, that's why I targetted 5.4, but could be considered as new feature, I'm not sure.


