### PR TITLE
[String] Method toByteString conversion using iconv is unreachable

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -577,8 +577,11 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         try {
             try {
                 $b->string = mb_convert_encoding($this->string, $toEncoding, 'UTF-8');
-            } catch (InvalidArgumentException $e) {
+            } catch (InvalidArgumentException|\ValueError $e) {
                 if (!\function_exists('iconv')) {
+                    if ($e instanceof \ValueError) {
+                        throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+                    }
                     throw $e;
                 }
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1583,4 +1583,22 @@ abstract class AbstractAsciiTestCase extends TestCase
             [17, "\u{007f}\u{007f}f\u{001b}[0moo\u{0001}bar\u{007f}cccïf\u{008e}cy\u{0005}1", false], // f[0moobarcccïfcy1
         ];
     }
+
+    /**
+     * @dataProvider provideToByteString
+     */
+    public function testToByteString(string $origin, string $encoding)
+    {
+        $instance = static::createFromString($origin)->toByteString($encoding);
+        $this->assertInstanceOf(ByteString::class, $instance);
+    }
+
+    public static function provideToByteString(): array
+    {
+        return [
+            ['žsžsý', 'UTF-8'],
+            ['žsžsý', 'windows-1250'],
+            ['žsžsý', 'Windows-1252'],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #52489 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
Originating from original issue: 
>It is possible that nobody noticed that PHP 8.0 added ValueError exception https://www.php.net/manual/en/function.mb-convert-encoding so the code is not compatible with php >= 8.0

That seems indeed to be the case