### PR TITLE
[Cache] Fix return type of `Redis6Proxy::mget()`

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -653,7 +653,14 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 
     public function mget($keys): \Redis|array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget(...\func_get_args());
+        /**
+         * Handle the special case where `mget()` returns false, waiting for the stub to be fixed.
+         *
+         * @see https://github.com/phpredis/phpredis/issues/1810
+         */
+        $v = ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget(...\func_get_args());
+
+        return $v === false ? [] : $v;
     }
 
     public function migrate($host, $port, $key, $dstdb, $timeout, $copy = false, $replace = false, #[\SensitiveParameter] $credentials = null): \Redis|bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52668
| License       | MIT

After @dkarlovi's [comment](https://github.com/symfony/symfony/pull/52690#issuecomment-1823544628), here is another try that will not break returns types. Thank you for taking the time to explain where the exact problem is, Dalibor :+1: 

_Todo: having a look at failing tests_