### PR TITLE
[Validator] Add additional versions  (`*_NO_PUBLIC`, `*_ONLY_PRIV` & `*_ONLY_RES`) in IP address & CIDR constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add support for `Stringable` values when using the `Cidr`, `CssColor`, `ExpressionSyntax` and `PasswordStrength` constraints
  * Add `MacAddress` constraint
+ * Add `*_NO_PUBLIC`, `*_ONLY_PRIVATE` and `*_ONLY_RESERVED` versions to `Ip` constraint
+ * Possibility to use all `Ip` constraint versions for `Cidr` constraint
  * Add `list` and `associative_array` types to `Type` constraint
  * Add the `Charset` constraint
 

--- a/src/Symfony/Component/Validator/Constraints/Cidr.php
+++ b/src/Symfony/Component/Validator/Constraints/Cidr.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
 
 /**
  * Validates that a value is a valid CIDR notation.
@@ -21,6 +22,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  *
  * @author Sorin Pop <popsorin15@gmail.com>
  * @author Calin Bolea <calin.bolea@gmail.com>
+ * @author Ninos Ego <me@ninosego.de>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Cidr extends Constraint
@@ -34,9 +36,33 @@ class Cidr extends Constraint
     ];
 
     private const NET_MAXES = [
-        Ip::ALL => 128,
         Ip::V4 => 32,
         Ip::V6 => 128,
+        Ip::ALL => 128,
+
+        Ip::V4_NO_PUBLIC => 32,
+        Ip::V6_NO_PUBLIC => 128,
+        Ip::ALL_NO_PUBLIC => 128,
+
+        Ip::V4_NO_PRIVATE => 32,
+        Ip::V6_NO_PRIVATE => 128,
+        Ip::ALL_NO_PRIVATE => 128,
+
+        Ip::V4_NO_RESERVED => 32,
+        Ip::V6_NO_RESERVED => 128,
+        Ip::ALL_NO_RESERVED => 128,
+
+        Ip::V4_ONLY_PUBLIC => 32,
+        Ip::V6_ONLY_PUBLIC => 128,
+        Ip::ALL_ONLY_PUBLIC => 128,
+
+        Ip::V4_ONLY_PRIVATE => 32,
+        Ip::V6_ONLY_PRIVATE => 128,
+        Ip::ALL_ONLY_PRIVATE => 128,
+
+        Ip::V4_ONLY_RESERVED => 32,
+        Ip::V6_ONLY_RESERVED => 128,
+        Ip::ALL_ONLY_RESERVED => 128,
     ];
 
     public string $version = Ip::ALL;
@@ -45,13 +71,9 @@ class Cidr extends Constraint
     public int $netmaskMin = 0;
     public int $netmaskMax;
 
-    /**
-     * @param array<string,mixed>|null $options
-     * @param string|null              $version    The CIDR version to validate (4, 6 or all, defaults to all)
-     * @param int|null                 $netmaskMin The lowest valid for a valid netmask (defaults to 0)
-     * @param int|null                 $netmaskMax The biggest valid for a valid netmask (defaults to 32 for IPv4, 128 for IPv6)
-     * @param string[]|null            $groups
-     */
+    /** @var callable|null */
+    public $normalizer;
+
     public function __construct(
         ?array $options = null,
         ?string $version = null,
@@ -60,6 +82,7 @@ class Cidr extends Constraint
         ?string $message = null,
         ?array $groups = null,
         $payload = null,
+        ?callable $normalizer = null,
     ) {
         $this->version = $version ?? $options['version'] ?? $this->version;
 
@@ -70,11 +93,16 @@ class Cidr extends Constraint
         $this->netmaskMin = $netmaskMin ?? $options['netmaskMin'] ?? $this->netmaskMin;
         $this->netmaskMax = $netmaskMax ?? $options['netmaskMax'] ?? self::NET_MAXES[$this->version];
         $this->message = $message ?? $this->message;
+        $this->normalizer = $normalizer ?? $this->normalizer;
 
         unset($options['netmaskMin'], $options['netmaskMax'], $options['version']);
 
         if ($this->netmaskMin < 0 || $this->netmaskMax > self::NET_MAXES[$this->version] || $this->netmaskMin > $this->netmaskMax) {
             throw new ConstraintDefinitionException(sprintf('The netmask range must be between 0 and %d.', self::NET_MAXES[$this->version]));
+        }
+
+        if (null !== $this->normalizer && !\is_callable($this->normalizer)) {
+            throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/CidrValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CidrValidator.php
@@ -16,6 +16,13 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
+/**
+ * Validates whether a value is a CIDR notation.
+ *
+ * @author Sorin Pop <popsorin15@gmail.com>
+ * @author Calin Bolea <calin.bolea@gmail.com>
+ * @author Ninos Ego <me@ninosego.de>
+ */
 class CidrValidator extends ConstraintValidator
 {
     public function validate($value, Constraint $constraint): void
@@ -28,8 +35,14 @@ class CidrValidator extends ConstraintValidator
             return;
         }
 
-        if (!\is_string($value) && !$value instanceof \Stringable) {
+        if (!\is_scalar($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
+        }
+
+        $value = (string) $value;
+
+        if (null !== $constraint->normalizer) {
+            $value = ($constraint->normalizer)($value);
         }
 
         $cidrParts = explode('/', $value, 2);
@@ -49,20 +62,17 @@ class CidrValidator extends ConstraintValidator
         $ipAddress = $cidrParts[0];
         $netmask = (int) $cidrParts[1];
 
-        $validV4 = Ip::V6 !== $constraint->version
-            && filter_var($ipAddress, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)
-            && $netmask <= 32;
-
-        $validV6 = Ip::V4 !== $constraint->version
-            && filter_var($ipAddress, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6);
-
-        if (!$validV4 && !$validV6) {
+        if (!IpValidator::checkIP($ipAddress, $constraint->version)) {
             $this->context
                 ->buildViolation($constraint->message)
                 ->setCode(Cidr::INVALID_CIDR_ERROR)
                 ->addViolation();
 
             return;
+        }
+
+        if (filter_var($ipAddress, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4) && $constraint->netmaskMax > 32) {
+            $constraint->netmaskMax = 32;
         }
 
         if ($netmask < $constraint->netmaskMin || $netmask > $constraint->netmaskMax) {

--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Exception\InvalidArgumentException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Joseph Bielawski <stloyd@gmail.com>
+ * @author Ninos Ego <me@ninosego.de>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Ip extends Constraint
@@ -28,20 +29,41 @@ class Ip extends Constraint
     public const V6 = '6';
     public const ALL = 'all';
 
+    // adds inverse FILTER_FLAG_NO_RES_RANGE and FILTER_FLAG_NO_PRIV_RANGE flags (skip both)
+    public const V4_NO_PUBLIC = '4_no_public';
+    public const V6_NO_PUBLIC = '6_no_public';
+    public const ALL_NO_PUBLIC = 'all_no_public';
+
     // adds FILTER_FLAG_NO_PRIV_RANGE flag (skip private ranges)
-    public const V4_NO_PRIV = '4_no_priv';
-    public const V6_NO_PRIV = '6_no_priv';
-    public const ALL_NO_PRIV = 'all_no_priv';
+    public const V4_NO_PRIVATE = '4_no_priv';
+    public const V4_NO_PRIV = self::V4_NO_PRIVATE; // BC: Alias
+    public const V6_NO_PRIVATE = '6_no_priv';
+    public const V6_NO_PRIV = self::V6_NO_PRIVATE; // BC: Alias
+    public const ALL_NO_PRIVATE = 'all_no_priv';
+    public const ALL_NO_PRIV = self::ALL_NO_PRIVATE; // BC: Alias
 
     // adds FILTER_FLAG_NO_RES_RANGE flag (skip reserved ranges)
-    public const V4_NO_RES = '4_no_res';
-    public const V6_NO_RES = '6_no_res';
-    public const ALL_NO_RES = 'all_no_res';
+    public const V4_NO_RESERVED = '4_no_res';
+    public const V4_NO_RES = self::V4_NO_RESERVED; // BC: Alias
+    public const V6_NO_RESERVED = '6_no_res';
+    public const V6_NO_RES = self::V6_NO_RESERVED; // BC: Alias
+    public const ALL_NO_RESERVED = 'all_no_res';
+    public const ALL_NO_RES = self::ALL_NO_RESERVED; // BC: Alias
 
     // adds FILTER_FLAG_NO_PRIV_RANGE and FILTER_FLAG_NO_RES_RANGE flags (skip both)
     public const V4_ONLY_PUBLIC = '4_public';
     public const V6_ONLY_PUBLIC = '6_public';
     public const ALL_ONLY_PUBLIC = 'all_public';
+
+    // adds inverse FILTER_FLAG_NO_PRIV_RANGE
+    public const V4_ONLY_PRIVATE = '4_private';
+    public const V6_ONLY_PRIVATE = '6_private';
+    public const ALL_ONLY_PRIVATE = 'all_private';
+
+    // adds inverse FILTER_FLAG_NO_RES_RANGE
+    public const V4_ONLY_RESERVED = '4_reserved';
+    public const V6_ONLY_RESERVED = '6_reserved';
+    public const ALL_ONLY_RESERVED = 'all_reserved';
 
     public const INVALID_IP_ERROR = 'b1b427ae-9f6f-41b0-aa9b-84511fbb3c5b';
 
@@ -50,17 +72,29 @@ class Ip extends Constraint
         self::V6,
         self::ALL,
 
-        self::V4_NO_PRIV,
-        self::V6_NO_PRIV,
-        self::ALL_NO_PRIV,
+        self::V4_NO_PUBLIC,
+        self::V6_NO_PUBLIC,
+        self::ALL_NO_PUBLIC,
 
-        self::V4_NO_RES,
-        self::V6_NO_RES,
-        self::ALL_NO_RES,
+        self::V4_NO_PRIVATE,
+        self::V6_NO_PRIVATE,
+        self::ALL_NO_PRIVATE,
+
+        self::V4_NO_RESERVED,
+        self::V6_NO_RESERVED,
+        self::ALL_NO_RESERVED,
 
         self::V4_ONLY_PUBLIC,
         self::V6_ONLY_PUBLIC,
         self::ALL_ONLY_PUBLIC,
+
+        self::V4_ONLY_PRIVATE,
+        self::V6_ONLY_PRIVATE,
+        self::ALL_ONLY_PRIVATE,
+
+        self::V4_ONLY_RESERVED,
+        self::V6_ONLY_RESERVED,
+        self::ALL_ONLY_RESERVED,
     ];
 
     protected const ERROR_NAMES = [

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -21,9 +21,50 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Joseph Bielawski <stloyd@gmail.com>
+ * @author Ninos Ego <me@ninosego.de>
  */
 class IpValidator extends ConstraintValidator
 {
+    /**
+     * Checks whether an IP address is valid.
+     *
+     * @internal
+     */
+    public static function checkIp(string $ip, mixed $version): bool
+    {
+        $flag = match ($version) {
+            Ip::V4, Ip::V4_NO_PUBLIC, Ip::V4_ONLY_PRIVATE, Ip::V4_ONLY_RESERVED => \FILTER_FLAG_IPV4,
+            Ip::V6, Ip::V6_NO_PUBLIC, Ip::V6_ONLY_PRIVATE, Ip::V6_ONLY_RESERVED => \FILTER_FLAG_IPV6,
+            Ip::V4_NO_PRIVATE => \FILTER_FLAG_IPV4 | \FILTER_FLAG_NO_PRIV_RANGE,
+            Ip::V6_NO_PRIVATE => \FILTER_FLAG_IPV6 | \FILTER_FLAG_NO_PRIV_RANGE,
+            Ip::ALL_NO_PRIVATE => \FILTER_FLAG_NO_PRIV_RANGE,
+            Ip::V4_NO_RESERVED => \FILTER_FLAG_IPV4 | \FILTER_FLAG_NO_RES_RANGE,
+            Ip::V6_NO_RESERVED => \FILTER_FLAG_IPV6 | \FILTER_FLAG_NO_RES_RANGE,
+            Ip::ALL_NO_RESERVED => \FILTER_FLAG_NO_RES_RANGE,
+            Ip::V4_ONLY_PUBLIC => \FILTER_FLAG_IPV4 | \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE,
+            Ip::V6_ONLY_PUBLIC => \FILTER_FLAG_IPV6 | \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE,
+            Ip::ALL_ONLY_PUBLIC => \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE,
+            default => 0,
+        };
+
+        if (!filter_var($ip, \FILTER_VALIDATE_IP, $flag)) {
+            return false;
+        }
+
+        $inverseFlag = match ($version) {
+            Ip::V4_NO_PUBLIC, Ip::V6_NO_PUBLIC, Ip::ALL_NO_PUBLIC => \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE,
+            Ip::V4_ONLY_PRIVATE, Ip::V6_ONLY_PRIVATE, Ip::ALL_ONLY_PRIVATE => \FILTER_FLAG_NO_PRIV_RANGE,
+            Ip::V4_ONLY_RESERVED, Ip::V6_ONLY_RESERVED, Ip::ALL_ONLY_RESERVED => \FILTER_FLAG_NO_RES_RANGE,
+            default => 0,
+        };
+
+        if ($inverseFlag && filter_var($ip, \FILTER_VALIDATE_IP, $inverseFlag)) {
+            return false;
+        }
+
+        return true;
+    }
+
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof Ip) {
@@ -44,22 +85,7 @@ class IpValidator extends ConstraintValidator
             $value = ($constraint->normalizer)($value);
         }
 
-        $flag = match ($constraint->version) {
-            Ip::V4 => \FILTER_FLAG_IPV4,
-            Ip::V6 => \FILTER_FLAG_IPV6,
-            Ip::V4_NO_PRIV => \FILTER_FLAG_IPV4 | \FILTER_FLAG_NO_PRIV_RANGE,
-            Ip::V6_NO_PRIV => \FILTER_FLAG_IPV6 | \FILTER_FLAG_NO_PRIV_RANGE,
-            Ip::ALL_NO_PRIV => \FILTER_FLAG_NO_PRIV_RANGE,
-            Ip::V4_NO_RES => \FILTER_FLAG_IPV4 | \FILTER_FLAG_NO_RES_RANGE,
-            Ip::V6_NO_RES => \FILTER_FLAG_IPV6 | \FILTER_FLAG_NO_RES_RANGE,
-            Ip::ALL_NO_RES => \FILTER_FLAG_NO_RES_RANGE,
-            Ip::V4_ONLY_PUBLIC => \FILTER_FLAG_IPV4 | \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE,
-            Ip::V6_ONLY_PUBLIC => \FILTER_FLAG_IPV6 | \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE,
-            Ip::ALL_ONLY_PUBLIC => \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE,
-            default => 0,
-        };
-
-        if (!filter_var($value, \FILTER_VALIDATE_IP, $flag)) {
+        if (!self::checkIp($value, $constraint->version)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Ip::INVALID_IP_ERROR)

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
@@ -49,7 +49,15 @@ class CidrTest extends TestCase
 
     public function testWithInvalidVersion()
     {
-        $availableVersions = [Ip::ALL, Ip::V4, Ip::V6];
+        $availableVersions = [
+            Ip::V4, Ip::V6, Ip::ALL,
+            Ip::V4_NO_PUBLIC, Ip::V6_NO_PUBLIC, Ip::ALL_NO_PUBLIC,
+            Ip::V4_NO_PRIVATE, Ip::V6_NO_PRIVATE, Ip::ALL_NO_PRIVATE,
+            Ip::V4_NO_RESERVED, Ip::V6_NO_RESERVED, Ip::ALL_NO_RESERVED,
+            Ip::V4_ONLY_PUBLIC, Ip::V6_ONLY_PUBLIC, Ip::ALL_ONLY_PUBLIC,
+            Ip::V4_ONLY_PRIVATE, Ip::V6_ONLY_PRIVATE, Ip::ALL_ONLY_PRIVATE,
+            Ip::V4_ONLY_RESERVED, Ip::V6_ONLY_RESERVED, Ip::ALL_ONLY_RESERVED,
+        ];
 
         self::expectException(ConstraintDefinitionException::class);
         self::expectExceptionMessage(sprintf('The option "version" must be one of "%s".', implode('", "', $availableVersions)));

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
@@ -52,7 +52,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     {
         $this->expectException(UnexpectedValueException::class);
 
-        $this->validator->validate(123456, new Cidr());
+        $this->validator->validate([123456], new Cidr());
     }
 
     /**
@@ -205,7 +205,6 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
         return [
             ['192.168.1.0/-1'],
             ['0.0.0.0/foobar'],
-            ['10.0.0.0/128'],
             ['123.45.67.178/aaa'],
             ['172.16.0.0//'],
             ['255.255.255.255/1/4'],
@@ -223,7 +222,6 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     {
         return [
             ['0.0.0.0/foobar'],
-            ['10.0.0.0/128'],
             ['123.45.67.178/aaa'],
             ['172.16.0.0//'],
             ['172.16.0.0/a/'],
@@ -243,6 +241,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     {
         return [
             ['10.0.0.0/24', Ip::V4, 10, 20],
+            ['10.0.0.0/128'],
             ['2001:0DB8:85A3:0000:0000:8A2E:0370:7334/24', Ip::V6, 10, 20],
         ];
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -185,6 +185,33 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    /**
+     * @dataProvider getValidPublicIpsV4
+     */
+    public function testInvalidNoPublicIpsV4($ip)
+    {
+        $constraint = new Ip([
+            'version' => Ip::V4_NO_PUBLIC,
+            'message' => 'myMessage',
+        ]);
+
+        $this->validator->validate($ip, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
+            ->assertRaised();
+    }
+
+    public static function getValidPublicIpsV4()
+    {
+        return [
+            ['8.0.0.0'],
+            ['90.0.0.0'],
+            ['110.0.0.110'],
+        ];
+    }
+
     public static function getInvalidIpsV4()
     {
         return [
@@ -201,12 +228,24 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @dataProvider getInvalidPrivateIpsV4
+     * @dataProvider getValidPrivateIpsV4
+     */
+    public function testValidPrivateIpsV4($ip)
+    {
+        $this->validator->validate($ip, new Ip([
+            'version' => Ip::V4_ONLY_PRIVATE,
+        ]));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getValidPrivateIpsV4
      */
     public function testInvalidPrivateIpsV4($ip)
     {
         $constraint = new Ip([
-            'version' => Ip::V4_NO_PRIV,
+            'version' => Ip::V4_NO_PRIVATE,
             'message' => 'myMessage',
         ]);
 
@@ -218,7 +257,25 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function getInvalidPrivateIpsV4()
+    /**
+     * @dataProvider getInvalidPrivateIpsV4
+     */
+    public function testInvalidOnlyPrivateIpsV4($ip)
+    {
+        $constraint = new Ip([
+            'version' => Ip::V4_ONLY_PRIVATE,
+            'message' => 'myMessage',
+        ]);
+
+        $this->validator->validate($ip, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
+            ->assertRaised();
+    }
+
+    public static function getValidPrivateIpsV4()
     {
         return [
             ['10.0.0.0'],
@@ -227,13 +284,30 @@ class IpValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
+    public static function getInvalidPrivateIpsV4()
+    {
+        return array_merge(self::getValidPublicIpsV4(), self::getValidReservedIpsV4());
+    }
+
     /**
-     * @dataProvider getInvalidReservedIpsV4
+     * @dataProvider getValidReservedIpsV4
+     */
+    public function testValidReservedIpsV4($ip)
+    {
+        $this->validator->validate($ip, new Ip([
+            'version' => Ip::V4_ONLY_RESERVED,
+        ]));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getValidReservedIpsV4
      */
     public function testInvalidReservedIpsV4($ip)
     {
         $constraint = new Ip([
-            'version' => Ip::V4_NO_RES,
+            'version' => Ip::V4_NO_RESERVED,
             'message' => 'myMessage',
         ]);
 
@@ -245,13 +319,36 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function getInvalidReservedIpsV4()
+    /**
+     * @dataProvider getInvalidReservedIpsV4
+     */
+    public function testInvalidOnlyReservedIpsV4($ip)
+    {
+        $constraint = new Ip([
+            'version' => Ip::V4_ONLY_RESERVED,
+            'message' => 'myMessage',
+        ]);
+
+        $this->validator->validate($ip, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
+            ->assertRaised();
+    }
+
+    public static function getValidReservedIpsV4()
     {
         return [
             ['0.0.0.0'],
             ['240.0.0.1'],
             ['255.255.255.255'],
         ];
+    }
+
+    public static function getInvalidReservedIpsV4()
+    {
+        return array_merge(self::getValidPublicIpsV4(), self::getValidPrivateIpsV4());
     }
 
     /**
@@ -274,7 +371,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
 
     public static function getInvalidPublicIpsV4()
     {
-        return array_merge(self::getInvalidPrivateIpsV4(), self::getInvalidReservedIpsV4());
+        return array_merge(self::getValidPrivateIpsV4(), self::getValidReservedIpsV4());
     }
 
     /**
@@ -320,7 +417,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidPrivateIpsV6($ip)
     {
         $constraint = new Ip([
-            'version' => Ip::V6_NO_PRIV,
+            'version' => Ip::V6_NO_PRIVATE,
             'message' => 'myMessage',
         ]);
 
@@ -347,7 +444,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidReservedIpsV6($ip)
     {
         $constraint = new Ip([
-            'version' => Ip::V6_NO_RES,
+            'version' => Ip::V6_NO_RESERVED,
             'message' => 'myMessage',
         ]);
 
@@ -419,7 +516,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidPrivateIpsAll($ip)
     {
         $constraint = new Ip([
-            'version' => Ip::ALL_NO_PRIV,
+            'version' => Ip::ALL_NO_PRIVATE,
             'message' => 'myMessage',
         ]);
 
@@ -433,7 +530,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
 
     public static function getInvalidPrivateIpsAll()
     {
-        return array_merge(self::getInvalidPrivateIpsV4(), self::getInvalidPrivateIpsV6());
+        return array_merge(self::getValidPrivateIpsV4(), self::getInvalidPrivateIpsV6());
     }
 
     /**
@@ -442,7 +539,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidReservedIpsAll($ip)
     {
         $constraint = new Ip([
-            'version' => Ip::ALL_NO_RES,
+            'version' => Ip::ALL_NO_RESERVED,
             'message' => 'myMessage',
         ]);
 
@@ -456,7 +553,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
 
     public static function getInvalidReservedIpsAll()
     {
-        return array_merge(self::getInvalidReservedIpsV4(), self::getInvalidReservedIpsV6());
+        return array_merge(self::getValidReservedIpsV4(), self::getInvalidReservedIpsV6());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Possibility to allow no public, only private or only reserved ips.

- Enhancement: Add `*_NO_PUBLIC`, `*_ONLY_PRIV` & `*_ONLY_RES` as possible versions in `Ip` constraint
- Enhancement: Possibility to use all `Ip` versions in `Cidr` constraint

See also old MR: #51777