### PR TITLE
[Serializer] Fix XML attributes not added on empty node

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -140,26 +140,22 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         // todo: throw an exception if the root node name is not correctly configured (bc)
 
         if ($rootNode->hasChildNodes()) {
-            $xpath = new \DOMXPath($dom);
-            $data = [];
-            foreach ($xpath->query('namespace::*', $dom->documentElement) as $nsNode) {
-                $data['@'.$nsNode->nodeName] = $nsNode->nodeValue;
+            $data = $this->parseXml($rootNode, $context);
+            if (\is_array($data)) {
+                $data = $this->addXmlNamespaces($data, $rootNode, $dom);
             }
 
-            unset($data['@xmlns:xml']);
-
-            if (empty($data)) {
-                return $this->parseXml($rootNode, $context);
-            }
-
-            return array_merge($data, (array) $this->parseXml($rootNode, $context));
+            return $data;
         }
 
         if (!$rootNode->hasAttributes()) {
             return $rootNode->nodeValue;
         }
 
-        return array_merge($this->parseXmlAttributes($rootNode, $context), ['#' => $rootNode->nodeValue]);
+        $data = array_merge($this->parseXmlAttributes($rootNode, $context), ['#' => $rootNode->nodeValue]);
+        $data = $this->addXmlNamespaces($data, $rootNode, $dom);
+
+        return $data;
     }
 
     /**
@@ -342,6 +338,19 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         }
 
         return $value;
+    }
+
+    private function addXmlNamespaces(array $data, \DOMNode $node, \DOMDocument $document): array
+    {
+        $xpath = new \DOMXPath($document);
+
+        foreach ($xpath->query('namespace::*', $node) as $nsNode) {
+            $data['@'.$nsNode->nodeName] = $nsNode->nodeValue;
+        }
+
+        unset($data['@xmlns:xml']);
+
+        return $data;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -450,6 +450,17 @@ XML;
         $array = $this->getNamespacedArray();
 
         $this->assertEquals($array, $this->encoder->decode($source, 'xml'));
+
+        $source = '<?xml version="1.0"?>'."\n".
+            '<response xmlns="http://www.w3.org/2005/Atom" xmlns:app="http://www.w3.org/2007/app" app:foo="bar">'.
+            '</response>'."\n";
+
+        $this->assertEquals([
+            '@xmlns' => 'http://www.w3.org/2005/Atom',
+            '@xmlns:app' => 'http://www.w3.org/2007/app',
+            '@app:foo' => 'bar',
+            '#' => '',
+        ], $this->encoder->decode($source, 'xml'));
     }
 
     public function testDecodeScalarWithAttribute()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52385
| License       | MIT

Add XML namespace attributes on node whether they have chlidren or not.