### PR TITLE
[HttpFoundation] Fix/parameterbag get method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.phar
 package.tar
 /packages.json
 /.phpunit
+.idea/

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -89,7 +89,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function get(string $key, $default = null)
     {
-        return \array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
+        return $this->parameters[$key] ?? $default;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | 
| License       | MIT

This pull request replaces the **array_key_exists** check with the **null coalescing operator**. The change aims to improve the robustness and consistency of the code.

Problem:

Using **array_key_exists** in this specific context results in a problem identified in the **basename()** function. When encountering a null value for parameter ($path), the function call becomes obsolete, generating the following warning message:

`basename(): Passing null to parameter ($path) of type string is deprecated in Request.php`

This is because **array_key_exists** returns true when an array's key matches a null value, which leads to deprecation of the **basename()** function.

Solution:

Replacing the null navigation **operator (??)** provides a safer approach by properly handling null values. This solves the problem with the **basename()** function and contributes to improving the overall stability of the code.

