### PR TITLE
Mailer : add microsoft graph api mailer bridge

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitignore
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+6.4.0
+-----
+
+ * Added the bridge

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SendMailException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SendMailException.php
@@ -1,8 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
 
 class SendMailException extends \RuntimeException
 {
-
 }

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SendMailException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SendMailException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
+
+class SendMailException extends \RuntimeException
+{
+
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SenderNotFoundException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SenderNotFoundException.php
@@ -1,8 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
 
 class SenderNotFoundException extends SendMailException
 {
-
 }

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SenderNotFoundException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SenderNotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
+
+class SenderNotFoundException extends SendMailException
+{
+
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/UnAuthorizedException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/UnAuthorizedException.php
@@ -1,8 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
 
 class UnAuthorizedException extends SendMailException
 {
-
 }

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/UnAuthorizedException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/UnAuthorizedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
+
+class UnAuthorizedException extends SendMailException
+{
+
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019-present Fabien Potencier
+Copyright (c) 2023-present Kevin Nguyen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023-present Kevin Nguyen
+Copyright (c) 2023-present Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
@@ -1,0 +1,54 @@
+Microsoft Graph API Mailer
+=============
+
+Provides Microsoft Graph API integration for Symfony Mailer.
+
+
+Prerequisites
+---------
+You will need to:
+ * Register an application in your Microsoft Azure portal,
+ * Grant this application the Microsoft Graph `Mail.Send` permission,
+ * Create a secret for that app.
+
+
+Configuration example
+---------
+
+```env
+# MAILER
+MAILER_DSN=microsoft+graph://CLIENT_APP_ID:SECRET@default?tenant=TENANT_ID
+```
+
+If you need to use third parties operated or specific regions Microsoft services (China, US Government, etc.), you can specify Auth Endpoint and Graph Endpoint.
+
+```env
+# MAILER e.g. for China
+MAILER_DSN=microsoft+graph://CLIENT_APP_ID:SECRET@login.partner.microsoftonline.cn?tenant=TENANT_ID&graphEndpoint=https://microsoftgraph.chinacloudapi.cn
+```
+
+|                        | Authentication endpoint                  | Graph Endpoint                          |
+|------------------------|------------------------------------------|-----------------------------------------|
+| Global (default)       | https://login.microsoftonline.com        | https://graph.microsoft.com             |
+| US Government L4       | https://login.microsoftonline.us         | https://graph.microsoft.us              |
+| US Government L5 (DOD) | https://login.microsoftonline.us         | https://dod-graph.microsoft.us          |
+| China                  | https://login.partner.microsoftonline.cn | https://microsoftgraph.chinacloudapi.cn |
+
+More details can be found in the Microsoft documentation :
+ * [Auth Endpoints](https://learn.microsoft.com/en-us/entra/identity-platform/authentication-national-cloud#microsoft-entra-authentication-endpoints)
+ * [Grpah Endpoints](https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
+
+
+Troubleshooting
+--------
+//TODO : erreur stack trace
+Beware that the sender email address needs to be an address of an account inside your tenant.
+
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Google\Tests\Transport;
+
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransport;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
+use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+class MicrosoftGraphTransportFactoryTest extends TransportFactoryTestCase
+{
+    protected const TENANT = 'tenantId';
+
+    public function getFactory(): TransportFactoryInterface
+    {
+        return new MicrosoftGraphTransportFactory(new NullAdapter());
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [
+            new Dsn('microsoft+graph', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('microsoft+graph', 'example.com'),
+            true,
+        ];
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            new Dsn('microsoft+graph', 'default', self::USER, self::PASSWORD, null, ["tenant" => self::TENANT]),
+            new MicrosoftGraphTransport(self::USER, self::PASSWORD, 'https://login.microsoftonline.com/tenantId/oauth2/v2.0/token', 'https://graph.microsoft.com', new NullAdapter()),
+        ];
+        yield [
+            new Dsn('microsoft+graph', 'https://example.com', self::USER, self::PASSWORD, null, ["tenant" => self::TENANT, "graphEndpoint" => "https://another-example.com"]),
+            new MicrosoftGraphTransport(self::USER, self::PASSWORD, 'https://example.com/tenantId/oauth2/v2.0/token', 'https://another-example.com', new NullAdapter()),
+        ];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield [
+            new Dsn('microsoft+smtp', 'default', self::USER, self::PASSWORD),
+            'The "microsoft+smtp" scheme is not supported; supported schemes for mailer "microsoft graph" are: "microsoft+graph".',
+        ];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield [new Dsn('microsoft+graph', 'default', self::USER)];
+
+        yield [new Dsn('microsoft+graph', 'default', null, self::PASSWORD)];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Mailer\Bridge\Google\Tests\Transport;
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\Transport;
 
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransport;

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -43,11 +43,11 @@ class MicrosoftGraphTransportFactoryTest extends TransportFactoryTestCase
     public static function createProvider(): iterable
     {
         yield [
-            new Dsn('microsoft+graph', 'default', self::USER, self::PASSWORD, null, ["tenant" => self::TENANT]),
+            new Dsn('microsoft+graph', 'default', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
             new MicrosoftGraphTransport(self::USER, self::PASSWORD, 'https://login.microsoftonline.com/tenantId/oauth2/v2.0/token', 'https://graph.microsoft.com', new NullAdapter()),
         ];
         yield [
-            new Dsn('microsoft+graph', 'https://example.com', self::USER, self::PASSWORD, null, ["tenant" => self::TENANT, "graphEndpoint" => "https://another-example.com"]),
+            new Dsn('microsoft+graph', 'https://example.com', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT, 'graphEndpoint' => 'https://another-example.com']),
             new MicrosoftGraphTransport(self::USER, self::PASSWORD, 'https://example.com/tenantId/oauth2/v2.0/token', 'https://another-example.com', new NullAdapter()),
         ];
     }

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -1,0 +1,222 @@
+<?php
+declare(strict_types=1);
+/*
+ * This file is part of the Symfony package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
+
+use DateInterval;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Utils;
+use Microsoft\Graph\Graph;
+use Microsoft\Graph\Model\BodyType;
+use Microsoft\Graph\Model\EmailAddress;
+use Microsoft\Graph\Model\FileAttachment;
+use Microsoft\Graph\Model\ItemBody;
+use Microsoft\Graph\Model\Message;
+use Microsoft\Graph\Model\Recipient;
+use Safe\Exceptions\JsonException;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception\SenderNotFoundException;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception\SendMailException;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception\UnAuthorizedException;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\ParameterizedHeader;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+use function array_map;
+use function assert;
+use function count;
+use function Safe\json_decode;
+
+class MicrosoftGraphTransport implements TransportInterface
+{
+    public const AUTH_TOKEN_CACHE_KEY = 'SENDMAIL_OAUTH_TOKEN';
+    private Graph $graph;
+
+    public function __construct(
+        private readonly string         $clientId,
+        private readonly string         $clientSecret,
+        private readonly string         $authEndpoint,
+        private readonly string         $graphEndpoint,
+        private readonly CacheInterface $cache,
+    )
+    {
+        $this->graph = new Graph();
+        $this->graph->setBaseUrl($graphEndpoint);
+    }
+
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+    {
+        $envelope = $envelope !== null ? clone $envelope : Envelope::create($message);
+
+        if (!$message instanceof Email) {
+            throw new SendEmailError(
+                \sprintf(
+                    "This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed",
+                    Email::class,
+                    $message::class
+                ),
+            );
+        }
+
+        $this->auth();
+
+        try {
+            $this->sendMail($message);
+        } catch (UnAuthorizedException $exception) {
+            // Token may have expired, we need to refresh the token and try again
+            $this->auth(refresh: true);
+            $this->sendMail($message);
+        }
+
+        return new SentMessage($message, $envelope);
+    }
+
+    private function sendMail(Email $message): void
+    {
+        $message = $this->convertEmailToGraphMessage($message);
+
+        //Make sure $message->getFrom()->getEmailAddress()->getAddress() returns the email of an account in the tenant
+        $senderAddress = $message->getFrom()->getEmailAddress()->getAddress();
+        try{
+            $this->graph->createRequest('POST', '/users/' . $senderAddress . '/sendMail')
+                ->attachBody(['message' => $message])
+                ->execute();
+        }catch (ClientException $clientException){
+            $statusCode = $clientException->getCode();
+            if ($statusCode === 401) {
+                throw new UnAuthorizedException("Send mail request failed: received 401 - Unauthorized", $statusCode, $clientException);
+            }else if ($statusCode === 404){
+                $responseBody = $clientException->getResponse()->getBody()->getContents();
+                try{
+                    $responseBody = json_decode($responseBody, true);
+                    if ($responseBody['error']['code'] === 'ErrorInvalidUser') {
+                        var_export($responseBody);
+                        throw new SenderNotFoundException("Sender email address '" . $senderAddress . "' could not be found when calling the Graph API. This is usually because the email address doesn't exist in the tenant.", 404, $clientException);
+                    }
+                }catch (JsonException){
+                    // no JSON content, silently ignore, will bubble up at the end
+                }
+            }
+            throw new SendMailException("Something went wrong while sending email", $statusCode, $clientException);
+        }
+    }
+
+    private function auth(bool $refresh = false): void
+    {
+        if ($refresh) {
+            $this->cache->delete(key: self::AUTH_TOKEN_CACHE_KEY);
+        }
+
+        $accessToken = $this->cache->get(
+            key: self::AUTH_TOKEN_CACHE_KEY,
+            callback: function (ItemInterface $item) {
+                $guzzle = new Client();
+                $response = $guzzle->post($this->authEndpoint, [
+                    'form_params' => [
+                        'client_id' => $this->clientId,
+                        'client_secret' => $this->clientSecret,
+                        'scope' => $this->graphEndpoint . '/.default',
+                        'grant_type' => 'client_credentials',
+                    ],
+                ])->getBody()->getContents();
+                $token  = json_decode($response, true);
+
+                $item->expiresAfter(new DateInterval('PT' . ($token['expires_in'] - 60) . 'S'));
+
+                return $token['access_token'];
+            }
+        );
+
+        $this->graph->setAccessToken($accessToken);
+    }
+
+    private function convertEmailToGraphMessage(Email $source): Message
+    {
+        $message = new Message();
+
+        // From
+        if (count($source->getFrom()) === 0) {
+            throw new SendEmailError("Cannot send mail without 'From'");
+        }
+
+        $message->setFrom(self::convertAddressToGraphRecipient($source->getFrom()[0]));
+
+        // to
+        $message->setToRecipients(array_map(
+            static fn(Address $address) => self::convertAddressToGraphRecipient($address),
+            $source->getTo()
+        ));
+
+        // CC
+        $message->setCcRecipients(array_map(
+            static fn(Address $address) => self::convertAddressToGraphRecipient($address),
+            $source->getCc()
+        ));
+
+        // BCC
+        $message->setBccRecipients(array_map(
+            static fn(Address $address) => self::convertAddressToGraphRecipient($address),
+            $source->getBcc()
+        ));
+
+        // Subject & body
+        $message->setSubject($source->getSubject() ?? 'No subject');
+        $message->setBody(
+            (new ItemBody())->setContent((string)$source->getHtmlBody())
+                ->setContentType((new BodyType(BodyType::HTML)))
+        );
+
+        $message->setAttachments(array_map(
+            static fn(DataPart $attachment) => self::convertAttachmentGraphAttachment($attachment),
+            $source->getAttachments()
+        ));
+
+        return $message;
+    }
+
+    private static function convertAddressToGraphRecipient(Address $source): Recipient
+    {
+        return (new Recipient())
+            ->setEmailAddress((new EmailAddress())
+                ->setAddress($source->getAddress())
+                ->setName($source->getName()));
+    }
+
+    private static function convertAttachmentGraphAttachment(DataPart $source): FileAttachment
+    {
+        $attachment = new FileAttachment();
+
+        $contentDisposition = $source->getPreparedHeaders()->get('content-disposition');
+        assert($contentDisposition instanceof ParameterizedHeader);
+        $filename = $contentDisposition->getParameter('filename');
+
+        $fileStream = Utils::streamFor($source->bodyToString());
+        assert($fileStream instanceof Stream);
+
+        $attachment->setContentBytes($fileStream)
+            ->setContentType($source->getMediaType() . '/' . $source->getMediaSubtype())
+            ->setName($filename)
+            ->setODataType('#microsoft.graph.fileAttachment');
+
+        return $attachment;
+    }
+
+    public function __toString(): string
+    {
+        return 'microsoft_graph://oauth_mail';
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -1,7 +1,11 @@
 <?php
+
 declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -9,7 +13,6 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
 
-use DateInterval;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Stream;
@@ -36,9 +39,6 @@ use Symfony\Component\Mime\RawMessage;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
-use function array_map;
-use function assert;
-use function count;
 use function Safe\json_decode;
 
 class MicrosoftGraphTransport implements TransportInterface
@@ -47,29 +47,22 @@ class MicrosoftGraphTransport implements TransportInterface
     private Graph $graph;
 
     public function __construct(
-        private readonly string         $clientId,
-        private readonly string         $clientSecret,
-        private readonly string         $authEndpoint,
-        private readonly string         $graphEndpoint,
+        private readonly string $clientId,
+        private readonly string $clientSecret,
+        private readonly string $authEndpoint,
+        private readonly string $graphEndpoint,
         private readonly CacheInterface $cache,
-    )
-    {
+    ) {
         $this->graph = new Graph();
         $this->graph->setBaseUrl($graphEndpoint);
     }
 
-    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
-        $envelope = $envelope !== null ? clone $envelope : Envelope::create($message);
+        $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
 
         if (!$message instanceof Email) {
-            throw new SendEmailError(
-                \sprintf(
-                    "This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed",
-                    Email::class,
-                    $message::class
-                ),
-            );
+            throw new SendEmailError(sprintf("This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed", Email::class, $message::class));
         }
 
         $this->auth();
@@ -89,29 +82,29 @@ class MicrosoftGraphTransport implements TransportInterface
     {
         $message = $this->convertEmailToGraphMessage($message);
 
-        //Make sure $message->getFrom()->getEmailAddress()->getAddress() returns the email of an account in the tenant
+        // Make sure $message->getFrom()->getEmailAddress()->getAddress() returns the email of an account in the tenant
         $senderAddress = $message->getFrom()->getEmailAddress()->getAddress();
-        try{
-            $this->graph->createRequest('POST', '/users/' . $senderAddress . '/sendMail')
+        try {
+            $this->graph->createRequest('POST', '/users/'.$senderAddress.'/sendMail')
                 ->attachBody(['message' => $message])
                 ->execute();
-        }catch (ClientException $clientException){
+        } catch (ClientException $clientException) {
             $statusCode = $clientException->getCode();
-            if ($statusCode === 401) {
-                throw new UnAuthorizedException("Send mail request failed: received 401 - Unauthorized", $statusCode, $clientException);
-            }else if ($statusCode === 404){
+            if (401 === $statusCode) {
+                throw new UnAuthorizedException('Send mail request failed: received 401 - Unauthorized', $statusCode, $clientException);
+            } elseif (404 === $statusCode) {
                 $responseBody = $clientException->getResponse()->getBody()->getContents();
-                try{
+                try {
                     $responseBody = json_decode($responseBody, true);
-                    if ($responseBody['error']['code'] === 'ErrorInvalidUser') {
+                    if ('ErrorInvalidUser' === $responseBody['error']['code']) {
                         var_export($responseBody);
-                        throw new SenderNotFoundException("Sender email address '" . $senderAddress . "' could not be found when calling the Graph API. This is usually because the email address doesn't exist in the tenant.", 404, $clientException);
+                        throw new SenderNotFoundException("Sender email address '".$senderAddress."' could not be found when calling the Graph API. This is usually because the email address doesn't exist in the tenant.", 404, $clientException);
                     }
-                }catch (JsonException){
+                } catch (JsonException) {
                     // no JSON content, silently ignore, will bubble up at the end
                 }
             }
-            throw new SendMailException("Something went wrong while sending email", $statusCode, $clientException);
+            throw new SendMailException('Something went wrong while sending email', $statusCode, $clientException);
         }
     }
 
@@ -129,13 +122,13 @@ class MicrosoftGraphTransport implements TransportInterface
                     'form_params' => [
                         'client_id' => $this->clientId,
                         'client_secret' => $this->clientSecret,
-                        'scope' => $this->graphEndpoint . '/.default',
+                        'scope' => $this->graphEndpoint.'/.default',
                         'grant_type' => 'client_credentials',
                     ],
                 ])->getBody()->getContents();
-                $token  = json_decode($response, true);
+                $token = json_decode($response, true);
 
-                $item->expiresAfter(new DateInterval('PT' . ($token['expires_in'] - 60) . 'S'));
+                $item->expiresAfter(new \DateInterval('PT'.($token['expires_in'] - 60).'S'));
 
                 return $token['access_token'];
             }
@@ -149,39 +142,39 @@ class MicrosoftGraphTransport implements TransportInterface
         $message = new Message();
 
         // From
-        if (count($source->getFrom()) === 0) {
+        if (0 === \count($source->getFrom())) {
             throw new SendEmailError("Cannot send mail without 'From'");
         }
 
         $message->setFrom(self::convertAddressToGraphRecipient($source->getFrom()[0]));
 
         // to
-        $message->setToRecipients(array_map(
-            static fn(Address $address) => self::convertAddressToGraphRecipient($address),
+        $message->setToRecipients(\array_map(
+            static fn (Address $address) => self::convertAddressToGraphRecipient($address),
             $source->getTo()
         ));
 
         // CC
-        $message->setCcRecipients(array_map(
-            static fn(Address $address) => self::convertAddressToGraphRecipient($address),
+        $message->setCcRecipients(\array_map(
+            static fn (Address $address) => self::convertAddressToGraphRecipient($address),
             $source->getCc()
         ));
 
         // BCC
-        $message->setBccRecipients(array_map(
-            static fn(Address $address) => self::convertAddressToGraphRecipient($address),
+        $message->setBccRecipients(\array_map(
+            static fn (Address $address) => self::convertAddressToGraphRecipient($address),
             $source->getBcc()
         ));
 
         // Subject & body
         $message->setSubject($source->getSubject() ?? 'No subject');
         $message->setBody(
-            (new ItemBody())->setContent((string)$source->getHtmlBody())
-                ->setContentType((new BodyType(BodyType::HTML)))
+            (new ItemBody())->setContent((string) $source->getHtmlBody())
+                ->setContentType(new BodyType(BodyType::HTML))
         );
 
-        $message->setAttachments(array_map(
-            static fn(DataPart $attachment) => self::convertAttachmentGraphAttachment($attachment),
+        $message->setAttachments(\array_map(
+            static fn (DataPart $attachment) => self::convertAttachmentGraphAttachment($attachment),
             $source->getAttachments()
         ));
 
@@ -201,14 +194,14 @@ class MicrosoftGraphTransport implements TransportInterface
         $attachment = new FileAttachment();
 
         $contentDisposition = $source->getPreparedHeaders()->get('content-disposition');
-        assert($contentDisposition instanceof ParameterizedHeader);
+        \assert($contentDisposition instanceof ParameterizedHeader);
         $filename = $contentDisposition->getParameter('filename');
 
         $fileStream = Utils::streamFor($source->bodyToString());
-        assert($fileStream instanceof Stream);
+        \assert($fileStream instanceof Stream);
 
         $attachment->setContentBytes($fileStream)
-            ->setContentType($source->getMediaType() . '/' . $source->getMediaSubtype())
+            ->setContentType($source->getMediaType().'/'.$source->getMediaSubtype())
             ->setName($filename)
             ->setODataType('#microsoft.graph.fileAttachment');
 

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -1,8 +1,11 @@
 <?php
 
 declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -39,17 +42,18 @@ final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
             throw new UnsupportedSchemeException($dsn, 'microsoft graph', $this->getSupportedSchemes());
         }
         $tenantId = $dsn->getOption('tenant');
-        if ($tenantId === null){
+        if (null === $tenantId) {
             throw new IncompleteDsnException("Transport 'microsoft+graph' requires the 'tenant' option");
         }
 
         $graphEndpoint = $dsn->getOption('graphEndpoint', 'https://graph.microsoft.com');
         $authHost = 'default' === $dsn->getHost() ? 'https://login.microsoftonline.com' : $dsn->getHost();
+
         // This parses the MAILER_DSN containing Microsoft Graph API credentials
         return new MicrosoftGraphTransport(
             $this->getUser($dsn),
             $this->getPassword($dsn),
-            $authHost . '/' . $tenantId . '/oauth2/v2.0/token',
+            $authHost.'/'.$tenantId.'/oauth2/v2.0/token',
             $graphEndpoint,
             $this->cache
         );

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Symfony package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
+
+use Symfony\Component\Mailer\Exception\IncompleteDsnException;
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
+{
+    public function __construct(
+        private readonly CacheInterface $cache,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getSupportedSchemes(): array
+    {
+        return ['microsoft+graph'];
+    }
+
+    public function create(Dsn $dsn): TransportInterface
+    {
+        if ('microsoft+graph' !== $dsn->getScheme()) {
+            throw new UnsupportedSchemeException($dsn, 'microsoft graph', $this->getSupportedSchemes());
+        }
+        $tenantId = $dsn->getOption('tenant');
+        if ($tenantId === null){
+            throw new IncompleteDsnException("Transport 'microsoft+graph' requires the 'tenant' option");
+        }
+
+        $graphEndpoint = $dsn->getOption('graphEndpoint', 'https://graph.microsoft.com');
+        $authHost = 'default' === $dsn->getHost() ? 'https://login.microsoftonline.com' : $dsn->getHost();
+        // This parses the MAILER_DSN containing Microsoft Graph API credentials
+        return new MicrosoftGraphTransport(
+            $this->getUser($dsn),
+            $this->getPassword($dsn),
+            $authHost . '/' . $tenantId . '/oauth2/v2.0/token',
+            $graphEndpoint,
+            $this->cache
+        );
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "symfony/microsoft-graph-mailer",
+    "type": "symfony-mailer-bridge",
+    "description": "Symfony Microsoft Graph Mailer Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Kevin Nguyen",
+            "homepage": "https://github.com/nguyenk"
+        },
+        {
+            "name": "The Coding Machine",
+            "homepage": "https://github.com/thecodingmachine"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "symfony/mailer": "^5.4|^6.4|^7.0",
+        "thecodingmachine/safe": "^2.5.0",
+        "microsoft/microsoft-graph": "^1.109.0"
+    },
+    "require-dev": {
+        "symfony/http-client": "^5.4|^6.4|^7.0",
+        "symfony/cache": "6.4.x-dev"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\MicrosoftGraph\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
@@ -23,11 +23,12 @@
         "php": ">=8.1",
         "symfony/mailer": "^5.4|^6.4|^7.0",
         "thecodingmachine/safe": "^2.5.0",
-        "microsoft/microsoft-graph": "^1.109.0"
+        "microsoft/microsoft-graph": "^1.109.0",
+        "symfony/cache": "6.4.x-dev"
     },
     "require-dev": {
         "symfony/http-client": "^5.4|^6.4|^7.0",
-        "symfony/cache": "6.4.x-dev"
+        "microsoft/microsoft-graph": "^1.109.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\MicrosoftGraph\\": "" },

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Symfony Microsoft Graph API Bridge Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
+  <coverage/>
+  <source>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </source>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 for features / 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        |  N/A
| License       | MIT

This PR is initially comes from #48888 : Microsoft now forces OAuth for sending emails in SMTP which does not seem possible with the current mailer implementation.

I created a [gist](https://gist.github.com/nguyenk/15dd504dbcf7322807cb8f93371937d7) for a workaround

And I ended up proposing this PR after @xabbuh proposed

This is a Microsoft Graph API implementation, not an SMTP based.