### PR TITLE
[PropertyAccess] Allow usage of wildcard `[*]`

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -161,6 +161,11 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
         return false;
     }
 
+    public function isWildcard(int $index): bool
+    {
+        return false;
+    }
+
     /**
      * Returns whether an element maps directly to a form.
      *

--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+* Allow wildcard `[*]` usage for reading multiple values
+
 7.0
 ---
 

--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-7.1
+7.3
 ---
 
 * Allow wildcard `[*]` usage for reading multiple values

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -294,7 +294,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 // To be removed in Symfony 8 once we are sure isWildcard is always implemented.
                 $isWildcard = $propertyPath->isWildcard($i);
             } else {
-                trigger_deprecation('symfony/property-access', '7.1', 'The "%s()" method in class "%s" needs to be implemented in version 8.0, not defining it is deprecated.', 'isWildcard', PropertyPathInterface::class);
+                trigger_deprecation('symfony/property-access', '7.3', 'The "%s()" method in class "%s" needs to be implemented in version 8.0, not defining it is deprecated.', 'isWildcard', PropertyPathInterface::class);
             }
 
             if ($isIndex) {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -291,7 +291,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
             $isWildcard = false;
             if (method_exists($propertyPath, 'isWildcard')) {
-                // To be removed in symfony 8 once we are sure isNullSafe is always implemented.
+                // To be removed in Symfony 8 once we are sure isWildcard is always implemented.
                 $isWildcard = $propertyPath->isWildcard($i);
             } else {
                 trigger_deprecation('symfony/property-access', '7.1', 'The "%s()" method in class "%s" needs to be implemented in version 8.0, not defining it is deprecated.', 'isWildcard', PropertyPathInterface::class);

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -275,7 +275,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @throws UnexpectedTypeException if a value within the path is neither object nor array
      * @throws NoSuchIndexException    If a non-existing index is accessed
      */
-    private function readPropertiesUntil(array $zval, PropertyPathInterface $propertyPath, int $lastIndex, bool $ignoreInvalidIndices = true): array
+    private function readPropertiesUntil(array $zval, PropertyPathInterface $propertyPath, int $lastIndex, bool $ignoreInvalidIndices = true, int $startIndex = 0): array
     {
         if (!\is_object($zval[self::VALUE]) && !\is_array($zval[self::VALUE])) {
             throw new UnexpectedTypeException($zval[self::VALUE], $propertyPath, 0);
@@ -284,10 +284,18 @@ class PropertyAccessor implements PropertyAccessorInterface
         // Add the root object to the list
         $propertyValues = [$zval];
 
-        for ($i = 0; $i < $lastIndex; ++$i) {
+        for ($i = $startIndex; $i < $lastIndex; ++$i) {
             $property = $propertyPath->getElement($i);
             $isIndex = $propertyPath->isIndex($i);
             $isNullSafe = $propertyPath->isNullSafe($i);
+
+            $isWildcard = false;
+            if (method_exists($propertyPath, 'isWildcard')) {
+                // To be removed in symfony 8 once we are sure isNullSafe is always implemented.
+                $isWildcard = $propertyPath->isWildcard($i);
+            } else {
+                trigger_deprecation('symfony/property-access', '7.1', 'The "%s()" method in class "%s" needs to be implemented in version 8.0, not defining it is deprecated.', 'isWildcard', PropertyPathInterface::class);
+            }
 
             if ($isIndex) {
                 // Create missing nested arrays on demand
@@ -317,6 +325,40 @@ class PropertyAccessor implements PropertyAccessorInterface
                 }
 
                 $zval = $this->readIndex($zval, $property);
+            } elseif ($isWildcard) {
+                $newPropertyValues = [];
+
+                // replace wildcard with all posible values
+                // e.g. [*][foo] becomes [0][foo], [1][foo], ...
+                foreach (array_keys($zval[self::VALUE]) as $index) {
+                    $path = preg_replace('/\[\*\]/', "[$index]", (string) ($propertyPath), 1);
+                    $subPath = $this->readPropertiesUntil($zval, $this->getPropertyPath($path), $lastIndex, $ignoreInvalidIndices, $i);
+
+                    // merge property values from all sub paths
+                    // skip first because it's same for all paths and is already in $propertyValues
+                    for($j = 1; $j < count($subPath); $j++) {
+                        $newPropertyValues[$j][self::VALUE][] = $subPath[$j][self::VALUE];
+                    }
+                }
+
+                foreach ($newPropertyValues as &$newValue) {
+                    $shouldMerge = true;
+
+                    foreach ($newValue[self::VALUE] as $value) {
+                        $shouldMerge = is_array($value) && array_is_list($value);
+
+                        if(!$shouldMerge) {
+                            break;
+                        }
+                    }
+
+                    if($shouldMerge) {
+                        $newValue[self::VALUE] = array_merge(...$newValue[self::VALUE]);
+                    }
+                }
+
+                array_push($propertyValues, ...$newPropertyValues);
+                break;
             } elseif ($isNullSafe && !\is_object($zval[self::VALUE])) {
                 $zval[self::VALUE] = null;
             } else {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -331,12 +331,12 @@ class PropertyAccessor implements PropertyAccessorInterface
                 // replace wildcard with all posible values
                 // e.g. [*][foo] becomes [0][foo], [1][foo], ...
                 foreach (array_keys($zval[self::VALUE]) as $index) {
-                    $path = preg_replace('/\[\*\]/', "[$index]", (string) ($propertyPath), 1);
+                    $path = preg_replace('/\[\*\]/', "[$index]", (string) $propertyPath, 1);
                     $subPath = $this->readPropertiesUntil($zval, $this->getPropertyPath($path), $lastIndex, $ignoreInvalidIndices, $i);
 
                     // merge property values from all sub paths
                     // skip first because it's same for all paths and is already in $propertyValues
-                    for($j = 1; $j < count($subPath); $j++) {
+                    for ($j = 1; $j < \count($subPath); ++$j) {
                         $newPropertyValues[$j][self::VALUE][] = $subPath[$j][self::VALUE];
                     }
                 }
@@ -345,14 +345,14 @@ class PropertyAccessor implements PropertyAccessorInterface
                     $shouldMerge = true;
 
                     foreach ($newValue[self::VALUE] as $value) {
-                        $shouldMerge = is_array($value) && array_is_list($value);
+                        $shouldMerge = \is_array($value) && array_is_list($value);
 
-                        if(!$shouldMerge) {
+                        if (!$shouldMerge) {
                             break;
                         }
                     }
 
-                    if($shouldMerge) {
+                    if ($shouldMerge) {
                         $newValue[self::VALUE] = array_merge(...$newValue[self::VALUE]);
                     }
                 }

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -58,6 +58,14 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     private array $isNullSafe = [];
 
     /**
+     * Contains a Boolean for each property in $elements denoting whether this
+     * element is wildcard or not.
+     *
+     * @var array<bool>
+     */
+    private array $isWildcard = [];
+
+    /**
      * String representation of the path.
      */
     private string $pathAsString;
@@ -78,6 +86,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
             $this->isIndex = $propertyPath->isIndex;
             $this->isNullSafe = $propertyPath->isNullSafe;
             $this->pathAsString = $propertyPath->pathAsString;
+            $this->isWildcard = $propertyPath->isWildcard;
 
             return;
         }
@@ -97,9 +106,15 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
             if ('' !== $matches[2]) {
                 $element = $matches[2];
                 $this->isIndex[] = false;
+                $this->isWildcard[] = false;
+            } elseif ('[*]' === $matches[1]) {
+                $element = '*';
+                $this->isIndex[] = false;
+                $this->isWildcard[] = true;
             } else {
                 $element = $matches[3];
                 $this->isIndex[] = true;
+                $this->isWildcard[] = false;
             }
 
             // Mark as optional when last character is "?".
@@ -110,7 +125,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 $this->isNullSafe[] = false;
             }
 
-            $element = preg_replace('/\\\([.[])/', '$1', $element);
+            $element = preg_replace('/\\\([.[*])/', '$1', $element);
             if (str_ends_with($element, '\\\\')) {
                 $element = substr($element, 0, -1);
             }
@@ -151,6 +166,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         array_pop($parent->elements);
         array_pop($parent->isIndex);
         array_pop($parent->isNullSafe);
+        array_pop($parent->isWildcard);
 
         return $parent;
     }
@@ -202,5 +218,14 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         }
 
         return $this->isNullSafe[$index];
+    }
+
+    public function isWildcard(int $index): bool
+    {
+        if (!isset($this->isWildcard[$index])) {
+            throw new OutOfBoundsException(sprintf('The index "%s" is not within the property path.', $index));
+        }
+
+        return $this->isWildcard[$index];
     }
 }

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -58,7 +58,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     private array $isNullSafe = [];
 
     /**
-     * Contains a Boolean for each property in $elements denoting whether this
+     * Contains a boolean for each property in $elements denoting whether this
      * element is wildcard or not.
      *
      * @var array<bool>

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -223,7 +223,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     public function isWildcard(int $index): bool
     {
         if (!isset($this->isWildcard[$index])) {
-            throw new OutOfBoundsException(sprintf('The index "%s" is not within the property path.', $index));
+            throw new OutOfBoundsException(\sprintf('The index "%s" is not within the property path.', $index));
         }
 
         return $this->isWildcard[$index];

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\PropertyAccess;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
+ * @method bool isWildcard(int $index) Returns whether the element at the given index is wildcard. Not implementing it is deprecated since Symfony 7.1
+ *
  * @extends \Traversable<int, string>
  */
 interface PropertyPathInterface extends \Traversable, \Stringable

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\PropertyAccess;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @method bool isWildcard(int $index) Returns whether the element at the given index is wildcard. Not implementing it is deprecated since Symfony 7.1
+ * @method bool isWildcard(int $index) Returns whether the element at the given index is wildcard. Not implementing it is deprecated since Symfony 7.3
  *
  * @extends \Traversable<int, string>
  */

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorWildcardTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorWildcardTest.php
@@ -35,15 +35,15 @@ class PropertyAccessorWildcardTest extends TestCase
                     'title' => 'chef',
                     'info' => [
                         'experience' => 6,
-                        'salary' => 34
-                    ]
+                        'salary' => 34,
+                    ],
                 ],
                 [
                     'title' => 'waiter',
                     'info' => [
                         'experience' => 3,
-                        'salary' => 30
-                    ]
+                        'salary' => 30,
+                    ],
                 ],
             ],
             'info' => [
@@ -60,20 +60,20 @@ class PropertyAccessorWildcardTest extends TestCase
                     'title' => 'chef',
                     'info' => [
                         'experience' => 3,
-                        'salary' => 31
-                    ]
+                        'salary' => 31,
+                    ],
                 ],
                 [
                     'title' => 'bartender',
                     'info' => [
                         'experience' => 6,
-                        'salary' => 30
-                    ]
+                        'salary' => 30,
+                    ],
                 ],
             ],
             'info' => [
                 'age' => 28,
-            ]
+            ],
         ],
     ];
 
@@ -81,27 +81,27 @@ class PropertyAccessorWildcardTest extends TestCase
     {
         yield [
             'path' => '[*][id]',
-            'expected' => [1, 2]
+            'expected' => [1, 2],
         ];
 
         yield [
             'path' => '[*][name]',
-            'expected' => ['John', 'Luke']
+            'expected' => ['John', 'Luke'],
         ];
 
         yield [
             'path' => '[*][languages]',
-            'expected' => ['EN', 'EN', 'FR']
+            'expected' => ['EN', 'EN', 'FR'],
         ];
 
         yield [
             'path' => '[*][info][age]',
-            'expected' => [32, 28]
+            'expected' => [32, 28],
         ];
 
         yield [
             'path' => '[0][jobs][*][title]',
-            'expected' => ['chef', 'waiter']
+            'expected' => ['chef', 'waiter'],
         ];
 
         yield [
@@ -109,27 +109,27 @@ class PropertyAccessorWildcardTest extends TestCase
             'expected' => [
                 ['experience' => 6, 'salary' => 34],
                 ['experience' => 3, 'salary' => 30],
-            ]
+            ],
         ];
 
         yield [
             'path' => '[0][jobs][*][info][experience]',
-            'expected' => [6, 3]
+            'expected' => [6, 3],
         ];
 
         yield [
             'path' => '[*][jobs][0][title]',
-            'expected' => ['chef', 'chef']
+            'expected' => ['chef', 'chef'],
         ];
 
         yield [
             'path' => '[*][jobs][*][title]',
-            'expected' => ['chef', 'waiter', 'chef', 'bartender']
+            'expected' => ['chef', 'waiter', 'chef', 'bartender'],
         ];
 
         yield [
             'path' => '[*][jobs][*][info][*]',
-            'expected' => [6, 34, 3, 30, 3, 31, 6, 30]
+            'expected' => [6, 34, 3, 30, 3, 31, 6, 30],
         ];
 
         yield [
@@ -139,17 +139,17 @@ class PropertyAccessorWildcardTest extends TestCase
                 ['experience' => 3, 'salary' => 30],
                 ['experience' => 3, 'salary' => 31],
                 ['experience' => 6, 'salary' => 30],
-            ]
+            ],
         ];
 
         yield [
             'path' => '[0][\*]',
-            'expected' => 'wildcard1'
+            'expected' => 'wildcard1',
         ];
 
         yield [
             'path' => '[*][\*]',
-            'expected' => ['wildcard1', 'wildcard2']
+            'expected' => ['wildcard1', 'wildcard2'],
         ];
     }
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorWildcardTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorWildcardTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
+
+class PropertyAccessorWildcardTest extends TestCase
+{
+    private PropertyAccessor $propertyAccessor;
+
+    protected function setUp(): void
+    {
+        $this->propertyAccessor = new PropertyAccessor();
+    }
+
+    private const TEST_ARRAY = [
+        [
+            'id' => 1,
+            'name' => 'John',
+            'languages' => ['EN'],
+            '*' => 'wildcard1',
+            'jobs' => [
+                [
+                    'title' => 'chef',
+                    'info' => [
+                        'experience' => 6,
+                        'salary' => 34
+                    ]
+                ],
+                [
+                    'title' => 'waiter',
+                    'info' => [
+                        'experience' => 3,
+                        'salary' => 30
+                    ]
+                ],
+            ],
+            'info' => [
+                'age' => 32,
+            ],
+        ],
+        [
+            'id' => 2,
+            'name' => 'Luke',
+            'languages' => ['EN', 'FR'],
+            '*' => 'wildcard2',
+            'jobs' => [
+                [
+                    'title' => 'chef',
+                    'info' => [
+                        'experience' => 3,
+                        'salary' => 31
+                    ]
+                ],
+                [
+                    'title' => 'bartender',
+                    'info' => [
+                        'experience' => 6,
+                        'salary' => 30
+                    ]
+                ],
+            ],
+            'info' => [
+                'age' => 28,
+            ]
+        ],
+    ];
+
+    public static function provideWildcardPaths(): iterable
+    {
+        yield [
+            'path' => '[*][id]',
+            'expected' => [1, 2]
+        ];
+
+        yield [
+            'path' => '[*][name]',
+            'expected' => ['John', 'Luke']
+        ];
+
+        yield [
+            'path' => '[*][languages]',
+            'expected' => ['EN', 'EN', 'FR']
+        ];
+
+        yield [
+            'path' => '[*][info][age]',
+            'expected' => [32, 28]
+        ];
+
+        yield [
+            'path' => '[0][jobs][*][title]',
+            'expected' => ['chef', 'waiter']
+        ];
+
+        yield [
+            'path' => '[0][jobs][*][info]',
+            'expected' => [
+                ['experience' => 6, 'salary' => 34],
+                ['experience' => 3, 'salary' => 30],
+            ]
+        ];
+
+        yield [
+            'path' => '[0][jobs][*][info][experience]',
+            'expected' => [6, 3]
+        ];
+
+        yield [
+            'path' => '[*][jobs][0][title]',
+            'expected' => ['chef', 'chef']
+        ];
+
+        yield [
+            'path' => '[*][jobs][*][title]',
+            'expected' => ['chef', 'waiter', 'chef', 'bartender']
+        ];
+
+        yield [
+            'path' => '[*][jobs][*][info][*]',
+            'expected' => [6, 34, 3, 30, 3, 31, 6, 30]
+        ];
+
+        yield [
+            'path' => '[*][jobs][*][info]',
+            'expected' => [
+                ['experience' => 6, 'salary' => 34],
+                ['experience' => 3, 'salary' => 30],
+                ['experience' => 3, 'salary' => 31],
+                ['experience' => 6, 'salary' => 30],
+            ]
+        ];
+
+        yield [
+            'path' => '[0][\*]',
+            'expected' => 'wildcard1'
+        ];
+
+        yield [
+            'path' => '[*][\*]',
+            'expected' => ['wildcard1', 'wildcard2']
+        ];
+    }
+
+    /**
+     * @dataProvider provideWildcardPaths
+     */
+    public function testAccessorWithWildcard(string $path, string|array $expected): void
+    {
+        self::assertSame($expected, $this->propertyAccessor->getValue(self::TEST_ARRAY, $path));
+    }
+
+    public function testAccessorWithWildcardAndObject(): void
+    {
+        $array = self::TEST_ARRAY;
+
+        $array[0]['class'] = new TestClass('foo');
+        $array[1]['class'] = new TestClass('bar');
+
+        self::assertSame(['foo', 'bar'], $this->propertyAccessor->getValue($array, '[*][class].publicAccessor'));
+
+        $array[0]['classes'] = [
+            new TestClass('foo'),
+            new TestClass('bar'),
+        ];
+        $array[1]['classes'] = [
+            new TestClass('baz'),
+            new TestClass('qux'),
+        ];
+
+        self::assertSame(['foo', 'bar', 'baz', 'qux'], $this->propertyAccessor->getValue($array, '[*][classes][*].publicAccessor'));
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorWildcardTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorWildcardTest.php
@@ -156,12 +156,12 @@ class PropertyAccessorWildcardTest extends TestCase
     /**
      * @dataProvider provideWildcardPaths
      */
-    public function testAccessorWithWildcard(string $path, string|array $expected): void
+    public function testAccessorWithWildcard(string $path, string|array $expected)
     {
         self::assertSame($expected, $this->propertyAccessor->getValue(self::TEST_ARRAY, $path));
     }
 
-    public function testAccessorWithWildcardAndObject(): void
+    public function testAccessorWithWildcardAndObject()
     {
         $array = self::TEST_ARRAY;
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
@@ -205,7 +205,7 @@ class PropertyPathTest extends TestCase
         $propertyPath->isIndex(-1);
     }
 
-    public function testIsWildcard(): void
+    public function testIsWildcard()
     {
         $propertyPath = new PropertyPath('[*][parent][child].name');
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
@@ -204,4 +204,16 @@ class PropertyPathTest extends TestCase
 
         $propertyPath->isIndex(-1);
     }
+
+    public function testIsWildcard(): void
+    {
+        $propertyPath = new PropertyPath('[*][parent][child].name');
+
+        $this->assertTrue($propertyPath->isWildcard(0));
+        $this->assertFalse($propertyPath->isIndex(0));
+
+        $this->assertFalse($propertyPath->isWildcard(1));
+        $this->assertFalse($propertyPath->isWildcard(2));
+        $this->assertFalse($propertyPath->isWildcard(3));
+    }
 }

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/property-info": "^6.4|^7.0"
+        "symfony/property-info": "^6.4|^7.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "symfony/cache": "^6.4|^7.0"

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -33,10 +33,6 @@ CHANGELOG
  * Add `--as-tree` option to `translation:pull` command to write YAML messages as a tree-like structure
  * [BC BREAK] Add argument `$buildDir` to `DataCollectorTranslator::warmUp()`
  * Add `DataCollectorTranslatorPass` and `LoggingTranslatorPass`  (moved from `FrameworkBundle`)
-
-6.3
----
-
  * Add `PhraseTranslationProvider`
 
 6.2.7

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -33,6 +33,10 @@ CHANGELOG
  * Add `--as-tree` option to `translation:pull` command to write YAML messages as a tree-like structure
  * [BC BREAK] Add argument `$buildDir` to `DataCollectorTranslator::warmUp()`
  * Add `DataCollectorTranslatorPass` and `LoggingTranslatorPass`  (moved from `FrameworkBundle`)
+
+6.3
+---
+
  * Add `PhraseTranslationProvider`
 
 6.2.7


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | 
| License       | MIT

This feature allows usage of wildcards to read values from multiple arrays/objects.

Examples:
```php
$persons = [
    [
        'first_name' => 'Wouter',
    ],
    [
        'first_name' => 'Ryan',
    ],
];

var_dump($propertyAccessor->getValue($persons, '[*][first_name]')); // ['Wouter', 'Ryan']
```

```php
$persons = [
    [
        'first_name' => 'Wouter',
        'pets' => ['Tom', 'Jerry']
    ],
    [
        'first_name' => 'Ryan',
        'pets' => ['Garfield']
    ],
];

var_dump($propertyAccessor->getValue($persons, '[*][pets]')); // ['Tom', 'Jerry', 'Garfield']
```
```php
$persons = [
    [
        'first_name' => 'Wouter',
        'pets' => [
            'cats' => ['Tom', 'Garfield'],
            'mouses' => ['Jerry']
        ]
    ],
    [
        'first_name' => 'Ryan',
        'pets' => [
            'cats' => ['Sylvester', 'Felix'],
            'mouses' => ['Speedy Gonzales']
        ]
    ],
];

var_dump($propertyAccessor->getValue($persons, '[*][pets][mouses]')); // ['Jerry', 'Speedy Gonzales']
```

```php
$persons = [
    [
        'first_name' => 'Wouter',
        'pets' => [
            [
                'name' => 'Tom',
                'type' => 'cat',
            ],
            [
                'name' => 'Garfield',
                'type' => 'cat',
            ],
            [
                'name' => 'Jerry',
                'type' => 'mouse',
            ]
        ]
    ],
    [
        'first_name' => 'Ryan',
        'pets' => [
            [
                'name' => 'Sylvester',
                'type' => 'cat',
            ],
            [
                'name' => 'Felix',
                'type' => 'cat',
            ],
            [
                'name' => 'Speedy Gonzales',
                'type' => 'mouse',
            ]
        ]
    ],
];
var_dump($propertyAccessor->getValue($persons, '[*][pets][*][name]')); // ['Tom', 'Garfield', 'Jerry', 'Sylvester', 'Felix', 'Speedy Gonzales']
var_dump($propertyAccessor->getValue($persons, '[*][pets][*][type]')); // ['cat', 'cat', 'mouse', 'cat', 'cat', 'mouse']
var_dump($propertyAccessor->getValue($persons, '[0][pets][*][*]')); // ['Tom', 'cat', 'Garfield', 'cat', 'Jerry', 'mouse']
```
More examples in `PropertyAccessorWildcardTest`.

If there is `*` key in array it should be accesed with `[\*]`

How does it work?
Whenever [*] is detected, it is replaced with all possible values:
 - 1st example: `[*][first_name]` becomes `[0][first_name]` and `[1][first_name]`
 - `readPropertiesUntil` is then recursively called for each of them whenever wildcard is detected
 - returned paths from each of them are merged together

Notes:
 - `public function isWildcard(int $index): bool` should be added to `PropertyPathInterface `in next major version
 - currently deprecation is triggered when method does not exists in class implementing that interface
