### PR TITLE
[HttpClient][WebProfilerBundle] Do not generate cURL command when files are uploaded

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient\DataCollector;
 
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\HttpClientTrait;
 use Symfony\Component\HttpClient\TraceableHttpClient;
 use Symfony\Component\HttpFoundation\Request;
@@ -199,7 +200,11 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             if (\is_string($body)) {
                 $dataArg[] = '--data-raw '.$this->escapePayload($body);
             } elseif (\is_array($body)) {
-                $body = explode('&', self::normalizeBody($body));
+                try {
+                    $body = explode('&', self::normalizeBody($body));
+                } catch (TransportException) {
+                    return null;
+                }
                 foreach ($body as $value) {
                     $dataArg[] = '--data-raw '.$this->escapePayload(urldecode($value));
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51366
| License       | MIT

I also removed `@requires extension openssl` annotations since that does not seem to be the case since #45729.

Failures in AppVeyor occur because double quotes are missing around `--data-raw` values. Possibly related to #52429.