### PR TITLE
[Messenger] Fix message handlers with multiple `from_transports`

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -106,6 +106,7 @@ class MessengerPass implements CompilerPassInterface
                     unset($options['handles']);
                     $priority = $options['priority'] ?? 0;
                     $method = $options['method'] ?? '__invoke';
+                    $fromTransport = $options['from_transport'] ?? '';
 
                     if (isset($options['bus'])) {
                         if (!\in_array($options['bus'], $busIds)) {
@@ -131,10 +132,10 @@ class MessengerPass implements CompilerPassInterface
                         throw new RuntimeException(sprintf('Invalid handler service "%s": method "%s::%s()" does not exist.', $serviceId, $r->getName(), $method));
                     }
 
-                    if ('__invoke' !== $method) {
+                    if ('__invoke' !== $method || '' !== $fromTransport) {
                         $wrapperDefinition = (new Definition('Closure'))->addArgument([new Reference($serviceId), $method])->setFactory('Closure::fromCallable');
 
-                        $definitions[$definitionId = '.messenger.method_on_object_wrapper.'.ContainerBuilder::hash($message.':'.$priority.':'.$serviceId.':'.$method)] = $wrapperDefinition;
+                        $definitions[$definitionId = '.messenger.method_on_object_wrapper.'.ContainerBuilder::hash($message.':'.$priority.':'.$serviceId.':'.$method.':'.$fromTransport)] = $wrapperDefinition;
                     } else {
                         $definitionId = $serviceId;
                     }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandler.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandler.php
@@ -15,4 +15,10 @@ class TaggedDummyHandler
     public function handleSecondMessage(SecondMessage $message)
     {
     }
+
+    #[AsMessageHandler(fromTransport: 'a')]
+    #[AsMessageHandler(fromTransport: 'b')]
+    public function handleThirdMessage(ThirdMessage $message): void
+    {
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/ThirdMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/ThirdMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class ThirdMessage
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues | Fix #48529 
| License       | MIT

When you define multiple `AsMessageHandler` attributes or `messenger.message_handler` tags with otherwise same definitions but with different transports, the last definition overwrites all previous ones, despite `debug:messenger` showing it correctly:

```
 The following messages can be dispatched:

 -------------------------------------------------------------------------------------------------------------------- 
  App\Message\TriggeringMessage                                                                                       
      handled by App\MessageHandler\TriggeringMessageHandler (when from_transport=a)                                  
      handled by App\MessageHandler\TriggeringMessageHandler (when from_transport=b)                                  
      handled by App\MessageHandler\TriggeringMessageHandler (when method=handleTriggeringMessage, from_transport=a)  
      handled by App\MessageHandler\TriggeringMessageHandler (when method=handleTriggeringMessage, from_transport=b)  
```

Example code:

```php
#[AsMessageHandler(fromTransport: 'a', handles: TriggeringMessage::class)]
#[AsMessageHandler(fromTransport: 'b', handles: TriggeringMessage::class)]
class TriggeringMessageHandler
{
    public function __invoke(): void
    {
        echo __FUNCTION__."\n";
    }

    #[AsMessageHandler(fromTransport: 'a', handles: TriggeringMessage::class)]
    #[AsMessageHandler(fromTransport: 'b', handles: TriggeringMessage::class)]
    public function handleTriggeringMessage(): void
    {
        echo __FUNCTION__."\n";
    }
}
```



When sending a `TriggeringMessage` to both `a` & `b` transports, I get following `bin/console messenger:consume a b` output on **6.3**:

```
[critical] Error thrown while handling message App\Message\TriggeringMessage. Removing from transport after 0 retries. Error: "No handler for message "App\Message\TriggeringMessage"."
__invoke
handleTriggeringMessage
```

And with this fix:
```
__invoke
handleTriggeringMessage
__invoke
handleTriggeringMessage
```