### PR TITLE
[Messenger] Use extension_loaded call to check if pcntl extension is loaded, as SIGTERM might be set be swoole

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -258,7 +258,7 @@ EOF
 
     public function getSubscribedSignals(): array
     {
-        return $this->signals ?? (\defined('SIGTERM') ? [\SIGTERM, \SIGINT] : []);
+        return $this->signals ?? (\extension_loaded('pcntl') ? [\SIGTERM, \SIGINT] : []);
     }
 
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -134,7 +134,7 @@ EOF
 
     public function getSubscribedSignals(): array
     {
-        return $this->signals ?? (\defined('SIGTERM') ? [\SIGTERM, \SIGINT] : []);
+        return $this->signals ?? (\extension_loaded('pcntl') ? [\SIGTERM, \SIGINT] : []);
     }
 
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSignalsListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSignalsListener.php
@@ -26,7 +26,7 @@ class StopWorkerOnSignalsListener implements EventSubscriberInterface
 
     public function __construct(array $signals = null, LoggerInterface $logger = null)
     {
-        if (null === $signals && \defined('SIGTERM')) {
+        if (null === $signals && \extension_loaded('pcntl')) {
             $signals = [SIGTERM, SIGINT];
         }
         $this->signals = $signals ?? [];

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
@@ -24,6 +24,6 @@ class StopWorkerOnSigtermSignalListener extends StopWorkerOnSignalsListener
 {
     public function __construct(LoggerInterface $logger = null)
     {
-        parent::__construct(\defined('SIGTERM') ? [SIGTERM] : [], $logger);
+        parent::__construct(\extension_loaded('pcntl') ? [SIGTERM] : [], $logger);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52586
| License       | MIT

It was assumed. that SIGTERM constant is set only by `pcntl` PHP extension. But it is also set by `swoole`. So in some cases `SIGTERM` might be set when `pcntl` is disabled but `swoole` is enabled.
