### PR TITLE
[Cache] Fix return type of `Redis6Proxy::mget()`

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -651,7 +651,7 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
         return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim(...\func_get_args());
     }
 
-    public function mget($keys): \Redis|array
+    public function mget($keys): \Redis|array|false
     {
         return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget(...\func_get_args());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52668
| License       | MIT

This class is internal, the return type can be safely updated. For the record, the `false` return type is already added on `Redis6Proxy::hmget()`.