### PR TITLE
[WebProfilerBundle] Fix intercept external redirects

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_redirect.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_redirect.html.twig
@@ -39,10 +39,10 @@
             <div class="block-exception">
                 <h1>Redirection Intercepted</h1>
 
-                {% set absolute_url = host in location ? location : host ~ location %}
+                {% set absolute_url = absolute_url(location) %}
                 <p>This request redirects to <strong>{{ absolute_url }}</strong></p>
 
-                <p><a class="btn" href="{{ location }}">Follow redirect</a></p>
+                <p><a class="btn" href="{{ absolute_url }}">Follow redirect</a></p>
 
                 <p class="sf-redirection-help">
                     The redirect was intercepted by the Symfony Web Debug toolbar to help debugging.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | ~
| License       | MIT

When intercepting a redirect to an external host the current output gives:

> This request redirects to **http://current-host.orghttp://target-host.org/**

With this PR, it fixes it too:

> This request redirects to **http://target-host.org/**

We could eventually get rid of the first part of the condition, WDYT?