### PR TITLE
[DoctrineBridge][Form] Introducing new `LazyChoiceLoader` class and `choice_lazy` option for `ChoiceType`

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate the `VersionAwareTest` trait, use feature detection instead
  * Add support for the `calendar` option in `DateType`
+ * Add `LazyChoiceLoader` and `choice_lazy` option in `ChoiceType` for loading and rendering choices on demand
 
 7.1
 ---

--- a/src/Symfony/Component/Form/ChoiceList/Loader/LazyChoiceLoader.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/LazyChoiceLoader.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\ChoiceList\Loader;
+
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+
+/**
+ * A choice loader that loads its choices and values lazily, only when necessary.
+ *
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+class LazyChoiceLoader implements ChoiceLoaderInterface
+{
+    private ?ChoiceListInterface $choiceList = null;
+
+    public function __construct(
+        private readonly ChoiceLoaderInterface $loader,
+    ) {
+    }
+
+    public function loadChoiceList(?callable $value = null): ChoiceListInterface
+    {
+        return $this->choiceList ??= new ArrayChoiceList([], $value);
+    }
+
+    public function loadChoicesForValues(array $values, ?callable $value = null): array
+    {
+        $choices = $this->loader->loadChoicesForValues($values, $value);
+        $this->choiceList = new ArrayChoiceList($choices, $value);
+
+        return $choices;
+    }
+
+    public function loadValuesForChoices(array $choices, ?callable $value = null): array
+    {
+        $values = $this->loader->loadValuesForChoices($choices, $value);
+
+        if ($this->choiceList?->getValuesForChoices($choices) !== $values) {
+            $this->loadChoicesForValues($values, $value);
+        }
+
+        return $values;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/LazyChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/LazyChoiceLoaderTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\ChoiceList\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\ChoiceList\Loader\LazyChoiceLoader;
+use Symfony\Component\Form\Tests\Fixtures\ArrayChoiceLoader;
+
+class LazyChoiceLoaderTest extends TestCase
+{
+    private LazyChoiceLoader $loader;
+
+    protected function setUp(): void
+    {
+        $this->loader = new LazyChoiceLoader(new ArrayChoiceLoader(['A', 'B', 'C']));
+    }
+
+    public function testInitialEmptyChoiceListLoading()
+    {
+        $this->assertSame([], $this->loader->loadChoiceList()->getChoices());
+    }
+
+    public function testOnDemandChoiceListAfterLoadingValuesForChoices()
+    {
+        $this->loader->loadValuesForChoices(['A']);
+        $this->assertSame(['A' => 'A'], $this->loader->loadChoiceList()->getChoices());
+    }
+
+    public function testOnDemandChoiceListAfterLoadingChoicesForValues()
+    {
+        $this->loader->loadChoicesForValues(['B']);
+        $this->assertSame(['B' => 'B'], $this->loader->loadChoiceList()->getChoices());
+    }
+
+    public function testOnDemandChoiceList()
+    {
+        $this->loader->loadValuesForChoices(['A']);
+        $this->loader->loadChoicesForValues(['B']);
+        $this->assertSame(['B' => 'B'], $this->loader->loadChoiceList()->getChoices());
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -6,6 +6,7 @@
             "choice_attr",
             "choice_filter",
             "choice_label",
+            "choice_lazy",
             "choice_loader",
             "choice_name",
             "choice_translation_domain",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -8,22 +8,22 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   choice_attr                     FormType             FormType                       FormTypeCsrfExtension  
   choice_filter                  -------------------- ------------------------------ ----------------------- 
   choice_label                    compound             action                         csrf_field_name        
-  choice_loader                   data_class           allow_file_upload              csrf_message           
-  choice_name                     empty_data           attr                           csrf_protection        
-  choice_translation_domain       error_bubbling       attr_translation_parameters    csrf_token_id          
-  choice_translation_parameters   invalid_message      auto_initialize                csrf_token_manager     
-  choice_value                    trim                 block_name                                            
-  choices                                              block_prefix                                          
-  duplicate_preferred_choices                          by_reference                                          
-  expanded                                             data                                                  
-  group_by                                             disabled                                              
-  multiple                                             form_attr                                             
-  placeholder                                          getter                                                
-  placeholder_attr                                     help                                                  
-  preferred_choices                                    help_attr                                             
-  separator                                            help_html                                             
-  separator_html                                       help_translation_parameters                           
-                                                       inherit_data                                          
+  choice_lazy                     data_class           allow_file_upload              csrf_message           
+  choice_loader                   empty_data           attr                           csrf_protection        
+  choice_name                     error_bubbling       attr_translation_parameters    csrf_token_id          
+  choice_translation_domain       invalid_message      auto_initialize                csrf_token_manager     
+  choice_translation_parameters   trim                 block_name                                            
+  choice_value                                         block_prefix                                          
+  choices                                              by_reference                                          
+  duplicate_preferred_choices                          data                                                  
+  expanded                                             disabled                                              
+  group_by                                             form_attr                                             
+  multiple                                             getter                                                
+  placeholder                                          help                                                  
+  placeholder_attr                                     help_attr                                             
+  preferred_choices                                    help_html                                             
+  separator                                            help_translation_parameters                           
+  separator_html                                       inherit_data                                          
                                                        invalid_message_parameters                            
                                                        is_empty_callback                                     
                                                        label                                                 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #57724
| License       | MIT

It's quite usual to work with forms that process large datasets. In Symfony Form + Doctrine ORM, if you define an `EntityType`, it typically loads all choices/entities fully into memory, and this can lead to serious performance problems if your entity table contain several hundred or thousands of records.

The new `LazyChoiceLoader` class addresses this performance issue by implementing an on-demand choice loading strategy. This class is integrated with any `ChoiceType` subtype by using a new boolean option named `choice_lazy`, which activates the feature.

Basic usage in a Symfony form looks like this:
```php
$formBuilder->add('user', EntityType::class, [
    'class' => User::class, // a ton of users...
    'choice_lazy' => true,
]);
```

**How does it work?**

The loader operates by keeping the choice list empty until values are needed (avoiding unnecessary database queries). When form values are provided or submitted, it retrieves and caches only the necessary choices.

As you can see in the code, all this happens behind the `LazyChoiceLoader` class, which delegates the loading of choices to a wrapped `ChoiceLoaderInterface` adapter (in this case, the `DoctrineChoiceLoader`).

**Frontend Considerations**

Certainly, you may need a JavaScript component for dynamically loading `<select>` options, aka autocomplete plugins. You'll need to develop the endpoint/controller to fetch this data on your own, ensuring it corresponds to the form field data source. This aspect is not included in this project.

As a point of reference, the [Autocomplete UX Component](https://symfony.com/bundles/ux-autocomplete/current/index.html) now uses this choice loading strategy, simplifying its autocomplete form type to a single field:

<img src="https://symfony.com/doc/bundles/ux-autocomplete/2.x/ux-autocomplete-animation.gif"/>

**A Handy Use Case without Javascript?**

The `disabled` option renders an `EntityType` form field read-only, and when combined with the `choice_lazy` option, it prevents the loading of unnecessary entities in your choice list (only the pre-selected entities will be loaded), thereby enhancing performance.

---

Hope this helps to create simpler autocomplete components for Symfony forms.

Cheers!