### PR TITLE
[Security] set configured claim as userIdentifier on OidcUser using OidcUserInfoTokenHandler

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
@@ -46,6 +46,8 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
                 throw new MissingClaimException(sprintf('"%s" claim not found on OIDC server response.', $this->claim));
             }
 
+            $claims['userIdentifier'] = $claims[$this->claim];
+
             // UserLoader argument can be overridden by a UserProvider on AccessTokenAuthenticator::authenticate
             return new UserBadge($claims[$this->claim], new FallbackUserLoader(fn () => $this->createUser($claims)), $claims);
         } catch (\Exception $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

As I was trying to use the `oidc_user_info` token handler with a custom `claim` setting, I noticed (debugged) that the specified claim is only set on the `UserBadge`, but not on the actual `OidcUser` object. The latter gets the original `$claims` array as the constructor parameters through the `\Symfony\Component\Security\Http\AccessToken\Oidc\OidcTrait::createUser`, that's why the selected claim does not get set currently.

This patch does solve this case.

----

I.e. using this example [from the doc](https://symfony.com/doc/current/security/access_token.html#1-configure-the-oidcuserinfotokenhandler) does not set the `email` claim as `OidcUser::userIdentifier`, that property will never be set.

```
# config/packages/security.yaml
security:
    firewalls:
        main:
            access_token:
                token_handler:
                    oidc_user_info:
                        claim: email
                        base_uri: https://www.example.com/realms/demo/protocol/openid-connect/userinfo
```

----

Please let me know if it's not the intended way to set up the user class.

If this is should be the correct flow (as I assume), I'm willing to cover it with tests in this PR.
