### PR TITLE
[Process] `ExecutableFinder::addSuffix()` has no effect

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -19,7 +19,15 @@ namespace Symfony\Component\Process;
  */
 class ExecutableFinder
 {
-    private array $suffixes = ['.exe', '.bat', '.cmd', '.com'];
+    private array $suffixes = [];
+
+    public function __construct()
+    {
+        // Set common extensions on Windows.
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->suffixes = ['.exe', '.bat', '.cmd', '.com'];
+        }
+    }
 
     /**
      * Replaces default suffixes of executable.
@@ -30,7 +38,10 @@ class ExecutableFinder
     }
 
     /**
-     * Adds new possible suffix to check for executable.
+     * Adds new possible suffix to check for executable, including the dot (.).
+     *
+     *     $finder = new ExecutableFinder();
+     *     $finder->addSuffix('.foo');
      */
     public function addSuffix(string $suffix): void
     {
@@ -52,10 +63,10 @@ class ExecutableFinder
         );
 
         $suffixes = [''];
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $pathExt = getenv('PATHEXT');
-            $suffixes = array_merge($pathExt ? explode(\PATH_SEPARATOR, $pathExt) : $this->suffixes, $suffixes);
+        if ('\\' === \DIRECTORY_SEPARATOR && $pathExt = getenv('PATHEXT')) {
+            $suffixes = array_merge(explode(\PATH_SEPARATOR, $pathExt), $suffixes);
         }
+        $suffixes = array_merge($suffixes, $this->suffixes);
         foreach ($suffixes as $suffix) {
             foreach ($dirs as $dir) {
                 if (@is_file($file = $dir.\DIRECTORY_SEPARATOR.$name.$suffix) && ('\\' === \DIRECTORY_SEPARATOR || @is_executable($file))) {

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -85,6 +85,31 @@ class ExecutableFinderTest extends TestCase
         $this->assertSamePath(\PHP_BINARY, $result);
     }
 
+    public function testFindWithoutSuffix()
+    {
+        $fixturesDir = __DIR__.\DIRECTORY_SEPARATOR.'Fixtures';
+        $name = 'executable_without_suffix';
+
+        $finder = new ExecutableFinder();
+        $result = $finder->find($name, null, [$fixturesDir]);
+
+        $this->assertSamePath($fixturesDir.\DIRECTORY_SEPARATOR.$name, $result);
+    }
+
+    public function testFindWithAddedSuffixes()
+    {
+        $fixturesDir = __DIR__.\DIRECTORY_SEPARATOR.'Fixtures';
+        $name = 'executable_with_added_suffix';
+        $suffix = '.foo';
+
+        $finder = new ExecutableFinder();
+        $finder->addSuffix($suffix);
+
+        $result = $finder->find($name, null, [$fixturesDir]);
+
+        $this->assertSamePath($fixturesDir.\DIRECTORY_SEPARATOR.$name.$suffix, $result);
+    }
+
     /**
      * @runInSeparateProcess
      */

--- a/src/Symfony/Component/Process/Tests/Fixtures/executable_with_added_suffix.foo
+++ b/src/Symfony/Component/Process/Tests/Fixtures/executable_with_added_suffix.foo
@@ -1,0 +1,1 @@
+See \Symfony\Component\Process\Tests\ExecutableFinderTest::testFindWithAddedSuffixes()

--- a/src/Symfony/Component/Process/Tests/Fixtures/executable_without_suffix
+++ b/src/Symfony/Component/Process/Tests/Fixtures/executable_without_suffix
@@ -1,0 +1,1 @@
+See \Symfony\Component\Process\Tests\ExecutableFinderTest::testFindWithoutSuffix()


### PR DESCRIPTION
...except (probably) on Windows.

| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

`ExecutableFinder::addSuffix()` currently has no effect on non-Windows systems because `ExecutableFinder::find()` altogether ignores added suffixes on them. This PR adds tests that prove that it's broken and then fixes it. It clarifies a related docblock along the way.

**Note**: I tried to follow the pattern in similar tests of creating fixture files in the temp directory, but `ExecutableFinder::find()` returned a different temp path than `sys_get_temp_dir()`, rendering path comparison impossible. So I added a few fixture files directly to the repo.
