### PR TITLE
[Cache] Remove database server version detection

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -54,6 +54,7 @@ Cache
 -----
 
  * Add parameter `\Closure $isSameDatabase` to `DoctrineDbalAdapter::configureSchema()`
+ * Drop support for Postgres < 9.5 and SQL Server < 2008 in `DoctrineDbalAdapter`
 
 Config
 ------

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add parameter `$isSameDatabase` to `DoctrineDbalAdapter::configureSchema()`
+ * Drop support for Postgres < 9.5 and SQL Server < 2008 in `DoctrineDbalAdapter`
 
 6.4
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Our DoctrineDbalAdapter is currently sniffing for the database server version to implement workarounds for very old database servers:

* SQL Server before 2008: DBAL 3 does not support older SQL server releases than this one.
* Postgres before 9.5: Postgres 9.5 has been released in Jan 2016, it predecessor 9.4 is EOL since Feb 2020.

I think it's fair to not support those old releases anymore at this point.