### PR TITLE
Add some more non-countable English nouns

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -21,7 +21,7 @@ final class EnglishInflector implements InflectorInterface
     private const PLURAL_MAP = [
         // First entry: plural suffix, reversed
         // Second entry: length of plural suffix
-        // Third entry: Whether the suffix may succeed a vocal
+        // Third entry: Whether the suffix may succeed a vowel
         // Fourth entry: Whether the suffix may succeed a consonant
         // Fifth entry: singular suffix, normal
 
@@ -162,7 +162,7 @@ final class EnglishInflector implements InflectorInterface
     private const SINGULAR_MAP = [
         // First entry: singular suffix, reversed
         // Second entry: length of singular suffix
-        // Third entry: Whether the suffix may succeed a vocal
+        // Third entry: Whether the suffix may succeed a vowel
         // Fourth entry: Whether the suffix may succeed a consonant
         // Fifth entry: plural suffix, normal
 
@@ -343,14 +343,29 @@ final class EnglishInflector implements InflectorInterface
         // deer
         'reed',
 
+        // equipment
+        'tnempiuqe',
+
         // feedback
         'kcabdeef',
 
         // fish
         'hsif',
 
+        // health
+        'htlaeh',
+
+        // history
+        'yrotsih',
+
         // info
         'ofni',
+
+        // information
+        'noitamrofni',
+
+        // money
+        'yenom',
 
         // moose
         'esoom',
@@ -363,6 +378,9 @@ final class EnglishInflector implements InflectorInterface
 
         // species
         'seiceps',
+
+        // traffic
+        'ciffart',
     ];
 
     /**
@@ -399,14 +417,14 @@ final class EnglishInflector implements InflectorInterface
                 if ($j === $suffixLength) {
                     // Is there any character preceding the suffix in the plural string?
                     if ($j < $pluralLength) {
-                        $nextIsVocal = false !== strpos('aeiou', $lowerPluralRev[$j]);
+                        $nextIsVowel = false !== strpos('aeiou', $lowerPluralRev[$j]);
 
-                        if (!$map[2] && $nextIsVocal) {
-                            // suffix may not succeed a vocal but next char is one
+                        if (!$map[2] && $nextIsVowel) {
+                            // suffix may not succeed a vowel but next char is one
                             break;
                         }
 
-                        if (!$map[3] && !$nextIsVocal) {
+                        if (!$map[3] && !$nextIsVowel) {
                             // suffix may not succeed a consonant but next char is one
                             break;
                         }
@@ -479,14 +497,14 @@ final class EnglishInflector implements InflectorInterface
                 if ($j === $suffixLength) {
                     // Is there any character preceding the suffix in the plural string?
                     if ($j < $singularLength) {
-                        $nextIsVocal = false !== strpos('aeiou', $lowerSingularRev[$j]);
+                        $nextIsVowel = false !== strpos('aeiou', $lowerSingularRev[$j]);
 
-                        if (!$map[2] && $nextIsVocal) {
-                            // suffix may not succeed a vocal but next char is one
+                        if (!$map[2] && $nextIsVowel) {
+                            // suffix may not succeed a vowel but next char is one
                             break;
                         }
 
-                        if (!$map[3] && !$nextIsVocal) {
+                        if (!$map[3] && !$nextIsVowel) {
                             // suffix may not succeed a consonant but next char is one
                             break;
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

@acirulis spotted that equipment was missing here: https://github.com/api-platform/core/issues/5957

I've added that and a few more non-countable nouns that I think are reasonably likely to be used by someone.  Arguably, time and work could also be here since they are normally non-countable, but there cases where times and works would be correct too.

And I corrected vocal to vowel, which is the correct English term

I'm not sure if this needs extra tests - happy to add if needed.