### PR TITLE
[Console] Add `assertCommandIsFaulty` assertion

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `assertCommandIsFaulty` assertion
+
 7.0
 ---
 

--- a/src/Symfony/Component/Console/Tester/Constraint/CommandIsFaulty.php
+++ b/src/Symfony/Component/Console/Tester/Constraint/CommandIsFaulty.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tester\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\Console\Command\Command;
+
+final class CommandIsFaulty extends Constraint
+{
+    public function toString(): string
+    {
+        return 'is faulty';
+    }
+
+    protected function matches($other): bool
+    {
+        return Command::FAILURE === $other || Command::INVALID === $other;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'the command '.$this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        return Command::SUCCESS === $other
+            ? 'Command was successful.'
+            : sprintf('Command returned exit status %d.', $other);
+    }
+}

--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\Constraint\CommandIsFaulty;
 use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
 
 /**
@@ -102,6 +103,11 @@ trait TesterTrait
     public function assertCommandIsSuccessful(string $message = ''): void
     {
         Assert::assertThat($this->statusCode, new CommandIsSuccessful(), $message);
+    }
+
+    public function assertCommandIsFaulty(string $message = ''): void
+    {
+        Assert::assertThat($this->statusCode, new CommandIsFaulty(), $message);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsFaultyTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsFaultyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Tester\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\Constraint\CommandIsFaulty;
+
+final class CommandIsFaultyTest extends TestCase
+{
+    public function testConstraint()
+    {
+        $constraint = new CommandIsFaulty();
+
+        $this->assertFalse($constraint->evaluate(Command::SUCCESS, returnResult: true));
+        $this->assertTrue($constraint->evaluate(Command::FAILURE, returnResult: true));
+        $this->assertTrue($constraint->evaluate(Command::INVALID, returnResult: true));
+    }
+
+    public function testSuccessfulCommand()
+    {
+        $constraint = new CommandIsFaulty();
+
+        try {
+            $constraint->evaluate(Command::SUCCESS);
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('Failed asserting that the command is faulty.', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #52478 
| License       | MIT

Adds the complement of the `assertCommandIsSuccessful` assertion and improves thereby test readability.