### PR TITLE
[Cache] Add url decoding of password in `RedisTrait` DSN

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,6 +48,12 @@ jobs:
         image: redis:6.2.8
         ports:
           - 16379:6379
+      redis-authenticated:
+        image: redis:6.2.8
+        ports:
+          - 16380:6379
+        env:
+          REDIS_ARGS: "--requirepass p@ssword"
       redis-cluster:
         image: grokzen/redis-cluster:6.2.8
         ports:
@@ -172,6 +178,7 @@ jobs:
         run: ./phpunit --group integration -v
         env:
           REDIS_HOST: 'localhost:16379'
+          REDIS_AUTHENTICATED_HOST: 'localhost:16380'
           REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
           REDIS_SENTINEL_HOSTS: 'localhost:26379 localhost:26379 localhost:26379'
           REDIS_SENTINEL_SERVICE: redis_sentinel

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -105,7 +105,7 @@ trait RedisTrait
 
         $params = preg_replace_callback('#^'.$scheme.':(//)?(?:(?:[^:@]*+:)?([^@]*+)@)?#', function ($m) use (&$auth) {
             if (isset($m[2])) {
-                $auth = $m[2];
+                $auth = rawurldecode($m[2]);
 
                 if ('' === $auth) {
                     $auth = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52420
| License       | MIT

This brings support for `@` char in passwords