### PR TITLE
[Config] Prefixing `FileExistenceResource::__toString()` to avoid conflict with `FileResource`

### DIFF
--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -38,7 +38,7 @@ class FileExistenceResource implements SelfCheckingResourceInterface
 
     public function __toString(): string
     {
-        return $this->resource;
+        return 'existence.'.$this->resource;
     }
 
     public function getResource(): string

--- a/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
@@ -36,7 +36,7 @@ class FileExistenceResourceTest extends TestCase
 
     public function testToString()
     {
-        $this->assertSame($this->file, (string) $this->resource);
+        $this->assertSame('existence.'.$this->file, (string) $this->resource);
     }
 
     public function testGetResource()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fixes issue in AssetMapper 6.4
| License       | MIT

Hi!

This bug causes a pretty critical AssetMapper 6.4 bug. The problem is that both `FileResource` and `FileExistenceResource` return the same `__toString()` for the same file:

* [FileResource::__toString()](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Config/Resource/FileResource.php#L43-L46)
* [FileExistenceResource::__toString()](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Config/Resource/FileExistenceResource.php#L39-L41)

[SelfCheckingResourceChecker](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Config/Resource/SelfCheckingResourceChecker.php#L40-L45) uses a static cache where the `ResourceInterface::__toString()` is the key for that string. That creates the following bug situation:

A) Something checks for `FileExistenceResource` for `foo/bar.php`. This returns true and `SelfCheckingResourceChecker` now has `true` for fresh in its static cache
B) Something else checks for `FileResource` for `foo/bar.php`: they are checking to see if the file has been *modified*. But in instead of calling the actual `FileResource::isFresh()` method, it uses the `true` value from the static cache.

Cheers!