### PR TITLE
[AssetMapper] Fix eager imports are not deduplicated

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
@@ -671,6 +671,25 @@ class ImportMapGeneratorTest extends TestCase
             ['/assets/imports_simple.js', '/assets/simple.js'],
             [$simpleAsset, $importsSimpleAsset],
         ];
+
+        $importsSimpleAsset2 = new MappedAsset(
+            'imports_simple2.js',
+            '/path/to/imports_simple2.js',
+            publicPathWithoutDigest: '/assets/imports_simple2.js',
+            javaScriptImports: [new JavaScriptImport('/assets/simple.js', assetLogicalPath: $simpleAsset->logicalPath, assetSourcePath: $simpleAsset->sourcePath, isLazy: false)]
+        );
+        yield 'an entry recursive dependencies are deduplicated' => [
+            new MappedAsset(
+                'app.js',
+                publicPath: '/assets/app.js',
+                javaScriptImports: [
+                    new JavaScriptImport('/assets/imports_simple.js', assetLogicalPath: $importsSimpleAsset->logicalPath, assetSourcePath: $importsSimpleAsset->sourcePath, isLazy: false),
+                    new JavaScriptImport('/assets/imports_simple2.js', assetLogicalPath: $importsSimpleAsset2->logicalPath, assetSourcePath: $importsSimpleAsset2->sourcePath, isLazy: false),
+                ]
+            ),
+            ['/assets/imports_simple.js', '/assets/imports_simple2.js', '/assets/simple.js'],
+            [$simpleAsset, $importsSimpleAsset, $importsSimpleAsset2],
+        ];
     }
 
     public function testFindEagerEntrypointImportsUsesCacheFile()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes ?
| New feature?  | no
| Deprecations? | no
| Issues        | Fix 
| License       | MIT

While recursively collecting eager imports, there may be duplicates. 

```
app.js
L  A_1.js
    L B.js 
L  A_2.js
    L B.js     
```

Removing them early avoid a lot of useless computation afterwards (and eventual side effects)

Exemple with the generated app.entrypoint.json of the Symfony UX website
- before: 78 entries
- after: 53 entries
