### PR TITLE
[DependencyInjection] Prepend extension config with `ContainerConfigurator`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add argument `$prepend` to `ContainerConfigurator::extension()` to prepend the configuration instead of appending it
+
 7.0
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -48,8 +48,14 @@ class ContainerConfigurator extends AbstractConfigurator
         $this->env = $env;
     }
 
-    final public function extension(string $namespace, array $config): void
+    final public function extension(string $namespace, array $config, bool $prepend = false): void
     {
+        if ($prepend) {
+            $this->container->prependExtensionConfig($namespace, static::processValue($config));
+
+            return;
+        }
+
         if (!$this->container->hasExtension($namespace)) {
             $extensions = array_filter(array_map(fn (ExtensionInterface $ext) => $ext->getAlias(), $this->container->getExtensions()));
             throw new InvalidArgumentException(sprintf('There is no extension able to load the configuration for "%s" (in "%s"). Looked for namespace "%s", found "%s".', $namespace, $this->file, $namespace, $extensions ? implode('", "', $extensions) : 'none'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Extension/AbstractExtensionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Extension/AbstractExtensionTest.php
@@ -63,7 +63,7 @@ class AbstractExtensionTest extends TestCase
                 $container->extension('third', ['foo' => 'append']);
 
                 // prepend config
-                $builder->prependExtensionConfig('third', ['foo' => 'prepend']);
+                $container->extension('third', ['foo' => 'prepend'], true);
             }
         };
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/AcmeFooBundle/AcmeFooBundle.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/AcmeFooBundle/AcmeFooBundle.php
@@ -31,7 +31,7 @@ class AcmeFooBundle extends AbstractBundle
 
     public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $container->extension('loaded', ['bar' => 'baz']);
+        $container->extension('loaded', ['bar' => 'baz'], true);
     }
 
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

I found this by fixing an issue in a bundle that was trying to prepend extension configs using `$container->extension('namespace', [...])` in `AbstractBundle::prependExtension()`, which indeed was appending that config instead of prepending it. Most importantly, the append strategy requires the extension namespace to be loaded beforehand, which is not required when prepend is used.

This title DX improvement helps to avoid the confusion between `ContainerConfigurator $container` and `ContainerBuilder $builder` to prepend extension config by allowing `ContainerConfigurator` to do the same now.

Example:
```php
class AcmeFooBundle extends AbstractBundle
{
    public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
    {
        // Before (only way)
        $builder->prependExtensionConfig('namespace', ['foo' => 'bar']);

        // After (also this way) passing "true" as the 3rd parameter
        $container->extension('namespace', ['foo' => 'bar'], true);
    }
}
```
Instead of adding a new `$prepend` argument to the existing method, I could create a new method, e.g., `ContainerConfigurator::prependExtension()`. What do you prefer?

This also helps when you want to prepend several or large configs in your bundle or extension class. Actually, using just `$container->import('...')` doesn't work because internally it will always append the configs, unless you do the following hidden trick below.

```php
// acme-bundle/config/packages/configs.php
use Symfony\Component\DependencyInjection\ContainerBuilder;

return static function (ContainerBuilder $container) {
    $container->prependExtensionConfig('namespace', ['large' => 'config', ...]);
};
```
If you type `ContainerBuilder` instead of `ContainerConfigurator` in the external PHP config file, the builder instance will be passed instead, allowing you to use the `prependExtensionConfig()` method.

But with this proposal, it's simpler as you can keep using `ContainerConfigurator` to prepend extension configs without doing any tactic.