### PR TITLE
[HttpFoundation] Add `UploadedFile::getClientOriginalPath()` to support directory uploads

### DIFF
--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -29,6 +29,7 @@ class NativeRequestHandler implements RequestHandlerInterface
      */
     private const FILE_KEYS = [
         'error',
+        'full_path',
         'name',
         'size',
         'tmp_name',
@@ -186,9 +187,7 @@ class NativeRequestHandler implements RequestHandlerInterface
             return $data;
         }
 
-        // Remove extra key added by PHP 8.1.
-        unset($data['full_path']);
-        $keys = array_keys($data);
+        $keys = array_keys($data + ['full_path' => null]);
         sort($keys);
 
         if (self::FILE_KEYS !== $keys || !isset($data['name']) || !\is_array($data['name'])) {
@@ -207,7 +206,9 @@ class NativeRequestHandler implements RequestHandlerInterface
                 'type' => $data['type'][$key],
                 'tmp_name' => $data['tmp_name'][$key],
                 'size' => $data['size'][$key],
-            ]);
+            ] + (isset($data['full_path'][$key]) ? [
+                'full_path' => $data['full_path'][$key],
+            ] : []));
         }
 
         return $files;
@@ -219,7 +220,7 @@ class NativeRequestHandler implements RequestHandlerInterface
             return $data;
         }
 
-        $keys = array_keys($data);
+        $keys = array_keys($data + ['full_path' => null]);
         sort($keys);
 
         if (self::FILE_KEYS === $keys) {

--- a/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
@@ -99,6 +99,9 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTestCase
             'name' => [
                 'field' => 'upload.txt',
             ],
+            'full_path' => [
+                'field' => 'path/to/file/upload.txt',
+            ],
             'type' => [
                 'field' => 'text/plain',
             ],
@@ -118,6 +121,7 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTestCase
         $this->assertTrue($form->isSubmitted());
         $this->assertEquals([
             'name' => 'upload.txt',
+            'full_path' => 'path/to/file/upload.txt',
             'type' => 'text/plain',
             'tmp_name' => 'owfdskjasdfsa',
             'error' => \UPLOAD_ERR_OK,

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `UploadedFile::getClientOriginalPath()`
+
 7.0
 ---
 

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -35,6 +35,7 @@ class UploadedFile extends File
     private string $originalName;
     private string $mimeType;
     private int $error;
+    private string $originalPath;
 
     /**
      * Accepts the information of the uploaded file as provided by the PHP global $_FILES.
@@ -63,6 +64,7 @@ class UploadedFile extends File
     public function __construct(string $path, string $originalName, string $mimeType = null, int $error = null, bool $test = false)
     {
         $this->originalName = $this->getName($originalName);
+        $this->originalPath = strtr($originalName, '\\', '/');
         $this->mimeType = $mimeType ?: 'application/octet-stream';
         $this->error = $error ?: \UPLOAD_ERR_OK;
         $this->test = $test;
@@ -90,6 +92,21 @@ class UploadedFile extends File
     public function getClientOriginalExtension(): string
     {
         return pathinfo($this->originalName, \PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Returns the original file full path.
+     *
+     * It is extracted from the request from which the file has been uploaded.
+     * This should not be considered as a safe value to use for a file name/path on your servers.
+     *
+     * If this file was uploaded with the "webkitdirectory" upload directive, this will contain
+     * the path of the file relative to the uploaded root directory. Otherwise this will be identical
+     * to getClientOriginalName().
+     */
+    public function getClientOriginalPath(): string
+    {
+        return $this->originalPath;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/File/Fixtures/webkitdirectory/nested/test.txt
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/Fixtures/webkitdirectory/nested/test.txt
@@ -1,0 +1,1 @@
+nested webkitdirectory text

--- a/src/Symfony/Component/HttpFoundation/Tests/File/Fixtures/webkitdirectory/test.txt
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/Fixtures/webkitdirectory/test.txt
@@ -1,0 +1,1 @@
+webkitdirectory text

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -322,4 +322,26 @@ class UploadedFileTest extends TestCase
             $this->assertSame(\PHP_INT_MAX, $size);
         }
     }
+
+    public function testgetClientOriginalPath()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'test.gif',
+            'image/gif'
+        );
+
+        $this->assertEquals('test.gif', $file->getClientOriginalPath());
+    }
+
+    public function testgetClientOriginalPathWebkitDirectory()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/webkitdirectory/test.txt',
+            'webkitdirectory/test.txt',
+            'text/plain',
+        );
+
+        $this->assertEquals('webkitdirectory/test.txt', $file->getClientOriginalPath());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      |  no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This removes the "hotfix" https://github.com/symfony/symfony/pull/42112/ and now supports "full_path" PHP file uploads.

Since PHP 8.1 is now the lowest allowed version of PHP, this shouldnt cause any problems. 

---

Although I'm quite certain that I understand the messy FileBag code, I'm very concerned for the potential impact this change might have because of the widespread use of http-foundation.

To the best of my knowledge, this won't break Symfony BC (yet) because this is all done by an `optional` argument in the constructor of UploadedFile (this should eventually be replaced by a mandatory argument though).

Also, I'm not quite happy with the tests. Since this is only a "passthrough" of the PHP value, this _shouldnt_ be a huge problem. 

Someone should definitly go through this change very carefully. The tests pass and I also threw some "real world" application tests at it and everything seems to work just fine. But because of the nature of HttpFoundation and its intangled mess, I can't guarantee that I accounted for every possible or even simple edge case.

---

Though it would be nice to still see this in 7.0, I know that it will probably be pushed back to 7.1.