### PR TITLE
[ErrorHandler] Do not use hyphens in exception message

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -641,6 +641,7 @@ table tbody td.num-col {
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     hyphens: auto;
+    hyphenate-character: '';
 }
 .text-small {
     font-size: 12px !important;

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -132,7 +132,7 @@ table th { background-color: var(--base-2); font-weight: bold; text-align: left;
 .prewrap { white-space: pre-wrap; }
 .nowrap { white-space: nowrap; }
 .newline { display: block; }
-.break-long-words { word-wrap: break-word; overflow-wrap: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; min-width: 0; }
+.break-long-words { word-wrap: break-word; overflow-wrap: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; hyphenate-character: ''; min-width: 0; }
 .text-small { font-size: 12px !important; }
 .text-muted { color: #999; }
 .text-bold { font-weight: bold; }

--- a/src/Symfony/Component/ErrorHandler/Resources/views/exception.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/exception.html.php
@@ -15,7 +15,7 @@
     </div>
     <div class="exception-message-wrapper">
         <div class="container">
-            <h1 class="break-long-words exception-message<?= mb_strlen($exceptionMessage) > 180 ? ' long' : ''; ?>"><?= $this->formatFileFromText(nl2br($exceptionMessage)); ?></h1>
+            <h1 class="exception-message<?= mb_strlen($exceptionMessage) > 180 ? ' long' : ''; ?>"><?= $this->formatFileFromText(nl2br($exceptionMessage)); ?></h1>
 
             <div class="exception-illustration hidden-xs-down">
                 <?= $this->include('assets/images/symfony-ghost.svg.php'); ?>

--- a/src/Symfony/Component/ErrorHandler/Resources/views/exception.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/exception.html.php
@@ -15,7 +15,7 @@
     </div>
     <div class="exception-message-wrapper">
         <div class="container">
-            <h1 class="exception-message<?= mb_strlen($exceptionMessage) > 180 ? ' long' : ''; ?>"><?= $this->formatFileFromText(nl2br($exceptionMessage)); ?></h1>
+            <h1 class="break-long-words exception-message<?= mb_strlen($exceptionMessage) > 180 ? ' long' : ''; ?>"><?= $this->formatFileFromText(nl2br($exceptionMessage)); ?></h1>
 
             <div class="exception-illustration hidden-xs-down">
                 <?= $this->include('assets/images/symfony-ghost.svg.php'); ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This is just a minor cosmetic change in the error handler. Currently, error messages are shown with hyphenation if they exceed the available with. But in technical texts like exception messages, a hyphen could give the message a slightly different meaning. To reduce the risk for confusion, I removed the hyphenation.