### PR TITLE
[Cache] Fix property types in PdoAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -25,14 +25,14 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
     private string $dsn;
     private string $driver;
     private string $serverVersion;
-    private mixed $table = 'cache_items';
-    private mixed $idCol = 'item_id';
-    private mixed $dataCol = 'item_data';
-    private mixed $lifetimeCol = 'item_lifetime';
-    private mixed $timeCol = 'item_time';
-    private mixed $username = '';
-    private mixed $password = '';
-    private mixed $connectionOptions = [];
+    private string $table = 'cache_items';
+    private string $idCol = 'item_id';
+    private string $dataCol = 'item_data';
+    private string $lifetimeCol = 'item_lifetime';
+    private string $timeCol = 'item_time';
+    private ?string $username = '';
+    private ?string $password = '';
+    private array $connectionOptions = [];
     private string $namespace;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I've noticed this while working on #52457, there's no reason these properties should be mixed as far as I can tell.