### PR TITLE
[Messenger] pcntl PHP extension is required since v6.3.5 with test

### DIFF
--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "ext-pcntl": "*",
         "psr/log": "^1|^2|^3",
         "symfony/clock": "^6.3",
         "symfony/deprecation-contracts": "^2.5|^3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Created this one as the follow-up to https://github.com/symfony/symfony/pull/52574. This time I added `testBasicApplicationRun` test to demonstrate the issue.

Successful run when `pcntl` extension is installed and `pcntl_signal` function is available:
```bash
php phpunit --filter testBasicApplicationRun src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php        
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

Testing Symfony\Component\Messenger\Tests\Command\ConsumeMessagesCommandTest

                                                                                                                        
 [OK] Consuming messages from transport "dummy-receiver".                                                               
                                                                                                                        

 // The worker will automatically exit once it has processed 1 messages or received a stop signal via the               
 // messenger:stop-workers command.                                                                                     

 // Quit the worker with CONTROL-C.                                                                                     

 // Re-run the command with a -vv option to see logs about consumed messages.                                           

.                                                                   1 / 1 (100%)

Time: 00:00.081, Memory: 12.00 MB

OK (1 test, 4 assertions)
```

Error when `pcntl_signal` function is disabled:
```bash
php -d disable_functions=pcntl_signal phpunit --filter testBasicApplicationRun src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

Testing Symfony\Component\Messenger\Tests\Command\ConsumeMessagesCommandTest
E                                                                   1 / 1 (100%)

Time: 00:00.655, Memory: 10.00 MB

There was 1 error:

1) Symfony\Component\Messenger\Tests\Command\ConsumeMessagesCommandTest::testBasicApplicationRun
Symfony\Component\Console\Exception\RuntimeException: Unable to subscribe to signal events. Make sure that the "pcntl" extension is installed and that "pcntl_*" functions are not disabled by your php.ini's "disable_functions" directive.

/Users/sergiid/Projects/symfony/src/Symfony/Component/Console/Application.php:1006
/Users/sergiid/Projects/symfony/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php:75

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```
