### PR TITLE
[HttpFoundation] ensure string type with mbstring func overloading enabled

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderUtils.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderUtils.php
@@ -256,7 +256,7 @@ class HeaderUtils
     private static function groupParts(array $matches, string $separators, bool $first = true): array
     {
         $separator = $separators[0];
-        $separators = substr($separators, 1);
+        $separators = substr($separators, 1) ?: '';
         $i = 0;
 
         if ('' === $separators && !$first) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52419
| License       | MIT