### PR TITLE
Release v7.0.0-RC1

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -7,6 +7,17 @@ in 7.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.0.0...v7.0.1
 
+* 7.0.0-RC1 (2023-11-15)
+
+ * bug #52597 [DependencyInjection] Fix dumping containers with null-referenced services (nicolas-grekas)
+ * bug #52588 [Messenger] Use extension_loaded call to check if pcntl extension is loaded, as SIGTERM might be set be swoole (Sergii Dolgushev)
+ * feature #52569 [VarExporter] Drop support for partially initialized lazy object (nicolas-grekas)
+ * bug #52567 [AssetMapper] Fixing js sourceMappingURL extraction when sourceMappingURL used in code (weaverryan)
+ * bug #52579 [DomCrawler] UriResolver support path with colons (vdauchy)
+ * bug #52581 [Messenger] attach all required parameters to query (xabbuh)
+ * feature #52568 [VarExporter] Deprecate per-property lazy-initializers (nicolas-grekas)
+ * feature #52560 [Mailer] Update default Mailjet port (Katario)
+
 * 7.0.0-BETA3 (2023-11-10)
 
  * bug #51666 [RateLimiter] CompoundLimiter was accepting requests even when some limiters already consumed all tokens (10n)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.0.0-DEV';
+    public const VERSION = '7.0.0-RC1';
     public const VERSION_ID = 70000;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = 'RC1';
 
     public const END_OF_MAINTENANCE = '07/2024';
     public const END_OF_LIFE = '07/2024';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.0.0-BETA3...v7.0.0-RC1)

 * bug #52597 [DependencyInjection] Fix dumping containers with null-referenced services (@nicolas-grekas)
 * bug #52588 [Messenger] Use extension_loaded call to check if pcntl extension is loaded, as SIGTERM might be set be swoole (Sergii Dolgushev)
 * feature #52569 [VarExporter] Drop support for partially initialized lazy object (@nicolas-grekas)
 * bug #52567 [AssetMapper] Fixing js sourceMappingURL extraction when sourceMappingURL used in code (@weaverryan)
 * bug #52579 [DomCrawler] UriResolver support path with colons (@vdauchy)
 * bug #52581 [Messenger] attach all required parameters to query (@xabbuh)
 * feature #52568 [VarExporter] Deprecate per-property lazy-initializers (@nicolas-grekas)
 * feature #52560 [Mailer] Update default Mailjet port (@Katario)
