### PR TITLE
[Messenger] pcntl PHP extension is required since v6.3.5

### DIFF
--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "ext-pcntl": "*",
         "psr/log": "^1|^2|^3",
         "symfony/clock": "^6.3",
         "symfony/deprecation-contracts": "^2.5|^3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

After https://github.com/symfony/symfony/pull/50787 have been released in https://github.com/symfony/messenger/releases/tag/v6.3.5 `FailedMessagesRetryCommand` implements `Symfony\Component\Console\Command\SignalableCommandInterface`. And because of this pcntl PHP extension is required: https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Console/Application.php#L1003-L1007

