### PR TITLE
[Translation] Fix Translation changelog for Phrase provider

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -8,10 +8,6 @@ CHANGELOG
  * Add `--as-tree` option to `translation:pull` command to write YAML messages as a tree-like structure
  * [BC BREAK] Add argument `$buildDir` to `DataCollectorTranslator::warmUp()`
  * Add `DataCollectorTranslatorPass` and `LoggingTranslatorPass`  (moved from `FrameworkBundle`)
-
-6.3
----
-
  * Add `PhraseTranslationProvider`
 
 6.2.7


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Phrase provider has been added to 6.4, not 6.3

Flex recipe has been fixed in https://github.com/symfony/recipes/pull/1259