### PR TITLE
UriResolver support path with columns

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/UriResolverTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/UriResolverTest.php
@@ -84,6 +84,10 @@ class UriResolverTest extends TestCase
 
             ['foo', 'http://localhost?bar=1', 'http://localhost/foo'],
             ['foo', 'http://localhost#bar', 'http://localhost/foo'],
+
+            ['foo:1', 'http://localhost', 'http://localhost/foo:1'],
+            ['/bar:1', 'http://localhost', 'http://localhost/bar:1'],
+            ['foo/bar:1', 'http://localhost', 'http://localhost/foo/bar:1'],
         ];
     }
 }

--- a/src/Symfony/Component/DomCrawler/UriResolver.php
+++ b/src/Symfony/Component/DomCrawler/UriResolver.php
@@ -33,7 +33,7 @@ class UriResolver
         $uri = trim($uri);
 
         // absolute URL?
-        if (null !== parse_url($uri, \PHP_URL_SCHEME)) {
+        if (is_string(parse_url($uri, \PHP_URL_SCHEME))) {
             return $uri;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix UriResolver bad handling of column in path
| License       | MIT

Resolving links on pages using weird pagination like: ```https://localhost/domain/search/page:5``` fails due to `:` making 

```
var_dump(parse_url('/page:1', \PHP_URL_SCHEME));
```

Return `false` (and not null as expected in the code).

This simply ensure the absolute URL is returned only if the SCHEME is found (ie a string is returned by `parse_url`).
