### PR TITLE
[Ldap] Set exception code to ldap error number

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -110,7 +110,7 @@ class Query extends AbstractQuery
                         $this->resetPagination();
                     }
 
-                    throw new LdapException(sprintf('Could not complete search with dn "%s", query "%s" and filters "%s".%s.', $this->dn, $this->query, implode(',', $this->options['filter']), $ldapError));
+                    throw new LdapException(sprintf('Could not complete search with dn "%s", query "%s" and filters "%s".%s.', $this->dn, $this->query, implode(',', $this->options['filter']), $ldapError), $errno);
                 }
 
                 $this->results[] = $search;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

To be conistent with https://github.com/symfony/symfony/commit/db46f3bedee14760fe9c938aaead5e3e3d5829ae, also add the LDAP error number to the exception in this case.

This is especially useful to perform a reconnect for long running php processes without doing something like this: ```if(str_contains($ex->getMessage(), 'LDAP error was [-1]')) {```
Or to check for a ```[32] No such object``` error.