### PR TITLE
[DependencyInjection] Allow multiple configurators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
@@ -30,6 +30,6 @@ class AddDebugLogProcessorPass implements CompilerPassInterface
         }
 
         $container->getDefinition('monolog.logger_prototype')
-            ->setConfigurator([new Reference('debug.debug_logger_configurator'), 'pushDebugLogger']);
+            ->addConfigurator([new Reference('debug.debug_logger_configurator'), 'pushDebugLogger']);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -29,7 +29,11 @@ class Autoconfigure
         public ?bool $autowire = null,
         public ?array $properties = null,
         public array|string|null $configurator = null,
+        public array $configurators = [],
         public ?string $constructor = null,
     ) {
+        if(!is_null($this->configurator)) {
+            trigger_deprecation('symfony/dependency-injection', '7.1', 'The "configurator" option of #[Autoconfigure] is deprecated, use the "configurators" option instead.');
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+7.1
+---
+ * Add `configurations` option to service definitions to allow defining multiple configurations for a single service
+
 7.0
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -107,8 +107,8 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
                 }
                 $value->setFactory($factory);
             }
-            if (isset($changes['configurator'])) {
-                $value->setConfigurator($this->processValue($value->getConfigurator()));
+            if (isset($changes['configurators'])) {
+                $value->setConfigurators(array_map([$this, 'processValue'], $value->getConfigurators()));
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -185,7 +185,7 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
         if (!$this->onlyConstructorArguments) {
             $this->processValue($properties);
             $this->processValue($setters);
-            array_map([$this, 'processValue'], $value->getConfigurators());
+            array_map($this->processValue(...), $value->getConfigurators());
         }
         $this->lazy = $lazy;
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -185,7 +185,7 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
         if (!$this->onlyConstructorArguments) {
             $this->processValue($properties);
             $this->processValue($setters);
-            $this->processValue($value->getConfigurator());
+            array_map([$this, 'processValue'], $value->getConfigurators());
         }
         $this->lazy = $lazy;
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -107,7 +107,7 @@ class ResolveChildDefinitionsPass extends AbstractRecursivePass
             $def->setDeprecated($deprecation['package'], $deprecation['version'], $deprecation['message']);
         }
         $def->setFactory($parentDef->getFactory());
-        $def->setConfigurator($parentDef->getConfigurator());
+        $def->setConfigurators($parentDef->getConfigurators());
         $def->setFile($parentDef->getFile());
         $def->setPublic($parentDef->isPublic());
         $def->setLazy($parentDef->isLazy());
@@ -126,8 +126,8 @@ class ResolveChildDefinitionsPass extends AbstractRecursivePass
         if (isset($changes['factory'])) {
             $def->setFactory($definition->getFactory());
         }
-        if (isset($changes['configurator'])) {
-            $def->setConfigurator($definition->getConfigurator());
+        if (isset($changes['configurators'])) {
+            $def->setConfigurators($definition->getConfigurators());
         }
         if (isset($changes['file'])) {
             $def->setFile($definition->getFile());

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1156,7 +1156,18 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 }
 
                 if (!\is_callable($callable)) {
-                    throw new InvalidArgumentException(sprintf('The configure callable for class "%s" is not a callable.', get_debug_type($service)));
+                    if (\is_object($callable)) {
+                        $stringConfigurator = \get_class($callable);
+                    } elseif (\is_array($callable)) {
+                        if (\is_object($callable[0]))
+                        {
+                            $callable[0] = \get_class($callable[0]);
+                        }
+                        $stringConfigurator = implode('::', array_splice($callable, 0, 2));
+                    } else {
+                        $stringConfigurator = $callable;
+                    }
+                    throw new InvalidArgumentException(sprintf('The configure callable "%s" for class "%s" is not a callable.', $stringConfigurator, get_debug_type($service)));
                 }
 
                 $callable($service);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1143,22 +1143,24 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             }
         }
 
-        if ($callable = $definition->getConfigurator()) {
-            if (\is_array($callable)) {
-                $callable[0] = $parameterBag->resolveValue($callable[0]);
+        foreach ($definition->getConfigurators() as $configurator) {
+            if ($callable = $configurator) {
+                if (\is_array($callable)) {
+                    $callable[0] = $parameterBag->resolveValue($callable[0]);
 
-                if ($callable[0] instanceof Reference) {
-                    $callable[0] = $this->doGet((string) $callable[0], $callable[0]->getInvalidBehavior(), $inlineServices);
-                } elseif ($callable[0] instanceof Definition) {
-                    $callable[0] = $this->createService($callable[0], $inlineServices);
+                    if ($callable[0] instanceof Reference) {
+                        $callable[0] = $this->doGet((string)$callable[0], $callable[0]->getInvalidBehavior(), $inlineServices);
+                    } elseif ($callable[0] instanceof Definition) {
+                        $callable[0] = $this->createService($callable[0], $inlineServices);
+                    }
                 }
-            }
 
-            if (!\is_callable($callable)) {
-                throw new InvalidArgumentException(sprintf('The configure callable for class "%s" is not a callable.', get_debug_type($service)));
-            }
+                if (!\is_callable($callable)) {
+                    throw new InvalidArgumentException(sprintf('The configure callable for class "%s" is not a callable.', get_debug_type($service)));
+                }
 
-            $callable($service);
+                $callable($service);
+            }
         }
 
         return $service;

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -699,7 +699,7 @@ class Definition
      */
     public function setConfigurator(string|array|Reference|null $configurator): static
     {
-        return $this->addConfigurator($configurator);
+        return $this->setConfigurators([$configurator]);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -702,17 +702,17 @@ class Definition
     {
         trigger_deprecation('symfony/dependency-injection', '7.1', 'Method "%s()" is deprecated, use "%s()" or "%s()" instead.', __METHOD__, 'setConfigurators', 'addConfigurator');
 
-        return $this->setConfigurators([$configurator]);
+        return $this->setConfigurators(null === $configurator ? [] : [$configurator]);
     }
 
     /**
      * Add a configurator to the configurator list.
      *
-     * @param string|array|Reference|null $configurator A PHP function, reference or an array containing a class/Reference and a method to call
+     * @param string|callable|Reference|array{0:class-string|Reference,1:string} $configurator A PHP function, reference or an array containing a class/Reference and a method to call
      *
      * @return $this
      */
-    public function addConfigurator(string|array|Reference|null $configurator): static
+    public function addConfigurator(string|callable|Reference|array $configurator): static
     {
         $this->changes['configurators'] = true;
 
@@ -732,7 +732,7 @@ class Definition
     /**
      * Sets the configurator list to call after the service is fully initialized.
      *
-     * @param array $configurators A PHP function, reference or an array containing a class/Reference and a method to call
+     * @param list<string|callable|Reference|array{0:class-string|Reference,1:string}> $configurators A list of PHP functions, references or an arrays containing a class/Reference and a method to call
      *
      * @return $this
      */
@@ -761,7 +761,7 @@ class Definition
     /**
      * Gets the configurators list after the service is fully initialized.
      *
-     * @return array<array|callable>
+     * @return list<string|callable|Reference|array{0:class-string|Reference,1:string}>
      */
     public function getConfigurators(): array
     {

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -699,6 +699,7 @@ class Definition
      */
     public function setConfigurator(string|array|Reference|null $configurator): static
     {
+        trigger_deprecation('symfony/dependency-injection', '7.1', 'Method "%s()" is deprecated, use "%s()" or "%s()" instead.', __METHOD__, 'setConfigurators', 'addConfigurator');
         return $this->setConfigurators([$configurator]);
     }
 
@@ -749,6 +750,7 @@ class Definition
      */
     public function getConfigurator(): string|array|null
     {
+        trigger_deprecation('symfony/dependency-injection', '7.1', 'Method "%s()" is deprecated, use "%s()" instead.', __METHOD__, 'getConfigurators');
         return $this->configurators[0] ?? null;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -695,11 +695,13 @@ class Definition
      * @param string|array|Reference|null $configurator A PHP function, reference or an array containing a class/Reference and a method to call
      *
      * @return $this
+     *
      * @deprecated since Symfony 7.1 and will be removed in 8.0, use addConfigurator() or setConfigurators() instead
      */
     public function setConfigurator(string|array|Reference|null $configurator): static
     {
         trigger_deprecation('symfony/dependency-injection', '7.1', 'Method "%s()" is deprecated, use "%s()" or "%s()" instead.', __METHOD__, 'setConfigurators', 'addConfigurator');
+
         return $this->setConfigurators([$configurator]);
     }
 
@@ -720,7 +722,7 @@ class Definition
             $configurator = [$configurator, '__invoke'];
         }
 
-        if (!in_array($configurator, $this->configurators)) {
+        if (!\in_array($configurator, $this->configurators)) {
             $this->configurators[] = $configurator;
         }
 
@@ -746,11 +748,13 @@ class Definition
 
     /**
      * Gets the configurator to call after the service is fully initialized.
+     *
      * @deprecated since Symfony 7.1 and will be removed in 8.0, use getConfigurators() instead
      */
     public function getConfigurator(): string|array|null
     {
         trigger_deprecation('symfony/dependency-injection', '7.1', 'Method "%s()" is deprecated, use "%s()" instead.', __METHOD__, 'getConfigurators');
+
         return $this->configurators[0] ?? null;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1923,7 +1923,7 @@ EOF;
                 throw new RuntimeException('Cannot dump definitions which have properties.');
             }
             if (0 !== count($value->getConfigurators())) {
-                throw new RuntimeException('Cannot dump definitions which have a configurator.');
+                throw new RuntimeException('Cannot dump definitions which have configurators.');
             }
 
             return $this->addNewInstance($value);

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -799,27 +799,27 @@ EOF;
                 if ($callable[0] instanceof Reference
                     || ($callable[0] instanceof Definition && $this->definitionVariables->contains($callable[0]))
                 ) {
-                    $code.= sprintf("        %s->%s(\$%s);\n", $this->dumpValue($callable[0]), $callable[1], $variableName);
+                    $code .= sprintf("        %s->%s(\$%s);\n", $this->dumpValue($callable[0]), $callable[1], $variableName);
                     continue;
                 }
 
                 $class = $this->dumpValue($callable[0]);
                 // If the class is a string we can optimize away
                 if (str_starts_with($class, "'") && !str_contains($class, '$')) {
-                    $code.= sprintf("        %s::%s(\$%s);\n", $this->dumpLiteralClass($class), $callable[1], $variableName);
+                    $code .= sprintf("        %s::%s(\$%s);\n", $this->dumpLiteralClass($class), $callable[1], $variableName);
                     continue;
                 }
 
                 if (str_starts_with($class, 'new ')) {
-                    $code.= sprintf("        (%s)->%s(\$%s);\n", $this->dumpValue($callable[0]), $callable[1], $variableName);
+                    $code .= sprintf("        (%s)->%s(\$%s);\n", $this->dumpValue($callable[0]), $callable[1], $variableName);
                     continue;
                 }
 
-                $code.= sprintf("        [%s, '%s'](\$%s);\n", $this->dumpValue($callable[0]), $callable[1], $variableName);
+                $code .= sprintf("        [%s, '%s'](\$%s);\n", $this->dumpValue($callable[0]), $callable[1], $variableName);
                 continue;
             }
 
-            $code.= sprintf("        %s(\$%s);\n", $callable, $variableName);
+            $code .= sprintf("        %s(\$%s);\n", $callable, $variableName);
         }
 
         return $code;
@@ -1922,7 +1922,7 @@ EOF;
             if ($value->getProperties()) {
                 throw new RuntimeException('Cannot dump definitions which have properties.');
             }
-            if (0 !== count($value->getConfigurators())) {
+            if (0 !== \count($value->getConfigurators())) {
                 throw new RuntimeException('Cannot dump definitions which have configurators.');
             }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -211,19 +211,20 @@ class XmlDumper extends Dumper
             $service->setAttribute('abstract', 'true');
         }
 
-        if ($callable = $definition->getConfigurator()) {
-            $configurator = $this->document->createElement('configurator');
-
-            if (\is_array($callable) && $callable[0] instanceof Definition) {
-                $this->addService($callable[0], null, $configurator);
-                $configurator->setAttribute('method', $callable[1]);
-            } elseif (\is_array($callable)) {
-                $configurator->setAttribute($callable[0] instanceof Reference ? 'service' : 'class', $callable[0]);
-                $configurator->setAttribute('method', $callable[1]);
-            } else {
-                $configurator->setAttribute('function', $callable);
+        if ($callables = $definition->getConfigurators()) {
+            foreach ($callables as $callable) {
+                $configurator = $this->document->createElement('configurator');
+                if (\is_array($callable) && $callable[0] instanceof Definition) {
+                    $this->addService($callable[0], null, $configurator);
+                    $configurator->setAttribute('method', $callable[1]);
+                } elseif (\is_array($callable)) {
+                    $configurator->setAttribute($callable[0] instanceof Reference ? 'service' : 'class', $callable[0]);
+                    $configurator->setAttribute('method', $callable[1]);
+                } else {
+                    $configurator->setAttribute('function', $callable);
+                }
+                $service->appendChild($configurator);
             }
-            $service->appendChild($configurator);
         }
 
         $parent->appendChild($service);

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -160,8 +160,13 @@ class YamlDumper extends Dumper
             }
         }
 
-        if ($callable = $definition->getConfigurator()) {
-            $code .= sprintf("        configurator: %s\n", $this->dumper->dump($this->dumpCallable($callable), 0));
+        if (is_array($definition->getConfigurators()) && count($definition->getConfigurators()) > 0) {
+            $code .= "        configurators:\n";
+            foreach ($definition->getConfigurators() as $configurator) {
+                if ($configurator) {
+                    $code .= sprintf("            - %s\n", $this->dumper->dump($this->dumpCallable($configurator), 0));
+                }
+            }
         }
 
         return $code;

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
@@ -22,7 +22,7 @@ trait ConfiguratorTrait
      */
     final public function configurator(string|array|ReferenceConfigurator $configurator): static
     {
-        $this->definition->setConfigurator(static::processValue($configurator, true));
+        $this->definition->addConfigurator(static::processValue($configurator, true));
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -323,18 +323,19 @@ class XmlFileLoader extends FileLoader
             $definition->setFactory([null, $constructor]);
         }
 
-        if ($configurators = $this->getChildren($service, 'configurator')) {
-            $configurator = $configurators[0];
-            if ($function = $configurator->getAttribute('function')) {
-                $definition->setConfigurator($function);
-            } else {
-                if ($childService = $configurator->getAttribute('service')) {
-                    $class = new Reference($childService, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
+        if ($configurators = array_merge($this->getChildren($service, 'configurator'), $this->getChildren($service, 'configurators'))) {
+            foreach ($configurators as $configurator) {
+                if ($function = $configurator->getAttribute('function')) {
+                    $definition->addConfigurator($function);
                 } else {
-                    $class = $configurator->getAttribute('class');
-                }
+                    if ($childService = $configurator->getAttribute('service')) {
+                        $class = new Reference($childService, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
+                    } else {
+                        $class = $configurator->getAttribute('class');
+                    }
 
-                $definition->setConfigurator([$class, $configurator->getAttribute('method') ?: '__invoke']);
+                    $definition->addConfigurator([$class, $configurator->getAttribute('method') ?: '__invoke']);
+                }
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -557,7 +557,6 @@ class YamlFileLoader extends FileLoader
             }
         }
 
-
         if (isset($service['calls'])) {
             if (!\is_array($service['calls'])) {
                 throw new InvalidArgumentException(sprintf('Parameter "calls" must be an array for service "%s" in "%s". Check your YAML syntax.', $id, $file));

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -55,6 +55,7 @@ class YamlFileLoader extends FileLoader
         'arguments' => 'arguments',
         'properties' => 'properties',
         'configurator' => 'configurator',
+        'configurators' => 'configurators',
         'calls' => 'calls',
         'tags' => 'tags',
         'decorates' => 'decorates',
@@ -81,6 +82,7 @@ class YamlFileLoader extends FileLoader
         'arguments' => 'arguments',
         'properties' => 'properties',
         'configurator' => 'configurator',
+        'configurators' => 'configurators',
         'calls' => 'calls',
         'tags' => 'tags',
         'autowire' => 'autowire',
@@ -95,6 +97,7 @@ class YamlFileLoader extends FileLoader
         'public' => 'public',
         'properties' => 'properties',
         'configurator' => 'configurator',
+        'configurators' => 'configurators',
         'calls' => 'calls',
         'tags' => 'tags',
         'autowire' => 'autowire',
@@ -542,8 +545,18 @@ class YamlFileLoader extends FileLoader
         }
 
         if (isset($service['configurator'])) {
-            $definition->setConfigurator($this->parseCallable($service['configurator'], 'configurator', $id, $file));
+            $definition->addConfigurator($this->parseCallable($service['configurator'], 'configurator', $id, $file));
         }
+
+        if (isset($service['configurators'])) {
+            if (!\is_array($service['configurators'])) {
+                throw new InvalidArgumentException(sprintf('Parameter "configurators" must be an array for service "%s" in "%s". Check your YAML syntax.', $id, $file));
+            }
+            foreach ($service['configurators'] as $configurator) {
+                $definition->addConfigurator($this->parseCallable($configurator, 'configurator', $id, $file));
+            }
+        }
+
 
         if (isset($service['calls'])) {
             if (!\is_array($service['calls'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -545,6 +545,7 @@ class YamlFileLoader extends FileLoader
         }
 
         if (isset($service['configurator'])) {
+            trigger_deprecation('symfony/dependency-injection', '7.1', 'Using the "configurator" key to configure the "%s" service is deprecated, use the "configurators" key instead.', $id);
             $definition->addConfigurator($this->parseCallable($service['configurator'], 'configurator', $id, $file));
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
@@ -45,7 +45,7 @@ class ChildDefinitionTest extends TestCase
         return [
             ['class', 'class'],
             ['factory', 'factory'],
-            ['configurator', 'configurator'],
+            ['configurator', 'configurators'],
             ['file', 'file'],
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
@@ -145,4 +145,15 @@ class ChildDefinitionTest extends TestCase
 
         $this->assertSame($conditionals, $def->getInstanceofConditionals());
     }
+
+    public function testConfigurators()
+    {
+        $def = new ChildDefinition('foo');
+
+        $this->assertEmpty($def->getConfigurators());
+        $this->assertSame($def, $def->setConfigurators(['foo']));
+        $this->assertSame(['foo'], $def->getConfigurators());
+        $this->assertSame(['configurators' => true], $def->getChanges());
+        $this->assertSame(['foo', 'bar'], $def->addConfigurator('bar')->getConfigurators());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
@@ -47,7 +47,7 @@ class AnalyzeServiceReferencesPassTest extends TestCase
 
         $container
             ->register('e')
-            ->setConfigurator([$ref6 = new Reference('b'), 'methodName'])
+            ->addConfigurator([$ref6 = new Reference('b'), 'methodName'])
         ;
 
         $graph = $this->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -1039,7 +1039,7 @@ class IntegrationTest extends TestCase
                 $definition
                     ->addMethodCall('doSomething', [1, 2, 3])
                     ->setBindings(['string $foo' => 'bar'])
-                    ->setConfigurator(new Reference('my_configurator'))
+                    ->addConfigurator(new Reference('my_configurator'))
                 ;
             }
         );

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAutoconfigureAttributesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAutoconfigureAttributesPassTest.php
@@ -40,7 +40,7 @@ class RegisterAutoconfigureAttributesPassTest extends TestCase
             ->setAutowired(true)
             ->setShared(true)
             ->setProperties(['bar' => 'baz'])
-            ->setConfigurator(new Reference('bla'))
+            ->addConfigurator(new Reference('bla'))
             ->addTag('a_tag')
             ->addTag('another_tag', ['attr' => 234])
             ->addMethodCall('setBar', [2, 3])

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -462,7 +462,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowired', [new Autowire(service: 'service.id')])),
             'autowired.nullable' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'autowired.nullable', [new Autowire(service: 'service.id')])),
             'autowired.parameter' => new ServiceClosureArgument('foobar'),
-            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.oO4rxCy.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
+            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.3CLRjPT.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'target', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -275,7 +275,7 @@ class ResolveChildDefinitionsPassTest extends TestCase
 
         $container->register('parent', 'parentClass');
         $container->register('sibling', 'siblingClass')
-            ->setConfigurator([new ChildDefinition('parent'), 'foo'])
+            ->addConfigurator([new ChildDefinition('parent'), 'foo'])
             ->setFactory([new ChildDefinition('parent'), 'foo'])
             ->addArgument(new ChildDefinition('parent'))
             ->setProperty('prop', new ChildDefinition('parent'))
@@ -284,7 +284,7 @@ class ResolveChildDefinitionsPassTest extends TestCase
 
         $this->process($container);
 
-        $configurator = $container->getDefinition('sibling')->getConfigurator();
+        $configurator = $container->getDefinition('sibling')->getConfigurators()[0];
         $this->assertSame('Symfony\Component\DependencyInjection\Definition', $configurator[0]::class);
         $this->assertSame('parentClass', $configurator[0]->getClass());
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -581,13 +581,13 @@ class ContainerBuilderTest extends TestCase
     public function testCreateServiceConfigurator()
     {
         $builder = new ContainerBuilder();
-        $builder->register('foo1', 'Bar\FooClass')->setConfigurator('sc_configure');
-        $builder->register('foo2', 'Bar\FooClass')->setConfigurator(['%class%', 'configureStatic']);
+        $builder->register('foo1', 'Bar\FooClass')->addConfigurator('sc_configure');
+        $builder->register('foo2', 'Bar\FooClass')->addConfigurator(['%class%', 'configureStatic']);
         $builder->setParameter('class', 'BazClass');
         $builder->register('baz', 'BazClass');
-        $builder->register('foo3', 'Bar\FooClass')->setConfigurator([new Reference('baz'), 'configure']);
-        $builder->register('foo4', 'Bar\FooClass')->setConfigurator([$builder->getDefinition('baz'), 'configure']);
-        $builder->register('foo5', 'Bar\FooClass')->setConfigurator('foo');
+        $builder->register('foo3', 'Bar\FooClass')->addConfigurator([new Reference('baz'), 'configure']);
+        $builder->register('foo4', 'Bar\FooClass')->addConfigurator([$builder->getDefinition('baz'), 'configure']);
+        $builder->register('foo5', 'Bar\FooClass')->addConfigurator('foo');
 
         $this->assertTrue($builder->get('foo1')->configured, '->createService() calls the configurator');
         $this->assertTrue($builder->get('foo2')->configured, '->createService() calls the configurator');

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -216,6 +216,29 @@ class DefinitionTest extends TestCase
         $this->assertEquals('foo', $def->getConfigurator(), '->getConfigurator() returns the configurator');
     }
 
+    public function testSetGetConfigurators()
+    {
+        $def = new Definition('stdClass');
+        $this->assertSame($def, $def->setConfigurators(['foo']), '->setConfigurators() implements a fluent interface');
+        $this->assertSame($def, $def->addConfigurator('bar'), '->addConfigurator() implements a fluent interface');
+        $this->assertEquals(['foo', 'bar'], $def->getConfigurators(), '->getConfigurators() returns the configurator');
+        $this->assertEquals(['foo', 'bar'], $def->addConfigurator('foo')->getConfigurators(), '->addConfigurator() doesn\'t add if already present in the array');
+    }
+
+    public function testConfiguratorBackwardCompatibility()
+    {
+        $def1 = new Definition('stdClass');
+        $def2 = new Definition('stdClass');
+        // addConfigurator
+        $this->assertEquals($def1->addConfigurator('foo'), $def2->setConfigurator('foo'), '->setConfigurator() is the same as ->addConfigurator() on an empty configurator array');
+        $this->assertNotEquals($def1->addConfigurator('bar'), $def2->setConfigurator('bar'), '->setConfigurator() is not the same as ->addConfigurator() if the configurator array is not empty');
+        // setConfigurator
+        $this->assertEquals($def1->setConfigurators(['foo']), $def2->setConfigurator('foo'), '->setConfigurator($item) is the same as ->setConfigurators([$item])');
+        $this->assertEquals($def1->setConfigurators(['foo'])->setConfigurators(['bar']), $def2->setConfigurator('foo')->setConfigurator('bar'), '->setConfigurator($item) is the same as ->setConfigurators([$item]) whatever the number of time it is called');
+        // getConfigurator
+        $this->assertEquals($def1->getConfigurators()[0], $def2->getConfigurator(), '->getConfigurator() returns the first configurator');
+    }
+
     public function testClearTags()
     {
         $def = new Definition('stdClass');

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -369,7 +369,7 @@ class DefinitionTest extends TestCase
         $this->assertSame([
             'class' => true,
             'autowired' => true,
-            'configurator' => true,
+            'configurators' => true,
             'decorated_service' => true,
             'deprecated' => true,
             'factory' => true,

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
@@ -15,7 +15,8 @@ services:
             - [setFoo, ['@foo']]
 
         shared: false
-        configurator: c
+        configurators:
+            - c
     foo:
         class: App\FooService
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -24,19 +24,19 @@ $container
     ->setProperties(['foo' => 'bar', 'moo' => new Reference('foo.baz'), 'qux' => ['%foo%' => 'foo is %foo%', 'foobar' => '%foo%']])
     ->addMethodCall('setBar', [new Reference('bar')])
     ->addMethodCall('initialize')
-    ->setConfigurator('sc_configure')
+    ->setConfigurators(['sc_configure'])
     ->setPublic(true)
 ;
 $container
     ->register('foo.baz', '%baz_class%')
     ->setFactory(['%baz_class%', 'getInstance'])
-    ->setConfigurator(['%baz_class%', 'configureStatic1'])
+    ->setConfigurators([['%baz_class%', 'configureStatic1']])
     ->setPublic(true)
 ;
 $container
     ->register('bar', 'Bar\FooClass')
     ->setArguments(['foo', new Reference('foo.baz'), new Parameter('foo_bar')])
-    ->setConfigurator([new Reference('foo.baz'), 'configure'])
+    ->setConfigurators([[new Reference('foo.baz'), 'configure']])
     ->setPublic(true)
 ;
 $container
@@ -87,7 +87,7 @@ $container
 ;
 $container
     ->register('configured_service', 'stdClass')
-    ->setConfigurator([new Reference('configurator_service'), 'configureStdClass'])
+    ->setConfigurators([[new Reference('configurator_service'), 'configureStdClass']])
     ->setPublic(true)
 ;
 $container
@@ -96,7 +96,7 @@ $container
 ;
 $container
     ->register('configured_service_simple', 'stdClass')
-    ->setConfigurator([new Reference('configurator_service_simple'), 'configureStdClass'])
+    ->setConfigurators([[new Reference('configurator_service_simple'), 'configureStdClass']])
     ->setPublic(true)
 ;
 $container

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_duplicates.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_duplicates.php
@@ -41,7 +41,7 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.mtT6G8y' => true,
+            '.service_locator.2TQpAP5' => true,
             'foo' => true,
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -43,7 +43,7 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.PWbaRiJ' => true,
+            '.service_locator.LaZ1R3K' => true,
         ];
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
@@ -44,7 +44,7 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.ZP1tNYN' => true,
+            '.service_locator.eUc_qSN' => true,
             'foo2' => true,
             'foo3' => true,
             'foo4' => true,

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -43,9 +43,9 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.2hyyc9y' => true,
-            '.service_locator.KGUGnmw' => true,
-            '.service_locator.KGUGnmw.foo_service' => true,
+            '.service_locator.BNh2qct' => true,
+            '.service_locator.BNh2qct.foo_service' => true,
+            '.service_locator.TwB2jIB' => true,
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => true,
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -27,6 +27,11 @@
     <service id="configurator3" class="FooClass">
       <configurator class="BazClass" method="configureStatic" />
     </service>
+    <service id="configurator4" class="FooClass">
+      <configurator function="sc_configure" />
+      <configurator service="baz" method="configure" />
+      <configurator class="BazClass" method="configureStatic" />
+    </service>
     <service id="method_call1" class="FooClass">
       <call method="setBar" />
       <call method="setBar">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -4,9 +4,11 @@ services:
     not_shared: { class: FooClass, shared: false }
     file: { class: FooClass, file: '%path%/foo.php' }
     arguments: { class: FooClass, arguments: [foo, '@foo', [true, false]] }
-    configurator1: { class: FooClass, configurator: sc_configure }
-    configurator2: { class: FooClass, configurator: ['@baz', configure] }
-    configurator3: { class: FooClass, configurator: [BazClass, configureStatic] }
+    configurator_legacy: { class: FooClass, configurator: sc_configure }
+    configurator1: { class: FooClass, configurators: [sc_configure] }
+    configurator2: { class: FooClass, configurators: [['@baz', configure]] }
+    configurator3: { class: FooClass, configurators: [[BazClass, configureStatic]] }
+    configurator4: { class: FooClass, configurators: [sc_configure, ['@baz', configure], [BazClass, configureStatic]] }
     method_call1:
         class: FooClass
         calls:

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -22,17 +22,17 @@ services:
             - [initialize, {  }]
 
         constructor: getInstance
-        configurator: sc_configure
+        configurators: [sc_configure]
         public: true
     foo.baz:
         class: '%baz_class%'
         constructor: getInstance
-        configurator: ['%baz_class%', configureStatic1]
+        configurators: [['%baz_class%', configureStatic1]]
         public: true
     bar:
         class: Bar\FooClass
         arguments: [foo, '@foo.baz', '%foo_bar%']
-        configurator: ['@foo.baz', configure]
+        configurators: [['@foo.baz', configure]]
         public: true
     foo_bar:
         class: '%foo_class%'
@@ -79,14 +79,14 @@ services:
 
     configured_service:
         class: stdClass
-        configurator: ['@configurator_service', configureStdClass]
+        configurators: [['@configurator_service', configureStdClass]]
         public: true
     configurator_service_simple:
         class: ConfClass
         arguments: ['bar']
     configured_service_simple:
         class: stdClass
-        configurator: ['@configurator_service_simple', configureStdClass]
+        configurators: [['@configurator_service_simple', configureStdClass]]
         public: true
     decorated:
         class: stdClass

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -340,6 +340,7 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals('sc_configure', $services['configurator1']->getConfigurators()[0], '->load() parses the configurator tag');
         $this->assertEquals([new Reference('baz'), 'configure'], $services['configurator2']->getConfigurators()[0], '->load() parses the configurator tag');
         $this->assertEquals(['BazClass', 'configureStatic'], $services['configurator3']->getConfigurators()[0], '->load() parses the configurator tag');
+        $this->assertEquals(['sc_configure', [new Reference('baz'), 'configure'], ['BazClass', 'configureStatic']], $services['configurator4']->getConfigurators(), '->load() parses the configurator tag');
         $this->assertEquals([['setBar', []], ['setBar', [new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')]]], $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals([['setBar', ['foo', new Reference('foo'), [true, false]]]], $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -337,9 +337,9 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals('FooClass', $services['foo']->getClass(), '->load() parses the class attribute');
         $this->assertEquals('%path%/foo.php', $services['file']->getFile(), '->load() parses the file tag');
         $this->assertEquals(['foo', new Reference('foo'), [true, false]], $services['arguments']->getArguments(), '->load() parses the argument tags');
-        $this->assertEquals('sc_configure', $services['configurator1']->getConfigurator(), '->load() parses the configurator tag');
-        $this->assertEquals([new Reference('baz'), 'configure'], $services['configurator2']->getConfigurator(), '->load() parses the configurator tag');
-        $this->assertEquals(['BazClass', 'configureStatic'], $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
+        $this->assertEquals('sc_configure', $services['configurator1']->getConfigurators()[0], '->load() parses the configurator tag');
+        $this->assertEquals([new Reference('baz'), 'configure'], $services['configurator2']->getConfigurators()[0], '->load() parses the configurator tag');
+        $this->assertEquals(['BazClass', 'configureStatic'], $services['configurator3']->getConfigurators()[0], '->load() parses the configurator tag');
         $this->assertEquals([['setBar', []], ['setBar', [new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')]]], $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals([['setBar', ['foo', new Reference('foo'), [true, false]]]], $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');
@@ -725,14 +725,14 @@ class XmlFileLoaderTest extends TestCase
         $this->assertSame('Foobar', $container->getDefinition((string) $fooFactoryFactory[0])->getClass());
         $this->assertSame('createFooFactory', $fooFactoryFactory[1]);
 
-        $fooConfigurator = $foo->getConfigurator();
+        $fooConfigurator = $foo->getConfigurators()[0];
         $this->assertInstanceOf(Reference::class, $fooConfigurator[0]);
         $this->assertTrue($container->has((string) $fooConfigurator[0]));
         $fooConfiguratorDefinition = $container->getDefinition((string) $fooConfigurator[0]);
         $this->assertSame('Bar', $fooConfiguratorDefinition->getClass());
         $this->assertSame('configureFoo', $fooConfigurator[1]);
 
-        $barConfigurator = $fooConfiguratorDefinition->getConfigurator();
+        $barConfigurator = $fooConfiguratorDefinition->getConfigurators()[0];
         $this->assertInstanceOf(Reference::class, $barConfigurator[0]);
         $this->assertSame('Baz', $container->getDefinition((string) $barConfigurator[0])->getClass());
         $this->assertSame('configureBar', $barConfigurator[1]);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -219,9 +219,11 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals('FooClass', $services['foo']->getClass(), '->load() parses the class attribute');
         $this->assertEquals('%path%/foo.php', $services['file']->getFile(), '->load() parses the file tag');
         $this->assertEquals(['foo', new Reference('foo'), [true, false]], $services['arguments']->getArguments(), '->load() parses the argument tags');
-        $this->assertEquals('sc_configure', $services['configurator1']->getConfigurators()[0], '->load() parses the configurator tag');
-        $this->assertEquals([new Reference('baz'), 'configure'], $services['configurator2']->getConfigurators()[0], '->load() parses the configurator tag');
-        $this->assertEquals(['BazClass', 'configureStatic'], $services['configurator3']->getConfigurators()[0], '->load() parses the configurator tag');
+        $this->assertEquals('sc_configure', $services['configurator_legacy']->getConfigurator(), '->load() parses the legacy configurator tag');
+        $this->assertEquals('sc_configure', $services['configurator1']->getConfigurators()[0], '->load() parses the configurators tag');
+        $this->assertEquals([new Reference('baz'), 'configure'], $services['configurator2']->getConfigurators()[0], '->load() parses the configurators tag');
+        $this->assertEquals(['BazClass', 'configureStatic'], $services['configurator3']->getConfigurators()[0], '->load() parses the configurators tag');
+        $this->assertEquals(['sc_configure', [new Reference('baz'), 'configure'], ['BazClass', 'configureStatic']], $services['configurator4']->getConfigurators(), '->load() parses the configurators tag');
         $this->assertEquals([['setBar', []], ['setBar', []], ['setBar', [new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')]]], $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals([['setBar', ['foo', new Reference('foo'), [true, false]]]], $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -219,9 +219,9 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals('FooClass', $services['foo']->getClass(), '->load() parses the class attribute');
         $this->assertEquals('%path%/foo.php', $services['file']->getFile(), '->load() parses the file tag');
         $this->assertEquals(['foo', new Reference('foo'), [true, false]], $services['arguments']->getArguments(), '->load() parses the argument tags');
-        $this->assertEquals('sc_configure', $services['configurator1']->getConfigurator(), '->load() parses the configurator tag');
-        $this->assertEquals([new Reference('baz'), 'configure'], $services['configurator2']->getConfigurator(), '->load() parses the configurator tag');
-        $this->assertEquals(['BazClass', 'configureStatic'], $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
+        $this->assertEquals('sc_configure', $services['configurator1']->getConfigurators()[0], '->load() parses the configurator tag');
+        $this->assertEquals([new Reference('baz'), 'configure'], $services['configurator2']->getConfigurators()[0], '->load() parses the configurator tag');
+        $this->assertEquals(['BazClass', 'configureStatic'], $services['configurator3']->getConfigurators()[0], '->load() parses the configurator tag');
         $this->assertEquals([['setBar', []], ['setBar', []], ['setBar', [new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')]]], $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals([['setBar', ['foo', new Reference('foo'), [true, false]]]], $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | #52607 
| License       | MIT

This feature allows the use of multiple configurators for a single service.  
A new service definition option is introduced : `configurators`.  
The previous `configurator`, as well as  the`Defintion::getConfigurator` and `Defintion::setConfigurator` that now trigger deprecations and make use of the new `Defintion::getConfigurators`,  `Defintion::setConfigurators` and `Defintion::setConfigurators`.  

```yaml
services:
  App\MyService:
    configurators:
      - ['@App\MyConfigurator1']
      - ['@App\MyConfigurator2', 'methodName']
      - ['@App\MyConfigurator3', 'methodName']
```