### PR TITLE
[PropertyInfo] Fixed promoted property type detection for `PhpStanExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -183,9 +183,7 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
             return null;
         }
 
-        $tokens = new TokenIterator($this->lexer->tokenize($rawDocNode));
-        $phpDocNode = $this->phpDocParser->parse($tokens);
-        $tokens->consumeTokenType(Lexer::TOKEN_END);
+        $phpDocNode = $this->getPhpDocNode($rawDocNode);
 
         return $this->filterDocBlockParams($phpDocNode, $property);
     }
@@ -239,23 +237,26 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
             return null;
         }
 
+        // Type can be inside property docblock as `@var`
+        $rawDocNode = $reflectionProperty->getDocComment();
+        $phpDocNode = $rawDocNode ? $this->getPhpDocNode($rawDocNode) : null;
         $source = self::PROPERTY;
 
-        if ($reflectionProperty->isPromoted()) {
+        if (!$phpDocNode?->getTagsByName('@var')) {
+            $phpDocNode = null;
+        }
+
+        // or in the constructor as `@param` for promoted properties
+        if (!$phpDocNode && $reflectionProperty->isPromoted()) {
             $constructor = new \ReflectionMethod($class, '__construct');
             $rawDocNode = $constructor->getDocComment();
+            $phpDocNode = $rawDocNode ? $this->getPhpDocNode($rawDocNode) : null;
             $source = self::MUTATOR;
-        } else {
-            $rawDocNode = $reflectionProperty->getDocComment();
         }
 
-        if (!$rawDocNode) {
+        if (!$phpDocNode) {
             return null;
         }
-
-        $tokens = new TokenIterator($this->lexer->tokenize($rawDocNode));
-        $phpDocNode = $this->phpDocParser->parse($tokens);
-        $tokens->consumeTokenType(Lexer::TOKEN_END);
 
         return [$phpDocNode, $source, $reflectionProperty->class];
     }
@@ -296,10 +297,17 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
             return null;
         }
 
+        $phpDocNode = $this->getPhpDocNode($rawDocNode);
+
+        return [$phpDocNode, $prefix, $reflectionMethod->class];
+    }
+
+    private function getPhpDocNode(string $rawDocNode): PhpDocNode
+    {
         $tokens = new TokenIterator($this->lexer->tokenize($rawDocNode));
         $phpDocNode = $this->phpDocParser->parse($tokens);
         $tokens->consumeTokenType(Lexer::TOKEN_END);
 
-        return [$phpDocNode, $prefix, $reflectionMethod->class];
+        return $phpDocNode;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -474,6 +474,8 @@ class PhpStanExtractorTest extends TestCase
     public static function php80TypesProvider()
     {
         return [
+            [Php80Dummy::class, 'promotedWithDocCommentAndType', [new Type(Type::BUILTIN_TYPE_INT)]],
+            [Php80Dummy::class, 'promotedWithDocComment', [new Type(Type::BUILTIN_TYPE_STRING)]],
             [Php80Dummy::class, 'promotedAndMutated', [new Type(Type::BUILTIN_TYPE_STRING)]],
             [Php80Dummy::class, 'promoted', null],
             [Php80Dummy::class, 'collection', [new Type(Type::BUILTIN_TYPE_ARRAY, collection: true, collectionValueType: new Type(Type::BUILTIN_TYPE_STRING))]],

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
@@ -17,9 +17,23 @@ class Php80Dummy
 
     /**
      * @param string $promotedAndMutated
+     * @param string $promotedWithDocComment
+     * @param string $promotedWithDocCommentAndType
      * @param array<string> $collection
      */
-    public function __construct(private mixed $promoted, private mixed $promotedAndMutated, private array $collection)
+    public function __construct(
+        private mixed $promoted,
+        private mixed $promotedAndMutated,
+        /**
+         * Comment without @var.
+         */
+        private mixed $promotedWithDocComment,
+        /**
+         * @var int
+         */
+        private mixed $promotedWithDocCommentAndType,
+        private array $collection,
+    )
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #52682 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Implementation aligned with actual phpstan behaviour, please see https://phpstan.org/r/8278f037-5a67-4e53-8352-a13585d2eca5

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
