### PR TITLE
[HttpKernel] Check controllers are allowed when using the fallback surrogate strategy

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -59,6 +59,8 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
     public function render(string|ControllerReference $uri, Request $request, array $options = []): Response
     {
         if (!$this->surrogate || !$this->surrogate->hasSurrogateCapability($request)) {
+            $request->attributes->set('_check_controller_is_allowed', -1); // @deprecated, switch to true in Symfony 7
+
             if ($uri instanceof ControllerReference && $this->containsNonScalars($uri->attributes)) {
                 throw new \InvalidArgumentException('Passing non-scalar values as part of URI attributes to the ESI and SSI rendering strategies is not supported. Use a different rendering strategy or pass scalar values.');
             }

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -133,6 +133,9 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         if ($request->attributes->has('_stateless')) {
             $subRequest->attributes->set('_stateless', $request->attributes->get('_stateless'));
         }
+        if ($request->attributes->has('_check_controller_is_allowed')) {
+            $subRequest->attributes->set('_check_controller_is_allowed', $request->attributes->get('_check_controller_is_allowed'));
+        }
 
         return $subRequest;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A good idea suggested by @stof to help spot not allowed controllers before they hit production.