### PR TITLE
[Intl][PhpUnitBridge] Fix invalid composer.json files & add composer.json validation integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -151,6 +151,12 @@ jobs:
           entrypoint: /bin/bash
           args: -c "(/opt/bitnami/openldap/bin/ldapwhoami -H ldap://ldap:3389 -D cn=admin,dc=symfony,dc=com -w symfony||sleep 5) && /opt/bitnami/openldap/bin/ldapadd -H ldap://ldap:3389 -D cn=admin,dc=symfony,dc=com -w symfony -f src/Symfony/Component/Ldap/Tests/Fixtures/data/fixtures.ldif && /opt/bitnami/openldap/bin/ldapdelete -H ldap://ldap:3389 -D cn=admin,dc=symfony,dc=com -w symfony cn=a,ou=users,dc=symfony,dc=com"
 
+      - name: Composer Validate Main composer.json
+        run: composer validate --strict --no-ansi --no-interaction --with-dependencies
+
+      - name: Composer Validate composer.json Files in src/ Directory
+        run: find src -regex ".*composer.json" | xargs -n1 composer validate --strict --no-ansi --no-interaction --with-dependencies
+
       - name: Install dependencies
         run: |
           COMPOSER_HOME="$(composer config home)"

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -16,8 +16,6 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3 EVEN ON LATEST SYMFONY VERSIONS TO ALLOW USING",
-        "php": "THIS BRIDGE WHEN TESTING LOWEST SYMFONY VERSIONS.",
         "php": ">=7.1.3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Intl/Resources/emoji/composer.json
+++ b/src/Symfony/Component/Intl/Resources/emoji/composer.json
@@ -1,4 +1,7 @@
 {
+    "name": "symfony/intl-emoji",
+    "description": "Import Unicode Common Locale Data Repository and dependencies for the Emoji Transliterator Builder",
+    "license": "Unicode-DFS-2016",
     "repositories": [
         {
             "type": "package",
@@ -18,6 +21,6 @@
         "symfony/filesystem": "^6",
         "symfony/finder": "^6",
         "symfony/var-exporter": "^6",
-        "unicode-org/cldr": "*"
+        "unicode-org/cldr": "^2022"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52529 
| License       | MIT / Unicode-DFS-2016 (see clarifying [comment](https://github.com/symfony/symfony/pull/52555#discussion_r1390331865))

As described in issue #52529, this fix addresses the following things:

1) Fix Errors in `src/Symfony/Bridge/PhpUnit/composer.json` (introduced before Symfony 5.4).
2) Fix Errors in `src/Symfony/Component/Intl/Resources/emoji/composer.json` (introduced in Symfony v6.2).
3) Since this project is split up into a bunch of different subtree split repositories that depend on it, I have added integration tests to run a complete composer validate check for all `composer.json` files in the `src/` directory of this repository as well as the main `composer.json` file via 2 new GitHub Actions. This will ensure that when developers add new composer files in the future we will have a full guarantee of validity for all Symfony subtrees splits.