### PR TITLE
[Mime] Add `TemplatedEmail::$locale` to the serialized props

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -100,7 +100,7 @@ class TemplatedEmail extends Email
      */
     public function __serialize(): array
     {
-        return [$this->htmlTemplate, $this->textTemplate, $this->context, parent::__serialize()];
+        return [$this->htmlTemplate, $this->textTemplate, $this->context, parent::__serialize(),  $this->locale];
     }
 
     /**
@@ -109,6 +109,7 @@ class TemplatedEmail extends Email
     public function __unserialize(array $data): void
     {
         [$this->htmlTemplate, $this->textTemplate, $this->context, $parentData] = $data;
+        $this->locale = $data[4] ?? null;
 
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -43,12 +43,14 @@ class TemplatedEmailTest extends TestCase
             ->textTemplate('text.txt.twig')
             ->htmlTemplate('text.html.twig')
             ->context($context = ['a' => 'b'])
+            ->locale($locale = 'fr_FR')
         ;
 
         $email = unserialize(serialize($email));
         $this->assertEquals('text.txt.twig', $email->getTextTemplate());
         $this->assertEquals('text.html.twig', $email->getHtmlTemplate());
         $this->assertEquals($context, $email->getContext());
+        $this->assertEquals($locale, $email->getLocale());
     }
 
     public function testSymfonySerialize()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no 
| Issues        | Fix #52718
| License       | MIT

To use the locale-property when working with Symfony Messenger asynchronously it has to be serialized.