### PR TITLE
[Serializer] Fix deserialization_path missing using contructor

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1029,15 +1029,6 @@ class SerializerTest extends TestCase
                 'expectedTypes' => [
                     'float',
                 ],
-                'path' => 'php74FullWithTypedConstructor',
-                'useMessageForUser' => false,
-                'message' => 'The type of the "something" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor" must be one of "float" ("string" given).',
-            ],
-            [
-                'currentType' => 'string',
-                'expectedTypes' => [
-                    'float',
-                ],
                 'path' => 'php74FullWithTypedConstructor.something',
                 'useMessageForUser' => false,
                 'message' => 'The type of the "something" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor" must be one of "float" ("string" given).',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #44925 #52683
| License       | MIT

While trying to fix #44925, I used a wrong approach (#52683), and therefore introduced a bug.

This PR fixes it and solve the previous issue in a better way.