### PR TITLE
[Serializer] Fix constructor deserialization path

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -489,6 +489,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      */
     protected function createChildContext(array $parentContext, string $attribute, ?string $format): array
     {
+        $parentContext['deserialization_path'] = ($parentContext['deserialization_path'] ?? false) ? $parentContext['deserialization_path'].'.'.$attribute : $attribute;
+
         if (isset($parentContext[self::ATTRIBUTES][$attribute])) {
             $parentContext[self::ATTRIBUTES] = $parentContext[self::ATTRIBUTES][$attribute];
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #44925
| License       | MIT

This fix doesn't have to be upmerged because it already has been covered by https://github.com/symfony/symfony/pull/46680.