### PR TITLE
Hint that changing input arguments has no effect

### DIFF
--- a/src/Symfony/Component/Console/Event/ConsoleCommandEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleCommandEvent.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Console\Event;
 
 /**
- * Allows to do things before the command is executed, like skipping the command or changing the input.
+ * Allows to do things before the command is executed, like skipping the command or executing code before the command is
+ * going to be executed.
+ *
+ * Changing the input arguments will have no effect.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | #52415
| License       | MIT

Adding a hint to `\Symfony\Component\Console\Event\ConsoleCommandEvent` that changing the input arguments has no effect.