### PR TITLE
[Serializer] add normalizer for non-backed enumerations

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add support of PHP non-backed enumerations
+
 7.0
 ---
 

--- a/src/Symfony/Component/Serializer/Normalizer/NonBackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NonBackedEnumNormalizer.php
@@ -54,18 +54,18 @@ final class NonBackedEnumNormalizer implements NormalizerInterface, Denormalizer
         }
 
         if (!\is_string($data) && !($context[BackedEnumNormalizer::ALLOW_INVALID_VALUES] ?? false)) {
-            throw NotNormalizableValueException::createForUnexpectedDataType("The data is not a string, you should pass a string that can be parsed as an enumeration case of type $type.", $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
+            throw NotNormalizableValueException::createForUnexpectedDataType(sprintf("The data is not a string, you should pass a string that can be parsed as an enumeration case of type %s.", $type), $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
         }
 
         try {
             $constantName = "$type::$data";
             if (!\defined($constantName)) {
-                throw new \ValueError("$data is not a valid case for enum $type.");
+                throw new \ValueError(sprintf("%s is not a valid case for enum %s.", $data, $type));
             }
 
             $value = \constant($constantName);
             if (!\is_object($value) || $value::class !== $type) {
-                throw new \ValueError("$constantName is not a valid enum case.");
+                throw new \ValueError(sprintf("%s is not a valid enum case.", $constantName));
             }
 
             return $value;
@@ -74,9 +74,9 @@ final class NonBackedEnumNormalizer implements NormalizerInterface, Denormalizer
                 return null;
             }
             if (isset($context['has_constructor'])) {
-                throw new InvalidArgumentException("The data must belong to a non-backed enumeration of type $type.");
+                throw new InvalidArgumentException(sprintf("The data must belong to a non-backed enumeration of type %s.", $type));
             }
-            throw NotNormalizableValueException::createForUnexpectedDataType("The data must belong to a non-backed enumeration of type $type.", $data, [$type], $context['deserialization_path'] ?? null, true, 0, $e);
+            throw NotNormalizableValueException::createForUnexpectedDataType(sprintf("The data must belong to a non-backed enumeration of type %s.", $type), $data, [$type], $context['deserialization_path'] ?? null, true, 0, $e);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/NonBackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NonBackedEnumNormalizer.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+
+/**
+ * Normalizes a {@see \UnitEnum} that is not a {@see \BackedEnum} to a string identifier.
+ *
+ * @author Misha Kulakovsky <misha@kulakovs.ky>
+ */
+final class NonBackedEnumNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            \UnitEnum::class => true,
+        ];
+    }
+
+    public function normalize(mixed $object, string $format = null, array $context = []): int|string
+    {
+        if (!$object instanceof \UnitEnum || $object instanceof \BackedEnum) {
+            throw new InvalidArgumentException('The data must belong to a non-backed enumeration.');
+        }
+
+        return $object->name;
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    {
+        return $data instanceof \UnitEnum
+            && !$data instanceof \BackedEnum;
+    }
+
+    /**
+     * @throws NotNormalizableValueException
+     */
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    {
+        if (!is_subclass_of($type, \UnitEnum::class) || is_subclass_of($type, \BackedEnum::class)) {
+            throw new InvalidArgumentException('The data must belong to a non-backed enumeration.');
+        }
+
+        if (!\is_string($data) && !($context[BackedEnumNormalizer::ALLOW_INVALID_VALUES] ?? false)) {
+            throw NotNormalizableValueException::createForUnexpectedDataType(
+                "The data is not a string, you should pass a string that can be parsed as an enumeration case of type $type.",
+                $data, [ Type::BUILTIN_TYPE_STRING ], $context['deserialization_path'] ?? null, true
+            );
+        }
+
+        try {
+            $constantName = "$type::$data";
+            if (!defined($constantName)) {
+                throw new \ValueError("$data is not a valid case for enum $type");
+            }
+
+            $value = constant($constantName);
+            if (!is_object($value) || get_class($value) !== $type) {
+                throw new \ValueError("$constantName is not a valid enum case");
+            }
+
+            return $value;
+
+        } catch (\ValueError $e) {
+            if ($context[BackedEnumNormalizer::ALLOW_INVALID_VALUES] ?? false) {
+                return null;
+            }
+            if (isset($context['has_constructor'])) {
+                throw new InvalidArgumentException("The data must belong to a non-backed enumeration of type $type.");
+            }
+            throw NotNormalizableValueException::createForUnexpectedDataType(
+                "The data must belong to a non-backed enumeration of type $type.",
+                $data, [ $type ], $context['deserialization_path'] ?? null, true, 0, $e
+            );
+        }
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    {
+        return is_subclass_of($type, \UnitEnum::class)
+            && !is_subclass_of($type, \BackedEnum::class);
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/NonBackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NonBackedEnumNormalizer.php
@@ -54,25 +54,21 @@ final class NonBackedEnumNormalizer implements NormalizerInterface, Denormalizer
         }
 
         if (!\is_string($data) && !($context[BackedEnumNormalizer::ALLOW_INVALID_VALUES] ?? false)) {
-            throw NotNormalizableValueException::createForUnexpectedDataType(
-                "The data is not a string, you should pass a string that can be parsed as an enumeration case of type $type.",
-                $data, [ Type::BUILTIN_TYPE_STRING ], $context['deserialization_path'] ?? null, true
-            );
+            throw NotNormalizableValueException::createForUnexpectedDataType("The data is not a string, you should pass a string that can be parsed as an enumeration case of type $type.", $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
         }
 
         try {
             $constantName = "$type::$data";
-            if (!defined($constantName)) {
-                throw new \ValueError("$data is not a valid case for enum $type");
+            if (!\defined($constantName)) {
+                throw new \ValueError("$data is not a valid case for enum $type.");
             }
 
-            $value = constant($constantName);
-            if (!is_object($value) || get_class($value) !== $type) {
-                throw new \ValueError("$constantName is not a valid enum case");
+            $value = \constant($constantName);
+            if (!\is_object($value) || $value::class !== $type) {
+                throw new \ValueError("$constantName is not a valid enum case.");
             }
 
             return $value;
-
         } catch (\ValueError $e) {
             if ($context[BackedEnumNormalizer::ALLOW_INVALID_VALUES] ?? false) {
                 return null;
@@ -80,10 +76,7 @@ final class NonBackedEnumNormalizer implements NormalizerInterface, Denormalizer
             if (isset($context['has_constructor'])) {
                 throw new InvalidArgumentException("The data must belong to a non-backed enumeration of type $type.");
             }
-            throw NotNormalizableValueException::createForUnexpectedDataType(
-                "The data must belong to a non-backed enumeration of type $type.",
-                $data, [ $type ], $context['deserialization_path'] ?? null, true, 0, $e
-            );
+            throw NotNormalizableValueException::createForUnexpectedDataType("The data must belong to a non-backed enumeration of type $type.", $data, [$type], $context['deserialization_path'] ?? null, true, 0, $e);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/NonBackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/NonBackedEnumNormalizerTest.php
@@ -91,7 +91,7 @@ class NonBackedEnumNormalizerTest extends TestCase
     public function testDenormalizeBadCaseThrowsException()
     {
         $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('The data must belong to a non-backed enumeration of type ' . UnitEnumDummy::class);
+        $this->expectExceptionMessage('The data must belong to a non-backed enumeration of type '.UnitEnumDummy::class);
 
         $this->normalizer->denormalize('POST', UnitEnumDummy::class);
     }
@@ -135,6 +135,7 @@ class NonBackedEnumNormalizerTest extends TestCase
 
     /**
      * @dataProvider providerInvalidCases
+     *
      * @return void
      */
     public function testItProducesNullForInvalidCasesIfContextIsPassed($normalized)
@@ -144,7 +145,7 @@ class NonBackedEnumNormalizerTest extends TestCase
                 $normalized,
                 UnitEnumDummy::class,
                 null,
-                [ BackedEnumNormalizer::ALLOW_INVALID_VALUES => true ]
+                [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]
             )
         );
     }
@@ -157,19 +158,18 @@ class NonBackedEnumNormalizerTest extends TestCase
                 'GET',
                 UnitEnumDummy::class,
                 null,
-                [ BackedEnumNormalizer::ALLOW_INVALID_VALUES => true ]
+                [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]
             )
         );
-
     }
 
     protected function providerInvalidCases()
     {
         return [
-            'integer'           => [ 1 ],
-            'empty string'      => [ '' ],
-            'non-existing case' => [ 'WRONG' ],
-            'null'              => [ null ],
+            'integer' => [1],
+            'empty string' => [''],
+            'non-existing case' => ['WRONG'],
+            'null' => [null],
         ];
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/NonBackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/NonBackedEnumNormalizerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
+use Symfony\Component\Serializer\Normalizer\NonBackedEnumNormalizer;
+use Symfony\Component\Serializer\Tests\Fixtures\IntegerBackedEnumDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\UnitEnumDummy;
+
+/**
+ * @author Misha Kulakovsky <misha@kulakovs.ky>
+ */
+class NonBackedEnumNormalizerTest extends TestCase
+{
+    /**
+     * @var NonBackedEnumNormalizer
+     */
+    private $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new NonBackedEnumNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertFalse($this->normalizer->supportsNormalization(StringBackedEnumDummy::GET));
+        $this->assertFalse($this->normalizer->supportsNormalization(IntegerBackedEnumDummy::SUCCESS));
+        $this->assertTrue($this->normalizer->supportsNormalization(UnitEnumDummy::GET));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testNormalize()
+    {
+        $this->assertSame('GET', $this->normalizer->normalize(UnitEnumDummy::GET));
+    }
+
+    public function testNormalizeBadObjectTypeThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->normalizer->normalize(new \stdClass());
+    }
+
+    public function testSupportsDenormalization()
+    {
+        $this->assertFalse($this->normalizer->supportsDenormalization(null, StringBackedEnumDummy::class));
+        $this->assertFalse($this->normalizer->supportsDenormalization(null, IntegerBackedEnumDummy::class));
+        $this->assertTrue($this->normalizer->supportsDenormalization(null, UnitEnumDummy::class));
+        $this->assertFalse($this->normalizer->supportsDenormalization(null, \stdClass::class));
+    }
+
+    public function testDenormalize()
+    {
+        $this->assertSame(
+            UnitEnumDummy::GET,
+            $this->normalizer->denormalize('GET', UnitEnumDummy::class)
+        );
+    }
+
+    public function testDenormalizeNullValueThrowsException()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->normalizer->denormalize(null, UnitEnumDummy::class);
+    }
+
+    public function testDenormalizeBooleanValueThrowsException()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->normalizer->denormalize(true, UnitEnumDummy::class);
+    }
+
+    public function testDenormalizeObjectThrowsException()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->normalizer->denormalize(new \stdClass(), UnitEnumDummy::class);
+    }
+
+    public function testDenormalizeBadCaseThrowsException()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data must belong to a non-backed enumeration of type ' . UnitEnumDummy::class);
+
+        $this->normalizer->denormalize('POST', UnitEnumDummy::class);
+    }
+
+    public function testNormalizeShouldThrowExceptionForNonEnumObjects()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The data must belong to a non-backed enumeration.');
+
+        $this->normalizer->normalize(\stdClass::class);
+    }
+
+    public function testNormalizeShouldThrowExceptionForBackedEnumObjects()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The data must belong to a non-backed enumeration.');
+
+        $this->normalizer->normalize(\StringBackedEnum::class);
+    }
+
+    public function testDenormalizeShouldThrowExceptionForNonEnumObjects()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The data must belong to a non-backed enumeration.');
+
+        $this->normalizer->denormalize('GET', \stdClass::class);
+    }
+
+    public function testDenormalizeShouldThrowExceptionForBackedEnumObjects()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The data must belong to a non-backed enumeration.');
+
+        $this->normalizer->denormalize('GET', \StringBackedEnum::class);
+    }
+
+    public function testSupportsNormalizationShouldFailOnAnyPHPVersionForNonEnumObjects()
+    {
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    /**
+     * @dataProvider providerInvalidCases
+     * @return void
+     */
+    public function testItProducesNullForInvalidCasesIfContextIsPassed($normalized)
+    {
+        $this->assertNull(
+            $this->normalizer->denormalize(
+                $normalized,
+                UnitEnumDummy::class,
+                null,
+                [ BackedEnumNormalizer::ALLOW_INVALID_VALUES => true ]
+            )
+        );
+    }
+
+    public function testItProducesEnumForValidCasesIfContextIsPassed()
+    {
+        $this->assertSame(
+            UnitEnumDummy::GET,
+            $this->normalizer->denormalize(
+                'GET',
+                UnitEnumDummy::class,
+                null,
+                [ BackedEnumNormalizer::ALLOW_INVALID_VALUES => true ]
+            )
+        );
+
+    }
+
+    protected function providerInvalidCases()
+    {
+        return [
+            'integer'           => [ 1 ],
+            'empty string'      => [ '' ],
+            'non-existing case' => [ 'WRONG' ],
+            'null'              => [ null ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds a de/normalizer for enum values, that do not have a backing type.

Before, a default object normalization approach is used on those values, resulting in a `{name: "CASE_NAME"}` serialized value, that can not be denormalized.

With this PR, `MyEnum::CASE_NAME` is normalized as `"CASE_NAME"`. For denormalization, `defined(...)` and `constant(...)` are used to check and instantiate the enum value.