### PR TITLE
[WebProfilerBundle] Mark CodeExtension as non-internal

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/CodeExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/CodeExtension.php
@@ -22,8 +22,6 @@ use Twig\TwigFilter;
  * that is never executed in a production environment.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @internal
  */
 final class CodeExtension extends AbstractExtension
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

From https://github.com/symfony/symfony/pull/52449#issuecomment-1804257834 by @GromNaN 

Using those twig helpers in a profiler page is 100% legit. I think that the notice in the class' docbloc + the fact it moved to the WebProfilerBundle namespace allows us to mark the class back as non-internal.