### PR TITLE
[Dotenv] Add `SYMFONY_DOTENV_PATH`, consumed by `debug:dotenv` for custom `.env` path

### DIFF
--- a/src/Symfony/Component/Dotenv/CHANGELOG.md
+++ b/src/Symfony/Component/Dotenv/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `SYMFONY_DOTENV_PATH` variable with the path to the `.env` file loaded by `Dotenv::loadEnv()` or `Dotenv::bootEnv()`
+
 6.2
 ---
 

--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -70,21 +70,23 @@ EOT
             return 1;
         }
 
-        $envFiles = $this->getEnvFiles();
-        $availableFiles = array_filter($envFiles, fn (string $file) => is_file($this->getFilePath($file)));
+        $filePath = $_SERVER['SYMFONY_DOTENV_PATH'] ?? $this->projectDirectory.\DIRECTORY_SEPARATOR.'.env';
 
-        if (\in_array('.env.local.php', $availableFiles, true)) {
-            $io->warning('Due to existing dump file (.env.local.php) all other dotenv files are skipped.');
+        $envFiles = $this->getEnvFiles($filePath);
+        $availableFiles = array_filter($envFiles, fn (string $file) => is_file($file));
+
+        if (\in_array(sprintf('%s.local.php', $filePath), $availableFiles, true)) {
+            $io->warning(sprintf('Due to existing dump file (%s.local.php) all other dotenv files are skipped.', $this->getRelativeName($filePath)));
         }
 
-        if (is_file($this->getFilePath('.env')) && is_file($this->getFilePath('.env.dist'))) {
-            $io->warning('The file .env.dist gets skipped due to the existence of .env.');
+        if (is_file($filePath) && is_file(sprintf('%s.dist', $filePath))) {
+            $io->warning(sprintf('The file %s.dist gets skipped due to the existence of %1$s.', $this->getRelativeName($filePath)));
         }
 
         $io->section('Scanned Files (in descending priority)');
-        $io->listing(array_map(static fn (string $envFile) => \in_array($envFile, $availableFiles, true)
-            ? sprintf('<fg=green>✓</> %s', $envFile)
-            : sprintf('<fg=red>⨯</> %s', $envFile), $envFiles));
+        $io->listing(array_map(fn (string $envFile) => \in_array($envFile, $availableFiles, true)
+            ? sprintf('<fg=green>✓</> %s', $this->getRelativeName($envFile))
+            : sprintf('<fg=red>⨯</> %s', $this->getRelativeName($envFile)), $envFiles));
 
         $nameFilter = $input->getArgument('filter');
         $variables = $this->getVariables($availableFiles, $nameFilter);
@@ -93,7 +95,7 @@ EOT
 
         if ($variables || null === $nameFilter) {
             $io->table(
-                array_merge(['Variable', 'Value'], $availableFiles),
+                array_merge(['Variable', 'Value'], array_map($this->getRelativeName(...), $availableFiles)),
                 $this->getVariables($availableFiles, $nameFilter)
             );
 
@@ -147,36 +149,38 @@ EOT
         return $vars;
     }
 
-    private function getEnvFiles(): array
+    private function getEnvFiles(string $filePath): array
     {
         $files = [
-            '.env.local.php',
-            sprintf('.env.%s.local', $this->kernelEnvironment),
-            sprintf('.env.%s', $this->kernelEnvironment),
+            sprintf('%s.local.php', $filePath),
+            sprintf('%s.%s.local', $filePath, $this->kernelEnvironment),
+            sprintf('%s.%s', $filePath, $this->kernelEnvironment),
         ];
 
         if ('test' !== $this->kernelEnvironment) {
-            $files[] = '.env.local';
+            $files[] = sprintf('%s.local', $filePath);
         }
 
-        if (!is_file($this->getFilePath('.env')) && is_file($this->getFilePath('.env.dist'))) {
-            $files[] = '.env.dist';
+        if (!is_file($filePath) && is_file(sprintf('%s.dist', $filePath))) {
+            $files[] = sprintf('%s.dist', $filePath);
         } else {
-            $files[] = '.env';
+            $files[] = $filePath;
         }
 
         return $files;
     }
 
-    private function getFilePath(string $file): string
+    private function getRelativeName(string $filePath): string
     {
-        return $this->projectDirectory.\DIRECTORY_SEPARATOR.$file;
+        if (str_starts_with($filePath, $this->projectDirectory)) {
+            return substr($filePath, \strlen($this->projectDirectory) + 1);
+        }
+
+        return basename($filePath);
     }
 
-    private function loadValues(string $file): array
+    private function loadValues(string $filePath): array
     {
-        $filePath = $this->getFilePath($file);
-
         if (str_ends_with($filePath, '.php')) {
             return include $filePath;
         }

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -107,6 +107,7 @@ EOF;
         try {
             $dotenv->loadEnv($dotenvPath, null, 'dev', $testEnvs);
             unset($_ENV['SYMFONY_DOTENV_VARS']);
+            unset($_ENV['SYMFONY_DOTENV_PATH']);
 
             return $_ENV;
         } finally {

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -100,6 +100,8 @@ final class Dotenv
      */
     public function loadEnv(string $path, string $envKey = null, string $defaultEnv = 'dev', array $testEnvs = ['test'], bool $overrideExistingVars = false): void
     {
+        $this->populatePath($path);
+
         $k = $envKey ?? $this->envKey;
 
         if (is_file($path) || !is_file($p = "$path.dist")) {
@@ -144,6 +146,7 @@ final class Dotenv
         $k = $this->envKey;
 
         if (\is_array($env) && ($overrideExistingVars || !isset($env[$k]) || ($_SERVER[$k] ?? $_ENV[$k] ?? $env[$k]) === $env[$k])) {
+            $this->populatePath($path);
             $this->populate($env, $overrideExistingVars);
         } else {
             $this->loadEnv($path, $k, $defaultEnv, $testEnvs, $overrideExistingVars);
@@ -554,6 +557,15 @@ final class Dotenv
             }
 
             $this->populate($this->parse(file_get_contents($path), $path), $overrideExistingVars);
+        }
+    }
+
+    private function populatePath(string $path): void
+    {
+        $_ENV['SYMFONY_DOTENV_PATH'] = $_SERVER['SYMFONY_DOTENV_PATH'] = $path;
+
+        if ($this->usePutenv) {
+            putenv('SYMFONY_DOTENV_PATH='.$path);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #47880
| License       | MIT

Continuation of #47901

Introduce `SYMFONY_DOTENV_PATH` set by DotEnv class and read by the `debug:dotenv` command to contextualize the debug info with the file that was actually parsed.

The custom path can be set in many ways:

- Doing a call to `(new Dotenv())->bootEnv(dirname(__DIR__).'my/custom/path/to/.env');`
- In `composer.json`: `"extra": { "runtime": { "dotenv_path": "my/custom/path/to/.env" }`
- With the env var: `$_SERVER['APP_RUNTIME_OPTIONS'] = ['dotenv_path' => 'my/custom/path/to/.env'];`

The dotenv file can be outside of the `project_dir`.