### PR TITLE
[HttpKernel] Fix DebugLoggerConfigurator

### DIFF
--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
@@ -18,12 +18,12 @@ use Monolog\Logger;
  */
 class DebugLoggerConfigurator
 {
-    private ?\Closure $processor = null;
+    private ?object $processor = null;
 
     public function __construct(callable $processor, bool $enable = null)
     {
         if ($enable ?? !\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-            $this->processor = $processor(...);
+            $this->processor = \is_object($processor) ? $processor : $processor(...);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Issue introduced in #52426: by turning the callable into a closure, we broke the `instanceof` check later in the class.