### PR TITLE
[Routing] Extend old Annotations from new Attributes

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -17,7 +17,7 @@ class_exists(\Symfony\Component\Routing\Attribute\Route::class);
 
 if (false) {
     #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
-    class Route
+    class Route extends \Symfony\Component\Routing\Attribute\Route
     {
     }
 }

--- a/src/Symfony/Component/Routing/Attribute/Route.php
+++ b/src/Symfony/Component/Routing/Attribute/Route.php
@@ -20,6 +20,8 @@ namespace Symfony\Component\Routing\Attribute;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Alexander M. Turek <me@derrabus.de>
+ *
+ * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class Route

--- a/src/Symfony/Component/Serializer/Annotation/Context.php
+++ b/src/Symfony/Component/Serializer/Annotation/Context.php
@@ -17,7 +17,7 @@ class_exists(\Symfony\Component\Serializer\Attribute\Context::class);
 
 if (false) {
     #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-    class Context
+    class Context extends \Symfony\Component\Serializer\Attribute\Context
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
@@ -15,7 +15,7 @@ class_exists(\Symfony\Component\Serializer\Attribute\DiscriminatorMap::class);
 
 if (false) {
     #[\Attribute(\Attribute::TARGET_CLASS)]
-    class DiscriminatorMap
+    class DiscriminatorMap extends \Symfony\Component\Serializer\Attribute\DiscriminatorMap
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -15,7 +15,7 @@ class_exists(\Symfony\Component\Serializer\Attribute\Groups::class);
 
 if (false) {
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_CLASS)]
-    class Groups
+    class Groups extends \Symfony\Component\Serializer\Attribute\Groups
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Annotation/Ignore.php
+++ b/src/Symfony/Component/Serializer/Annotation/Ignore.php
@@ -15,7 +15,7 @@ class_exists(\Symfony\Component\Serializer\Attribute\Ignore::class);
 
 if (false) {
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-    final class Ignore
+    class Ignore extends \Symfony\Component\Serializer\Attribute\Ignore
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -15,7 +15,7 @@ class_exists(\Symfony\Component\Serializer\Attribute\MaxDepth::class);
 
 if (false) {
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-    class MaxDepth
+    class MaxDepth extends \Symfony\Component\Serializer\Attribute\MaxDepth
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Annotation/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedName.php
@@ -15,7 +15,7 @@ class_exists(\Symfony\Component\Serializer\Attribute\SerializedName::class);
 
 if (false) {
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-    final class SerializedName
+    class SerializedName extends \Symfony\Component\Serializer\Attribute\SerializedName
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Annotation/SerializedPath.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedPath.php
@@ -15,7 +15,7 @@ class_exists(\Symfony\Component\Serializer\Attribute\SerializedPath::class);
 
 if (false) {
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-    final class SerializedPath
+    class SerializedPath extends \Symfony\Component\Serializer\Attribute\SerializedPath
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Attribute/Context.php
+++ b/src/Symfony/Component/Serializer/Attribute/Context.php
@@ -21,6 +21,8 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Context

--- a/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
@@ -21,6 +21,8 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"CLASS"})
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
+ *
+ * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class DiscriminatorMap

--- a/src/Symfony/Component/Serializer/Attribute/Groups.php
+++ b/src/Symfony/Component/Serializer/Attribute/Groups.php
@@ -21,6 +21,8 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD", "CLASS"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_CLASS)]
 class Groups

--- a/src/Symfony/Component/Serializer/Attribute/Ignore.php
+++ b/src/Symfony/Component/Serializer/Attribute/Ignore.php
@@ -18,9 +18,11 @@ namespace Symfony\Component\Serializer\Attribute;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class Ignore
+class Ignore
 {
 }
 

--- a/src/Symfony/Component/Serializer/Attribute/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Attribute/MaxDepth.php
@@ -21,6 +21,8 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 class MaxDepth

--- a/src/Symfony/Component/Serializer/Attribute/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Attribute/SerializedName.php
@@ -21,9 +21,11 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class SerializedName
+class SerializedName
 {
     public function __construct(private readonly string $serializedName)
     {

--- a/src/Symfony/Component/Serializer/Attribute/SerializedPath.php
+++ b/src/Symfony/Component/Serializer/Attribute/SerializedPath.php
@@ -23,9 +23,11 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Tobias Bönner <tobi@boenner.family>
+ *
+ * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class SerializedPath
+class SerializedPath
 {
     private PropertyPath $serializedPath;
 


### PR DESCRIPTION
If the base class is missing PHPStan fails to recognize the aliasing correctly.

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | sort of
| New feature?  | no
| Deprecations? | no
| License       | MIT

Due to a shortcoming in PHPStan it does not pick up the previous aliasing correctly (ref. https://phpstan.org/r/2c7a9166-e8e1-42e5-8448-54c7d814e7d9).

This will cause projects to start failing their static analysis when they upgrade to 6.4. Explicitly extending the new attribute in the Attribute namespace has no runtime impact and shuts up PHPStan.