### PR TITLE
[AssetMapper] Only download a CSS file if it is explicitly advertised

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -129,8 +129,9 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
 
             $entrypoints = $cssEntrypointResponse->toArray()['entrypoints'] ?? [];
             $cssFile = $entrypoints['css']['file'] ?? null;
+            $guessed = $entrypoints['css']['guessed'] ?? true;
 
-            if (!$cssFile) {
+            if (!$cssFile || $guessed) {
                 continue;
             }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -224,7 +224,7 @@ class JsDelivrEsmResolverTest extends TestCase
                 [
                     'url' => '/v1/packages/npm/bootstrap@5.2.0/entrypoints',
                     'response' => ['body' => ['entrypoints' => [
-                        'css' => ['file' => '/dist/css/bootstrap.min.css'],
+                        'css' => ['file' => '/dist/css/bootstrap.min.css', 'guessed' => false],
                     ]]],
                 ],
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

When we download a JS package, we check to see if that JS package has a CSS file. And if it does, we add that too. This is purely to be helpful. For example, `importmap:require bootstrap` grabs the Bootstrap CSS file.

A JavaScript package can explicitly advertise that it has a CSS file or jsdelivr can "guess". It tells us if it's guessing or not:

* Not guessing: https://data.jsdelivr.com/v1/packages/npm/bootstrap@5.0.0/entrypoints
* Yes guessing: https://data.jsdelivr.com/v1/packages/npm/tom-select@2.3.1/entrypoints

I propose we only grab the CSS file if it's a "sure thing". Right now, when you install `tom-select`, it's grabbing a CSS file that... we certainly don't use and I'm not sure if anyone does. It'd be better if it grabbed nothing. And, if needed (probably will be), we an make Flex install any enabled "autoimports" - e.g. https://github.com/symfony/ux/blob/2.x/src/Autocomplete/assets/package.json#L17

Overall, I'm still tweaking with the ideal UX here. I think life will be better if we only install "for sure" CSS files.

Thanks!