### PR TITLE
[Serializer] Remove wrong final tags

### DIFF
--- a/src/Symfony/Component/Serializer/Attribute/Context.php
+++ b/src/Symfony/Component/Serializer/Attribute/Context.php
@@ -21,8 +21,6 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
- *
- * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Context

--- a/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
@@ -21,8 +21,6 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"CLASS"})
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
- *
- * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class DiscriminatorMap

--- a/src/Symfony/Component/Serializer/Attribute/Groups.php
+++ b/src/Symfony/Component/Serializer/Attribute/Groups.php
@@ -21,8 +21,6 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD", "CLASS"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
- *
- * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_CLASS)]
 class Groups

--- a/src/Symfony/Component/Serializer/Attribute/Ignore.php
+++ b/src/Symfony/Component/Serializer/Attribute/Ignore.php
@@ -18,8 +18,6 @@ namespace Symfony\Component\Serializer\Attribute;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
- *
- * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 class Ignore

--- a/src/Symfony/Component/Serializer/Attribute/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Attribute/MaxDepth.php
@@ -21,8 +21,6 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
- *
- * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 class MaxDepth

--- a/src/Symfony/Component/Serializer/Attribute/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Attribute/SerializedName.php
@@ -21,8 +21,6 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
- *
- * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 class SerializedName

--- a/src/Symfony/Component/Serializer/Attribute/SerializedPath.php
+++ b/src/Symfony/Component/Serializer/Attribute/SerializedPath.php
@@ -23,8 +23,6 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Tobias Bönner <tobi@boenner.family>
- *
- * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 class SerializedPath


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

~When `@final` was added to `Groups` and `Context`, the related and therefore deprecated tests weren't removed.
This PR removes them.~

According to https://github.com/symfony/symfony/pull/52646#issuecomment-1818401464, `final` should not have been added to attributes in the first time, this PR removes them.