### PR TITLE
[Serializer] Fix denormalize constructor arguments

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -350,6 +350,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             $constructorParameters = $constructor->getParameters();
             $missingConstructorArguments = [];
             $params = [];
+            $unsetKeys = [];
             foreach ($constructorParameters as $constructorParameter) {
                 $paramName = $constructorParameter->name;
                 $key = $this->nameConverter ? $this->nameConverter->normalize($paramName, $class, $format, $context) : $paramName;
@@ -368,18 +369,17 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         }
 
                         $params = array_merge($params, $variadicParameters);
-                        unset($data[$key]);
+                        $unsetKeys[] = $key;
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data))) {
                     $parameterData = $data[$key];
                     if (null === $parameterData && $constructorParameter->allowsNull()) {
                         $params[] = null;
-                        // Don't run set for a parameter passed to the constructor
-                        unset($data[$key]);
+                        $unsetKeys[] = $key;
+
                         continue;
                     }
 
-                    // Don't run set for a parameter passed to the constructor
                     try {
                         $params[] = $this->denormalizeParameter($reflectionClass, $constructorParameter, $paramName, $parameterData, $context, $format);
                     } catch (NotNormalizableValueException $exception) {
@@ -390,7 +390,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         $context['not_normalizable_value_exceptions'][] = $exception;
                         $params[] = $parameterData;
                     }
-                    unset($data[$key]);
+
+                    $unsetKeys[] = $key;
                 } elseif (\array_key_exists($key, $context[static::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class] ?? [])) {
                     $params[] = $context[static::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class][$key];
                 } elseif (\array_key_exists($key, $this->defaultContext[self::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class] ?? [])) {
@@ -421,11 +422,25 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             }
 
             if (!$constructor->isConstructor()) {
-                return $constructor->invokeArgs(null, $params);
+                $instance = $constructor->invokeArgs(null, $params);
+
+                // do not set a parameter that has been set in the constructor
+                foreach ($unsetKeys as $key) {
+                    unset($data[$key]);
+                }
+
+                return $instance;
             }
 
             try {
-                return $reflectionClass->newInstanceArgs($params);
+                $instance = $reflectionClass->newInstanceArgs($params);
+
+                // do not set a parameter that has been set in the constructor
+                foreach ($unsetKeys as $key) {
+                    unset($data[$key]);
+                }
+
+                return $instance;
             } catch (\TypeError $e) {
                 if (!isset($context['not_normalizable_value_exceptions'])) {
                     throw $e;

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -228,8 +228,20 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             $context['not_normalizable_value_exceptions'] = [];
             $errors = &$context['not_normalizable_value_exceptions'];
             $denormalized = $normalizer->denormalize($data, $type, $format, $context);
+
             if ($errors) {
-                throw new PartialDenormalizationException($denormalized, $errors);
+                // merge errors so that one path has only one error
+                $uniqueErrors = [];
+                foreach ($errors as $error) {
+                    if (null === $error->getPath()) {
+                        $uniqueErrors[] = $error;
+                        continue;
+                    }
+
+                    $uniqueErrors[$error->getPath()] = $uniqueErrors[$error->getPath()] ?? $error;
+                }
+
+                throw new PartialDenormalizationException($denormalized, array_values($uniqueErrors));
             }
 
             return $denormalized;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
@@ -46,7 +46,7 @@ final class Php74FullWithConstructor
 
 final class Php74FullWithTypedConstructor
 {
-    public function __construct(float $something)
+    public function __construct(float $something, bool $somethingElse)
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ConstructorArgumentsTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ConstructorArgumentsTestTrait.php
@@ -58,7 +58,7 @@ trait ConstructorArgumentsTestTrait
     public function testConstructorWithMissingData()
     {
         $data = [
-            'foo' => 10,
+            'bar' => 10,
         ];
 
         $normalizer = $this->getDenormalizerForConstructArguments();
@@ -66,15 +66,15 @@ trait ConstructorArgumentsTestTrait
             $normalizer->denormalize($data, ConstructorArgumentsObject::class);
             self::fail(sprintf('Failed asserting that exception of type "%s" is thrown.', MissingConstructorArgumentsException::class));
         } catch (MissingConstructorArgumentsException $e) {
-            self::assertSame(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires the following parameters to be present : "$bar", "$baz".', ConstructorArgumentsObject::class), $e->getMessage());
-            self::assertSame(['bar', 'baz'], $e->getMissingConstructorArguments());
+            self::assertSame(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires the following parameters to be present : "$foo", "$baz".', ConstructorArgumentsObject::class), $e->getMessage());
+            self::assertSame(['foo', 'baz'], $e->getMissingConstructorArguments());
         }
     }
 
     public function testExceptionsAreCollectedForConstructorWithMissingData()
     {
         $data = [
-            'foo' => 10,
+            'bar' => 10,
         ];
 
         $exceptions = [];
@@ -85,7 +85,7 @@ trait ConstructorArgumentsTestTrait
         ]);
 
         self::assertCount(2, $exceptions);
-        self::assertSame('Failed to create object because the class misses the "bar" property.', $exceptions[0]->getMessage());
+        self::assertSame('Failed to create object because the class misses the "foo" property.', $exceptions[0]->getMessage());
         self::assertSame('Failed to create object because the class misses the "baz" property.', $exceptions[1]->getMessage());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -868,7 +868,8 @@ class SerializerTest extends TestCase
             ],
             "php74FullWithConstructor": {},
             "php74FullWithTypedConstructor": {
-                "something": "not a float"
+                "something": "not a float",
+                "somethingElse": "not a bool"
             },
             "dummyMessage": {
             },
@@ -1031,6 +1032,24 @@ class SerializerTest extends TestCase
                 'path' => 'php74FullWithTypedConstructor',
                 'useMessageForUser' => false,
                 'message' => 'The type of the "something" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor" must be one of "float" ("string" given).',
+            ],
+            [
+                'currentType' => 'string',
+                'expectedTypes' => [
+                    'float',
+                ],
+                'path' => 'php74FullWithTypedConstructor.something',
+                'useMessageForUser' => false,
+                'message' => 'The type of the "something" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor" must be one of "float" ("string" given).',
+            ],
+            [
+                'currentType' => 'string',
+                'expectedTypes' => [
+                    'bool',
+                ],
+                'path' => 'php74FullWithTypedConstructor.somethingElse',
+                'useMessageForUser' => false,
+                'message' => 'The type of the "somethingElse" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor" must be one of "bool" ("string" given).',
             ],
             $classMetadataFactory ?
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52499, Fix #52422
| License       | MIT

Since this PR: https://github.com/symfony/symfony/pull/51907, objects with partial constructor parameters were wrongly instantiated.

This PR fixes that issue by delegating the properties values assignment, by unsetting normalized data only when the constructor has been called properly.

This might correct #50759 as well.
