### PR TITLE
[AssetMapper] Fixing js sourceMappingURL extraction when sourceMappingURL used in code

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -248,7 +248,10 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         }, $content);
 
         // source maps are not also downloaded - so remove the sourceMappingURL
-        $content = preg_replace('{//# sourceMappingURL=.*$}m', '', $content);
+        // remove the final one only (in case sourceMappingURL is used in the code)
+        if (false !== $lastPos = strrpos($content, '//# sourceMappingURL=')) {
+            $content = substr($content, 0, $lastPos).preg_replace('{//# sourceMappingURL=.*$}m', '', substr($content, $lastPos));
+        }
 
         return preg_replace('{/\*# sourceMappingURL=[^ ]*+ \*/}', '', $content);
     }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -430,7 +430,30 @@ class JsDelivrEsmResolverTest extends TestCase
             ],
         ];
 
-        yield 'css file removes importmap' => [
+        yield 'js sourcemap is correctly removed when sourceMapping appears in the JS' => [
+            [
+                'es-module-shims' => self::createRemoteEntry('es-module-shims', version: '1.8.2'),
+            ],
+            [
+                [
+                    'url' => '/es-module-shims@1.8.2/+esm',
+                    'body' => <<<'EOF'
+const je="\n//# sourceURL=",Ue="\n//# sourceMappingURL=",Me=/^(text|application)\/(x-)?javascript(;|$)/,_e=/^(application)\/wasm(;|$)/,Ie=/^(text|application)\/json(;|$)/,Re=/^(text|application)\/css(;|$)/,Te=/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g;export{t as default};
+//# sourceMappingURL=/sm/ef3916de598f421a779ba0e69af94655b2043095cde2410cc01893452d893338.map
+EOF
+                ],
+            ],
+            [
+                'es-module-shims' => [
+                    'content' => <<<'EOF'
+const je="\n//# sourceURL=",Ue="\n//# sourceMappingURL=",Me=/^(text|application)\/(x-)?javascript(;|$)/,_e=/^(application)\/wasm(;|$)/,Ie=/^(text|application)\/json(;|$)/,Re=/^(text|application)\/css(;|$)/,Te=/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g;export{t as default};
+EOF,
+                    'dependencies' => [],
+                ],
+            ],
+        ];
+
+        yield 'css file removes sourcemap' => [
             ['lodash' => self::createRemoteEntry('bootstrap/dist/bootstrap.css', version: '5.0.6', type: ImportMapType::CSS)],
             [
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52547
| License       | MIT

We extract & remove `sourceMappingURL` because we don't (at least currently) also download the source map file. This fixes the case where the `sourceMappingURL` string itself is used in the code.

Cheers!
