### PR TITLE
Rate Limiter requires Symfony Lock

### DIFF
--- a/src/Symfony/Component/RateLimiter/composer.json
+++ b/src/Symfony/Component/RateLimiter/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/lock": "^6.4|^7.0",
         "symfony/options-resolver": "^6.4|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

When we install and configure Symfony's Rate Limiter component, we get an error reporting this component depends on Symfony's Lock component (understandable to prevent further access/attempts). Hence, it should be included as one of the required dependencies.

I assume previous versions of this component are also suffering from the same problem, but I just found it by testing the RC1 for the Symfony 7 branch

I understand this can be flagged as a bug because we should not expect to get an error after installing it