### PR TITLE
Release v4.4.51

### DIFF
--- a/CHANGELOG-4.4.md
+++ b/CHANGELOG-4.4.md
@@ -7,6 +7,10 @@ in 4.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.4.0...v4.4.1
 
+* 4.4.51 (2023-11-10)
+
+ * security #cve-2023-46734 [TwigBridge] Ensure CodeExtension's filters properly escape their input (nicolas-grekas, GromNaN)
+
 * 4.4.50 (2023-02-01)
 
  * security #cve-2022-24895 [Security/Http] Remove CSRF tokens from storage on successful login (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,11 +76,11 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    public const VERSION = '4.4.50';
-    public const VERSION_ID = 40450;
+    public const VERSION = '4.4.51';
+    public const VERSION_ID = 40451;
     public const MAJOR_VERSION = 4;
     public const MINOR_VERSION = 4;
-    public const RELEASE_VERSION = 50;
+    public const RELEASE_VERSION = 51;
     public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v4.4.50...v4.4.51)

 * security #cve-2023-46734 [TwigBridge] Ensure CodeExtension's filters properly escape their input (@nicolas-grekas, @GromNaN)
