### PR TITLE
[AssetMapper] Improving exception if a vendor asset's path is not mapped

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
@@ -232,7 +232,11 @@ class ImportMapGenerator
     private function createMissingImportMapAssetException(ImportMapEntry $entry): \InvalidArgumentException
     {
         if ($entry->isRemotePackage()) {
-            throw new LogicException(sprintf('The "%s" vendor asset is missing. Try running the "importmap:install" command.', $entry->importName));
+            if (!is_file($entry->path)) {
+                throw new LogicException(sprintf('The "%s" vendor asset is missing. Try running the "importmap:install" command.', $entry->importName));
+            }
+
+            throw new LogicException(sprintf('The "%s" vendor file exists locally (%s), but cannot be found in any asset map paths. Be sure the assets vendor directory is an asset mapper path.', $entry->importName, $entry->path));
         }
 
         throw new LogicException(sprintf('The asset "%s" cannot be found in any asset map paths.', $entry->path));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52513 
| License       | MIT

<img width="931" alt="Screenshot 2023-11-09 at 1 33 49 PM" src="https://github.com/symfony/symfony/assets/121003/71259583-97fa-40b6-9aab-ead80cf2d316">

It's a bit long - but this should be a RARE error, when users are messing around with asset mapper paths. So giving them more info is better.

/cc @evertharmeling :) 
