### PR TITLE
[Security] make secret required for DefaultLoginRateLimiter

### DIFF
--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -34,7 +34,7 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
     /**
      * @param non-empty-string $secret A secret to use for hashing the IP address and username
      */
-    public function __construct(RateLimiterFactory $globalFactory, RateLimiterFactory $localFactory, #[\SensitiveParameter] string $secret = '')
+    public function __construct(RateLimiterFactory $globalFactory, RateLimiterFactory $localFactory, #[\SensitiveParameter] string $secret)
     {
         if (!$secret) {
             throw new InvalidArgumentException('A non-empty secret is required.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | yes/no
| Issues        |
| License       | MIT

This tickets results from the discussion here: https://github.com/symfony/symfony/pull/52469#pullrequestreview-1747480994 and @nicolas-grekas requested a PR for it.

The `secret` parameter has been added in #51434 with a default value of `''` and a deprecation message that it is required / may not be empty. Which is fine and doesn't hurt backwards compatibility.

The later ticket #52469 changes the deprecation into an exception, as it is undesirable that no secret is used (in any scenario). This leads to the unintended side effect that there is a BC breakage when a developer manually creates a `DefaultLoginRateLimiter` as it is now actually required to provide a (non empty) value due to the check and exception.

Allowing the service / class to be used without providing the secret parameter, in a backwards compatible manner, but then still breaking the backwards compatibility by throwing due to the default value is confusing. So making the `secret` required makes more sense from a developer perspective as it is clear in that the parameter must be provided.