### PR TITLE
[Console] Support `ProgressBar::iterate()` on empty array

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -195,7 +195,7 @@ final class ProgressBar
 
     public function getMaxSteps(): int
     {
-        return $this->max;
+        return $this->max ?? 0;
     }
 
     public function getProgress(): int
@@ -215,7 +215,7 @@ final class ProgressBar
 
     public function getBarOffset(): float
     {
-        return floor($this->max ? $this->percent * $this->barWidth : (null === $this->redrawFreq ? (int) (min(5, $this->barWidth / 15) * $this->writeCount) : $this->step) % $this->barWidth);
+        return floor(null !== $this->max ? $this->percent * $this->barWidth : (null === $this->redrawFreq ? (int) (min(5, $this->barWidth / 15) * $this->writeCount) : $this->step) % $this->barWidth);
     }
 
     public function getEstimated(): float
@@ -253,7 +253,7 @@ final class ProgressBar
 
     public function getBarCharacter(): string
     {
-        return $this->barChar ?? ($this->max ? '=' : $this->emptyBarChar);
+        return $this->barChar ?? (null !== $this->max ? '=' : $this->emptyBarChar);
     }
 
     public function setEmptyBarCharacter(string $char): void
@@ -315,7 +315,21 @@ final class ProgressBar
      */
     public function iterate(iterable $iterable, int $max = null): iterable
     {
-        $this->start($max ?? (is_countable($iterable) ? \count($iterable) : 0));
+        if (0 === $max) {
+            $max = null;
+        }
+
+        $max ??= is_countable($iterable) ? \count($iterable) : null;
+
+        if (0 === $max) {
+            $this->max = 0;
+            $this->stepWidth = 2;
+            $this->finish();
+
+            return;
+        }
+
+        $this->start($max);
 
         foreach ($iterable as $key => $value) {
             yield $key => $value;
@@ -373,11 +387,15 @@ final class ProgressBar
             $step = 0;
         }
 
-        $redrawFreq = $this->redrawFreq ?? (($this->max ?: 10) / 10);
-        $prevPeriod = (int) ($this->step / $redrawFreq);
-        $currPeriod = (int) ($step / $redrawFreq);
+        $redrawFreq = $this->redrawFreq ?? (($this->max ?? 10) / 10);
+        $prevPeriod = $redrawFreq ? (int) ($this->step / $redrawFreq) : 0;
+        $currPeriod = $redrawFreq ? (int) ($step / $redrawFreq) : 0;
         $this->step = $step;
-        $this->percent = $this->max ? (float) $this->step / $this->max : 0;
+        $this->percent = match ($this->max) {
+            null => 0,
+            0 => 1,
+            default => (float) $this->step / $this->max,
+        };
         $timeInterval = microtime(true) - $this->lastWriteTime;
 
         // Draw regardless of other limits
@@ -398,11 +416,20 @@ final class ProgressBar
         }
     }
 
-    public function setMaxSteps(int $max): void
+    public function setMaxSteps(?int $max): void
     {
+        if (0 === $max) {
+            $max = null;
+        }
+
         $this->format = null;
-        $this->max = max(0, $max);
-        $this->stepWidth = $this->max ? Helper::width((string) $this->max) : 4;
+        if (null === $max) {
+            $this->max = null;
+            $this->stepWidth = 4;
+        } else {
+            $this->max = max(0, $max);
+            $this->stepWidth = Helper::width((string) $this->max);
+        }
     }
 
     /**
@@ -410,16 +437,16 @@ final class ProgressBar
      */
     public function finish(): void
     {
-        if (!$this->max) {
+        if (null === $this->max) {
             $this->max = $this->step;
         }
 
-        if ($this->step === $this->max && !$this->overwrite) {
+        if (($this->step === $this->max || null === $this->max) && !$this->overwrite) {
             // prevent double 100% output
             return;
         }
 
-        $this->setProgress($this->max);
+        $this->setProgress($this->max ?? $this->step);
     }
 
     /**
@@ -542,14 +569,14 @@ final class ProgressBar
             },
             'elapsed' => fn (self $bar) => Helper::formatTime(time() - $bar->getStartTime(), 2),
             'remaining' => function (self $bar) {
-                if (!$bar->getMaxSteps()) {
+                if (null === $bar->getMaxSteps()) {
                     throw new LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
                 }
 
                 return Helper::formatTime($bar->getRemaining(), 2);
             },
             'estimated' => function (self $bar) {
-                if (!$bar->getMaxSteps()) {
+                if (null === $bar->getMaxSteps()) {
                     throw new LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
                 }
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -1092,6 +1092,20 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         );
     }
 
+    public function testEmptyInputWithDebugFormat()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->setFormat('%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%');
+
+        $this->assertEquals([], iterator_to_array($bar->iterate([])));
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            ' 0/0 [============================] 100% < 1 sec/< 1 sec',
+            stream_get_contents($output->getStream())
+        );
+    }
+
     protected function getOutputStream($decorated = true, $verbosity = StreamOutput::VERBOSITY_NORMAL)
     {
         return new StreamOutput(fopen('php://memory', 'r+', false), $verbosity, $decorated);
@@ -1263,7 +1277,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
             'Foo!'.\PHP_EOL.
             $this->generateOutput('[--->------------------------]').
             "\nProcessing \"foobar\"...".
-            $this->generateOutput("[----->----------------------]\nProcessing \"foobar\"..."),
+            $this->generateOutput("[============================]\nProcessing \"foobar\"..."),
             stream_get_contents($output->getStream())
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #47244
| License       | MIT

Alternative to #47259

Use `$max = null` to indicate that the value is unknown. This allows `0` to be displayed by directly setting the progress bar to 100%.

Zero is only supported for `iterate()`. When passed to the constructor or `setMaxSteps`, it means "unknown max".



