### PR TITLE
[Serializer] Fix denormalizing date intervals having both weeks and days

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -128,6 +128,10 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
 
     private function isISO8601(string $string): bool
     {
+        if (\PHP_VERSION_ID >= 80000) {
+            return preg_match('/^[\-+]?P(?=\w*(?:\d|%\w))(?:\d+Y|%[yY]Y)?(?:\d+M|%[mM]M)?(?:\d+W|%[wW]W)?(?:\d+D|%[dD]D)?(?:T(?:\d+H|[hH]H)?(?:\d+M|[iI]M)?(?:\d+S|[sS]S)?)?$/', $string);
+        }
+
         return preg_match('/^[\-+]?P(?=\w*(?:\d|%\w))(?:\d+Y|%[yY]Y)?(?:\d+M|%[mM]M)?(?:(?:\d+D|%[dD]D)|(?:\d+W|%[wW]W))?(?:T(?:\d+H|[hH]H)?(?:\d+M|[iI]M)?(?:\d+S|[sS]S)?)?$/', $string);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
@@ -119,6 +119,21 @@ class DateIntervalNormalizerTest extends TestCase
         $this->assertDateIntervalEquals($this->getInterval('P0Y0M0DT12H34M0S'), $normalizer->denormalize('PT12H34M', \DateInterval::class));
     }
 
+    /**
+     * Since PHP 8.0 DateInterval::construct supports periods containing both D and W period designators.
+     *
+     * @requires PHP 8
+     */
+    public function testDenormalizeIntervalWithBothWeeksAndDays()
+    {
+        $input = 'P1W1D';
+        $interval = $this->normalizer->denormalize($input, \DateInterval::class, null, [
+            DateIntervalNormalizer::FORMAT_KEY => '%rP%yY%mM%wW%dDT%hH%iM%sS',
+        ]);
+        $this->assertDateIntervalEquals($this->getInterval($input), $interval);
+        $this->assertSame(8, $interval->d);
+    }
+
     public function testDenormalizeExpectsString()
     {
         $this->expectException(NotNormalizableValueException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #47629
| License       | MIT

Added support for date periods having both W and D period designators combined together (which is valid duration for ISO 8601-2). Starting from PHP 8 this is supported by \DateTimeInterval, see https://bugs.php.net/bug.php?id=61366 for reference