### PR TITLE
[Cache] Get TRUNCATE statement from platform

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -213,11 +213,7 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
     protected function doClear(string $namespace): bool
     {
         if ('' === $namespace) {
-            if ('sqlite' === $this->getPlatformName()) {
-                $sql = "DELETE FROM $this->table";
-            } else {
-                $sql = "TRUNCATE TABLE $this->table";
-            }
+            $sql = $this->conn->getDatabasePlatform()->getTruncateTableSQL($this->table);
         } else {
             $sql = "DELETE FROM $this->table WHERE $this->idCol LIKE '$namespace%'";
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The DBAL platform knows how to build a `TRUNCATE` query and which databases support it. Let's leverage that functionality.
