### PR TITLE
[Security] remove conflict with symfony/security-guard

### DIFF
--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -37,7 +37,6 @@
     "conflict": {
         "symfony/event-dispatcher": "<6.4",
         "symfony/http-foundation": "<6.4",
-        "symfony/security-guard": "<6.4",
         "symfony/ldap": "<6.4",
         "symfony/validator": "<6.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0 
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

`symfony/security-guard` [latest tag](https://packagist.org/packages/symfony/security-guard) is `5.4.*` which require `symfony/security-http: ^5.3`

This package cannot be installed in 7.1, so conflict is not required anymore
