### PR TITLE
fix symfony/security-http dependency on non-existing version of symfony/service-contracts:^1.10

### DIFF
--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -24,7 +24,7 @@
         "symfony/polyfill-php80": "^1.16",
         "symfony/property-access": "^4.4|^5.0|^6.0",
         "symfony/security-core": "^5.4.19|~6.0.19|~6.1.11|^6.2.5",
-        "symfony/service-contracts": "^1.10|^2|^3"
+        "symfony/service-contracts": "^1|^2|^3"
     },
     "require-dev": {
         "symfony/cache": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

the security release of `symfony/security-http:5.4.31` is not installable, when you are using `symfony/service-contracts:^1` due to a versionconstraint for a non-existing version. i hope that this is the correct version.