### PR TITLE
[FrameworkBundle] register the virtual request stack together with common profiling services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -108,6 +108,12 @@ class Application extends BaseApplication
                 }
 
                 (new SymfonyStyle($input, $output))->warning('The "--profile" option needs the Stopwatch component. Try running "composer require symfony/stopwatch".');
+            } elseif (!$container->has('.virtual_request_stack')) {
+                if ($output instanceof ConsoleOutputInterface) {
+                    $output = $output->getErrorOutput();
+                }
+
+                (new SymfonyStyle($input, $output))->warning('The "--profile" option needs the profiler integration. Try enabling the "framework.profiler" option.');
             } else {
                 $command = new TraceableCommand($command, $container->get('debug.stopwatch'));
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/VirtualRequestStackPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/VirtualRequestStackPass.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class VirtualRequestStackPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->has('.virtual_request_stack')) {
+            return;
+        }
+
+        if ($container->hasDefinition('debug.event_dispatcher')) {
+            $container->getDefinition('debug.event_dispatcher')->replaceArgument(3, new Reference('request_stack', ContainerBuilder::NULL_ON_INVALID_REFERENCE));
+        }
+
+        if ($container->hasDefinition('debug.log_processor')) {
+            $container->getDefinition('debug.log_processor')->replaceArgument(0, new Reference('request_stack'));
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSess
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerRealRefPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerWeakRefPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\UnusedTagsPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\VirtualRequestStackPass;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
@@ -184,6 +185,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RemoveUnusedSessionMarshallingHandlerPass());
         // must be registered after MonologBundle's LoggerChannelPass
         $container->addCompilerPass(new ErrorLoggerCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
+        $container->addCompilerPass(new VirtualRequestStackPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\NotTaggedController
 use Symfony\Component\HttpKernel\Controller\TraceableArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\TraceableControllerResolver;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
-use Symfony\Component\HttpKernel\Debug\VirtualRequestStack;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -47,9 +46,5 @@ return static function (ContainerConfigurator $container) {
         ->set('argument_resolver.not_tagged_controller', NotTaggedControllerValueResolver::class)
             ->args([abstract_arg('Controller argument, set in FrameworkExtension')])
             ->tag('controller.argument_value_resolver', ['priority' => -200])
-
-        ->set('.virtual_request_stack', VirtualRequestStack::class)
-            ->args([service('request_stack')])
-            ->public()
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\FrameworkBundle\EventListener\ConsoleProfilerListener;
+use Symfony\Component\HttpKernel\Debug\VirtualRequestStack;
 use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
@@ -45,5 +46,9 @@ return static function (ContainerConfigurator $container) {
                 service('router'),
             ])
             ->tag('kernel.event_subscriber')
+
+        ->set('.virtual_request_stack', VirtualRequestStack::class)
+            ->args([service('request_stack')])
+            ->public()
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/52280#issuecomment-1813218596
| License       | MIT

The debug.php file is never loaded when the Stopwatch component is not installed. However, the virtual request stack is always valuable as soon as the profiling feature is enabled.