### PR TITLE
[VarExporter] Fix handling mangled property names returned by __sleep()

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -157,11 +157,11 @@ class Exporter
                     $n = substr($n, 1 + $i);
                 }
                 if (null !== $sleep) {
-                    if (!isset($sleep[$n]) || ($i && $c !== $class)) {
+                    if (!isset($sleep[$name]) && (!isset($sleep[$n]) || ($i && $c !== $class))) {
                         unset($arrayValue[$name]);
                         continue;
                     }
-                    $sleep[$n] = false;
+                    unset($sleep[$name], $sleep[$n]);
                 }
                 if (!\array_key_exists($name, $proto) || $proto[$name] !== $v || "\x00Error\x00trace" === $name || "\x00Exception\x00trace" === $name) {
                     $properties[$c][$n] = $v;
@@ -169,9 +169,7 @@ class Exporter
             }
             if ($sleep) {
                 foreach ($sleep as $n => $v) {
-                    if (false !== $v) {
-                        trigger_error(sprintf('serialize(): "%s" returned as member variable from __sleep() but does not exist', $n), \E_USER_NOTICE);
-                    }
+                    trigger_error(sprintf('serialize(): "%s" returned as member variable from __sleep() but does not exist', $n), \E_USER_NOTICE);
                 }
             }
             if (method_exists($class, '__unserialize')) {

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/var-on-sleep.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/var-on-sleep.php
@@ -11,6 +11,14 @@ return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
                 'night',
             ],
         ],
+        'Symfony\\Component\\VarExporter\\Tests\\GoodNight' => [
+            'foo' => [
+                'afternoon',
+            ],
+            'bar' => [
+                'morning',
+            ],
+        ],
     ],
     $o[0],
     []

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -349,17 +349,21 @@ class MyArrayObject extends \ArrayObject
 class GoodNight
 {
     public $good;
+    protected $foo;
+    private $bar;
 
     public function __construct()
     {
         unset($this->good);
+        $this->foo = 'afternoon';
+        $this->bar = 'morning';
     }
 
     public function __sleep(): array
     {
         $this->good = 'night';
 
-        return ['good'];
+        return ['good', 'foo', "\0*\0foo", "\0".__CLASS__."\0bar"];
     }
 }
 

--- a/src/Symfony/Component/VarExporter/VarExporter.php
+++ b/src/Symfony/Component/VarExporter/VarExporter.php
@@ -83,7 +83,7 @@ final class VarExporter
         ksort($states);
 
         $wakeups = [null];
-        foreach ($states as $k => $v) {
+        foreach ($states as $v) {
             if (\is_array($v)) {
                 $wakeups[-$v[0]] = $v[1];
             } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52614
| License       | MIT

Did you know that __sleep can return mangled property names? I didn't :)
https://3v4l.org/3ckU7

Fixes https://github.com/doctrine/orm/issues/11063 also.