### PR TITLE
[TypeInfo] Introduce component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,7 @@
         "symfony/translation": "self.version",
         "symfony/twig-bridge": "self.version",
         "symfony/twig-bundle": "self.version",
+        "symfony/type-info": "self.version",
         "symfony/uid": "self.version",
         "symfony/validator": "self.version",
         "symfony/var-dumper": "self.version",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -44,6 +44,7 @@ use Symfony\Component\Semaphore\Semaphore;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Translation\Translator;
+use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Webhook\Controller\WebhookController;
@@ -164,6 +165,7 @@ class Configuration implements ConfigurationInterface
         $this->addAnnotationsSection($rootNode);
         $this->addSerializerSection($rootNode, $enableIfStandalone);
         $this->addPropertyAccessSection($rootNode, $willBeAvailable);
+        $this->addTypeInfoSection($rootNode, $enableIfStandalone);
         $this->addPropertyInfoSection($rootNode, $enableIfStandalone);
         $this->addCacheSection($rootNode, $willBeAvailable);
         $this->addPhpErrorsSection($rootNode);
@@ -1157,6 +1159,18 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('property_info')
                     ->info('Property info configuration')
                     ->{$enableIfStandalone('symfony/property-info', PropertyInfoExtractorInterface::class)}()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addTypeInfoSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('type_info')
+                    ->info('Type info configuration')
+                    ->{$enableIfStandalone('symfony/type-info', Type::class)}()
                 ->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -53,6 +53,7 @@ use Symfony\Component\Console\DataCollector\CommandDataCollector;
 use Symfony\Component\Console\Debug\CliRequest;
 use Symfony\Component\Console\Messenger\RunCommandMessageHandler;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -167,6 +168,8 @@ use Symfony\Component\Translation\Extractor\PhpAstExtractor;
 use Symfony\Component\Translation\LocaleSwitcher;
 use Symfony\Component\Translation\PseudoLocalizationTranslator;
 use Symfony\Component\Translation\Translator;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Validator\Constraints\ExpressionLanguageProvider;
@@ -386,6 +389,10 @@ class FrameworkExtension extends Extension
                 ->clearTag('kernel.event_subscriber');
 
             $container->removeDefinition('console.command.serializer_debug');
+        }
+
+        if ($this->readConfigEnabled('type_info', $container, $config['type_info'])) {
+            $this->registerTypeInfoConfiguration($container, $loader);
         }
 
         if ($propertyInfoEnabled) {
@@ -1950,6 +1957,25 @@ class FrameworkExtension extends Extension
 
         if ($container->getParameter('kernel.debug')) {
             $container->removeDefinition('property_info.cache');
+        }
+    }
+
+    private function registerTypeInfoConfiguration(ContainerBuilder $container, PhpFileLoader $loader): void
+    {
+        if (!class_exists(Type::class)) {
+            throw new LogicException('TypeInfo support cannot be enabled as the TypeInfo component is not installed. Try running "composer require symfony/type-info".');
+        }
+
+        $loader->load('type_info.php');
+
+        if (ContainerBuilder::willBeAvailable('phpstan/phpdoc-parser', PhpDocParser::class, ['symfony/framework-bundle', 'symfony/type-info'])) {
+            $container->register('type_info.resolver.string', StringTypeResolver::class);
+
+            /** @var ServiceLocatorArgument $resolversLocator */
+            $resolversLocator = $container->getDefinition('type_info.resolver')->getArgument(0);
+            $resolversLocator->setValues($resolversLocator->getValues() + [
+                'string' => new Reference('type_info.resolver.string'),
+            ]);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -27,6 +27,7 @@
             <xsd:element name="property-access" type="property_access" minOccurs="0" maxOccurs="1" />
             <xsd:element name="scheduler" type="scheduler" minOccurs="0" maxOccurs="1" />
             <xsd:element name="serializer" type="serializer" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="type-info" type="type_info" minOccurs="0" maxOccurs="1" />
             <xsd:element name="property-info" type="property_info" minOccurs="0" maxOccurs="1" />
             <xsd:element name="cache" type="cache" minOccurs="0" maxOccurs="1" />
             <xsd:element name="workflow" type="workflow" minOccurs="0" maxOccurs="unbounded" />
@@ -325,6 +326,10 @@
         <xsd:attribute name="name-converter" type="xsd:string" />
         <xsd:attribute name="circular-reference-handler" type="xsd:string" />
         <xsd:attribute name="max-depth-handler" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="type_info">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="property_info">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/type_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/type_info.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionParameterTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionPropertyTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionReturnTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolverInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        // type context
+        ->set('type_info.type_context_factory', TypeContextFactory::class)
+            ->args([service('type_info.resolver.string')->nullOnInvalid()])
+
+        // type resolvers
+        ->set('type_info.resolver', TypeResolver::class)
+            ->args([service_locator([
+                \ReflectionType::class => service('type_info.resolver.reflection_type'),
+                \ReflectionParameter::class => service('type_info.resolver.reflection_parameter'),
+                \ReflectionProperty::class => service('type_info.resolver.reflection_property'),
+                \ReflectionFunctionAbstract::class => service('type_info.resolver.reflection_return'),
+            ])])
+        ->alias(TypeResolverInterface::class, 'type_info.resolver')
+
+        ->set('type_info.resolver.reflection_type', ReflectionTypeResolver::class)
+            ->args([service('type_info.type_context_factory')])
+
+        ->set('type_info.resolver.reflection_parameter', ReflectionParameterTypeResolver::class)
+            ->args([service('type_info.resolver.reflection_type'), service('type_info.type_context_factory')])
+
+        ->set('type_info.resolver.reflection_property', ReflectionPropertyTypeResolver::class)
+            ->args([service('type_info.resolver.reflection_type'), service('type_info.type_context_factory')])
+
+        ->set('type_info.resolver.reflection_return', ReflectionReturnTypeResolver::class)
+            ->args([service('type_info.resolver.reflection_type'), service('type_info.type_context_factory')])
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
 use Symfony\Component\Scheduler\Messenger\SchedulerTransportFactory;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\Uid\Factory\UuidFactory;
 
 class ConfigurationTest extends TestCase
@@ -623,6 +624,9 @@ class ConfigurationTest extends TestCase
                 'magic_set' => true,
                 'throw_exception_on_invalid_index' => false,
                 'throw_exception_on_invalid_property_path' => true,
+            ],
+            'type_info' => [
+                'enabled' => !class_exists(FullStack::class) && class_exists(Type::class),
             ],
             'property_info' => [
                 'enabled' => !class_exists(FullStack::class),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -70,6 +70,7 @@ $container->loadFromExtension('framework', [
         'default_context' => ['enable_max_depth' => true],
     ],
     'property_info' => true,
+    'type_info' => true,
     'ide' => 'file%%link%%format',
     'request' => [
         'formats' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/type_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/type_info.php
@@ -1,0 +1,11 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'type_info' => [
+        'enabled' => true,
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -40,5 +40,6 @@
             </framework:default-context>
         </framework:serializer>
         <framework:property-info />
+        <framework:type-info />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/type_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/type_info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
+        <framework:type-info enabled="true" />
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -59,6 +59,7 @@ framework:
          max_depth_handler:          my.max.depth.handler
          default_context:
              enable_max_depth: true
+    type_info: ~
     property_info: ~
     ide: file%%link%%format
     request:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/type_info.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/type_info.yml
@@ -1,0 +1,8 @@
+framework:
+    annotations: false
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    type_info:
+        enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1616,6 +1616,12 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertFalse($container->hasDefinition('serializer'));
     }
 
+    public function testTypeInfoEnabled()
+    {
+        $container = $this->createContainerFromFile('type_info');
+        $this->assertTrue($container->has('type_info.resolver'));
+    }
+
     public function testPropertyInfoEnabled()
     {
         $container = $this->createContainerFromFile('property_info');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TypeInfoTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TypeInfoTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\app\TypeInfo\Dummy;
+use Symfony\Component\TypeInfo\Type;
+
+class TypeInfoTest extends AbstractWebTestCase
+{
+    public function testComponent()
+    {
+        static::bootKernel(['test_case' => 'TypeInfo']);
+
+        $this->assertEquals(Type::string(), static::getContainer()->get('type_info.resolver')->resolve(new \ReflectionProperty(Dummy::class, 'name')));
+
+        if (!class_exists(PhpDocParser::class)) {
+            $this->markTestSkipped('"phpstan/phpdoc-parser" dependency is required.');
+        }
+
+        $this->assertEquals(Type::int(), static::getContainer()->get('type_info.resolver')->resolve('int'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TypeInfo/Dummy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TypeInfo/Dummy.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\app\TypeInfo;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class Dummy
+{
+    public string $name;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TypeInfo/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TypeInfo/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TypeInfo/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TypeInfo/config.yml
@@ -1,0 +1,11 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    http_method_override: false
+    type_info: true
+
+services:
+    type_info.resolver.alias:
+        alias: type_info.resolver
+        public: true

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -64,6 +64,7 @@
         "symfony/string": "^6.4|^7.0",
         "symfony/translation": "^6.4|^7.0",
         "symfony/twig-bundle": "^6.4|^7.0",
+        "symfony/type-info": "^7.1",
         "symfony/validator": "^6.4|^7.0",
         "symfony/workflow": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0",

--- a/src/Symfony/Component/TypeInfo/.gitattributes
+++ b/src/Symfony/Component/TypeInfo/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/TypeInfo/.gitignore
+++ b/src/Symfony/Component/TypeInfo/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.1
+---
+
+ * Add the component

--- a/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Exception;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Exception;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/TypeInfo/Exception/LogicException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/LogicException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Exception;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/TypeInfo/Exception/RuntimeException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/RuntimeException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Exception;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/TypeInfo/Exception/UnsupportedException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/UnsupportedException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Exception;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class UnsupportedException extends \LogicException implements ExceptionInterface
+{
+    public function __construct(
+        string $message,
+        public readonly mixed $subject,
+        int $code = 0,
+        \Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/LICENSE
+++ b/src/Symfony/Component/TypeInfo/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/TypeInfo/README.md
+++ b/src/Symfony/Component/TypeInfo/README.md
@@ -1,0 +1,42 @@
+TypeInfo Component
+==================
+
+The TypeInfo component extracts PHP types information.
+
+Getting Started
+---------------
+
+```bash
+composer require symfony/type-info
+composer require phpstan/phpdoc-parser # to support raw string resolving
+```
+
+```php
+<?php
+
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+
+// Instantiate a new resolver
+$typeResolver = TypeResolver::create();
+
+// Then resolve types for any subject
+$typeResolver->resolve(new \ReflectionProperty(Dummy::class, 'id')); // returns an "int" Type instance
+$typeResolver->resolve('bool'); // returns a "bool" Type instance
+
+// Types can be instantiated thanks to static factories
+$type = Type::list(Type::nullable(Type::bool()));
+
+// Type instances have several helper methods
+$type->getBaseType() // returns an "array" Type instance
+$type->getCollectionKeyType(); // returns an "int" Type instance
+$type->getCollectionValueType()->isNullable(); // returns true
+```
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/AbstractDummy.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/AbstractDummy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+abstract class AbstractDummy
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/Dummy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+final class Dummy extends AbstractDummy
+{
+    private int $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyBackedEnum.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+enum DummyBackedEnum: string
+{
+    case ONE = 'one';
+    case TWO = 'two';
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyEnum.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+enum DummyEnum
+{
+    case ONE;
+    case TWO;
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyExtendingStdClass.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyExtendingStdClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+final class DummyExtendingStdClass extends \stdClass
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTemplates.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTemplates.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @template T of int|string
+ * @template U
+ */
+final class DummyWithTemplates
+{
+    private int $price;
+
+    /**
+     * @template T of int|float
+     * @template V
+     *
+     * @return T
+     */
+    public function getPrice(bool $inCents = false): int|float
+    {
+        return $inCents ? $this->price : $this->price / 100;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUses.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUses.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+use Symfony\Component\TypeInfo\Type;
+use \DateTimeInterface;
+use \DateTimeImmutable as DateTime;
+
+final class DummyWithUses
+{
+    private DateTimeInterface $createdAt;
+
+    public function setCreatedAt(DateTime $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getType(): Type
+    {
+        throw new \LogicException('Should not be called.');
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableDummy.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableDummy.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+final class ReflectionExtractableDummy extends AbstractDummy
+{
+    public int $builtin;
+    public ?int $nullableBuiltin;
+
+    public array $array;
+    public ?array $nullableArray;
+
+    public iterable $iterable;
+    public ?iterable $nullableIterable;
+
+    public Dummy $class;
+    public ?Dummy $nullableClass;
+
+    public self $self;
+    public ?self $nullableSelf;
+
+    public parent $parent;
+    public ?parent $nullableParent;
+
+    public DummyEnum $enum;
+    public ?DummyEnum $nullableEnum;
+
+    public DummyBackedEnum $backedEnum;
+    public ?DummyBackedEnum $nullableBackedEnum;
+
+    public int|string $union;
+    public \Traversable&\Stringable $intersection;
+
+    public $nothing;
+
+    public function getBuiltin(): int
+    {
+        return $this->builtin;
+    }
+
+    public function getSelf(): self
+    {
+        return $this->self;
+    }
+
+    public function getStatic(): static
+    {
+        return $this;
+    }
+
+    public function getNullableStatic(): ?static
+    {
+        return null;
+    }
+
+    public function getNothing()
+    {
+        return $this->nothing;
+    }
+
+    public function setBuiltin(int $builtin): void
+    {
+        $this->builtin = $builtin;
+    }
+
+    public function setSelf(self $self): void
+    {
+        $this->self = $self;
+    }
+
+    public function setNothing($nothing): void
+    {
+        $this->nothing = $nothing;
+    }
+
+    public function setOptional(int $optional = null): void
+    {
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/BackedEnumTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/BackedEnumTypeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnum;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BackedEnumType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class BackedEnumTypeTest extends TestCase
+{
+    public function testToString()
+    {
+        $this->assertSame(DummyBackedEnum::class, (string) new BackedEnumType(DummyBackedEnum::class, Type::int()));
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isNullable());
+    }
+
+    public function testAsNonNullable()
+    {
+        $type = new BackedEnumType(DummyBackedEnum::class, Type::int());
+
+        $this->assertSame($type, $type->asNonNullable());
+    }
+
+    public function testIsA()
+    {
+        $this->assertFalse((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isA(TypeIdentifier::ARRAY));
+        $this->assertTrue((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isA(TypeIdentifier::OBJECT));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/BuiltinTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/BuiltinTypeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\LogicException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class BuiltinTypeTest extends TestCase
+{
+    public function testToString()
+    {
+        $this->assertSame('int', (string) new BuiltinType(TypeIdentifier::INT));
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse((new BuiltinType(TypeIdentifier::INT))->isNullable());
+        $this->assertTrue((new BuiltinType(TypeIdentifier::NULL))->isNullable());
+        $this->assertTrue((new BuiltinType(TypeIdentifier::MIXED))->isNullable());
+    }
+
+    public function testAsNonNullable()
+    {
+        $type = new BuiltinType(TypeIdentifier::INT);
+
+        $this->assertSame($type, $type->asNonNullable());
+        $this->assertEquals(
+            Type::union(
+                new BuiltinType(TypeIdentifier::OBJECT),
+                new BuiltinType(TypeIdentifier::RESOURCE),
+                new BuiltinType(TypeIdentifier::ARRAY),
+                new BuiltinType(TypeIdentifier::STRING),
+                new BuiltinType(TypeIdentifier::FLOAT),
+                new BuiltinType(TypeIdentifier::INT),
+                new BuiltinType(TypeIdentifier::BOOL),
+            ),
+            Type::nullable(new BuiltinType(TypeIdentifier::MIXED))->asNonNullable()
+        );
+    }
+
+    public function testCannotTurnNullAsNonNullable()
+    {
+        $this->expectException(LogicException::class);
+
+        (new BuiltinType(TypeIdentifier::NULL))->asNonNullable();
+    }
+
+    public function testIsA()
+    {
+        $this->assertFalse((new BuiltinType(TypeIdentifier::INT))->isA(TypeIdentifier::ARRAY));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::INT))->isA(TypeIdentifier::INT));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class CollectionTypeTest extends TestCase
+{
+    public function testCanOnlyConstructListWithIntKeyType()
+    {
+        new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::int(), Type::bool()), isList: true);
+        $this->addToAssertionCount(1);
+
+        $this->expectException(InvalidArgumentException::class);
+        new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()), isList: true);
+    }
+
+    public function testIsList()
+    {
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::bool()));
+        $this->assertFalse($type->isList());
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::bool()), isList: true);
+        $this->assertTrue($type->isList());
+    }
+
+    public function testGetCollectionKeyType()
+    {
+        $type = new CollectionType(Type::builtin(TypeIdentifier::ARRAY));
+        $this->assertEquals(Type::union(Type::int(), Type::string()), $type->getCollectionKeyType());
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::bool()));
+        $this->assertEquals(Type::int(), $type->getCollectionKeyType());
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
+        $this->assertEquals(Type::string(), $type->getCollectionKeyType());
+    }
+
+    public function testGetCollectionValueType()
+    {
+        $type = new CollectionType(Type::builtin(TypeIdentifier::ARRAY));
+        $this->assertEquals(Type::mixed(), $type->getCollectionValueType());
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::bool()));
+        $this->assertEquals(Type::bool(), $type->getCollectionValueType());
+
+        $type = new CollectionType(new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
+        $this->assertEquals(Type::bool(), $type->getCollectionValueType());
+    }
+
+    public function testToString()
+    {
+        $type = new CollectionType(Type::builtin(TypeIdentifier::ITERABLE));
+        $this->assertEquals('iterable', (string) $type);
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::bool()));
+        $this->assertEquals('array<bool>', (string) $type);
+
+        $type = new CollectionType(new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
+        $this->assertEquals('array<string,bool>', (string) $type);
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse((new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::int())))->isNullable());
+        $this->assertTrue((new CollectionType(Type::generic(Type::null(), Type::int())))->isNullable());
+        $this->assertTrue((new CollectionType(Type::generic(Type::mixed(), Type::int())))->isNullable());
+    }
+
+    public function testAsNonNullable()
+    {
+        $type = new CollectionType(Type::builtin(TypeIdentifier::ITERABLE));
+
+        $this->assertSame($type, $type->asNonNullable());
+    }
+
+    public function testIsA()
+    {
+        $type = new CollectionType(new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
+
+        $this->assertTrue($type->isA(TypeIdentifier::ARRAY));
+        $this->assertFalse($type->isA(TypeIdentifier::STRING));
+        $this->assertFalse($type->isA(TypeIdentifier::INT));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/EnumTypeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyEnum;
+use Symfony\Component\TypeInfo\Type\EnumType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class EnumTypeTest extends TestCase
+{
+    public function testToString()
+    {
+        $this->assertSame(DummyEnum::class, (string) new EnumType(DummyEnum::class));
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse((new EnumType(DummyEnum::class))->isNullable());
+    }
+
+    public function testAsNonNullable()
+    {
+        $type = new EnumType(DummyEnum::class);
+
+        $this->assertSame($type, $type->asNonNullable());
+    }
+
+    public function testIsA()
+    {
+        $this->assertFalse((new EnumType(DummyEnum::class))->isA(TypeIdentifier::ARRAY));
+        $this->assertTrue((new EnumType(DummyEnum::class))->isA(TypeIdentifier::OBJECT));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class GenericTypeTest extends TestCase
+{
+    public function testToString()
+    {
+        $type = new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::bool());
+        $this->assertEquals('array<bool>', (string) $type);
+
+        $type = new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool());
+        $this->assertEquals('array<string,bool>', (string) $type);
+
+        $type = new GenericType(Type::object(self::class), Type::union(Type::bool(), Type::string()), Type::int(), Type::float());
+        $this->assertEquals(sprintf('%s<bool|string,int,float>', self::class), (string) $type);
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse((new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::int()))->isNullable());
+        $this->assertTrue((new GenericType(Type::null(), Type::int()))->isNullable());
+        $this->assertTrue((new GenericType(Type::mixed(), Type::int()))->isNullable());
+    }
+
+    public function testAsNonNullable()
+    {
+        $type = new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::int());
+
+        $this->assertSame($type, $type->asNonNullable());
+    }
+
+    public function testIsA()
+    {
+        $type = new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool());
+        $this->assertTrue($type->isA(TypeIdentifier::ARRAY));
+        $this->assertFalse($type->isA(TypeIdentifier::STRING));
+
+        $type = new GenericType(Type::object(self::class), Type::union(Type::bool(), Type::string()), Type::int(), Type::float());
+        $this->assertTrue($type->isA(TypeIdentifier::OBJECT));
+        $this->assertFalse($type->isA(TypeIdentifier::INT));
+        $this->assertFalse($type->isA(TypeIdentifier::STRING));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Exception\LogicException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\Type\IntersectionType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class IntersectionTypeTest extends TestCase
+{
+    public function testCannotCreateWithOnlyOneType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new IntersectionType(Type::int());
+    }
+
+    public function testCannotCreateWithIntersectionTypeParts()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new IntersectionType(Type::int(), new IntersectionType());
+    }
+
+    public function testSortTypesOnCreation()
+    {
+        $type = new IntersectionType(Type::int(), Type::string(), Type::bool());
+        $this->assertEquals([Type::bool(), Type::int(), Type::string()], $type->getTypes());
+    }
+
+    public function testAtLeastOneTypeIs()
+    {
+        $type = new IntersectionType(Type::int(), Type::string(), Type::bool());
+
+        $this->assertTrue($type->atLeastOneTypeIs(fn (Type $t) => 'int' === (string) $t));
+        $this->assertFalse($type->atLeastOneTypeIs(fn (Type $t) => 'float' === (string) $t));
+    }
+
+    public function testEveryTypeIs()
+    {
+        $type = new IntersectionType(Type::int(), Type::string(), Type::bool());
+        $this->assertTrue($type->everyTypeIs(fn (Type $t) => $t instanceof BuiltinType));
+
+        $type = new IntersectionType(Type::int(), Type::string(), Type::template('T'));
+        $this->assertFalse($type->everyTypeIs(fn (Type $t) => $t instanceof BuiltinType));
+    }
+
+    public function testToString()
+    {
+        $type = new IntersectionType(Type::int(), Type::string(), Type::float());
+        $this->assertSame('float&int&string', (string) $type);
+
+        $type = new IntersectionType(Type::int(), Type::string(), Type::union(Type::float(), Type::bool()));
+        $this->assertSame('(bool|float)&int&string', (string) $type);
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse((new IntersectionType(Type::int(), Type::string(), Type::float()))->isNullable());
+        $this->assertTrue((new IntersectionType(Type::null(), Type::union(Type::int(), Type::mixed())))->isNullable());
+    }
+
+    public function testAsNonNullable()
+    {
+        $type = new IntersectionType(Type::int(), Type::string(), Type::float());
+
+        $this->assertSame($type, $type->asNonNullable());
+    }
+
+    public function testCannotTurnNullIntersectionAsNonNullable()
+    {
+        $this->expectException(LogicException::class);
+
+        $type = (new IntersectionType(Type::null(), Type::mixed()))->asNonNullable();
+    }
+
+    public function testIsA()
+    {
+        $type = new IntersectionType(Type::int(), Type::string(), Type::float());
+        $this->assertFalse($type->isA(TypeIdentifier::ARRAY));
+
+        $type = new IntersectionType(Type::int(), Type::string(), Type::union(Type::float(), Type::bool()));
+        $this->assertFalse($type->isA(TypeIdentifier::INT));
+
+        $type = new IntersectionType(Type::int(), Type::union(Type::int(), Type::int()));
+        $this->assertTrue($type->isA(TypeIdentifier::INT));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/ObjectTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/ObjectTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class ObjectTypeTest extends TestCase
+{
+    public function testToString()
+    {
+        $this->assertSame(self::class, (string) new ObjectType(self::class));
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse((new ObjectType(self::class))->isNullable());
+    }
+
+    public function testIsA()
+    {
+        $this->assertFalse((new ObjectType(self::class))->isA(TypeIdentifier::ARRAY));
+        $this->assertTrue((new ObjectType(self::class))->isA(TypeIdentifier::OBJECT));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\Type\UnionType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class UnionTypeTest extends TestCase
+{
+    public function testCannotCreateWithOnlyOneType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new UnionType(Type::int());
+    }
+
+    public function testCannotCreateWithUnionTypeParts()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new UnionType(Type::int(), new UnionType());
+    }
+
+    public function testSortTypesOnCreation()
+    {
+        $type = new UnionType(Type::int(), Type::string(), Type::bool());
+        $this->assertEquals([Type::bool(), Type::int(), Type::string()], $type->getTypes());
+    }
+
+    public function testAsNonNullable()
+    {
+        $type = new UnionType(Type::int(), Type::string(), Type::bool());
+        $this->assertInstanceOf(UnionType::class, $type->asNonNullable());
+        $this->assertEquals([Type::bool(), Type::int(), Type::string()], $type->asNonNullable()->getTypes());
+
+        $type = new UnionType(Type::int(), Type::string(), Type::null());
+        $this->assertInstanceOf(UnionType::class, $type->asNonNullable());
+        $this->assertEquals([Type::int(), Type::string()], $type->asNonNullable()->getTypes());
+
+        $type = new UnionType(Type::int(), Type::null());
+        $this->assertInstanceOf(BuiltinType::class, $type->asNonNullable());
+        $this->assertEquals(Type::int(), $type->asNonNullable());
+
+        $type = new UnionType(Type::int(), Type::object(\stdClass::class), Type::mixed());
+        $this->assertInstanceOf(UnionType::class, $type->asNonNullable());
+        $this->assertEquals([
+            Type::builtin(TypeIdentifier::ARRAY),
+            Type::bool(),
+            Type::float(),
+            Type::int(),
+            Type::object(),
+            Type::resource(),
+            Type::object(\stdClass::class),
+            Type::string(),
+        ], $type->asNonNullable()->getTypes());
+    }
+
+    public function testAtLeastOneTypeIs()
+    {
+        $type = new UnionType(Type::int(), Type::string(), Type::bool());
+
+        $this->assertTrue($type->atLeastOneTypeIs(fn (Type $t) => 'int' === (string) $t));
+        $this->assertFalse($type->atLeastOneTypeIs(fn (Type $t) => 'float' === (string) $t));
+    }
+
+    public function testEveryTypeIs()
+    {
+        $type = new UnionType(Type::int(), Type::string(), Type::bool());
+        $this->assertTrue($type->everyTypeIs(fn (Type $t) => $t instanceof BuiltinType));
+
+        $type = new UnionType(Type::int(), Type::string(), Type::template('T'));
+        $this->assertFalse($type->everyTypeIs(fn (Type $t) => $t instanceof BuiltinType));
+    }
+
+    public function testToString()
+    {
+        $type = new UnionType(Type::int(), Type::string(), Type::float());
+        $this->assertSame('float|int|string', (string) $type);
+
+        $type = new UnionType(Type::int(), Type::string(), Type::intersection(Type::float(), Type::bool()));
+        $this->assertSame('(bool&float)|int|string', (string) $type);
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse((new UnionType(Type::int(), Type::intersection(Type::float(), Type::int())))->isNullable());
+        $this->assertTrue((new UnionType(Type::int(), Type::null()))->isNullable());
+        $this->assertTrue((new UnionType(Type::int(), Type::mixed()))->isNullable());
+    }
+
+    public function testIsA()
+    {
+        $type = new UnionType(Type::int(), Type::string(), Type::float());
+        $this->assertFalse($type->isNullable());
+        $this->assertFalse($type->isA(TypeIdentifier::ARRAY));
+
+        $type = new UnionType(Type::int(), Type::string(), Type::intersection(Type::float(), Type::bool()));
+        $this->assertTrue($type->isA(TypeIdentifier::INT));
+        $this->assertTrue($type->isA(TypeIdentifier::STRING));
+        $this->assertFalse($type->isA(TypeIdentifier::FLOAT));
+        $this->assertFalse($type->isA(TypeIdentifier::BOOL));
+
+        $type = new UnionType(Type::string(), Type::intersection(Type::int(), Type::int()));
+        $this->assertTrue($type->isA(TypeIdentifier::INT));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeContext;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithUses;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
+
+class TypeContextFactoryTest extends TestCase
+{
+    private TypeContextFactory $typeContextFactory;
+
+    protected function setUp(): void
+    {
+        $this->typeContextFactory = new TypeContextFactory(new StringTypeResolver());
+    }
+
+    public function testCollectClassNames()
+    {
+        $typeContext = $this->typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class);
+        $this->assertSame('Dummy', $typeContext->calledClassName);
+        $this->assertSame('AbstractDummy', $typeContext->declaringClassName);
+
+        $typeContext = $this->typeContextFactory->createFromReflection(new \ReflectionClass(Dummy::class));
+        $this->assertSame('Dummy', $typeContext->calledClassName);
+        $this->assertSame('Dummy', $typeContext->declaringClassName);
+
+        $typeContext = $this->typeContextFactory->createFromReflection(new \ReflectionProperty(Dummy::class, 'id'));
+        $this->assertSame('Dummy', $typeContext->calledClassName);
+        $this->assertSame('Dummy', $typeContext->declaringClassName);
+
+        $typeContext = $this->typeContextFactory->createFromReflection(new \ReflectionMethod(Dummy::class, 'getId'));
+        $this->assertSame('Dummy', $typeContext->calledClassName);
+        $this->assertSame('Dummy', $typeContext->declaringClassName);
+
+        $typeContext = $this->typeContextFactory->createFromReflection(new \ReflectionParameter([Dummy::class, 'setId'], 'id'));
+        $this->assertSame('Dummy', $typeContext->calledClassName);
+        $this->assertSame('Dummy', $typeContext->declaringClassName);
+    }
+
+    public function testCollectNamespace()
+    {
+        $namespace = 'Symfony\\Component\\TypeInfo\\Tests\\Fixtures';
+
+        $this->assertSame($namespace, $this->typeContextFactory->createFromClassName(Dummy::class)->namespace);
+
+        $this->assertEquals($namespace, $this->typeContextFactory->createFromReflection(new \ReflectionClass(Dummy::class))->namespace);
+        $this->assertEquals($namespace, $this->typeContextFactory->createFromReflection(new \ReflectionProperty(Dummy::class, 'id'))->namespace);
+        $this->assertEquals($namespace, $this->typeContextFactory->createFromReflection(new \ReflectionMethod(Dummy::class, 'getId'))->namespace);
+        $this->assertEquals($namespace, $this->typeContextFactory->createFromReflection(new \ReflectionParameter([Dummy::class, 'setId'], 'id'))->namespace);
+    }
+
+    public function testCollectUses()
+    {
+        $this->assertSame([], $this->typeContextFactory->createFromClassName(Dummy::class)->uses);
+
+        $uses = [
+            'Type' => Type::class,
+            \DateTimeInterface::class => '\\'.\DateTimeInterface::class,
+            'DateTime' => '\\'.\DateTimeImmutable::class,
+        ];
+
+        $this->assertSame($uses, $this->typeContextFactory->createFromClassName(DummyWithUses::class)->uses);
+
+        $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithUses::class))->uses);
+        $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionProperty(DummyWithUses::class, 'createdAt'))->uses);
+        $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionMethod(DummyWithUses::class, 'setCreatedAt'))->uses);
+        $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionParameter([DummyWithUses::class, 'setCreatedAt'], 'createdAt'))->uses);
+    }
+
+    public function testCollectTemplates()
+    {
+        $this->assertEquals([], $this->typeContextFactory->createFromClassName(Dummy::class)->templates);
+        $this->assertEquals([
+            'T' => Type::union(Type::int(), Type::string()),
+            'U' => Type::mixed(),
+        ], $this->typeContextFactory->createFromClassName(DummyWithTemplates::class)->templates);
+
+        $this->assertEquals([
+            'T' => Type::union(Type::int(), Type::string()),
+            'U' => Type::mixed(),
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithTemplates::class))->templates);
+
+        $this->assertEquals([
+            'T' => Type::union(Type::int(), Type::string()),
+            'U' => Type::mixed(),
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionProperty(DummyWithTemplates::class, 'price'))->templates);
+
+        $this->assertEquals([
+            'T' => Type::union(Type::int(), Type::float()),
+            'U' => Type::mixed(),
+            'V' => Type::mixed(),
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionMethod(DummyWithTemplates::class, 'getPrice'))->templates);
+
+        $this->assertEquals([
+            'T' => Type::union(Type::int(), Type::float()),
+            'U' => Type::mixed(),
+            'V' => Type::mixed(),
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionParameter([DummyWithTemplates::class, 'getPrice'], 'inCents'))->templates);
+    }
+
+    public function testDoNotCollectTemplatesWhenToStringTypeResolver()
+    {
+        $typeContextFactory = new TypeContextFactory();
+
+        $this->assertEquals([], $typeContextFactory->createFromClassName(DummyWithTemplates::class)->templates);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeContext;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\LogicException;
+use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyExtendingStdClass;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithUses;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+
+class TypeContextTest extends TestCase
+{
+    public function testNormalize()
+    {
+        $typeContext = (new TypeContextFactory())->createFromClassName(DummyWithUses::class);
+
+        $this->assertSame(DummyWithUses::class, $typeContext->normalize('DummyWithUses'));
+        $this->assertSame(Type::class, $typeContext->normalize('Type'));
+        $this->assertSame('\\'.\DateTimeImmutable::class, $typeContext->normalize('DateTime'));
+        $this->assertSame('Symfony\\Component\\TypeInfo\\Tests\\Fixtures\\unknown', $typeContext->normalize('unknown'));
+        $this->assertSame('unknown', $typeContext->normalize('\\unknown'));
+
+        $typeContextWithoutNamespace = new TypeContext('Foo', 'Bar');
+        $this->assertSame('unknown', $typeContextWithoutNamespace->normalize('unknown'));
+    }
+
+    public function testGetDeclaringClass()
+    {
+        $this->assertSame(Dummy::class, (new TypeContextFactory())->createFromClassName(Dummy::class)->getDeclaringClass());
+        $this->assertSame(AbstractDummy::class, (new TypeContextFactory())->createFromClassName(Dummy::class, AbstractDummy::class)->getDeclaringClass());
+    }
+
+    public function testGetCalledClass()
+    {
+        $this->assertSame(Dummy::class, (new TypeContextFactory())->createFromClassName(Dummy::class)->getCalledClass());
+        $this->assertSame(Dummy::class, (new TypeContextFactory())->createFromClassName(Dummy::class, AbstractDummy::class)->getCalledClass());
+    }
+
+    public function testGetParentClass()
+    {
+        $this->assertSame(AbstractDummy::class, (new TypeContextFactory())->createFromClassName(Dummy::class)->getParentClass());
+        $this->assertSame(\stdClass::class, (new TypeContextFactory())->createFromClassName(DummyExtendingStdClass::class)->getParentClass());
+    }
+
+    public function testCannotGetParentClassWhenDoNotInherit()
+    {
+        $this->expectException(LogicException::class);
+        (new TypeContextFactory())->createFromClassName(AbstractDummy::class)->getParentClass();
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnum;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyEnum;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BackedEnumType;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\EnumType;
+use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\IntersectionType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\Type\TemplateType;
+use Symfony\Component\TypeInfo\Type\UnionType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class TypeFactoryTest extends TestCase
+{
+    public function testCreateBuiltin()
+    {
+        $this->assertEquals(new BuiltinType(TypeIdentifier::INT), Type::builtin(TypeIdentifier::INT));
+        $this->assertEquals(new BuiltinType(TypeIdentifier::INT), Type::builtin('int'));
+        $this->assertEquals(new BuiltinType(TypeIdentifier::INT), Type::int());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::FLOAT), Type::float());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::STRING), Type::string());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::BOOL), Type::bool());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::RESOURCE), Type::resource());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::FALSE), Type::false());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::TRUE), Type::true());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::CALLABLE), Type::callable());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::NULL), Type::null());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::MIXED), Type::mixed());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::VOID), Type::void());
+        $this->assertEquals(new BuiltinType(TypeIdentifier::NEVER), Type::never());
+    }
+
+    public function testCreateArray()
+    {
+        $this->assertEquals(new CollectionType(new BuiltinType(TypeIdentifier::ARRAY)), Type::array());
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ARRAY),
+                new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)),
+                new BuiltinType(TypeIdentifier::BOOL),
+            )),
+            Type::array(Type::bool()),
+        );
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ARRAY),
+                new BuiltinType(TypeIdentifier::STRING),
+                new BuiltinType(TypeIdentifier::BOOL),
+            )),
+            Type::array(Type::bool(), Type::string()),
+        );
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ARRAY),
+                new BuiltinType(TypeIdentifier::INT),
+                new BuiltinType(TypeIdentifier::BOOL),
+            ), isList: true),
+            Type::array(Type::bool(), Type::int(), true),
+        );
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ARRAY),
+                new BuiltinType(TypeIdentifier::INT),
+                new BuiltinType(TypeIdentifier::MIXED),
+            ), isList: true),
+            Type::list(),
+        );
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ARRAY),
+                new BuiltinType(TypeIdentifier::INT),
+                new BuiltinType(TypeIdentifier::BOOL),
+            ), isList: true),
+            Type::list(Type::bool()),
+        );
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ARRAY),
+                new BuiltinType(TypeIdentifier::STRING),
+                new BuiltinType(TypeIdentifier::MIXED),
+            )),
+            Type::dict(),
+        );
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ARRAY),
+                new BuiltinType(TypeIdentifier::STRING),
+                new BuiltinType(TypeIdentifier::BOOL),
+            )),
+            Type::dict(Type::bool()),
+        );
+    }
+
+    public function testCreateIterable()
+    {
+        $this->assertEquals(new CollectionType(new BuiltinType(TypeIdentifier::ITERABLE)), Type::iterable());
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ITERABLE),
+                new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)),
+                new BuiltinType(TypeIdentifier::BOOL),
+            )),
+            Type::iterable(Type::bool()),
+        );
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ITERABLE),
+                new BuiltinType(TypeIdentifier::STRING),
+                new BuiltinType(TypeIdentifier::BOOL),
+            )),
+            Type::iterable(Type::bool(), Type::string()),
+        );
+
+        $this->assertEquals(
+            new CollectionType(new GenericType(
+                new BuiltinType(TypeIdentifier::ITERABLE),
+                new BuiltinType(TypeIdentifier::INT),
+                new BuiltinType(TypeIdentifier::BOOL),
+            ), isList: true),
+            Type::iterable(Type::bool(), Type::int(), true),
+        );
+    }
+
+    public function testCreateObject()
+    {
+        $this->assertEquals(new BuiltinType(TypeIdentifier::OBJECT), Type::object());
+        $this->assertEquals(new ObjectType(self::class), Type::object(self::class));
+    }
+
+    public function testCreateEnum()
+    {
+        $this->assertEquals(new EnumType(DummyEnum::class), Type::enum(DummyEnum::class));
+        $this->assertEquals(new BackedEnumType(DummyBackedEnum::class, new BuiltinType(TypeIdentifier::STRING)), Type::enum(DummyBackedEnum::class));
+        $this->assertEquals(
+            new BackedEnumType(DummyBackedEnum::class, new BuiltinType(TypeIdentifier::INT)),
+            Type::enum(DummyBackedEnum::class, new BuiltinType(TypeIdentifier::INT)),
+        );
+    }
+
+    public function testCreateGeneric()
+    {
+        $this->assertEquals(
+            new GenericType(new ObjectType(self::class), new BuiltinType(TypeIdentifier::INT)),
+            Type::generic(Type::object(self::class), Type::int()),
+        );
+    }
+
+    public function testCreateTemplate()
+    {
+        $this->assertEquals(new TemplateType('T', new BuiltinType(TypeIdentifier::INT)), Type::template('T', Type::int()));
+        $this->assertEquals(new TemplateType('T', Type::mixed()), Type::template('T'));
+    }
+
+    public function testCreateUnion()
+    {
+        $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new ObjectType(self::class)), Type::union(Type::int(), Type::object(self::class)));
+        $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)), Type::union(Type::int(), Type::string(), Type::int()));
+        $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)), Type::union(Type::int(), Type::union(Type::int(), Type::string())));
+    }
+
+    public function testCreateIntersection()
+    {
+        $this->assertEquals(new IntersectionType(new BuiltinType(TypeIdentifier::INT), new ObjectType(self::class)), Type::intersection(Type::int(), Type::object(self::class)));
+        $this->assertEquals(new IntersectionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)), Type::intersection(Type::int(), Type::string(), Type::int()));
+        $this->assertEquals(new IntersectionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)), Type::intersection(Type::int(), Type::intersection(Type::int(), Type::string())));
+    }
+
+    public function testCreateNullable()
+    {
+        $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::NULL)), Type::nullable(Type::int()));
+        $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::NULL)), Type::nullable(Type::nullable(Type::int())));
+
+        $this->assertEquals(
+            new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING), new BuiltinType(TypeIdentifier::NULL)),
+            Type::nullable(Type::union(Type::int(), Type::string())),
+        );
+        $this->assertEquals(
+            new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING), new BuiltinType(TypeIdentifier::NULL)),
+            Type::nullable(Type::union(Type::int(), Type::string(), Type::null())),
+        );
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionParameterTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionParameterTypeResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummy;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionParameterTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionTypeResolver;
+
+class ReflectionParameterTypeResolverTest extends TestCase
+{
+    private ReflectionParameterTypeResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ReflectionParameterTypeResolver(new ReflectionTypeResolver(), new TypeContextFactory());
+    }
+
+    public function testCannotResolveNonReflectionParameter()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->resolver->resolve(123);
+    }
+
+    public function testCannotResolveReflectionParameterWithoutType()
+    {
+        $this->expectException(UnsupportedException::class);
+
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionParameter = $reflectionClass->getMethod('setNothing')->getParameters()[0];
+
+        $this->resolver->resolve($reflectionParameter);
+    }
+
+    public function testResolve()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionParameter = $reflectionClass->getMethod('setBuiltin')->getParameters()[0];
+
+        $this->assertEquals(Type::int(), $this->resolver->resolve($reflectionParameter));
+    }
+
+    public function testResolveOptionalParameter()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionParameter = $reflectionClass->getMethod('setOptional')->getParameters()[0];
+
+        $this->assertEquals(Type::nullable(Type::int()), $this->resolver->resolve($reflectionParameter));
+    }
+
+    public function testCreateTypeContextOrUseProvided()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionParameter = $reflectionClass->getMethod('setSelf')->getParameters()[0];
+
+        $this->assertEquals(Type::object(ReflectionExtractableDummy::class), $this->resolver->resolve($reflectionParameter));
+
+        $typeContext = (new TypeContextFactory())->createFromClassName(self::class);
+
+        $this->assertEquals(Type::object(self::class), $this->resolver->resolve($reflectionParameter, $typeContext));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionPropertyTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionPropertyTypeResolverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummy;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionPropertyTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionTypeResolver;
+
+class ReflectionPropertyTypeResolverTest extends TestCase
+{
+    private ReflectionPropertyTypeResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ReflectionPropertyTypeResolver(new ReflectionTypeResolver(), new TypeContextFactory());
+    }
+
+    public function testCannotResolveNonReflectionProperty()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->resolver->resolve(123);
+    }
+
+    public function testCannotResolveReflectionPropertyWithoutType()
+    {
+        $this->expectException(UnsupportedException::class);
+
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionProperty = $reflectionClass->getProperty('nothing');
+
+        $this->resolver->resolve($reflectionProperty);
+    }
+
+    public function testResolve()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionProperty = $reflectionClass->getProperty('builtin');
+
+        $this->assertEquals(Type::int(), $this->resolver->resolve($reflectionProperty));
+    }
+
+    public function testCreateTypeContextOrUseProvided()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionProperty = $reflectionClass->getProperty('self');
+
+        $this->assertEquals(Type::object(ReflectionExtractableDummy::class), $this->resolver->resolve($reflectionProperty));
+
+        $typeContext = (new TypeContextFactory())->createFromClassName(self::class);
+
+        $this->assertEquals(Type::object(self::class), $this->resolver->resolve($reflectionProperty, $typeContext));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionReturnTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionReturnTypeResolverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummy;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionReturnTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionTypeResolver;
+
+class ReflectionReturnTypeResolverTest extends TestCase
+{
+    private ReflectionReturnTypeResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ReflectionReturnTypeResolver(new ReflectionTypeResolver(), new TypeContextFactory());
+    }
+
+    public function testCannotResolveNonReflectionFunctionAbstract()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->resolver->resolve(123);
+    }
+
+    public function testCannotResolveReflectionFunctionAbstractWithoutType()
+    {
+        $this->expectException(UnsupportedException::class);
+
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionFunction = $reflectionClass->getMethod('getNothing');
+
+        $this->resolver->resolve($reflectionFunction);
+    }
+
+    public function testResolve()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionFunction = $reflectionClass->getMethod('getBuiltin');
+
+        $this->assertEquals(Type::int(), $this->resolver->resolve($reflectionFunction));
+    }
+
+    public function testCreateTypeContextOrUseProvided()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
+        $reflectionFunction = $reflectionClass->getMethod('getSelf');
+
+        $this->assertEquals(Type::object(ReflectionExtractableDummy::class), $this->resolver->resolve($reflectionFunction));
+
+        $typeContext = (new TypeContextFactory())->createFromClassName(self::class);
+
+        $this->assertEquals(Type::object(self::class), $this->resolver->resolve($reflectionFunction, $typeContext));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionTypeResolverTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnum;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyEnum;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummy;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\ReflectionTypeResolver;
+
+class ReflectionTypeResolverTest extends TestCase
+{
+    private ReflectionTypeResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ReflectionTypeResolver();
+    }
+
+    /**
+     * @dataProvider resolveDataProvider
+     */
+    public function testResolve(Type $expectedType, \ReflectionType $reflection, TypeContext $typeContext = null)
+    {
+        $this->assertEquals($expectedType, $this->resolver->resolve($reflection, $typeContext));
+    }
+
+    /**
+     * @return iterable<array{0: Type, 1: \ReflectionType, 2?: TypeContext}>
+     */
+    public function resolveDataProvider(): iterable
+    {
+        $typeContext = (new TypeContextFactory())->createFromClassName(ReflectionExtractableDummy::class);
+        $reflection = new \ReflectionClass(ReflectionExtractableDummy::class);
+
+        yield [Type::int(), $reflection->getProperty('builtin')->getType()];
+        yield [Type::nullable(Type::int()), $reflection->getProperty('nullableBuiltin')->getType()];
+        yield [Type::array(), $reflection->getProperty('array')->getType()];
+        yield [Type::nullable(Type::array()), $reflection->getProperty('nullableArray')->getType()];
+        yield [Type::iterable(), $reflection->getProperty('iterable')->getType()];
+        yield [Type::nullable(Type::iterable()), $reflection->getProperty('nullableIterable')->getType()];
+        yield [Type::object(Dummy::class), $reflection->getProperty('class')->getType()];
+        yield [Type::nullable(Type::object(Dummy::class)), $reflection->getProperty('nullableClass')->getType()];
+        yield [Type::object(ReflectionExtractableDummy::class), $reflection->getProperty('self')->getType(), $typeContext];
+        yield [Type::nullable(Type::object(ReflectionExtractableDummy::class)), $reflection->getProperty('nullableSelf')->getType(), $typeContext];
+        yield [Type::object(ReflectionExtractableDummy::class), $reflection->getMethod('getStatic')->getReturnType(), $typeContext];
+        yield [Type::nullable(Type::object(ReflectionExtractableDummy::class)), $reflection->getMethod('getNullableStatic')->getReturnType(), $typeContext];
+        yield [Type::object(AbstractDummy::class), $reflection->getProperty('parent')->getType(), $typeContext];
+        yield [Type::nullable(Type::object(AbstractDummy::class)), $reflection->getProperty('nullableParent')->getType(), $typeContext];
+        yield [Type::enum(DummyEnum::class), $reflection->getProperty('enum')->getType()];
+        yield [Type::nullable(Type::enum(DummyEnum::class)), $reflection->getProperty('nullableEnum')->getType()];
+        yield [Type::enum(DummyBackedEnum::class), $reflection->getProperty('backedEnum')->getType()];
+        yield [Type::nullable(Type::enum(DummyBackedEnum::class)), $reflection->getProperty('nullableBackedEnum')->getType()];
+        yield [Type::union(Type::int(), Type::string()), $reflection->getProperty('union')->getType()];
+        yield [Type::intersection(Type::object(\Traversable::class), Type::object(\Stringable::class)), $reflection->getProperty('intersection')->getType()];
+    }
+
+    public function testCannotResolveNonProperReflectionType()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->resolver->resolve(new \ReflectionClass(self::class));
+    }
+
+    /**
+     * @dataProvider classKeywordsTypesDataProvider
+     */
+    public function testCannotResolveClassKeywordsWithoutTypeContext(\ReflectionType $reflection)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve($reflection);
+    }
+
+    /**
+     * @return iterable<array{0: \ReflectionType}>
+     */
+    public function classKeywordsTypesDataProvider(): iterable
+    {
+        $reflection = new \ReflectionClass(ReflectionExtractableDummy::class);
+
+        yield [$reflection->getProperty('self')->getType()];
+        yield [$reflection->getMethod('getStatic')->getReturnType()];
+        yield [$reflection->getProperty('parent')->getType()];
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
+
+class StringTypeResolverTest extends TestCase
+{
+    private StringTypeResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new StringTypeResolver();
+    }
+
+    /**
+     * @dataProvider resolveDataProvider
+     */
+    public function testResolve(Type $expectedType, string $string, TypeContext $typeContext = null)
+    {
+        $this->assertEquals($expectedType, $this->resolver->resolve($string, $typeContext));
+    }
+
+    /**
+     * @return iterable<array{0: Type, 1: string, 2?: TypeContext}>
+     */
+    public function resolveDataProvider(): iterable
+    {
+        $typeContextFactory = new TypeContextFactory(new StringTypeResolver());
+
+        // callable
+        yield [Type::callable(), 'callable(string, int): mixed'];
+
+        // array
+        yield [Type::array(Type::bool()), 'bool[]'];
+
+        // array shape
+        yield [Type::array(), 'array{0: true, 1: false}'];
+
+        // object shape
+        yield [Type::object(), 'object{foo: true, bar: false}'];
+
+        // this
+        yield [Type::object(Dummy::class), '$this', $typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class)];
+
+        // const
+        yield [Type::array(), 'array[1, 2, 3]'];
+        yield [Type::false(), 'false'];
+        yield [Type::float(), '1.23'];
+        yield [Type::int(), '1'];
+        yield [Type::null(), 'null'];
+        yield [Type::string(), '"string"'];
+        yield [Type::true(), 'true'];
+
+        // identifiers
+        yield [Type::bool(), 'bool'];
+        yield [Type::bool(), 'boolean'];
+        yield [Type::true(), 'true'];
+        yield [Type::false(), 'false'];
+        yield [Type::int(), 'int'];
+        yield [Type::int(), 'integer'];
+        yield [Type::int(), 'positive-int'];
+        yield [Type::int(), 'negative-int'];
+        yield [Type::int(), 'non-positive-int'];
+        yield [Type::int(), 'non-negative-int'];
+        yield [Type::int(), 'non-zero-int'];
+        yield [Type::float(), 'float'];
+        yield [Type::float(), 'double'];
+        yield [Type::string(), 'string'];
+        yield [Type::string(), 'class-string'];
+        yield [Type::string(), 'trait-string'];
+        yield [Type::string(), 'interface-string'];
+        yield [Type::string(), 'callable-string'];
+        yield [Type::string(), 'numeric-string'];
+        yield [Type::string(), 'lowercase-string'];
+        yield [Type::string(), 'non-empty-lowercase-string'];
+        yield [Type::string(), 'non-empty-string'];
+        yield [Type::string(), 'non-falsy-string'];
+        yield [Type::string(), 'truthy-string'];
+        yield [Type::string(), 'literal-string'];
+        yield [Type::string(), 'html-escaped-string'];
+        yield [Type::resource(), 'resource'];
+        yield [Type::object(), 'object'];
+        yield [Type::callable(), 'callable'];
+        yield [Type::array(), 'array'];
+        yield [Type::array(), 'non-empty-array'];
+        yield [Type::list(), 'list'];
+        yield [Type::list(), 'non-empty-list'];
+        yield [Type::iterable(), 'iterable'];
+        yield [Type::mixed(), 'mixed'];
+        yield [Type::null(), 'null'];
+        yield [Type::void(), 'void'];
+        yield [Type::never(), 'never'];
+        yield [Type::never(), 'never-return'];
+        yield [Type::never(), 'never-returns'];
+        yield [Type::never(), 'no-return'];
+        yield [Type::union(Type::int(), Type::string()), 'array-key'];
+        yield [Type::union(Type::int(), Type::float(), Type::string(), Type::bool()), 'scalar'];
+        yield [Type::union(Type::int(), Type::float()), 'number'];
+        yield [Type::union(Type::int(), Type::float(), Type::string()), 'numeric'];
+        yield [Type::object(AbstractDummy::class), 'self', $typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class)];
+        yield [Type::object(Dummy::class), 'static', $typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class)];
+        yield [Type::object(AbstractDummy::class), 'parent', $typeContextFactory->createFromClassName(Dummy::class)];
+        yield [Type::object(Dummy::class), 'Dummy', $typeContextFactory->createFromClassName(Dummy::class)];
+        yield [Type::template('T', Type::union(Type::int(), Type::string())), 'T', $typeContextFactory->createFromClassName(DummyWithTemplates::class)];
+        yield [Type::template('V'), 'V', $typeContextFactory->createFromReflection(new \ReflectionMethod(DummyWithTemplates::class, 'getPrice'))];
+
+        // nullable
+        yield [Type::nullable(Type::int()), '?int'];
+
+        // generic
+        yield [Type::generic(Type::object(), Type::string(), Type::bool()), 'object<string, bool>'];
+        yield [Type::generic(Type::object(), Type::generic(Type::string(), Type::bool())), 'object<string<bool>>'];
+        yield [Type::int(), 'int<0, 100>'];
+
+        // union
+        yield [Type::union(Type::int(), Type::string()), 'int|string'];
+
+        // intersection
+        yield [Type::intersection(Type::int(), Type::string()), 'int&string'];
+
+        // DNF
+        yield [Type::union(Type::int(), Type::intersection(Type::string(), Type::bool())), 'int|(string&bool)'];
+
+        // collection objects
+        yield [Type::collection(Type::object(\Traversable::class)), \Traversable::class];
+        yield [Type::collection(Type::object(\Traversable::class), Type::string()), \Traversable::class.'<string>'];
+        yield [Type::collection(Type::object(\Traversable::class), Type::bool(), Type::string()), \Traversable::class.'<string, bool>'];
+        yield [Type::collection(Type::object(\Iterator::class)), \Iterator::class];
+        yield [Type::collection(Type::object(\Iterator::class), Type::string()), \Iterator::class.'<string>'];
+        yield [Type::collection(Type::object(\Iterator::class), Type::bool(), Type::string()), \Iterator::class.'<string, bool>'];
+        yield [Type::collection(Type::object(\IteratorAggregate::class)), \IteratorAggregate::class];
+        yield [Type::collection(Type::object(\IteratorAggregate::class), Type::string()), \IteratorAggregate::class.'<string>'];
+        yield [Type::collection(Type::object(\IteratorAggregate::class), Type::bool(), Type::string()), \IteratorAggregate::class.'<string, bool>'];
+    }
+
+    public function testCannotResolveNonStringType()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->resolver->resolve(123);
+    }
+
+    public function testCannotResolveThisWithoutTypeContext()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('$this');
+    }
+
+    public function testCannotResolveSelfWithoutTypeContext()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('self');
+    }
+
+    public function testCannotResolveStaticWithoutTypeContext()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('static');
+    }
+
+    public function testCannotResolveParentWithoutTypeContext()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('parent');
+    }
+
+    public function testCannotUnknownIdentifier()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->resolver->resolve('unknown');
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/TypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/TypeResolverTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolverInterface;
+
+class TypeResolverTest extends TestCase
+{
+    public function testResolve()
+    {
+        $resolver = TypeResolver::create();
+
+        $this->assertEquals(Type::bool(), $resolver->resolve('bool'));
+        $this->assertEquals(Type::int(), $resolver->resolve((new \ReflectionProperty(Dummy::class, 'id'))->getType()));
+        $this->assertEquals(Type::int(), $resolver->resolve((new \ReflectionMethod(Dummy::class, 'setId'))->getParameters()[0]));
+        $this->assertEquals(Type::int(), $resolver->resolve(new \ReflectionProperty(Dummy::class, 'id')));
+        $this->assertEquals(Type::void(), $resolver->resolve(new \ReflectionMethod(Dummy::class, 'setId')));
+        $this->assertEquals(Type::string(), $resolver->resolve(new \ReflectionFunction(strtoupper(...))));
+    }
+
+    public function testCannotFindResolver()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->expectExceptionMessage('Cannot find any resolver for "int" type.');
+
+        $resolver = new TypeResolver(new ServiceLocator([]));
+        $resolver->resolve(1);
+    }
+
+    public function testUseProperResolver()
+    {
+        $stringResolver = $this->createMock(TypeResolverInterface::class);
+        $stringResolver->method('resolve')->willReturn(Type::template('STRING'));
+
+        $reflectionTypeResolver = $this->createMock(TypeResolverInterface::class);
+        $reflectionTypeResolver->method('resolve')->willReturn(Type::template('REFLECTION_TYPE'));
+
+        $reflectionParameterResolver = $this->createMock(TypeResolverInterface::class);
+        $reflectionParameterResolver->method('resolve')->willReturn(Type::template('REFLECTION_PARAMETER'));
+
+        $reflectionPropertyResolver = $this->createMock(TypeResolverInterface::class);
+        $reflectionPropertyResolver->method('resolve')->willReturn(Type::template('REFLECTION_PROPERTY'));
+
+        $reflectionReturnTypeResolver = $this->createMock(TypeResolverInterface::class);
+        $reflectionReturnTypeResolver->method('resolve')->willReturn(Type::template('REFLECTION_RETURN_TYPE'));
+
+        $resolver = new TypeResolver(new ServiceLocator([
+            'string' => fn () => $stringResolver,
+            \ReflectionType::class => fn () => $reflectionTypeResolver,
+            \ReflectionParameter::class => fn () => $reflectionParameterResolver,
+            \ReflectionProperty::class => fn () => $reflectionPropertyResolver,
+            \ReflectionFunctionAbstract::class => fn () => $reflectionReturnTypeResolver,
+        ]));
+
+        $this->assertEquals(Type::template('STRING'), $resolver->resolve('foo'));
+        $this->assertEquals(
+            Type::template('REFLECTION_TYPE'),
+            $resolver->resolve((new \ReflectionProperty(Dummy::class, 'id'))->getType()),
+        );
+        $this->assertEquals(
+            Type::template('REFLECTION_PARAMETER'),
+            $resolver->resolve((new \ReflectionMethod(Dummy::class, 'setId'))->getParameters()[0]),
+        );
+        $this->assertEquals(
+            Type::template('REFLECTION_PROPERTY'),
+            $resolver->resolve(new \ReflectionProperty(Dummy::class, 'id')),
+        );
+        $this->assertEquals(
+            Type::template('REFLECTION_RETURN_TYPE'),
+            $resolver->resolve(new \ReflectionMethod(Dummy::class, 'setId')),
+        );
+        $this->assertEquals(
+            Type::template('REFLECTION_RETURN_TYPE'),
+            $resolver->resolve(new \ReflectionFunction(strtoupper(...))),
+        );
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Exception\LogicException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class TypeTest extends TestCase
+{
+    public function testIs()
+    {
+        $isInt = fn (Type $t) => TypeIdentifier::INT === $t->getBaseType()->getTypeIdentifier();
+
+        $this->assertTrue(Type::int()->is($isInt));
+        $this->assertTrue(Type::union(Type::string(), Type::int())->is($isInt));
+        $this->assertTrue(Type::generic(Type::int(), Type::string())->is($isInt));
+
+        $this->assertFalse(Type::string()->is($isInt));
+        $this->assertFalse(Type::union(Type::string(), Type::float())->is($isInt));
+        $this->assertFalse(Type::generic(Type::string(), Type::int())->is($isInt));
+    }
+
+    public function testIsA()
+    {
+        $this->assertTrue(Type::int()->isA(TypeIdentifier::INT));
+        $this->assertTrue(Type::union(Type::string(), Type::int())->isA(TypeIdentifier::INT));
+        $this->assertTrue(Type::generic(Type::int(), Type::string())->isA(TypeIdentifier::INT));
+
+        $this->assertFalse(Type::string()->isA(TypeIdentifier::INT));
+        $this->assertFalse(Type::union(Type::string(), Type::float())->isA(TypeIdentifier::INT));
+        $this->assertFalse(Type::generic(Type::string(), Type::int())->isA(TypeIdentifier::INT));
+    }
+
+    public function testIsNullable()
+    {
+        $this->assertTrue(Type::null()->isNullable());
+        $this->assertTrue(Type::mixed()->isNullable());
+        $this->assertTrue(Type::nullable(Type::int())->isNullable());
+        $this->assertTrue(Type::union(Type::int(), Type::null())->isNullable());
+        $this->assertTrue(Type::union(Type::int(), Type::mixed())->isNullable());
+        $this->assertTrue(Type::generic(Type::null(), Type::string())->isNullable());
+
+        $this->assertFalse(Type::int()->isNullable());
+        $this->assertFalse(Type::union(Type::int(), Type::string())->isNullable());
+        $this->assertFalse(Type::generic(Type::int(), Type::nullable(Type::string()))->isNullable());
+        $this->assertFalse(Type::generic(Type::int(), Type::mixed())->isNullable());
+    }
+
+    public function testGetBaseType()
+    {
+        $this->assertEquals(Type::string(), Type::string()->getBaseType());
+        $this->assertEquals(Type::object(self::class), Type::object(self::class)->getBaseType());
+        $this->assertEquals(Type::object(), Type::generic(Type::object(), Type::int())->getBaseType());
+        $this->assertEquals(Type::builtin(TypeIdentifier::ARRAY), Type::list()->getBaseType());
+        $this->assertEquals(Type::int(), Type::collection(Type::generic(Type::int(), Type::string()))->getBaseType());
+    }
+
+    public function testCannotGetBaseTypeOnCompoundType()
+    {
+        $this->expectException(LogicException::class);
+        Type::union(Type::int(), Type::string())->getBaseType();
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo;
+
+use Symfony\Component\TypeInfo\Exception\LogicException;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\IntersectionType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\Type\UnionType;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+abstract class Type implements \Stringable
+{
+    use TypeFactoryTrait;
+
+    public function getBaseType(): BuiltinType|ObjectType
+    {
+        if ($this instanceof UnionType || $this instanceof IntersectionType) {
+            throw new LogicException(sprintf('Cannot get base type on "%s" compound type.', (string) $this));
+        }
+
+        $baseType = $this;
+
+        if ($baseType instanceof CollectionType) {
+            $baseType = $baseType->getType();
+        }
+
+        if ($baseType instanceof GenericType) {
+            $baseType = $baseType->getType();
+        }
+
+        return $baseType;
+    }
+
+    /**
+     * @param callable(Type): bool $callable
+     */
+    public function is(callable $callable): bool
+    {
+        return match(true) {
+            $this instanceof UnionType => $this->atLeastOneTypeIs($callable),
+            $this instanceof IntersectionType => $this->everyTypeIs($callable),
+            default => $callable($this),
+        };
+    }
+
+    public function isA(TypeIdentifier $typeIdentifier): bool
+    {
+        return $this->testIdentifier(fn (TypeIdentifier $i): bool => $typeIdentifier === $i);
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->testIdentifier(fn (TypeIdentifier $i): bool => TypeIdentifier::NULL === $i || TypeIdentifier::MIXED === $i);
+    }
+
+    abstract public function asNonNullable(): self;
+
+    /**
+     * @param callable(TypeIdentifier): bool $test
+     */
+    private function testIdentifier(callable $test): bool
+    {
+        $callable = function (self $t) use ($test, &$callable): bool {
+            // unwrap compound type to forward type identifier check
+            if ($t instanceof UnionType || $t instanceof IntersectionType) {
+                return $t->is($callable);
+            }
+
+            return $test($t->getBaseType()->getTypeIdentifier());
+        };
+
+        return $this->is($callable);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/BackedEnumType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BackedEnumType.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template T of class-string<\BackedEnum>
+ * @template U of BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>
+ *
+ * @extends EnumType<T>
+ */
+final class BackedEnumType extends EnumType
+{
+    /**
+     * @param T $className
+     * @param U $backingType
+     */
+    public function __construct(
+        string $className,
+        private readonly BuiltinType $backingType,
+    ) {
+        parent::__construct($className);
+    }
+
+    /**
+     * @return U
+     */
+    public function getBackingType(): BuiltinType
+    {
+        return $this->backingType;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Exception\LogicException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template T of TypeIdentifier
+ */
+final class BuiltinType extends Type
+{
+    /**
+     * @param T $typeIdentifier
+     */
+    public function __construct(
+        private readonly TypeIdentifier $typeIdentifier,
+    ) {
+    }
+
+    /**
+     * @return T
+     */
+    public function getTypeIdentifier(): TypeIdentifier
+    {
+        return $this->typeIdentifier;
+    }
+
+    /**
+     * @return self|UnionType<BuiltinType<TypeIdentifier::OBJECT>|BuiltinType<TypeIdentifier::RESOURCE>|BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::STRING>|BuiltinType<TypeIdentifier::FLOAT>|BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::BOOL>>
+     */
+    public function asNonNullable(): self|UnionType
+    {
+        if (TypeIdentifier::NULL === $this->typeIdentifier) {
+            throw new LogicException('"null" cannot be turned as non nullable.');
+        }
+
+        // "mixed" is an alias of "object|resource|array|string|float|int|bool|null"
+        // therefore, its non-nullable version is "object|resource|array|string|float|int|bool"
+        if (TypeIdentifier::MIXED === $this->typeIdentifier) {
+            return new UnionType(
+                new self(TypeIdentifier::OBJECT),
+                new self(TypeIdentifier::RESOURCE),
+                new self(TypeIdentifier::ARRAY),
+                new self(TypeIdentifier::STRING),
+                new self(TypeIdentifier::FLOAT),
+                new self(TypeIdentifier::INT),
+                new self(TypeIdentifier::BOOL),
+            );
+        }
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->typeIdentifier->value;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Represents a key/value collection type.
+ *
+ * It proxies every method to the main type and adds methods related to key and value types.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType|GenericType
+ */
+final class CollectionType extends Type
+{
+    /**
+     * @param T $type
+     */
+    public function __construct(
+        private readonly BuiltinType|ObjectType|GenericType $type,
+        private readonly bool $isList = false,
+    ) {
+        if ($this->isList()) {
+            $keyType = $this->getCollectionKeyType();
+
+            if (!$keyType instanceof BuiltinType || TypeIdentifier::INT !== $keyType->getTypeIdentifier()) {
+                throw new InvalidArgumentException(sprintf('"%s" is not a valid list key type.', (string) $keyType));
+            }
+        }
+    }
+
+    /**
+     * @return T
+     */
+    public function getType(): BuiltinType|ObjectType|GenericType
+    {
+        return $this->type;
+    }
+
+    public function isList(): bool
+    {
+        return $this->isList;
+    }
+
+    public function asNonNullable(): self
+    {
+        return $this;
+    }
+
+    public function getCollectionKeyType(): Type
+    {
+        $defaultCollectionKeyType = self::union(self::int(), self::string());
+
+        if ($this->type instanceof GenericType) {
+            return match (\count($this->type->getVariableTypes())) {
+                2 => $this->type->getVariableTypes()[0],
+                1 => self::int(),
+                default => $defaultCollectionKeyType,
+            };
+        }
+
+        return $defaultCollectionKeyType;
+    }
+
+    public function getCollectionValueType(): Type
+    {
+        $defaultCollectionValueType = self::mixed();
+
+        if ($this->type instanceof GenericType) {
+            return match (\count($this->type->getVariableTypes())) {
+                2 => $this->type->getVariableTypes()[1],
+                1 => $this->type->getVariableTypes()[0],
+                default => $defaultCollectionValueType,
+            };
+        }
+
+        return $defaultCollectionValueType;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->type;
+    }
+
+    /**
+     * Proxies all method calls to the original type.
+     *
+     * @param list<mixed> $arguments
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        return $this->type->{$method}(...$arguments);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/CompositeTypeTrait.php
+++ b/src/Symfony/Component/TypeInfo/Type/CompositeTypeTrait.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @internal
+ *
+ * @template T of Type
+ */
+trait CompositeTypeTrait
+{
+    /**
+     * @var list<T>
+     */
+    private readonly array $types;
+
+    /**
+     * @param list<T> $types
+     */
+    public function __construct(Type ...$types)
+    {
+        if (\count($types) < 2) {
+            throw new InvalidArgumentException(sprintf('"%s" expects at least 2 types.', self::class));
+        }
+
+        foreach ($types as $t) {
+            if ($t instanceof self) {
+                throw new InvalidArgumentException(sprintf('Cannot set "%s" as a "%1$s" part.', self::class));
+            }
+        }
+
+        usort($types, fn (Type $a, Type $b): int => (string) $a <=> (string) $b);
+        $this->types = array_values(array_unique($types));
+    }
+
+    /**
+     * @return list<T>
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * @param callable(T): bool $callable
+     */
+    public function atLeastOneTypeIs(callable $callable): bool
+    {
+        foreach ($this->types as $t) {
+            if ($callable($t)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param callable(T): bool $callable
+     */
+    public function everyTypeIs(callable $callable): bool
+    {
+        foreach ($this->types as $t) {
+            if (!$callable($t)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/EnumType.php
+++ b/src/Symfony/Component/TypeInfo/Type/EnumType.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template T of class-string<\UnitEnum>
+ *
+ * @extends ObjectType<T>
+ */
+class EnumType extends ObjectType
+{
+}

--- a/src/Symfony/Component/TypeInfo/Type/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/Type/GenericType.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Represents a generic type, which is a type that holds variable parts.
+ *
+ * It proxies every method to the main type and adds methods related to variable types.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType
+ */
+final class GenericType extends Type
+{
+    /**
+     * @var list<Type>
+     */
+    private readonly array $variableTypes;
+
+    /**
+     * @param T $type
+     */
+    public function __construct(
+        private readonly BuiltinType|ObjectType $type,
+        Type ...$variableTypes,
+    ) {
+        $this->variableTypes = $variableTypes;
+    }
+
+    /**
+     * @return T
+     */
+    public function getType(): BuiltinType|ObjectType
+    {
+        return $this->type;
+    }
+
+    public function asNonNullable(): self
+    {
+        return $this;
+    }
+
+    /**
+     * @return list<Type>
+     */
+    public function getVariableTypes(): array
+    {
+        return $this->variableTypes;
+    }
+
+    public function __toString(): string
+    {
+        $typeString = (string) $this->type;
+
+        $variableTypesString = '';
+        $glue = '';
+        foreach ($this->variableTypes as $t) {
+            $variableTypesString .= $glue.((string) $t);
+            $glue = ',';
+        }
+
+        return $typeString.'<'.$variableTypesString.'>';
+    }
+
+    /**
+     * Proxies all method calls to the original type.
+     *
+     * @param list<mixed> $arguments
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        return $this->type->{$method}(...$arguments);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Exception\LogicException;
+use Symfony\Component\TypeInfo\Type;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template T of Type
+ */
+final class IntersectionType extends Type
+{
+    /**
+     * @use CompositeTypeTrait<T>
+     */
+    use CompositeTypeTrait;
+
+    public function __toString(): string
+    {
+        $string = '';
+        $glue = '';
+
+        foreach ($this->types as $t) {
+            $string .= $glue.($t instanceof UnionType ? '('.((string) $t).')' : ((string) $t));
+            $glue = '&';
+        }
+
+        return $string;
+    }
+
+    public function asNonNullable(): self
+    {
+        if ($this->isNullable()) {
+            throw new LogicException(sprintf('"%s cannot be turned as non nullable.', (string) $this));
+        }
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/ObjectType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectType.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template T of class-string
+ */
+class ObjectType extends Type
+{
+    /**
+     * @param T $className
+     */
+    public function __construct(
+        private readonly string $className,
+    ) {
+    }
+
+    public function getTypeIdentifier(): TypeIdentifier
+    {
+        return TypeIdentifier::OBJECT;
+    }
+
+    /**
+     * @return T
+     */
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    public function asNonNullable(): static
+    {
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->className;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/TemplateType.php
+++ b/src/Symfony/Component/TypeInfo/Type/TemplateType.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Type;
+
+/**
+ * Represents a template placeholder, such as "T" in "Collection<T>".
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class TemplateType extends Type
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly Type $bound,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getBound(): Type
+    {
+        return $this->bound;
+    }
+
+    public function asNonNullable(): self
+    {
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template T of Type
+ */
+final class UnionType extends Type
+{
+    /**
+     * @use CompositeTypeTrait<T>
+     */
+    use CompositeTypeTrait;
+
+    public function asNonNullable(): Type
+    {
+        $nonNullableTypes = [];
+        foreach ($this->getTypes() as $type) {
+            if ($type->isA(TypeIdentifier::NULL)) {
+                continue;
+            }
+
+            $nonNullableType = $type->asNonNullable();
+            $nonNullableTypes = [
+                ...$nonNullableTypes,
+                ...($nonNullableType instanceof self ? $nonNullableType->getTypes() : [$nonNullableType]),
+            ];
+        }
+
+        return \count($nonNullableTypes) > 1 ? new self(...$nonNullableTypes) : $nonNullableTypes[0];
+    }
+
+    public function __toString(): string
+    {
+        $string = '';
+        $glue = '';
+
+        foreach ($this->types as $t) {
+            $string .= $glue.($t instanceof IntersectionType ? '('.((string) $t).')' : ((string) $t));
+            $glue = '|';
+        }
+
+        return $string;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeContext;
+
+use Symfony\Component\TypeInfo\Exception\LogicException;
+use Symfony\Component\TypeInfo\Type;
+
+/**
+ * Type resolving context.
+ *
+ * Helps to retrieve declaring class, called class, parent class, templates
+ * and normalize classes according to the current namespace and uses.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class TypeContext
+{
+    /**
+     * @var array<string, bool>
+     */
+    private static array $classExistCache = [];
+
+    /**
+     * @param array<string, string> $uses
+     * @param array<string, Type>   $templates
+     */
+    public function __construct(
+        public readonly string $calledClassName,
+        public readonly string $declaringClassName,
+        public readonly ?string $namespace = null,
+        public readonly array $uses = [],
+        public readonly array $templates = [],
+    ) {
+    }
+
+    /**
+     * Normalize class name according to current namespace and uses.
+     */
+    public function normalize(string $name): string
+    {
+        if (str_starts_with($name, '\\')) {
+            return ltrim($name, '\\');
+        }
+
+        $nameParts = explode('\\', $name);
+        $firstNamePart = $nameParts[0];
+        if (isset($this->uses[$firstNamePart])) {
+            if (1 === \count($nameParts)) {
+                return $this->uses[$firstNamePart];
+            }
+            array_shift($nameParts);
+
+            return sprintf('%s\\%s', $this->uses[$firstNamePart], implode('\\', $nameParts));
+        }
+
+        if (null !== $this->namespace) {
+            return sprintf('%s\\%s', $this->namespace, $name);
+        }
+
+        return $name;
+    }
+
+    /**
+     * @return class-string
+     */
+    public function getDeclaringClass(): string
+    {
+        return $this->normalize($this->declaringClassName);
+    }
+
+    /**
+     * @return class-string
+     */
+    public function getCalledClass(): string
+    {
+        return $this->normalize($this->calledClassName);
+    }
+
+    /**
+     * @return class-string
+     */
+    public function getParentClass(): string
+    {
+        $declaringClassName = $this->getDeclaringClass();
+
+        if (false === $parentClass = get_parent_class($declaringClassName)) {
+            throw new LogicException(sprintf('"%s" do not extend any class.', $declaringClassName));
+        }
+
+        if (!isset(self::$classExistCache[$parentClass])) {
+            self::$classExistCache[$parentClass] = false;
+
+            if (class_exists($parentClass)) {
+                self::$classExistCache[$parentClass] = true;
+            } else {
+                try {
+                    new \ReflectionClass($parentClass);
+                    self::$classExistCache[$parentClass] = true;
+                } catch (\Throwable) {
+                }
+            }
+        }
+
+        return self::$classExistCache[$parentClass] ? $parentClass : $this->normalize(str_replace($this->namespace.'\\', '', $parentClass));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeContext;
+
+use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use Symfony\Component\TypeInfo\Exception\RuntimeException;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
+
+/**
+ * Creates a type resolving context.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class TypeContextFactory
+{
+    /**
+     * @var array<class-string, \ReflectionClass>
+     */
+    private static array $reflectionClassCache = [];
+
+    private ?Lexer $phpstanLexer = null;
+    private ?PhpDocParser $phpstanParser = null;
+
+    public function __construct(
+        private readonly ?StringTypeResolver $stringTypeResolver = null,
+    ) {
+    }
+
+    public function createFromClassName(string $calledClassName, string $declaringClassName = null): TypeContext
+    {
+        $declaringClassName ??= $calledClassName;
+
+        $calledClassPath = explode('\\', $calledClassName);
+        $declaringClassPath = explode('\\', $declaringClassName);
+
+        $declaringClassReflection = (self::$reflectionClassCache[$declaringClassName] ??= new \ReflectionClass($declaringClassName));
+
+        $typeContext = new TypeContext(
+            array_pop($calledClassPath),
+            array_pop($declaringClassPath),
+            trim($declaringClassReflection->getNamespaceName(), '\\'),
+            $this->collectUses($declaringClassReflection),
+        );
+
+        return new TypeContext(
+            $typeContext->calledClassName,
+            $typeContext->declaringClassName,
+            $typeContext->namespace,
+            $typeContext->uses,
+            $this->collectTemplates($declaringClassReflection, $typeContext),
+        );
+    }
+
+    public function createFromReflection(\Reflector $reflection): ?TypeContext
+    {
+        $declaringClassReflection = match (true) {
+            $reflection instanceof \ReflectionClass => $reflection,
+            $reflection instanceof \ReflectionMethod => $reflection->getDeclaringClass(),
+            $reflection instanceof \ReflectionProperty => $reflection->getDeclaringClass(),
+            $reflection instanceof \ReflectionParameter => $reflection->getDeclaringClass(),
+            $reflection instanceof \ReflectionFunctionAbstract => $reflection->getClosureScopeClass(),
+            default => null,
+        };
+
+        if (null === $declaringClassReflection) {
+            return null;
+        }
+
+        $typeContext = new TypeContext(
+            $declaringClassReflection->getShortName(),
+            $declaringClassReflection->getShortName(),
+            $declaringClassReflection->getNamespaceName(),
+            $this->collectUses($declaringClassReflection),
+        );
+
+        $templates = match (true) {
+            $reflection instanceof \ReflectionFunctionAbstract => $this->collectTemplates($reflection, $typeContext) + $this->collectTemplates($declaringClassReflection, $typeContext),
+            $reflection instanceof \ReflectionParameter => $this->collectTemplates($reflection->getDeclaringFunction(), $typeContext) + $this->collectTemplates($declaringClassReflection, $typeContext),
+            default => $this->collectTemplates($declaringClassReflection, $typeContext),
+        };
+
+        return new TypeContext(
+            $typeContext->calledClassName,
+            $typeContext->declaringClassName,
+            $typeContext->namespace,
+            $typeContext->uses,
+            $templates,
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function collectUses(\ReflectionClass $reflection): array
+    {
+        $fileName = $reflection->getFileName();
+        if (!\is_string($fileName) || !is_file($fileName)) {
+            return [];
+        }
+
+        if (false === $lines = @file($fileName)) {
+            throw new RuntimeException(sprintf('Unable to read file "%s".', $fileName));
+        }
+
+        $uses = [];
+        $inUseSection = false;
+
+        foreach ($lines as $line) {
+            if (str_starts_with($line, 'use ')) {
+                $inUseSection = true;
+                $use = explode(' as ', substr($line, 4, -2), 2);
+
+                $alias = 1 === \count($use) ? substr($use[0], false !== ($p = strrpos($use[0], '\\')) ? 1 + $p : 0) : $use[1];
+                $uses[$alias] = $use[0];
+            } elseif ($inUseSection) {
+                break;
+            }
+        }
+
+        $traitUses = [];
+        foreach ($reflection->getTraits() as $traitReflection) {
+            $traitUses[] = $this->collectUses($traitReflection);
+        }
+
+        return array_merge($uses, ...$traitUses);
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    private function collectTemplates(\ReflectionClass|\ReflectionFunctionAbstract $reflection, TypeContext $typeContext): array
+    {
+        if (!$this->stringTypeResolver || !class_exists(PhpDocParser::class)) {
+            return [];
+        }
+
+        if (!$rawDocNode = $reflection->getDocComment()) {
+            return [];
+        }
+
+        $this->phpstanLexer ??= new Lexer();
+        $this->phpstanParser ??= new PhpDocParser(new TypeParser(new ConstExprParser()), new ConstExprParser());
+
+        $tokens = new TokenIterator($this->phpstanLexer->tokenize($rawDocNode));
+
+        $templates = [];
+        foreach ($this->phpstanParser->parse($tokens)->getTagsByName('@template') as $tag) {
+            if (!$tag->value instanceof TemplateTagValueNode) {
+                continue;
+            }
+
+            $type = Type::mixed();
+            $typeString = ((string) $tag->value->bound) ?: null;
+
+            try {
+                if (null !== $typeString) {
+                    $type = $this->stringTypeResolver->resolve($typeString, $typeContext);
+                }
+            } catch (UnsupportedException) {
+            }
+
+            $templates[$tag->value->name] = $type;
+        }
+
+        return $templates;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -1,0 +1,319 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo;
+
+use Symfony\Component\TypeInfo\Type\BackedEnumType;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\EnumType;
+use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\IntersectionType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\Type\TemplateType;
+use Symfony\Component\TypeInfo\Type\UnionType;
+
+/**
+ * Helper trait to create any type easily.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+trait TypeFactoryTrait
+{
+    /**
+     * @template T of TypeIdentifier
+     * @template U value-of<T>
+     *
+     * @param T|U $identifier
+     *
+     * @return BuiltinType<T>
+     */
+    public static function builtin(TypeIdentifier|string $identifier): BuiltinType
+    {
+        /** @var T $identifier */
+        $identifier = \is_string($identifier) ? TypeIdentifier::from($identifier) : $identifier;
+
+        return new BuiltinType($identifier);
+    }
+
+    public static function foo(): BackedEnumType
+    {
+        return new BackedEnumType(\BackedEnum::class, Type::int());
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::INT>
+     */
+    public static function int(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::INT);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::FLOAT>
+     */
+    public static function float(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::FLOAT);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::STRING>
+     */
+    public static function string(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::STRING);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::BOOL>
+     */
+    public static function bool(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::BOOL);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::RESOURCE>
+     */
+    public static function resource(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::RESOURCE);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::FALSE>
+     */
+    public static function false(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::FALSE);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::TRUE>
+     */
+    public static function true(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::TRUE);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::CALLABLE>
+     */
+    public static function callable(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::CALLABLE);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::MIXED>
+     */
+    public static function mixed(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::MIXED);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::NULL>
+     */
+    public static function null(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::NULL);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::VOID>
+     */
+    public static function void(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::VOID);
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::NEVER>
+     */
+    public static function never(): BuiltinType
+    {
+        return self::builtin(TypeIdentifier::NEVER);
+    }
+
+    /**
+     * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType|GenericType
+     *
+     * @param T $type
+     *
+     * @return CollectionType<T>
+     */
+    public static function collection(BuiltinType|ObjectType|GenericType $type, Type $value = null, Type $key = null, bool $asList = false): CollectionType
+    {
+        if (!$type instanceof GenericType && (null !== $value || null !== $key)) {
+            $type = self::generic($type, $key ?? self::union(self::int(), self::string()), $value ?? self::mixed());
+        }
+
+        return new CollectionType($type, $asList);
+    }
+
+    /**
+     * @return CollectionType<BuiltinType<TypeIdentifier::ARRAY>>
+     */
+    public static function array(Type $value = null, Type $key = null, bool $asList = false): CollectionType
+    {
+        return self::collection(self::builtin(TypeIdentifier::ARRAY), $value, $key, $asList);
+    }
+
+    /**
+     * @return CollectionType<BuiltinType<TypeIdentifier::ITERABLE>>
+     */
+    public static function iterable(Type $value = null, Type $key = null, bool $asList = false): CollectionType
+    {
+        return self::collection(self::builtin(TypeIdentifier::ITERABLE), $value, $key, $asList);
+    }
+
+    /**
+     * @return CollectionType<BuiltinType<TypeIdentifier::ARRAY>>
+     */
+    public static function list(Type $value = null): CollectionType
+    {
+        return self::array($value, self::int(), asList: true);
+    }
+
+    /**
+     * @return CollectionType<BuiltinType<TypeIdentifier::ARRAY>>
+     */
+    public static function dict(Type $value = null): CollectionType
+    {
+        return self::array($value, self::string());
+    }
+
+    /**
+     * @template T of class-string
+     *
+     * @param T|null $className
+     *
+     * @return ($className is class-string ? ObjectType<T> : BuiltinType<TypeIdentifier::OBJECT>)
+     */
+    public static function object(string $className = null): BuiltinType|ObjectType
+    {
+        return null !== $className ? new ObjectType($className) : new BuiltinType(TypeIdentifier::OBJECT);
+    }
+
+    /**
+     * @template T of class-string<\UnitEnum>|class-string<\BackedEnum>
+     * @template U of BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>
+     *
+     * @param T      $className
+     * @param U|null $backingType
+     *
+     * @return ($className is class-string<\BackedEnum> ? ($backingType is U ? BackedEnumType<T,U> : BackedEnumType<T,BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>>) : EnumType<T>))
+     */
+    public static function enum(string $className, BuiltinType $backingType = null): EnumType
+    {
+        if (is_subclass_of($className, \BackedEnum::class)) {
+            if (null === $backingType) {
+                $reflectionBackingType = (new \ReflectionEnum($className))->getBackingType();
+                $typeIdentifier = TypeIdentifier::INT->value === (string) $reflectionBackingType ? TypeIdentifier::INT : TypeIdentifier::STRING;
+                $backingType = new BuiltinType($typeIdentifier);
+            }
+
+            return new BackedEnumType($className, $backingType);
+        }
+
+        return new EnumType($className);
+    }
+
+    /**
+     * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType
+     *
+     * @param T $mainType
+     *
+     * @return GenericType<T>
+     */
+    public static function generic(Type $mainType, Type ...$variableTypes): GenericType
+    {
+        return new GenericType($mainType, ...$variableTypes);
+    }
+
+    public static function template(string $name, Type $bound = null): TemplateType
+    {
+        return new TemplateType($name, $bound ?? Type::mixed());
+    }
+
+    /**
+     * @template T of Type
+     *
+     * @param list<T> $types
+     *
+     * @return UnionType<Type>
+     */
+    public static function union(Type ...$types): UnionType
+    {
+        /** @var list<T> $unionTypes */
+        $unionTypes = [];
+
+        foreach ($types as $type) {
+            if (!$type instanceof UnionType) {
+                $unionTypes[] = $type;
+
+                continue;
+            }
+
+            foreach ($type->getTypes() as $unionType) {
+                $unionTypes[] = $unionType;
+            }
+        }
+
+        return new UnionType(...$unionTypes);
+    }
+
+    /**
+     * @template T of Type
+     *
+     * @param list<T> $types
+     *
+     * @return IntersectionType<Type>
+     */
+    public static function intersection(Type ...$types): IntersectionType
+    {
+        /** @var list<T> $intersectionTypes */
+        $intersectionTypes = [];
+
+        foreach ($types as $type) {
+            if (!$type instanceof IntersectionType) {
+                $intersectionTypes[] = $type;
+
+                continue;
+            }
+
+            foreach ($type->getTypes() as $intersectionType) {
+                $intersectionTypes[] = $intersectionType;
+            }
+        }
+
+        return new IntersectionType(...$intersectionTypes);
+    }
+
+    /**
+     * @template T of Type
+     *
+     * @param T $type
+     *
+     * @return (T is UnionType ? T : UnionType<T|BuiltinType<TypeIdentifier::NULL>>)
+     */
+    public static function nullable(Type $type): UnionType
+    {
+        if ($type instanceof UnionType) {
+            return Type::union(Type::null(), ...$type->getTypes());
+        }
+
+        return Type::union($type, Type::null());
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeIdentifier.php
+++ b/src/Symfony/Component/TypeInfo/TypeIdentifier.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo;
+
+/**
+ * Identifier of a PHP native type.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+enum TypeIdentifier: string
+{
+    case ARRAY = 'array';
+    case BOOL = 'bool';
+    case CALLABLE = 'callable';
+    case FALSE = 'false';
+    case FLOAT = 'float';
+    case INT = 'int';
+    case ITERABLE = 'iterable';
+    case MIXED = 'mixed';
+    case NULL = 'null';
+    case OBJECT = 'object';
+    case RESOURCE = 'resource';
+    case STRING = 'string';
+    case TRUE = 'true';
+    case NEVER = 'never';
+    case VOID = 'void';
+}

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionParameterTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionParameterTypeResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeResolver;
+
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+
+/**
+ * Resolves type for a given parameter reflection.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @internal
+ */
+final readonly class ReflectionParameterTypeResolver implements TypeResolverInterface
+{
+    public function __construct(
+        private ReflectionTypeResolver $reflectionTypeResolver,
+        private TypeContextFactory $typeContextFactory,
+    ) {
+    }
+
+    public function resolve(mixed $subject, TypeContext $typeContext = null): Type
+    {
+        if (!$subject instanceof \ReflectionParameter) {
+            throw new UnsupportedException(sprintf('Expected subject to be a "ReflectionParameter", "%s" given.', get_debug_type($subject)), $subject);
+        }
+
+        $typeContext ??= $this->typeContextFactory->createFromReflection($subject);
+
+        try {
+            return $this->reflectionTypeResolver->resolve($subject->getType(), $typeContext);
+        } catch (UnsupportedException $e) {
+            $path = null !== $typeContext
+                ? sprintf('%s::%s($%s)', $typeContext->calledClassName, $subject->getDeclaringFunction()->getName(), $subject->getName())
+                : sprintf('%s($%s)', $subject->getDeclaringFunction()->getName(), $subject->getName());
+
+            throw new UnsupportedException(sprintf('Cannot resolve type for "%s".', $path), $subject, previous: $e);
+        }
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionPropertyTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionPropertyTypeResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeResolver;
+
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+
+/**
+ * Resolves type for a given property reflection.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @internal
+ */
+final readonly class ReflectionPropertyTypeResolver implements TypeResolverInterface
+{
+    public function __construct(
+        private ReflectionTypeResolver $reflectionTypeResolver,
+        private TypeContextFactory $typeContextFactory,
+    ) {
+    }
+
+    public function resolve(mixed $subject, TypeContext $typeContext = null): Type
+    {
+        if (!$subject instanceof \ReflectionProperty) {
+            throw new UnsupportedException(sprintf('Expected subject to be a "ReflectionProperty", "%s" given.', get_debug_type($subject)), $subject);
+        }
+
+        $typeContext ??= $this->typeContextFactory->createFromReflection($subject);
+
+        try {
+            return $this->reflectionTypeResolver->resolve($subject->getType(), $typeContext);
+        } catch (UnsupportedException $e) {
+            $path = sprintf('%s::$%s', $subject->getDeclaringClass()->getName(), $subject->getName());
+
+            throw new UnsupportedException(sprintf('Cannot resolve type for "%s".', $path), $subject, previous: $e);
+        }
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionReturnTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionReturnTypeResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeResolver;
+
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+
+/**
+ * Resolves return type for a given function reflection.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @internal
+ */
+final readonly class ReflectionReturnTypeResolver implements TypeResolverInterface
+{
+    public function __construct(
+        private ReflectionTypeResolver $reflectionTypeResolver,
+        private TypeContextFactory $typeContextFactory,
+    ) {
+    }
+
+    public function resolve(mixed $subject, TypeContext $typeContext = null): Type
+    {
+        if (!$subject instanceof \ReflectionFunctionAbstract) {
+            throw new UnsupportedException(sprintf('Expected subject to be a "ReflectionFunctionAbstract", "%s" given.', get_debug_type($subject)), $subject);
+        }
+
+        $typeContext ??= $this->typeContextFactory->createFromReflection($subject);
+
+        try {
+            return $this->reflectionTypeResolver->resolve($subject->getReturnType(), $typeContext);
+        } catch (UnsupportedException $e) {
+            $path = null !== $typeContext
+                ? sprintf('%s::%s()', $typeContext->calledClassName, $subject->getName())
+                : sprintf('%s()', $subject->getName());
+
+            throw new UnsupportedException(sprintf('Cannot resolve type for "%s".', $path), $subject, previous: $e);
+        }
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionTypeResolver.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeResolver;
+
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Resolves type for a given type reflection.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @internal
+ */
+final class ReflectionTypeResolver implements TypeResolverInterface
+{
+    /**
+     * @var array<class-string, \ReflectionEnum>
+     */
+    private static array $reflectionEnumCache = [];
+
+    public function resolve(mixed $subject, TypeContext $typeContext = null): Type
+    {
+        if ($subject instanceof \ReflectionUnionType) {
+            return Type::union(...array_map(fn (mixed $t): Type => $this->resolve($t, $typeContext), $subject->getTypes()));
+        }
+
+        if ($subject instanceof \ReflectionIntersectionType) {
+            return Type::intersection(...array_map(fn (mixed $t): Type => $this->resolve($t, $typeContext), $subject->getTypes()));
+        }
+
+        if (!$subject instanceof \ReflectionNamedType) {
+            throw new UnsupportedException(sprintf('Expected subject to be a "ReflectionNamedType", a "ReflectionUnionType" or a "ReflectionIntersectionType", "%s" given.', get_debug_type($subject)), $subject);
+        }
+
+        $identifier = $subject->getName();
+        $nullable = $subject->allowsNull();
+
+        if (TypeIdentifier::ARRAY->value === $identifier) {
+            $type = Type::array();
+
+            return $nullable ? Type::nullable($type) : $type;
+        }
+
+        if (TypeIdentifier::ITERABLE->value === $identifier) {
+            $type = Type::iterable();
+
+            return $nullable ? Type::nullable($type) : $type;
+        }
+
+        if (TypeIdentifier::NULL->value === $identifier || TypeIdentifier::MIXED->value === $identifier) {
+            return Type::builtin($identifier);
+        }
+
+        if ($subject->isBuiltin()) {
+            $type = Type::builtin(TypeIdentifier::from($identifier));
+
+            return $nullable ? Type::nullable($type) : $type;
+        }
+
+        if (\in_array(strtolower($identifier), ['self', 'static', 'parent'], true) && !$typeContext) {
+            throw new InvalidArgumentException(sprintf('A "%s" must be provided to resolve "%s".', TypeContext::class, strtolower($identifier)));
+        }
+
+        /** @var class-string $className */
+        $className = match (true) {
+            'self' === strtolower($identifier) => $typeContext->getDeclaringClass(),
+            'static' === strtolower($identifier) => $typeContext->getCalledClass(),
+            'parent' === strtolower($identifier) => $typeContext->getParentClass(),
+            default => $identifier,
+        };
+
+        if (is_subclass_of($className, \BackedEnum::class)) {
+            $reflectionEnum = (self::$reflectionEnumCache[$className] ??= new \ReflectionEnum($className));
+            $backingType = $this->resolve($reflectionEnum->getBackingType(), $typeContext);
+            $type = Type::enum($className, $backingType);
+        } elseif (is_subclass_of($className, \UnitEnum::class)) {
+            $type = Type::enum($className);
+        } else {
+            $type = Type::object($className);
+        }
+
+        return $nullable ? Type::nullable($type) : $type;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeResolver;
+
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprArrayNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFalseNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFloatNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNullNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprTrueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\ObjectShapeNode;
+use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Resolves type for a given string.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @internal
+ */
+final class StringTypeResolver implements TypeResolverInterface
+{
+    private const COLLECTION_CLASS_NAMES = [\Traversable::class, \Iterator::class, \IteratorAggregate::class, \ArrayAccess::class, \Generator::class];
+
+    /**
+     * @var array<string, bool>
+     */
+    private static array $classExistCache = [];
+
+    private readonly Lexer $lexer;
+    private readonly TypeParser $parser;
+
+    public function __construct()
+    {
+        $this->lexer = new Lexer();
+        $this->parser = new TypeParser(new ConstExprParser());
+    }
+
+    public function resolve(mixed $subject, TypeContext $typeContext = null): Type
+    {
+        if (!\is_string($subject)) {
+            throw new UnsupportedException(sprintf('Expected subject to be a "string", "%s" given.', get_debug_type($subject)), $subject);
+        }
+
+        try {
+            $tokens = new TokenIterator($this->lexer->tokenize($subject));
+            $node = $this->parser->parse($tokens);
+
+            return $this->getTypeFromNode($node, $typeContext);
+        } catch (\DomainException $e) {
+            throw new UnsupportedException(sprintf('Cannot resolve "%s".', $subject), $subject, previous: $e);
+        }
+    }
+
+    private function getTypeFromNode(TypeNode $node, ?TypeContext $typeContext): Type
+    {
+        if ($node instanceof CallableTypeNode) {
+            return Type::callable();
+        }
+
+        if ($node instanceof ArrayTypeNode) {
+            return Type::array($this->getTypeFromNode($node->type, $typeContext));
+        }
+
+        if ($node instanceof ArrayShapeNode) {
+            return Type::array();
+        }
+
+        if ($node instanceof ObjectShapeNode) {
+            return Type::object();
+        }
+
+        if ($node instanceof ThisTypeNode) {
+            if (null === $typeContext) {
+                throw new InvalidArgumentException(sprintf('A "%s" must be provided to resolve "$this".', TypeContext::class));
+            }
+
+            return Type::object($typeContext->getCalledClass());
+        }
+
+        if ($node instanceof ConstTypeNode) {
+            return match ($node->constExpr::class) {
+                ConstExprArrayNode::class => Type::array(),
+                ConstExprFalseNode::class => Type::false(),
+                ConstExprFloatNode::class => Type::float(),
+                ConstExprIntegerNode::class => Type::int(),
+                ConstExprNullNode::class => Type::null(),
+                ConstExprStringNode::class => Type::string(),
+                ConstExprTrueNode::class => Type::true(),
+                default => throw new \DomainException(sprintf('Unhandled "%s" constant expression.', $node->constExpr::class)),
+            };
+        }
+
+        if ($node instanceof IdentifierTypeNode) {
+            $type = match ($node->name) {
+                'bool', 'boolean' => Type::bool(),
+                'true' => Type::true(),
+                'false' => Type::false(),
+                'int', 'integer', 'positive-int', 'negative-int', 'non-positive-int', 'non-negative-int', 'non-zero-int' => Type::int(),
+                'float', 'double' => Type::float(),
+                'string',
+                'class-string',
+                'trait-string',
+                'interface-string',
+                'callable-string',
+                'numeric-string',
+                'lowercase-string',
+                'non-empty-lowercase-string',
+                'non-empty-string',
+                'non-falsy-string',
+                'truthy-string',
+                'literal-string',
+                'html-escaped-string' => Type::string(),
+                'resource' => Type::resource(),
+                'object' => Type::object(),
+                'callable' => Type::callable(),
+                'array', 'non-empty-array' => Type::array(),
+                'list', 'non-empty-list' => Type::list(),
+                'iterable' => Type::iterable(),
+                'mixed' => Type::mixed(),
+                'null' => Type::null(),
+                'array-key' => Type::union(Type::int(), Type::string()),
+                'scalar' => Type::union(Type::int(), Type::float(), Type::string(), Type::bool()),
+                'number' => Type::union(Type::int(), Type::float()),
+                'numeric' => Type::union(Type::int(), Type::float(), Type::string()),
+                'self' => $typeContext ? Type::object($typeContext->getDeclaringClass()) : throw new InvalidArgumentException(sprintf('A "%s" must be provided to resolve "self".', TypeContext::class)),
+                'static' => $typeContext ? Type::object($typeContext->getCalledClass()) : throw new InvalidArgumentException(sprintf('A "%s" must be provided to resolve "static".', TypeContext::class)),
+                'parent' => $typeContext ? Type::object($typeContext->getParentClass()) : throw new InvalidArgumentException(sprintf('A "%s" must be provided to resolve "parent".', TypeContext::class)),
+                'void' => Type::void(),
+                'never', 'never-return', 'never-returns', 'no-return' => Type::never(),
+                default => $this->resolveCustomIdentifier($node->name, $typeContext),
+            };
+
+            if ($type instanceof ObjectType && \in_array($type->getClassName(), self::COLLECTION_CLASS_NAMES, true)) {
+                return Type::collection($type);
+            }
+
+            return $type;
+        }
+
+        if ($node instanceof NullableTypeNode) {
+            return Type::nullable($this->getTypeFromNode($node->type, $typeContext));
+        }
+
+        if ($node instanceof GenericTypeNode) {
+            $type = $this->getTypeFromNode($node->type, $typeContext);
+
+            // handle integer ranges as simple integers
+            if ($type->isA(TypeIdentifier::INT)) {
+                return $type;
+            }
+
+            $variableTypes = array_map(fn (TypeNode $t): Type => $this->getTypeFromNode($t, $typeContext), $node->genericTypes);
+
+            if ($type instanceof CollectionType) {
+                $keyType = $type->getCollectionKeyType();
+
+                $type = $type->getType();
+                if ($type instanceof GenericType) {
+                    $type = $type->getType();
+                }
+
+                if (1 === \count($variableTypes)) {
+                    return Type::collection($type, $variableTypes[0], $keyType);
+                } elseif (2 === \count($variableTypes)) {
+                    return Type::collection($type, $variableTypes[1], $variableTypes[0]);
+                }
+            }
+
+            if ($type instanceof ObjectType && \in_array($type->getClassName(), self::COLLECTION_CLASS_NAMES, true)) {
+                return match (\count($variableTypes)) {
+                    1 => Type::collection($type, $variableTypes[0]),
+                    2 => Type::collection($type, $variableTypes[1], $variableTypes[0]),
+                    default => Type::collection($type),
+                };
+            }
+
+            return Type::generic($type, ...$variableTypes);
+        }
+
+        if ($node instanceof UnionTypeNode) {
+            return Type::union(...array_map(fn (TypeNode $t): Type => $this->getTypeFromNode($t, $typeContext), $node->types));
+        }
+
+        if ($node instanceof IntersectionTypeNode) {
+            return Type::intersection(...array_map(fn (TypeNode $t): Type => $this->getTypeFromNode($t, $typeContext), $node->types));
+        }
+
+        throw new \DomainException(sprintf('Unhandled "%s" node.', $node::class));
+    }
+
+    private function resolveCustomIdentifier(string $identifier, ?TypeContext $typeContext): Type
+    {
+        $className = $typeContext ? $typeContext->normalize($identifier) : $identifier;
+
+        if (!isset(self::$classExistCache[$className])) {
+            self::$classExistCache[$className] = false;
+
+            if (class_exists($className) || interface_exists($className)) {
+                self::$classExistCache[$className] = true;
+            } else {
+                try {
+                    new \ReflectionClass($className);
+                    self::$classExistCache[$className] = true;
+
+                    return Type::object($className);
+                } catch (\Throwable) {
+                }
+            }
+        }
+
+        if (self::$classExistCache[$className]) {
+            return Type::object($className);
+        }
+
+        if (isset($typeContext?->templates[$identifier])) {
+            return Type::template($identifier, $typeContext->templates[$identifier]);
+        }
+
+        throw new \DomainException(sprintf('Unhandled "%s" identifier.', $identifier));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolver.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeResolver;
+
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+
+/**
+ * Resolves type for a given subject by delegating resolving to nested type resolvers.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final readonly class TypeResolver implements TypeResolverInterface
+{
+    /**
+     * @param ContainerInterface $resolvers Locator of type resolvers, keyed by supported subject type
+     */
+    public function __construct(
+        private ContainerInterface $resolvers,
+    ) {
+    }
+
+    public function resolve(mixed $subject, TypeContext $typeContext = null): Type
+    {
+        $subjectType = match (\is_object($subject)) {
+            true => match (true) {
+                is_subclass_of($subject::class, \ReflectionType::class) => \ReflectionType::class,
+                is_subclass_of($subject::class, \ReflectionFunctionAbstract::class) => \ReflectionFunctionAbstract::class,
+                default => $subject::class,
+            },
+            false => get_debug_type($subject),
+        };
+
+        if (!$this->resolvers->has($subjectType)) {
+            if ('string' === $subjectType) {
+                throw new UnsupportedException('Cannot find any resolver for "string" type. Try running "composer require phpstan/phpdoc-parser".', $subject);
+            }
+
+            throw new UnsupportedException(sprintf('Cannot find any resolver for "%s" type.', $subjectType), $subject);
+        }
+
+        /** @param TypeResolverInterface $resolver */
+        $resolver = $this->resolvers->get($subjectType);
+
+        return $resolver->resolve($subject, $typeContext);
+    }
+
+    public static function create(): self
+    {
+        $resolvers = new class() implements ContainerInterface {
+            private readonly array $resolvers;
+
+            public function __construct()
+            {
+                $stringTypeResolver = class_exists(PhpDocParser::class) ? new StringTypeResolver() : null;
+                $typeContextFactory = new TypeContextFactory($stringTypeResolver);
+                $reflectionTypeResolver = new ReflectionTypeResolver();
+
+                $resolvers = [
+                    \ReflectionType::class => $reflectionTypeResolver,
+                    \ReflectionParameter::class => new ReflectionParameterTypeResolver($reflectionTypeResolver, $typeContextFactory),
+                    \ReflectionProperty::class => new ReflectionPropertyTypeResolver($reflectionTypeResolver, $typeContextFactory),
+                    \ReflectionFunctionAbstract::class => new ReflectionReturnTypeResolver($reflectionTypeResolver, $typeContextFactory),
+                ];
+
+                if (null !== $stringTypeResolver) {
+                    $resolvers['string'] = $stringTypeResolver;
+                }
+
+                $this->resolvers = $resolvers;
+            }
+
+            public function has(string $id): bool
+            {
+                return isset($this->resolvers[$id]);
+            }
+
+            public function get(string $id): TypeResolverInterface
+            {
+                return $this->resolvers[$id];
+            }
+        };
+
+        return new self($resolvers);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolverInterface.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolverInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeResolver;
+
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+
+/**
+ * Resolves type for a given subject.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface TypeResolverInterface
+{
+    /**
+     * Try to resolve a {@see Type} on a $subject.
+     * If the resolver cannot resolve the type, it will throw a {@see UnsupportedException}.
+     *
+     * @throws UnsupportedException
+     */
+    public function resolve(mixed $subject, TypeContext $typeContext = null): Type;
+}

--- a/src/Symfony/Component/TypeInfo/composer.json
+++ b/src/Symfony/Component/TypeInfo/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "symfony/type-info",
+    "type": "library",
+    "description": "Extracts PHP types information.",
+    "keywords": [
+        "type",
+        "phpdoc",
+        "phpstan",
+        "symfony"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathias Arlaud",
+            "email": "mathias.arlaud@gmail.com"
+        },
+        {
+            "name": "Baptiste LEDUC",
+            "email": "baptiste.leduc@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "psr/container": "^1.1|^2.0"
+    },
+    "require-dev": {
+        "symfony/dependency-injection": "^7.1",
+        "phpstan/phpdoc-parser": "^1.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\TypeInfo\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/TypeInfo/phpunit.xml.dist
+++ b/src/Symfony/Component/TypeInfo/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+        >
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony TypeInfo Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | TODO

Introducing the brand new `TypeInfo` component

This work has been done with @Korbeil 

## State of the art

### Scope of the current `Symfony\Component\PropertyInfo\Type` class
Nowadays, when we need to work with types within Symfony, we have to use the `Type` class of the `PropertyInfo` component.

But what if we want to represent the type of a function's return type?

We still can use that `Type` class, but it won't make much sense as the `Symfony\Component\PropertyInfo\Type` is closely related to a property (as the namespace suggests).


Plus, when we need to extract types, we must use the `PropertyTypeExtractorInterface` service:

```php
readonly class Person
{
  public function __construct(
    public string $firstName,
  ) {
  }
}

// will return an array with a single Type object representing a string
$types = $this->propertyTypeExtractor->getTypes(Person::class, 'firstName');
```

Therefore, type retrieval in Symfony is limited to properties only.

### `Symfony\Component\PropertyInfo\Type`'s conceptual limitations

On top of that, there is a clear limitation of the current `Type` class where unions, intersections or
even generics can't be properly described.

The actual workaround is that the `PropertyTypeExtractorInterface` is returning an array of `Type`, which can be interpreted as a union type.

## The `TypeInfo` component

All these reasons bring us to create the `TypeInfo` component.

The aim here is to address these issues and:

- Have a powerful `Type` definition that can handle union, intersections, and generics (and could be even more extended)
- Being able to get types from anything, such as properties, method arguments, return types, and raw strings (and can also be extended).

### `Type` classes

To ensure a powerful `Type` definition, we defined multiple classes:
![Type classes](https://i.imgur.com/Exs5gcY.png)

The base `Type` class is an abstract one, so you'll always need to use one of the classes that extend it. 
Other types of classes are kinda self-explanatory.

### Type resolving

In the `TypeInfo` component, we added a `TypeResolverInterface`, and several implementations which allow developers to get a `Type` from many things:
- `ReflectionParameterTypeResolver` to resolve a function/method parameter type thanks to reflection
- `ReflectionPropertyTypeResolver` to resolve a property type thanks to reflection
- `ReflectionReturnTypeResolver` to resolve a function/method return type thanks to reflection
- `ReflectionTypeResolver` to resolve a `ReflectionNamedType`
- `StringTypeResolver` to resolve a type string representation. This can greatly work in combination with PHP documentation.
  > That resolver will only be available if the `phpstan/phpdoc-parser` package is installed.
- `ChainTypeResolver` to iterate over resolvers and to return a type as soon as a nested resolver succeeds in resolving.

### Type Creation

We also improved a lot the DX for the type creation with factories:
```php
<?php

use Symfony\Component\TypeInfo\Type;

Type::int();
Type::nullable(Type::string());
Type::generic(Type::object(Collection::class), Type::int());
Type::list(Type::bool());
Type::intersection(Type::object(\Stringable::class), Type::object(\Iterator::class));

// Many others are available and can be 
// found in Symfony\Component\TypeInfo\TypeFactoryTrait
```

### Upgrade path

This PR only introduces the `TypeInfo` component, but another one (which is already ready) will deprecate the `Symfony\Component\PropertyInfo\Type` in favor of `Symfony\Component\TypeInfo\Type`.