### PR TITLE
Move CodeExtension from TwigBridge to WebProfilerBundle

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -17,7 +17,6 @@ use Symfony\Bridge\Twig\DataCollector\TwigDataCollector;
 use Symfony\Bridge\Twig\ErrorRenderer\TwigErrorRenderer;
 use Symfony\Bridge\Twig\EventListener\TemplateAttributeListener;
 use Symfony\Bridge\Twig\Extension\AssetExtension;
-use Symfony\Bridge\Twig\Extension\CodeExtension;
 use Symfony\Bridge\Twig\Extension\ExpressionExtension;
 use Symfony\Bridge\Twig\Extension\HtmlSanitizerExtension;
 use Symfony\Bridge\Twig\Extension\HttpFoundationExtension;
@@ -105,10 +104,6 @@ return static function (ContainerConfigurator $container) {
 
         ->set('twig.extension.assets', AssetExtension::class)
             ->args([service('assets.packages')])
-
-        ->set('twig.extension.code', CodeExtension::class)
-            ->args([service('debug.file_link_formatter')->ignoreOnInvalid(), param('kernel.project_dir'), param('kernel.charset')])
-            ->tag('twig.extension')
 
         ->set('twig.extension.routing', RoutingExtension::class)
             ->args([service('router')])

--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/CodeExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/CodeExtension.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bridge\Twig\Extension;
+namespace Symfony\Bundle\WebProfilerBundle\Profiler;
 
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
 use Twig\Extension\AbstractExtension;
@@ -23,7 +23,7 @@ use Twig\TwigFilter;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @internal since Symfony 6.4
+ * @internal
  */
 final class CodeExtension extends AbstractExtension
 {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController;
 use Symfony\Bundle\WebProfilerBundle\Controller\RouterController;
 use Symfony\Bundle\WebProfilerBundle\Csp\ContentSecurityPolicyHandler;
 use Symfony\Bundle\WebProfilerBundle\Csp\NonceGenerator;
+use Symfony\Bundle\WebProfilerBundle\Profiler\CodeExtension;
 use Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension;
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
@@ -79,5 +80,9 @@ return static function (ContainerConfigurator $container) {
                 '_profiler_open_file',
                 '?file=%%f&line=%%l#line%%l',
             ])
+
+        ->set('twig.extension.code', CodeExtension::class)
+            ->args([service('debug.file_link_formatter'), param('kernel.project_dir'), param('kernel.charset')])
+            ->tag('twig.extension')
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The class is internal in 7.0 so we can move it closer to where it's used.