### PR TITLE
[HttpKernel] Fix quotes expectations in tests

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -175,7 +175,9 @@ class HttpClientDataCollectorTest extends TestCase
         $collectedData = $sut->getClients();
         self::assertCount(1, $collectedData['http_client']['traces']);
         $curlCommand = $collectedData['http_client']['traces'][0]['curlCommand'];
-        self::assertEquals(sprintf($expectedCurlCommand, '\\' === \DIRECTORY_SEPARATOR ? '"' : "'"), $curlCommand);
+
+        $isWindows = '\\' === \DIRECTORY_SEPARATOR;
+        self::assertEquals(sprintf($expectedCurlCommand, $isWindows ? '"' : "'", $isWindows ? '' : "'"), $curlCommand);
     }
 
     public static function provideCurlRequests(): iterable
@@ -234,7 +236,7 @@ class HttpClientDataCollectorTest extends TestCase
                 'method' => 'POST',
                 'url' => 'http://localhost:8057/json',
                 'options' => [
-                    'body' => 'foobarbaz',
+                    'body' => 'foo bar baz',
                 ],
             ],
             'curl \\
@@ -242,11 +244,11 @@ class HttpClientDataCollectorTest extends TestCase
   --request POST \\
   --url %1$shttp://localhost:8057/json%1$s \\
   --header %1$sAccept: */*%1$s \\
-  --header %1$sContent-Length: 9%1$s \\
+  --header %1$sContent-Length: 11%1$s \\
   --header %1$sContent-Type: application/x-www-form-urlencoded%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
   --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s \\
-  --data-raw %1$sfoobarbaz%1$s',
+  --data-raw %1$sfoo bar baz%1$s',
         ];
         yield 'POST with array body' => [
             [
@@ -284,7 +286,7 @@ class HttpClientDataCollectorTest extends TestCase
   --header %1$sContent-Length: 211%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
   --header %1$sUser-Agent: Symfony HttpClient (Native)%1$s \\
-  --data-raw %1$sfoo=fooval%1$s --data-raw %1$sbar=barval%1$s --data-raw %1$sbaz=bazval%1$s --data-raw %1$sfoobar[baz]=bazval%1$s --data-raw %1$sfoobar[qux]=quxval%1$s --data-raw %1$sbazqux[0]=bazquxval1%1$s --data-raw %1$sbazqux[1]=bazquxval2%1$s --data-raw %1$sobject[fooprop]=foopropval%1$s --data-raw %1$sobject[barprop]=barpropval%1$s --data-raw %1$stostring=tostringval%1$s',
+  --data-raw %2$sfoo=fooval%2$s --data-raw %2$sbar=barval%2$s --data-raw %2$sbaz=bazval%2$s --data-raw %2$sfoobar[baz]=bazval%2$s --data-raw %2$sfoobar[qux]=quxval%2$s --data-raw %2$sbazqux[0]=bazquxval1%2$s --data-raw %2$sbazqux[1]=bazquxval2%2$s --data-raw %2$sobject[fooprop]=foopropval%2$s --data-raw %2$sobject[barprop]=barpropval%2$s --data-raw %2$stostring=tostringval%2$s',
         ];
 
         // escapeshellarg on Windows replaces double quotes & percent signs with spaces


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Following https://github.com/symfony/symfony/pull/52472#issuecomment-1795734816

On Windows, quotes are only added when necessary. This means that for a value like `foobar`, no quotes are added. I updated the test so the first dataset shows the escaping whereas the second updated dataset shows that it is expected that no quotes are added around data.