### PR TITLE
[DomCrawler] Revert "bug #52579 UriResolver support path with colons"

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/UriResolverTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/UriResolverTest.php
@@ -85,9 +85,7 @@ class UriResolverTest extends TestCase
             ['foo', 'http://localhost?bar=1', 'http://localhost/foo'],
             ['foo', 'http://localhost#bar', 'http://localhost/foo'],
 
-            ['foo:1', 'http://localhost', 'http://localhost/foo:1'],
-            ['/bar:1', 'http://localhost', 'http://localhost/bar:1'],
-            ['foo/bar:1', 'http://localhost', 'http://localhost/foo/bar:1'],
+            ['http://', 'http://localhost', 'http://'],
         ];
     }
 }

--- a/src/Symfony/Component/DomCrawler/UriResolver.php
+++ b/src/Symfony/Component/DomCrawler/UriResolver.php
@@ -33,7 +33,7 @@ class UriResolver
         $uri = trim($uri);
 
         // absolute URL?
-        if (\is_string(parse_url($uri, \PHP_URL_SCHEME))) {
+        if (null !== parse_url($uri, \PHP_URL_SCHEME)) {
             return $uri;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | fix #52628
| License       | MIT
