### PR TITLE
[HttpKernel] Add `ControllerResolver::allowControllers()` to define which callables are legit controllers when the `_check_controller_is_allowed` request attribute is set

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver;
@@ -40,6 +41,7 @@ return static function (ContainerConfigurator $container) {
                 service('service_container'),
                 service('logger')->ignoreOnInvalid(),
             ])
+            ->call('allowControllers', [[AbstractController::class]])
             ->tag('monolog.logger', ['channel' => 'request'])
 
         ->set('argument_metadata_factory', ArgumentMetadataFactory::class)

--- a/src/Symfony/Component/HttpKernel/Attribute/AsController.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/AsController.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\HttpKernel\Attribute;
  * This enables injecting services as method arguments in addition
  * to other conventional dependency injection strategies.
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_FUNCTION)]
 class AsController
 {
     public function __construct()

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Deprecate `FileLinkFormatter`, use `FileLinkFormatter` from the ErrorHandler component instead
  * Add argument `$buildDir` to `WarmableInterface`
  * Add argument `$filter` to `Profiler::find()` and `FileProfilerStorage::find()`
+ * Add `ControllerResolver::allowControllers()` to define which callables are legit controllers when the `_check_controller_is_allowed` request attribute is set
 
 6.3
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\HttpKernel\Controller;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
 
 /**
  * This implementation uses the '_controller' request attribute to determine
@@ -24,12 +26,32 @@ use Symfony\Component\HttpFoundation\Request;
 class ControllerResolver implements ControllerResolverInterface
 {
     private ?LoggerInterface $logger;
+    private array $allowedControllerTypes = [];
+    private array $allowedControllerAttributes = [AsController::class => AsController::class];
 
     public function __construct(LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }
 
+    /**
+     * @param array<class-string> $types
+     * @param array<class-string> $attributes
+     */
+    public function allowControllers(array $types = [], array $attributes = []): void
+    {
+        foreach ($types as $type) {
+            $this->allowedControllerTypes[$type] = $type;
+        }
+
+        foreach ($attributes as $attribute) {
+            $this->allowedControllerAttributes[$attribute] = $attribute;
+        }
+    }
+
+    /**
+     * @throws BadRequestException when the request has attribute "_check_controller_is_allowed" set to true and the controller is not allowed
+     */
     public function getController(Request $request): callable|false
     {
         if (!$controller = $request->attributes->get('_controller')) {
@@ -44,7 +66,7 @@ class ControllerResolver implements ControllerResolverInterface
                     $controller[0] = $this->instantiateController($controller[0]);
                 } catch (\Error|\LogicException $e) {
                     if (\is_callable($controller)) {
-                        return $controller;
+                        return $this->checkController($request, $controller);
                     }
 
                     throw $e;
@@ -55,7 +77,7 @@ class ControllerResolver implements ControllerResolverInterface
                 throw new \InvalidArgumentException(sprintf('The controller for URI "%s" is not callable: ', $request->getPathInfo()).$this->getControllerError($controller));
             }
 
-            return $controller;
+            return $this->checkController($request, $controller);
         }
 
         if (\is_object($controller)) {
@@ -63,11 +85,11 @@ class ControllerResolver implements ControllerResolverInterface
                 throw new \InvalidArgumentException(sprintf('The controller for URI "%s" is not callable: ', $request->getPathInfo()).$this->getControllerError($controller));
             }
 
-            return $controller;
+            return $this->checkController($request, $controller);
         }
 
         if (\function_exists($controller)) {
-            return $controller;
+            return $this->checkController($request, $controller);
         }
 
         try {
@@ -80,7 +102,7 @@ class ControllerResolver implements ControllerResolverInterface
             throw new \InvalidArgumentException(sprintf('The controller for URI "%s" is not callable: ', $request->getPathInfo()).$this->getControllerError($callable));
         }
 
-        return $callable;
+        return $this->checkController($request, $callable);
     }
 
     /**
@@ -198,5 +220,60 @@ class ControllerResolver implements ControllerResolverInterface
         $methods = get_class_methods($classOrObject);
 
         return array_filter($methods, fn (string $method) => 0 !== strncmp($method, '__', 2));
+    }
+
+    private function checkController(Request $request, callable $controller): callable
+    {
+        if (!$request->attributes->get('_check_controller_is_allowed', false)) {
+            return $controller;
+        }
+
+        $r = null;
+
+        if (\is_array($controller)) {
+            [$class, $name] = $controller;
+            $name = (\is_string($class) ? $class : $class::class).'::'.$name;
+        } elseif (\is_object($controller) && !$controller instanceof \Closure) {
+            $class = $controller;
+            $name = $class::class.'::__invoke';
+        } else {
+            $r = new \ReflectionFunction($controller);
+            $name = $r->name;
+
+            if (str_contains($name, '{closure}')) {
+                $name = $class = \Closure::class;
+            } elseif ($class = \PHP_VERSION_ID >= 80111 ? $r->getClosureCalledClass() : $r->getClosureScopeClass()) {
+                $class = $class->name;
+                $name = $class.'::'.$name;
+            }
+        }
+
+        if ($class) {
+            foreach ($this->allowedControllerTypes as $type) {
+                if (is_a($class, $type, true)) {
+                    return $controller;
+                }
+            }
+        }
+
+        $r ??= new \ReflectionClass($class);
+
+        foreach ($r->getAttributes() as $attribute) {
+            if (isset($this->allowedControllerAttributes[$attribute->getName()])) {
+                return $controller;
+            }
+        }
+
+        if (str_contains($name, '@anonymous')) {
+            $name = preg_replace_callback('/[a-zA-Z_\x7f-\xff][\\\\a-zA-Z0-9_\x7f-\xff]*+@anonymous\x00.*?\.php(?:0x?|:[0-9]++\$)[0-9a-fA-F]++/', fn ($m) => class_exists($m[0], false) ? (get_parent_class($m[0]) ?: key(class_implements($m[0])) ?: 'class').'@anonymous' : $m[0], $name);
+        }
+
+        if (-1 === $request->attributes->get('_check_controller_is_allowed')) {
+            trigger_deprecation('symfony/http-kernel', '6.4', 'Callable "%s()" is not allowed as a controller. Did you miss tagging it with "#[AsController]" or registering its type with "%s::allowControllers()"?', $name, self::class);
+
+            return $controller;
+        }
+
+        throw new BadRequestException(sprintf('Callable "%s()" is not allowed as a controller. Did you miss tagging it with "#[AsController]" or registering its type with "%s::allowControllers()"?', $name, self::class));
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
@@ -70,6 +70,7 @@ class FragmentListener implements EventSubscriberInterface
         }
 
         parse_str($request->query->get('_path', ''), $attributes);
+        $attributes['_check_controller_is_allowed'] = -1; // @deprecated, switch to true in Symfony 7
         $request->attributes->add($attributes);
         $request->attributes->set('_route_params', array_replace($request->attributes->get('_route_params', []), $attributes));
         $request->query->remove('_path');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
@@ -83,7 +83,7 @@ class FragmentListenerTest extends TestCase
 
         $listener->onKernelRequest($event);
 
-        $this->assertEquals(['foo' => 'bar', '_controller' => 'foo'], $request->attributes->get('_route_params'));
+        $this->assertEquals(['foo' => 'bar', '_controller' => 'foo', '_check_controller_is_allowed' => -1], $request->attributes->get('_route_params'));
         $this->assertFalse($request->query->has('_path'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Right now, when one doesn't configure properly their APP_SECRET, this can too easily lead to an RCE.

This PR proposes to harden security by rejecting any not-allowed controllers when the `_check_controller_is_allowed` request attribute is set. We leverage this in FragmentListener to close the RCE gap.

In order to allow a controller, one should call `ControllerResolver::allowControllers()` during instantiation to tell which types or attributes should be accepted. #[AsController] is always allowed, and FrameworkBundle also allows instances of `AbstractController`.

Third-party bundles that provide controllers meant to be used as fragments should ensure their controllers are allowed by adding the method call to the `controller_resolver` service definition.

I propose this as a late 6.4 feature so that we can provide this hardening right away in 7.0. In 6.4, this would be only a deprecation.