### PR TITLE
[AssetMapper] Exclude dot files

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -899,6 +899,11 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                             ->example(['*/assets/build/*', '*/*_.scss'])
                         ->end()
+                        // boolean called  defaulting to true
+                        ->booleanNode('exclude_dotfiles')
+                            ->info('If true, any files starting with "." will be excluded from the asset mapper')
+                            ->defaultTrue()
+                        ->end()
                         ->booleanNode('server')
                             ->info('If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default)')
                             ->defaultValue($this->debug)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1351,7 +1351,8 @@ class FrameworkExtension extends Extension
 
         $container->getDefinition('asset_mapper.repository')
             ->setArgument(0, $paths)
-            ->setArgument(2, $excludedPathPatterns);
+            ->setArgument(2, $excludedPathPatterns)
+            ->setArgument(3, $config['exclude_dotfiles']);
 
         $container->getDefinition('asset_mapper.public_assets_path_resolver')
             ->setArgument(0, $config['public_prefix']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -74,6 +74,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('array of asset mapper paths'),
                 param('kernel.project_dir'),
                 abstract_arg('array of excluded path patterns'),
+                abstract_arg('exclude dot files'),
             ])
 
         ->set('asset_mapper.public_assets_path_resolver', PublicAssetsPathResolver::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -196,6 +196,7 @@
             <xsd:element name="importmap-script-attribute" type="asset_mapper_attribute" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="exclude-dotfiles" type="xsd:boolean" />
         <xsd:attribute name="server" type="xsd:boolean" />
         <xsd:attribute name="public-prefix" type="xsd:string" />
         <xsd:attribute name="missing-import-mode" type="missing-import-mode" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -137,6 +137,7 @@ class ConfigurationTest extends TestCase
             'importmap_polyfill' => 'es-module-shims',
             'vendor_dir' => '%kernel.project_dir%/assets/vendor',
             'importmap_script_attributes' => [],
+            'exclude_dotfiles' => true,
         ];
 
         $this->assertEquals($defaultConfig, $config['asset_mapper']);
@@ -674,6 +675,7 @@ class ConfigurationTest extends TestCase
                 'importmap_polyfill' => 'es-module-shims',
                 'vendor_dir' => '%kernel.project_dir%/assets/vendor',
                 'importmap_script_attributes' => [],
+                'exclude_dotfiles' => true,
             ],
             'cache' => [
                 'pools' => [],

--- a/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
@@ -33,6 +33,7 @@ class AssetMapperRepository
         private readonly array $paths,
         private readonly string $projectRootDir,
         private readonly array $excludedPathPatterns = [],
+        private readonly bool $excludeDotFiles = true,
     ) {
     }
 
@@ -183,6 +184,10 @@ class AssetMapperRepository
             if (preg_match($pattern, $filesystemPath)) {
                 return true;
             }
+        }
+
+        if ($this->excludeDotFiles && str_starts_with(basename($filesystemPath), '.')) {
+            return true;
         }
 
         return false;

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperRepositoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperRepositoryTest.php
@@ -162,4 +162,24 @@ class AssetMapperRepositoryTest extends TestCase
         $this->assertNull($repository->find('file3.css'));
         $this->assertNull($repository->findLogicalPath(__DIR__.'/Fixtures/dir2/file3.css'));
     }
+
+    public function testDotFilesExcluded()
+    {
+        $repository = new AssetMapperRepository([
+            'dot_file' => '',
+        ], __DIR__.'/Fixtures', [], true);
+
+        $actualAssets = array_keys($repository->all());
+        $this->assertEquals([], $actualAssets);
+    }
+
+    public function testDotFilesNotExcluded()
+    {
+        $repository = new AssetMapperRepository([
+            'dot_file' => '',
+        ], __DIR__.'/Fixtures', [], false);
+
+        $actualAssets = array_keys($repository->all());
+        $this->assertEquals(['.dotfile'], $actualAssets);
+    }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/Fixtures/dot_file/.dotfile
+++ b/src/Symfony/Component/AssetMapper/Tests/Fixtures/dot_file/.dotfile
@@ -1,0 +1,1 @@
+I'm a dot file!


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes - could possibly be considered a security fix 
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52697
| License       | MIT

See #52697. The biggest question is: should we do this? Is it enough to say "Hey! When you map an assets directory, EVERYTHING is published publicly?". Or should we be on the safe side and exclude dot files by default.

Cheers!