### PR TITLE
[DoctrineBridge] Fix use "attribute" driver by default

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -90,8 +90,8 @@ abstract class AbstractDoctrineExtension extends Extension
                 if (!$mappingConfig) {
                     continue;
                 }
-            } else {
-                $mappingConfig['type'] ??= 'attribute';
+            } elseif (!$mappingConfig['type']) {
+                $mappingConfig['type'] = 'attribute';
             }
 
             $this->assertValidMappingConfiguration($mappingConfig, $objectManager['name']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes 
| New feature?  | -
| Deprecations? | -
| Issues        | -
| License       | MIT

When I tested 7.0-RC1 version I noticed an error of detect doctrine driver type by default
```
In AbstractDoctrineExtension.php line 219:
                                                                                                               
  [InvalidArgumentException]                                                                                   
  Mapping definitions for Doctrine manager "default" require at least the "type", "dir" and "prefix" options.  
                                                                                                               

Exception trace:
  at /var/www/packeton5/vendor/symfony/doctrine-bridge/DependencyInjection/AbstractDoctrineExtension.php:219
 Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension->assertValidMappingConfiguration() at /var/www/packeton5/vendor/symfony/doctrine-bridge/DependencyInjection/AbstractDoctrineExtension.php:97
 Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension->loadMappingInformation() at /var/www/packeton5/vendor/doctrine/doctrine-bundle/DependencyInjection/DoctrineExtension.php:837
 Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension->loadOrmEntityManagerMappingInformation() at /var/www/packeton5/vendor/doctrine/doctrine-bundle/DependencyInjection/DoctrineExtension.php:657

```

my config 
```yaml
doctrine:
    orm:
        mappings:
            Packeton:
                is_bundle: false
                dir: '%kernel.project_dir%/src/Entity'
                prefix: 'Packeton\Entity'
                alias: Packeton
```

Bug was introduced here https://github.com/symfony/symfony/pull/52142/files#diff-0f981a325d8c9eea80a258c36237861d1d00b0fb62fb04f2488bf2165776c94eR94

This conditions is never executed, because `$mappingConfig['type']` is false by default  
```
$mappingConfig['type'] ??= 'attribute';
```
![Tooltip_016](https://github.com/symfony/symfony/assets/21358010/93fd8cd8-4432-47e4-89e1-348a63f5eb9a)
