### PR TITLE
[Validator] Luhn for numbers

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Luhn.php
+++ b/src/Symfony/Component/Validator/Constraints/Luhn.php
@@ -34,7 +34,7 @@ class Luhn extends Constraint
         self::CHECKSUM_FAILED_ERROR => 'CHECKSUM_FAILED_ERROR',
     ];
 
-    public $message = 'Invalid card number.';
+    public $message = 'This value is not a valid number for Lohn formula.';
 
     public function __construct(
         array $options = null,

--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 /**
  * Validates a PAN using the LUHN Algorithm.
  *
- * For a list of example card numbers that are used to test this
+ * For a list of example numbers that are used to test this
  * class, please see the LuhnValidatorTest class.
  *
  * @see    http://en.wikipedia.org/wiki/Luhn_algorithm
@@ -31,11 +31,11 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 class LuhnValidator extends ConstraintValidator
 {
     /**
-     * Validates a credit card number with the Luhn algorithm.
+     * Validates a number with the Luhn algorithm.
      *
      * @param mixed $value
      *
-     * @throws UnexpectedTypeException when the given credit card number is no string
+     * @throws UnexpectedTypeException when the given number is no string
      */
     public function validate($value, Constraint $constraint)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | minor text changes
| New feature?  | no
| Deprecations? | no
| Issues        | Not related to existing issue
| License       | MIT

Credit card numbers are a common use of the Luhn formula, but it can also be used for other things: IMEI number, EU patent application number, various numbers in some countries...

The implementation of this validator seems to have been made for use with card numbers (#4734) but I think the default error message and comments in the code should be independent of that as this validator is about Luhn and not only card numbers.

PR for doc will also be needed if accepted, i will work on it. 

What do you think about it ? 