### PR TITLE
[Translation] [Lokalise] Fix language format on Lokalise Provider

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -147,7 +147,6 @@ final class LokaliseProvider implements ProviderInterface
             'json' => [
                 'format' => 'symfony_xliff',
                 'original_filenames' => true,
-                'directory_prefix' => '%LANG_ISO%',
                 'filter_langs' => array_values($locales),
                 'filter_filenames' => array_map([$this, 'getLokaliseFilenameFromDomain'], $domains),
                 'export_empty_as' => 'skip',
@@ -167,7 +166,12 @@ final class LokaliseProvider implements ProviderInterface
             throw new ProviderException(sprintf('Unable to export translations from Lokalise: "%s".', $response->getContent(false)), $response);
         }
 
-        return $responseContent['files'];
+        // Lokalise returns languages with "-" separator, we need to reformat them to "_" separator.
+        $reformattedLanguages = array_map(function ($language) {
+            return str_replace('-', '_', $language);
+        }, array_keys($responseContent['files']));
+
+        return array_combine($reformattedLanguages, $responseContent['files']);
     }
 
     private function createKeys(array $keys, string $domain): array

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -559,7 +559,6 @@ class LokaliseProviderTest extends ProviderTestCase
             $expectedBody = json_encode([
                 'format' => 'symfony_xliff',
                 'original_filenames' => true,
-                'directory_prefix' => '%LANG_ISO%',
                 'filter_langs' => [$locale],
                 'filter_filenames' => [$domain.'.xliff'],
                 'export_empty_as' => 'skip',
@@ -581,15 +580,10 @@ class LokaliseProviderTest extends ProviderTestCase
             ]));
         };
 
-        $loader = $this->getLoader();
-        $loader->expects($this->once())
-            ->method('load')
-            ->willReturn((new XliffFileLoader())->load($responseContent, $locale, $domain));
-
         $provider = self::createProvider((new MockHttpClient($response))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
+        ]), new XliffFileLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
         $translatorBag = $provider->read([$domain], [$locale]);
 
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
@@ -759,6 +753,36 @@ class LokaliseProviderTest extends ProviderTestCase
 XLIFF
             ,
             $expectedTranslatorBagEn,
+        ];
+
+        $expectedTranslatorBagEnUS = new TranslatorBag();
+        $expectedTranslatorBagEnUS->addCatalogue($arrayLoader->load([
+            'index.hello' => 'Hello',
+            'index.greetings' => 'Welcome, {firstname}!',
+        ], 'en_US'));
+
+        yield ['en_US', 'messages', <<<'XLIFF'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+  <file original="" datatype="plaintext" xml:space="preserve" source-language="en" target-language="en-US">
+    <header>
+      <tool tool-id="lokalise.com" tool-name="Lokalise"/>
+    </header>
+    <body>
+      <trans-unit id="index.greetings" resname="index.greetings">
+        <source>index.greetings</source>
+        <target>Welcome, {firstname}!</target>
+      </trans-unit>
+      <trans-unit id="index.hello" resname="index.hello">
+        <source>index.hello</source>
+        <target>Hello</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+XLIFF
+            ,
+            $expectedTranslatorBagEnUS,
         ];
 
         $expectedTranslatorBagFr = new TranslatorBag();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Lokalise has changed their API a little bit, and ISO languages are formatted with a `-`, which is not wrong. But we use it as locale to load the translation with XliffLoader (and other loaders), and it leads to wrong filename like `messages+intl-icu.en-US.xlf`.

This PR fixes the issue.