### PR TITLE
[Serializer] Fix access to private properties/getters when using the `@Ignore` annotation

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -302,20 +302,16 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             return $this->attributesCache[$key];
         }
 
-        $allowedAttributes = $this->getAllowedAttributes($object, $context, true);
-
-        if (false !== $allowedAttributes) {
-            if ($context['cache_key']) {
-                $this->attributesCache[$key] = $allowedAttributes;
-            }
-
-            return $allowedAttributes;
-        }
-
         $attributes = $this->extractAttributes($object, $format, $context);
 
         if ($this->classDiscriminatorResolver && $mapping = $this->classDiscriminatorResolver->getMappingForMappedObject($object)) {
             array_unshift($attributes, $mapping->getTypeProperty());
+        }
+
+        $allowedAttributes = $this->getAllowedAttributes($object, $context, true);
+
+        if (false !== $allowedAttributes) {
+            $attributes = array_intersect($attributes, $allowedAttributes);
         }
 
         if ($context['cache_key'] && \stdClass::class !== $class) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -444,6 +445,14 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizedData = $normalizer->normalize(new EmptyDummy(), 'any', ['preserve_empty_objects' => true]);
         $this->assertEquals(new \ArrayObject(), $normalizedData);
     }
+
+    public function testNormalizeWithIgnoreAnnotationAndPrivateProperties()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $serializer = new Serializer([new ObjectNormalizer($classMetadataFactory)]);
+
+        $this->assertSame(['foo' => 'foo'], $serializer->normalize(new ObjectDummyWithIgnoreAnnotationAndPrivateProperty()));
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
@@ -482,6 +491,16 @@ class Dummy
 
 class EmptyDummy
 {
+}
+
+class ObjectDummyWithIgnoreAnnotationAndPrivateProperty
+{
+    public $foo = 'foo';
+
+    /** @Ignore */
+    public $ignored = 'ignored';
+
+    private $private = 'private';
 }
 
 class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -471,7 +471,7 @@ class SerializerTest extends TestCase
             'groups' => ['two'],
         ]);
 
-        $this->assertEquals('{"two":2,"type":"one"}', $serialized);
+        $this->assertEquals('{"type":"one","two":2}', $serialized);
     }
 
     public function testDeserializeAndSerializeNestedInterfacedObjectsWithTheClassMetadataDiscriminator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52673 #49710
| License       | MIT