### PR TITLE
[Messenger] Fix support for Redis Sentinel using php-redis 6.0.0

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -108,7 +108,21 @@ class Connection
                         }
 
                         try {
-                            $sentinel = new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout']);
+                            if (version_compare(phpversion('redis'), '6.0.0', '>=')) {
+                                $params = [
+                                    'host' => $host,
+                                    'port' => $port,
+                                    'connectTimeout' => $options['timeout'],
+                                    'persistent' => $options['persistent_id'],
+                                    'retryInterval' => $options['retry_interval'],
+                                    'readTimeout' => $options['read_timeout'],
+                                ];
+
+                                $sentinel = new \RedisSentinel($params);
+                            } else {
+                                $sentinel = new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout']);
+                            }
+
                             if ($address = $sentinel->getMasterAddrByName($sentinelMaster)) {
                                 [$host, $port] = $address;
                             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52487
| License       | MIT

Added support for [php-redis 6.0.0](https://github.com/phpredis/phpredis/blob/develop/CHANGELOG.md#600---2023-09-09-github-pecl) to Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.
A similar fix done for RedisTrait before https://github.com/symfony/symfony/pull/51683
