### PR TITLE
[HttpKernel] Fix logging deprecations to the "php" channel when channel "deprecation" is not defined

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.php
@@ -26,7 +26,7 @@ return static function (ContainerConfigurator $container) {
                 param('debug.error_handler.throw_at'),
                 param('kernel.debug'),
                 param('kernel.debug'),
-                service('logger')->nullOnInvalid(),
+                null, // Deprecation logger if different from the one above
             ])
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'php'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52672
| License       | MIT
