### PR TITLE
[AssetMapper] Fix jsdelivr import parsing with no imported value

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -26,7 +26,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     public const URL_PATTERN_DIST = self::URL_PATTERN_DIST_CSS.'/+esm';
     public const URL_PATTERN_ENTRYPOINT = 'https://data.jsdelivr.com/v1/packages/npm/%s@%s/entrypoints';
 
-    public const IMPORT_REGEX = '{from"/npm/((?:@[^/]+/)?[^@]+?)(?:@([^/]+))?((?:/[^/]+)*?)/\+esm"}';
+    public const IMPORT_REGEX = '#(?:import\s*(?:(?:\{[^}]*\}|\w+|\*\s*as\s+\w+)\s*\bfrom\s*)?|export\s*(?:\{[^}]*\}|\*)\s*from\s*)("/npm/((?:@[^/]+/)?[^@]+?)(?:@([^/]+))?((?:/[^/]+)*?)/\+esm")#';
 
     private HttpClientInterface $httpClient;
 
@@ -221,9 +221,9 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         // imports from jsdelivr follow a predictable format
         preg_match_all(self::IMPORT_REGEX, $content, $matches);
         $dependencies = [];
-        foreach ($matches[1] as $index => $packageName) {
-            $version = $matches[2][$index] ?: null;
-            $packageName .= $matches[3][$index]; // add the path if any
+        foreach ($matches[2] as $index => $packageName) {
+            $version = $matches[3][$index] ?: null;
+            $packageName .= $matches[4][$index]; // add the path if any
 
             $dependencies[] = new PackageRequireOptions($packageName, $version);
         }
@@ -239,10 +239,11 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
     private function makeImportsBare(string $content, array &$dependencies): string
     {
         $content = preg_replace_callback(self::IMPORT_REGEX, function ($matches) use (&$dependencies) {
-            $packageName = $matches[1].$matches[3]; // add the path if any
+            $packageName = $matches[2].$matches[4]; // add the path if any
             $dependencies[] = $packageName;
 
-            return sprintf('from"%s"', $packageName);
+            // replace the "/npm/package@version/+esm" with "package@version"
+            return str_replace($matches[1], sprintf('"%s"', $packageName), $matches[0]);
         }, $content);
 
         // source maps are not also downloaded - so remove the sourceMappingURL

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -463,12 +463,12 @@ class JsDelivrEsmResolverTest extends TestCase
             $expectedVersions[] = $packageData[1];
         }
         $actualNames = [];
-        foreach ($matches[1] as $i => $name) {
-            $actualNames[] = $name.$matches[3][$i];
+        foreach ($matches[2] as $i => $name) {
+            $actualNames[] = $name.$matches[4][$i];
         }
 
         $this->assertSame($expectedNames, $actualNames);
-        $this->assertSame($expectedVersions, $matches[2]);
+        $this->assertSame($expectedVersions, $matches[3]);
     }
 
     public static function provideImportRegex(): iterable
@@ -527,6 +527,26 @@ class JsDelivrEsmResolverTest extends TestCase
             [
                 ['prosemirror-transform/php/strings/vsprintf', ''],
                 ['prosemirror-state/php/strings/sprintf', '1.4.3'],
+            ],
+        ];
+
+        yield 'import without importing a value' => [
+            'import "/npm/jquery@3.7.1/+esm";',
+            [
+                ['jquery', '3.7.1'],
+            ],
+        ];
+
+        yield 'multiple imports and exports with and without values' => [
+            'import"/npm/jquery@3.7.1/+esm";import e from"/npm/datatables.net-bs5@1.13.7/+esm";export{default}from"/npm/datatables.net-bs5@1.13.7/+esm";import"/npm/datatables.net-select@1.7.0/+esm";
+            /*! Bootstrap 5 styling wrapper for Select
+             * © SpryMedia Ltd - datatables.net/license
+             */',
+            [
+                ['jquery', '3.7.1'],
+                ['datatables.net-bs5', '1.13.7'],
+                ['datatables.net-bs5', '1.13.7'],
+                ['datatables.net-select', '1.7.0'],
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52467
| License       | MIT

Another new import syntax found by @tacman! I think this one is kind of a bug in the library - a module environment should not `import 'foo'` (i.e. import a module and not actually use any value), but our job is just to find these, not judge them ;).

FYI - I have an issue on jsdelivr proposing that they create an API endpoint to expose this info, so we don't need to parse it. They agree and already were thinking about this - https://github.com/jsdelivr/jsdelivr/issues/18538 - so this may be something helpful in the future. 

Cheers!