### PR TITLE
[Validator] Fix type error for non-array items when `Unique::fields` is set

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -45,7 +45,7 @@ class UniqueValidator extends ConstraintValidator
         foreach ($value as $element) {
             $element = $normalizer($element);
 
-            if ($fields && !$element = $this->reduceElementKeys($fields, $element)) {
+            if ($fields && !(\is_array($element) && $element = $this->reduceElementKeys($fields, $element))) {
                 continue;
             }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -244,6 +244,30 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @dataProvider getValidCollectionValues
+     */
+    public function testValidCollectionValues(array $value, array $fields)
+    {
+        $this->validator->validate($value, new Unique(fields: $fields));
+
+        $this->assertNoViolation();
+    }
+
+    public static function getValidCollectionValues(): array
+    {
+        return [
+            'unique empty item' => [
+                [['field' => 1], ['field' => 2], []],
+                ['field'],
+            ],
+            'unique non-array item' => [
+                [['field' => 1], ['field' => 2], '', 1, null],
+                ['field'],
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider getInvalidCollectionValues
      */
     public function testInvalidCollectionValues(array $value, array $fields, string $expectedMessageParam)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT


The `UniqueValidator` crashes if:
- `fields` argument is set
- `value` is an array but some of the elements are not


Example value:
```php
$value = [
    [
        "field": 1
    ],
    "abc",
];
```

Example constraint config:
```php
new Unique(fields: ['field']);
```

Error thrown:
```text
Symfony\Component\Validator\Constraints\UniqueValidator::reduceElementKeys(): Argument #2 ($element) must be of type array, string given, called in /var/www/html/vendor/symfony/validator/Constraints/UniqueValidator.php on line 46
```



Solution:

Looking at the actual behavior, if one of its items, being an array, has none of the `fields`, is ignored.

So, continuing on this premise, if one of its items, is not an array, it should be ignored too.

That's what this PR is about (hope so)!