### PR TITLE
[HttpClient] Revert "minor #52418  add native argument for the test server working directory"

### DIFF
--- a/src/Symfony/Contracts/HttpClient/Test/TestHttpServer.php
+++ b/src/Symfony/Contracts/HttpClient/Test/TestHttpServer.php
@@ -18,9 +18,12 @@ class TestHttpServer
 {
     private static array $process = [];
 
-    public static function start(int $port = 8057, string $workingDirectory = null): Process
+    /**
+     * @param string|null $workingDirectory
+     */
+    public static function start(int $port = 8057/* , string $workingDirectory = null */): Process
     {
-        $workingDirectory ??= __DIR__.'/Fixtures/web';
+        $workingDirectory = \func_get_args()[1] ?? __DIR__.'/Fixtures/web';
 
         if (isset(self::$process[$port])) {
             self::$process[$port]->stop();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This reverts commit fa590af43d297995b24511d04f805550ffcadc4a, reversing changes made to 907b6833f4c3d7fea2afad17bb4ddea2b8feceb4.

I completly forgot that we don't want to release a new major for contracts so the code in 7.0 must be in sync with the one in 6.4. /cc @xabbuh 