### PR TITLE
[Mime] Allow array on `setParameter` `$value` parameter

### DIFF
--- a/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
+++ b/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
@@ -41,7 +41,10 @@ final class ParameterizedHeader extends UnstructuredHeader
         }
     }
 
-    public function setParameter(string $parameter, ?string $value): void
+    /**
+     * params null|string|array $value
+     */
+    public function setParameter(string $parameter, $value): void
     {
         $this->setParameters(array_merge($this->getParameters(), [$parameter => $value]));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #52696
| License       | MIT
