### PR TITLE
[Mailer] Update default Mailjet port

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetSmtpTransport.php
@@ -19,7 +19,7 @@ class MailjetSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, #[\SensitiveParameter] string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('in-v3.mailjet.com', 465, true, $dispatcher, $logger);
+        parent::__construct('in-v3.mailjet.com', 587, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add DSN parameter `peer_fingerprint` to verify TLS certificate fingerprint
+ * Change the default port for the `mailjet+smtp` transport from 465 to 587
 
 6.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Similar to [#49805](https://github.com/symfony/symfony/pull/49805), update the default to 587, which is recommended by Mailjet.
Changelog is also updated accordingly.

References:

> Nowadays, port 587 is used for secure submission of email for delivery. Most of the client software are configured to use this port to send your messages.
[Mailjet Blog Post about this](https://www.mailjet.com/blog/email-best-practices/which-smtp-port-mailjet/).
