### PR TITLE
[Cache][Lock] `PdoAdapter`/`PdoStore` minor cleanup

### DIFF
--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -95,7 +95,7 @@ class PdoStore implements PersistingStoreInterface
         try {
             $stmt = $conn->prepare($sql);
         } catch (\PDOException $e) {
-            if ($this->isTableMissing($e) && (!$conn->inTransaction() || \in_array($this->driver, ['pgsql', 'sqlite', 'sqlsrv'], true))) {
+            if ($this->isTableMissing($e) && (!$conn->inTransaction() || \in_array($this->getDriver(), ['pgsql', 'sqlite', 'sqlsrv'], true))) {
                 $this->createTable();
             }
             $stmt = $conn->prepare($sql);
@@ -107,12 +107,12 @@ class PdoStore implements PersistingStoreInterface
         try {
             $stmt->execute();
         } catch (\PDOException $e) {
-            if ($this->isTableMissing($e) && (!$conn->inTransaction() || \in_array($this->driver, ['pgsql', 'sqlite', 'sqlsrv'], true))) {
+            if ($this->isTableMissing($e) && (!$conn->inTransaction() || \in_array($this->getDriver(), ['pgsql', 'sqlite', 'sqlsrv'], true))) {
                 $this->createTable();
 
                 try {
                     $stmt->execute();
-                } catch (\PDOException $e) {
+                } catch (\PDOException) {
                     $this->putOffExpiration($key, $this->initialTtl);
                 }
             } else {
@@ -196,11 +196,7 @@ class PdoStore implements PersistingStoreInterface
      */
     public function createTable(): void
     {
-        // connect if we are not yet
-        $conn = $this->getConnection();
-        $driver = $this->getDriver();
-
-        $sql = match ($driver) {
+        $sql = match ($driver = $this->getDriver()) {
             'mysql' => "CREATE TABLE $this->table ($this->idCol VARCHAR(64) NOT NULL PRIMARY KEY, $this->tokenCol VARCHAR(44) NOT NULL, $this->expirationCol INTEGER UNSIGNED NOT NULL) COLLATE utf8mb4_bin, ENGINE = InnoDB",
             'sqlite' => "CREATE TABLE $this->table ($this->idCol TEXT NOT NULL PRIMARY KEY, $this->tokenCol TEXT NOT NULL, $this->expirationCol INTEGER)",
             'pgsql' => "CREATE TABLE $this->table ($this->idCol VARCHAR(64) NOT NULL PRIMARY KEY, $this->tokenCol VARCHAR(64) NOT NULL, $this->expirationCol INTEGER)",
@@ -209,7 +205,7 @@ class PdoStore implements PersistingStoreInterface
             default => throw new \DomainException(sprintf('Creating the lock table is currently not implemented for platform "%s".', $driver)),
         };
 
-        $conn->exec($sql);
+        $this->getConnection()->exec($sql);
     }
 
     /**
@@ -224,14 +220,7 @@ class PdoStore implements PersistingStoreInterface
 
     private function getDriver(): string
     {
-        if (isset($this->driver)) {
-            return $this->driver;
-        }
-
-        $conn = $this->getConnection();
-        $this->driver = $conn->getAttribute(\PDO::ATTR_DRIVER_NAME);
-
-        return $this->driver;
+        return $this->driver ??= $this->getConnection()->getAttribute(\PDO::ATTR_DRIVER_NAME);
     }
 
     /**
@@ -254,15 +243,13 @@ class PdoStore implements PersistingStoreInterface
         $driver = $this->getDriver();
         $code = $exception->getCode();
 
-        switch (true) {
-            case 'pgsql' === $driver && '42P01' === $code:
-            case 'sqlite' === $driver && str_contains($exception->getMessage(), 'no such table:'):
-            case 'oci' === $driver && 942 === $code:
-            case 'sqlsrv' === $driver && 208 === $code:
-            case 'mysql' === $driver && 1146 === $code:
-                return true;
-            default:
-                return false;
-        }
+        return match ($driver) {
+            'pgsql' => '42P01' === $code,
+            'sqlite' => str_contains($exception->getMessage(), 'no such table:'),
+            'oci' => 942 === $code,
+            'sqlsrv' => 208 === $code,
+            'mysql' => 1146 === $code,
+            default => false,
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow up to #52459.

Basically some code cleanup such as using `match` instead of `switch` + a minor sync between the `PdoAdapter` and `PdoStore`.

I've targeted 6.4 since this is just a minor code cleanup, but I can switch to 7.1 if needed.