### PR TITLE
[Workflow] Add `AsMarkingStore` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -71,6 +71,7 @@ use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\Registry;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowDebugPass;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowGuardListenerPass;
+use Symfony\Component\Workflow\DependencyInjection\WorkflowMarkingStorePass;
 
 // Help opcache.preload discover always-needed symbols
 class_exists(ApcuAdapter::class);
@@ -157,6 +158,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new CachePoolPrunerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $this->addCompilerPassIfExists($container, FormPass::class);
         $this->addCompilerPassIfExists($container, WorkflowGuardListenerPass::class);
+        $this->addCompilerPassIfExists($container, WorkflowMarkingStorePass::class);
         $container->addCompilerPass(new ResettableServicePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
         $container->addCompilerPass(new RegisterLocaleAwareServicesPass());
         $container->addCompilerPass(new TestServiceContainerWeakRefPass(), PassConfig::TYPE_BEFORE_REMOVING, -32);

--- a/src/Symfony/Component/Workflow/Attribute/AsMarkingStore.php
+++ b/src/Symfony/Component/Workflow/Attribute/AsMarkingStore.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Attribute;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsMarkingStore
+{
+    public function __construct(
+        /**
+         * The name of the property where the marking will be stored in the subject.
+         */
+        public string $markingName,
+        /**
+         * The name of the property where the marking name will be stored.
+         */
+        public string $property = 'property',
+    ) {
+    }
+}

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `AsMarkingStore` attribute
+
 7.0
 ---
 

--- a/src/Symfony/Component/Workflow/DependencyInjection/WorkflowMarkingStorePass.php
+++ b/src/Symfony/Component/Workflow/DependencyInjection/WorkflowMarkingStorePass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\Workflow\Attribute\AsMarkingStore;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class WorkflowMarkingStorePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        // Register marking store
+        $container->registerAttributeForAutoconfiguration(AsMarkingStore::class, static function (ChildDefinition $definition, AsMarkingStore $attribute, \ReflectionClass $reflector): void {
+            $tagAttributes = get_object_vars($attribute);
+            $invalid = true;
+
+            if ($constructor = $reflector->getConstructor()) {
+                foreach ($constructor->getParameters() as $parameters) {
+                    if ($tagAttributes['property'] === $parameters->getName()) {
+                        $type = $parameters->getType();
+                        $invalid = !$type instanceof \ReflectionNamedType || 'string' !== $type->getName();
+                    }
+                }
+            }
+
+            if ($invalid) {
+                throw new LogicException(sprintf('The "%s" class doesn\'t have a constructor with a string type-hinted argument named "%s".', $reflector->getName(), $tagAttributes['property']));
+            }
+
+            $definition->replaceArgument('$'.$tagAttributes['property'], $tagAttributes['markingName']);
+            $definition->addTag('workflow.marking_store', $tagAttributes);
+        });
+    }
+}

--- a/src/Symfony/Component/Workflow/MarkingStore/AbstractMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/AbstractMarkingStore.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\MarkingStore;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+abstract class AbstractMarkingStore implements MarkingStoreInterface
+{
+    public function __construct(protected string $property)
+    {
+    }
+}

--- a/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
@@ -29,7 +29,7 @@ use Symfony\Component\Workflow\Marking;
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-final class MethodMarkingStore implements MarkingStoreInterface
+final class MethodMarkingStore extends AbstractMarkingStore
 {
     /** @var array<class-string, MarkingStoreMethod> */
     private array $getters = [];
@@ -43,8 +43,9 @@ final class MethodMarkingStore implements MarkingStoreInterface
      */
     public function __construct(
         private bool $singleState = false,
-        private string $property = 'marking',
+        string $property = 'marking',
     ) {
+        parent::__construct($property);
     }
 
     public function getMarking(object $subject): Marking

--- a/src/Symfony/Component/Workflow/Tests/DependencyInjection/WorkflowMarkingStorePassTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DependencyInjection/WorkflowMarkingStorePassTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\AttributeAutoconfigurationPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\Workflow\DependencyInjection\WorkflowMarkingStorePass;
+use Symfony\Component\Workflow\Tests\Fixtures\AttributeMarkingStore;
+use Symfony\Component\Workflow\Tests\Fixtures\AttributeMarkingStoreWithCustomProperty;
+use Symfony\Component\Workflow\Tests\Fixtures\AttributeMarkingStoreWithoutConstructor;
+
+class WorkflowMarkingStorePassTest extends TestCase
+{
+    private ContainerBuilder $container;
+    private WorkflowMarkingStorePass $compilerPass;
+
+    protected function setUp(): void
+    {
+        $this->container = new ContainerBuilder();
+        $this->compilerPass = new WorkflowMarkingStorePass();
+    }
+
+    public function testRegistersMarkingStore()
+    {
+        $this->container->register(AttributeMarkingStore::class, AttributeMarkingStore::class)->setPublic(true)->setAutoconfigured(true);
+
+        (new AttributeAutoconfigurationPass())->process($this->container);
+        $this->compilerPass->process($this->container);
+        $this->container->compile();
+
+        $this->assertSame('currentPlace', $this->container->get(AttributeMarkingStore::class)->getProperty());
+        $this->assertSame(['currentPlace'], $this->container->getDefinition(AttributeMarkingStore::class)->getArguments());
+    }
+
+    public function testRegistersMarkingStoreWithCustomPropertyForMarking()
+    {
+        $this->container->register(AttributeMarkingStoreWithCustomProperty::class, AttributeMarkingStoreWithCustomProperty::class)->setPublic(true)->setAutoconfigured(true);
+
+        (new AttributeAutoconfigurationPass())->process($this->container);
+        $this->compilerPass->process($this->container);
+        $this->container->compile();
+
+        $this->assertSame('currentPlace', $this->container->get(AttributeMarkingStoreWithCustomProperty::class)->getAnother());
+        $this->assertSame(['currentPlace'], $this->container->getDefinition(AttributeMarkingStoreWithCustomProperty::class)->getArguments());
+    }
+
+    public function testRegisterMakingStoreWithoutConstructor()
+    {
+        $this->container->register(AttributeMarkingStoreWithoutConstructor::class, AttributeMarkingStoreWithoutConstructor::class)->setPublic(true)->setAutoconfigured(true);
+
+        (new AttributeAutoconfigurationPass())->process($this->container);
+        $this->compilerPass->process($this->container);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Workflow\Tests\Fixtures\AttributeMarkingStoreWithoutConstructor" class doesn\'t have a constructor with a string type-hinted argument named "another".');
+        $this->container->compile();
+    }
+}

--- a/src/Symfony/Component/Workflow/Tests/Fixtures/AttributeMarkingStore.php
+++ b/src/Symfony/Component/Workflow/Tests/Fixtures/AttributeMarkingStore.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\Workflow\Tests\Fixtures;
+
+use Symfony\Component\Workflow\Attribute\AsMarkingStore;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\MarkingStore\AbstractMarkingStore;
+
+#[AsMarkingStore('currentPlace')]
+class AttributeMarkingStore extends AbstractMarkingStore
+{
+    public function getMarking(object $subject): Marking
+    {
+        return new Marking([$subject->{$this->property} => 1]);
+    }
+
+    public function setMarking(object $subject, Marking $marking, array $context = []): void
+    {
+        $subject->{$this->property} = key($marking->getPlaces());
+    }
+
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+}

--- a/src/Symfony/Component/Workflow/Tests/Fixtures/AttributeMarkingStoreWithCustomProperty.php
+++ b/src/Symfony/Component/Workflow/Tests/Fixtures/AttributeMarkingStoreWithCustomProperty.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\Workflow\Tests\Fixtures;
+
+use Symfony\Component\Workflow\Attribute\AsMarkingStore;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\MarkingStore\AbstractMarkingStore;
+use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
+
+#[AsMarkingStore(markingName: 'currentPlace', property: 'another')]
+class AttributeMarkingStoreWithCustomProperty implements MarkingStoreInterface
+{
+    public function __construct(private string $another)
+    {
+    }
+
+    public function getMarking(object $subject): Marking
+    {
+        return new Marking();
+    }
+
+    public function setMarking(object $subject, Marking $marking, array $context = []): void
+    {
+    }
+
+    public function getAnother(): string
+    {
+        return $this->another;
+    }
+}

--- a/src/Symfony/Component/Workflow/Tests/Fixtures/AttributeMarkingStoreWithoutConstructor.php
+++ b/src/Symfony/Component/Workflow/Tests/Fixtures/AttributeMarkingStoreWithoutConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Workflow\Tests\Fixtures;
+
+use Symfony\Component\Workflow\Attribute\AsMarkingStore;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\MarkingStore\AbstractMarkingStore;
+use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
+
+#[AsMarkingStore(markingName: 'currentPlace', property: 'another')]
+class AttributeMarkingStoreWithoutConstructor
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Originally, this idea came up after I implemented a new marking store as stated [here](https://github.com/symfony/symfony/issues/44211#issuecomment-1075401547).

In a project we're working on, we're using the Workflow component. We created a marking store to support enums for our markings. We'd like to make it a bit generic (understand: support enum and just give to the marking store the property that hold the marking on the subject). Here is the simplified marking store:

```php
final readonly class DeploymentStatusMarkingStore implements MarkingStoreInterface
{
    public function __construct(private string $property)
    {
    }

    public function getMarking(object $subject): Marking
    {
        return new Marking(/* ... */);
    }

    public function setMarking(object $subject, Marking $marking, array $context = []): void
    {
        // ...

        try {
            $marking = [$enumClass, 'from']($marking);
        } catch (\Error) {
            throw new InvalidArgumentException(sprintf('The constant "%s" does not exist.', $marking));
        }

        $subject->{$method}($marking);
    }
}
```

The `$property` attribute holds the fieldname of the marking in the subject. However, in the current state, we must define manually the service to provide `$property` to the constructor:

```php
return static function (FrameworkConfig $frameworkConfig, ContainerConfigurator $configurator): void {
    $configurator->services()
        ->set('workflow.marking_store.status_enum', DeploymentStatusMarkingStore::class)
        ->args(['status']); // This is the boilerplate that I'd like to remove

    // ...

    $deploymentStatus->markingStore()
        ->service('workflow.marking_store.status_enum');

    // ...
};
```

Yes! We can now use the marking store.

But I'd like to remove this boilerplate by introducing `AsMarkingStore`. Thanks to this attribute, we can now define our marking store like this:

```php
#[AsMarkingStore('status')]
final readonly class DeploymentStatusMarkingStore extends AbstractMarkingStore
{
    public function getMarking(object $subject): Marking
    {
        // ...
    }

    public function setMarking(object $subject, Marking $marking, array $context = []): void
    {
        // ...
    }
}
```

The configuration is also simplified:

```php
return static function (FrameworkConfig $frameworkConfig, ContainerConfigurator $configurator): void {
    // ...

    // No more marking store definition to do by hand!
    $deploymentStatus->markingStore()
        ->service(DeploymentStatusMarkingStore::class);

    // ...
};
```

This attribute also allows to configure the name of the property that hold the marking field name in the store:

```php
#[AsMarkingStore(markingName: 'status', property: 'markingField')]
final readonly class SingleStateEnumMarkingStore implements MarkingStoreInterface
{
    public function __construct(private string $markingField)
    {
    }

    public function getMarking(object $subject): Marking
    {
        // ...
    }

    public function setMarking(object $subject, Marking $marking, array $context = []): void
    {
        // ...
    }
}
```

Thanks to this, we could even create in our app an `AbstractEnumMarkingStore`, making some store inherit this class and just define the `AsMarkingStore` attribute with the good field name.