### PR TITLE
[VarDumper] Accept mixed key on `DsPairStub`

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DsPairStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/DsPairStub.php
@@ -18,7 +18,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class DsPairStub extends Stub
 {
-    public function __construct(string|int $key, mixed $value)
+    public function __construct(mixed $key, mixed $value)
     {
         $this->value = [
             Caster::PREFIX_VIRTUAL.'key' => $key,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52495
| License       | MIT

`Db\Map` accepts any types as key