### PR TITLE
[Cache][HttpFoundation][Lock] Fix empty username/password for PDO PostgreSQL

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -34,8 +34,8 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
     private $dataCol = 'item_data';
     private $lifetimeCol = 'item_lifetime';
     private $timeCol = 'item_time';
-    private $username = '';
-    private $password = '';
+    private $username = null;
+    private $password = null;
     private $connectionOptions = [];
     private $namespace;
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -112,16 +112,16 @@ class PdoSessionHandler extends AbstractSessionHandler
     /**
      * Username when lazy-connect.
      *
-     * @var string
+     * @var string|null
      */
-    private $username = '';
+    private $username = null;
 
     /**
      * Password when lazy-connect.
      *
-     * @var string
+     * @var string|null
      */
-    private $password = '';
+    private $password = null;
 
     /**
      * Connection options when lazy-connect.

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -24,7 +24,7 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  *
  * Lock metadata are stored in a table. You can use createTable() to initialize
  * a correctly defined table.
-
+ *
  * CAUTION: This store relies on all client and server nodes to have
  * synchronized clocks for lock expiry to occur at the correct time.
  * To ensure locks don't expire prematurely; the TTLs should be set with enough
@@ -40,8 +40,8 @@ class PdoStore implements PersistingStoreInterface
     private $conn;
     private $dsn;
     private $driver;
-    private $username = '';
-    private $password = '';
+    private $username = null;
+    private $password = null;
     private $connectionOptions = [];
 
     private $dbalStore;

--- a/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
@@ -29,8 +29,8 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
 {
     private $conn;
     private $dsn;
-    private $username = '';
-    private $password = '';
+    private $username = null;
+    private $password = null;
     private $connectionOptions = [];
     private static $storeRegistry = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently [pdo_pgsql has a bug](https://github.com/php/php-src/issues/12423) where the username & password arguments have precedence over the DSN, even thought [according to the docs](https://www.php.net/manual/en/ref.pdo-pgsql.connection.php) it should be the other way. This was recently fixed on PHP's side, but it [won't be available till 8.4](https://github.com/php/php-src/pull/12424).

Since the bug is not present when the values passed are `null`, which are the default argument values anyway, this PR changes the default values of the properties to match.