### PR TITLE
[AssetMapper] Fix: also download files referenced by url() in CSS

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
@@ -64,7 +64,7 @@ final class ImportMapInstallCommand extends Command
         }
 
         $io->success(sprintf(
-            'Downloaded %d asset%s into %s.',
+            'Downloaded %d package%s into %s.',
             \count($downloadedPackages),
             1 === \count($downloadedPackages) ? '' : 's',
             str_replace($this->projectDir.'/', '', $this->packageDownloader->getVendorDir()),

--- a/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageStorage.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageStorage.php
@@ -34,6 +34,15 @@ class RemotePackageStorage
         return is_file($this->getDownloadPath($entry->packageModuleSpecifier, $entry->type));
     }
 
+    public function isExtraFileDownloaded(ImportMapEntry $entry, string $extraFilename): bool
+    {
+        if (!$entry->isRemotePackage()) {
+            throw new \InvalidArgumentException(sprintf('The entry "%s" is not a remote package.', $entry->importName));
+        }
+
+        return is_file($this->getExtraFileDownloadPath($entry, $extraFilename));
+    }
+
     public function save(ImportMapEntry $entry, string $contents): void
     {
         if (!$entry->isRemotePackage()) {
@@ -41,6 +50,18 @@ class RemotePackageStorage
         }
 
         $vendorPath = $this->getDownloadPath($entry->packageModuleSpecifier, $entry->type);
+
+        @mkdir(\dirname($vendorPath), 0777, true);
+        file_put_contents($vendorPath, $contents);
+    }
+
+    public function saveExtraFile(ImportMapEntry $entry, string $extraFilename, string $contents): void
+    {
+        if (!$entry->isRemotePackage()) {
+            throw new \InvalidArgumentException(sprintf('The entry "%s" is not a remote package.', $entry->importName));
+        }
+
+        $vendorPath = $this->getExtraFileDownloadPath($entry, $extraFilename);
 
         @mkdir(\dirname($vendorPath), 0777, true);
         file_put_contents($vendorPath, $contents);
@@ -67,5 +88,10 @@ class RemotePackageStorage
         }
 
         return $this->vendorDir.'/'.$filename;
+    }
+
+    private function getExtraFileDownloadPath(ImportMapEntry $entry, string $extraFilename): string
+    {
+        return $this->vendorDir.'/'.$entry->getPackageName().'/'.ltrim($extraFilename, '/');
     }
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/PackageResolverInterface.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/PackageResolverInterface.php
@@ -37,7 +37,7 @@ interface PackageResolverInterface
      *
      * @param array<string, ImportMapEntry> $importMapEntries
      *
-     * @return array<string, array{content: string, dependencies: string[]}>
+     * @return array<string, array{content: string, dependencies: string[], extraFiles: array<string, string>}>
      */
     public function downloadPackages(array $importMapEntries, callable $progressCallback = null): array;
 }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
@@ -52,12 +52,33 @@ class RemotePackageStorageTest extends TestCase
         $this->assertTrue($storage->isDownloaded($entry));
     }
 
+    public function testIsExtraFileDownloaded()
+    {
+        $storage = new RemotePackageStorage(self::$writableRoot.'/assets/vendor');
+        $entry = ImportMapEntry::createRemote('foo', ImportMapType::JS, '/does/not/matter', '1.0.0', 'module_specifier', false);
+        $this->assertFalse($storage->isExtraFileDownloaded($entry, '/path/to/extra.woff'));
+        $targetPath = self::$writableRoot.'/assets/vendor/module_specifier/path/to/extra.woff';
+        @mkdir(\dirname($targetPath), 0777, true);
+        file_put_contents($targetPath, 'any content');
+        $this->assertTrue($storage->isExtraFileDownloaded($entry, '/path/to/extra.woff'));
+    }
+
     public function testSave()
     {
         $storage = new RemotePackageStorage(self::$writableRoot.'/assets/vendor');
         $entry = ImportMapEntry::createRemote('foo', ImportMapType::JS, '/does/not/matter', '1.0.0', 'module_specifier', false);
         $storage->save($entry, 'any content');
         $targetPath = self::$writableRoot.'/assets/vendor/module_specifier/module_specifier.index.js';
+        $this->assertFileExists($targetPath);
+        $this->assertEquals('any content', file_get_contents($targetPath));
+    }
+
+    public function testSaveExtraFile()
+    {
+        $storage = new RemotePackageStorage(self::$writableRoot.'/assets/vendor');
+        $entry = ImportMapEntry::createRemote('foo', ImportMapType::JS, '/does/not/matter', '1.0.0', 'module_specifier', false);
+        $storage->saveExtraFile($entry, '/path/to/extra-file.woff2', 'any content');
+        $targetPath = self::$writableRoot.'/assets/vendor/module_specifier/path/to/extra-file.woff2';
         $this->assertFileExists($targetPath);
         $this->assertEquals('any content', file_get_contents($targetPath));
     }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -268,7 +268,7 @@ class JsDelivrEsmResolverTest extends TestCase
     /**
      * @dataProvider provideDownloadPackagesTests
      */
-    public function testDownloadPackages(array $importMapEntries, array $expectedRequests, array $expectedReturn, array $expectedDependencies = [])
+    public function testDownloadPackages(array $importMapEntries, array $expectedRequests, array $expectedReturn)
     {
         $responses = [];
         foreach ($expectedRequests as $expectedRequest) {
@@ -305,7 +305,7 @@ class JsDelivrEsmResolverTest extends TestCase
                 ],
             ],
             [
-                'lodash' => ['content' => 'lodash contents', 'dependencies' => []],
+                'lodash' => ['content' => 'lodash contents', 'dependencies' => [], 'extraFiles' => []],
             ],
         ];
 
@@ -318,7 +318,7 @@ class JsDelivrEsmResolverTest extends TestCase
                 ],
             ],
             [
-                'lodash' => ['content' => 'lodash contents', 'dependencies' => []],
+                'lodash' => ['content' => 'lodash contents', 'dependencies' => [], 'extraFiles' => []],
             ],
         ];
 
@@ -331,7 +331,7 @@ class JsDelivrEsmResolverTest extends TestCase
                 ],
             ],
             [
-                'lodash' => ['content' => 'chart.js contents', 'dependencies' => []],
+                'lodash' => ['content' => 'chart.js contents', 'dependencies' => [], 'extraFiles' => []],
             ],
         ];
 
@@ -344,7 +344,7 @@ class JsDelivrEsmResolverTest extends TestCase
                 ],
             ],
             [
-                'lodash' => ['content' => 'bootstrap.css contents', 'dependencies' => []],
+                'lodash' => ['content' => 'bootstrap.css contents', 'dependencies' => [], 'extraFiles' => []],
             ],
         ];
 
@@ -369,9 +369,9 @@ class JsDelivrEsmResolverTest extends TestCase
                 ],
             ],
             [
-                'lodash' => ['content' => 'lodash contents', 'dependencies' => []],
-                'chart.js/auto' => ['content' => 'chart.js contents', 'dependencies' => []],
-                'bootstrap/dist/bootstrap.css' => ['content' => 'bootstrap.css contents', 'dependencies' => []],
+                'lodash' => ['content' => 'lodash contents', 'dependencies' => [], 'extraFiles' => []],
+                'chart.js/auto' => ['content' => 'chart.js contents', 'dependencies' => [], 'extraFiles' => []],
+                'bootstrap/dist/bootstrap.css' => ['content' => 'bootstrap.css contents', 'dependencies' => [], 'extraFiles' => []],
             ],
         ];
 
@@ -389,6 +389,7 @@ class JsDelivrEsmResolverTest extends TestCase
                 '@chart.js/auto' => [
                     'content' => 'import{Color as t}from"@kurkle/color";function e(){}const i=(()=',
                     'dependencies' => ['@kurkle/color'],
+                    'extraFiles' => [],
                 ],
             ],
         ];
@@ -407,6 +408,7 @@ class JsDelivrEsmResolverTest extends TestCase
                 'twig' => [
                     'content' => 'import e from"locutus/php/strings/sprintf";console.log()',
                     'dependencies' => ['locutus/php/strings/sprintf'],
+                    'extraFiles' => [],
                 ],
             ],
         ];
@@ -426,6 +428,7 @@ class JsDelivrEsmResolverTest extends TestCase
                 '@chart.js/auto' => [
                     'content' => 'as Ticks,ta as TimeScale,ia as TimeSeriesScale,oo as Title,wo as Tooltip,Ci as _adapters,us as _detectPlatform,Ye as animator,Si as controllers,tn as default,St as defaults,Pn as elements,qi as layouts,ko as plugins,na as registerables,Ps as registry,sa as scales};',
                     'dependencies' => [],
+                    'extraFiles' => [],
                 ],
             ],
         ];
@@ -449,6 +452,7 @@ EOF
 const je="\n//# sourceURL=",Ue="\n//# sourceMappingURL=",Me=/^(text|application)\/(x-)?javascript(;|$)/,_e=/^(application)\/wasm(;|$)/,Ie=/^(text|application)\/json(;|$)/,Re=/^(text|application)\/css(;|$)/,Te=/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g;export{t as default};
 EOF,
                     'dependencies' => [],
+                    'extraFiles' => [],
                 ],
             ],
         ];
@@ -466,9 +470,118 @@ EOF,
                 'lodash' => [
                     'content' => 'print-table-row{display:table-row!important}.d-print-table-cell{display:table-cell!important}.d-print-flex{display:flex!important}.d-print-inline-flex{display:inline-flex!important}.d-print-none{display:none!important}}',
                     'dependencies' => [],
+                    'extraFiles' => [],
                 ],
             ],
         ];
+    }
+
+    public function testDownloadCssFileWithUrlReferences()
+    {
+        $expectedRequests = [
+            [
+                'url' => '/npm/bootstrap-icons@1.1.1/font/bootstrap-icons.min.css',
+                'body' => <<<EOF
+                @font-face{font-display:block;font-family:bootstrap-icons;src:
+                    url("fonts/bootstrap-icons.woff2?2820a3852bdb9a5832199cc61cec4e65") format("woff2"),
+                    url("fonts/bootstrap-icons.woff?2820a3852bdb9a5832199cc61cec4e65") format("woff")},
+                    url("./fonts/bootstrap-icons.woff-fake-dot-slash") format("woff-fake-dot-slash"),
+                    url("../fonts/bootstrap-icons.woff-fake-dot-dot-slash") format("woff-fake-dot-dot-slash"),
+                    url("data:will-be-ignored") format("woff-fake-data-format"),
+                    url("data:https://example.com/will-be-ignored") format("woff-fake-absolute-url"),
+                    .bi::before,[class*=" bi-"]::before,[class^=bi-]::before{display:inline-block;font-family:bootstrap-icons!important;font-style:normal;font-weight:400!important;font-variant:normal;text-transform:none;
+                EOF
+                ,
+            ],
+            [
+                'url' => '/npm/bootstrap-icons@1.1.1/font/fonts/bootstrap-icons.woff2',
+                'body' => 'woff2 font contents',
+            ],
+            [
+                'url' => '/npm/bootstrap-icons@1.1.1/font/fonts/bootstrap-icons.woff',
+                'body' => 'woff font contents',
+            ],
+            [
+                'url' => '/npm/bootstrap-icons@1.1.1/font/fonts/bootstrap-icons.woff-fake-dot-slash',
+                'body' => 'woff font fake dot slash contents',
+            ],
+            [
+                'url' => '/npm/bootstrap-icons@1.1.1/fonts/bootstrap-icons.woff-fake-dot-dot-slash',
+                'body' => 'woff font fake dot dot slash contents',
+            ],
+        ];
+        $responses = [];
+        foreach ($expectedRequests as $expectedRequest) {
+            $responses[] = function ($method, $url) use ($expectedRequest) {
+                $this->assertSame('GET', $method);
+                $this->assertStringEndsWith($expectedRequest['url'], $url);
+
+                return new MockResponse($expectedRequest['body']);
+            };
+        }
+
+        $httpClient = new MockHttpClient($responses);
+
+        $provider = new JsDelivrEsmResolver($httpClient);
+        $actualReturn = $provider->downloadPackages([
+            'bootstrap-icons/font/bootstrap-icons.min.css' => self::createRemoteEntry('bootstrap-icons/font/bootstrap-icons.min.css', version: '1.1.1', type: ImportMapType::CSS),
+        ]);
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+
+        $packageData = $actualReturn['bootstrap-icons/font/bootstrap-icons.min.css'];
+        $extraFiles = $packageData['extraFiles'];
+        $this->assertCount(4, $extraFiles);
+
+        $this->assertSame($extraFiles, [
+            '/font/fonts/bootstrap-icons.woff2' => 'woff2 font contents',
+            '/font/fonts/bootstrap-icons.woff' => 'woff font contents',
+            '/font/fonts/bootstrap-icons.woff-fake-dot-slash' => 'woff font fake dot slash contents',
+            '/fonts/bootstrap-icons.woff-fake-dot-dot-slash' => 'woff font fake dot dot slash contents',
+        ]);
+    }
+
+    public function testDownloadCssRecursivelyDownloadsUrlCss()
+    {
+        $expectedRequests = [
+            [
+                'url' => '/npm/bootstrap-icons@1.1.1/font/bootstrap-icons.min.css',
+                'body' => '@import url("../other.css");',
+            ],
+            [
+                'url' => '/npm/bootstrap-icons@1.1.1/other.css',
+                'body' => '@font-face{font-display:block;font-family:bootstrap-icons;src:url("fonts/bootstrap-icons.woff2?2820a3852bdb9a5832199cc61cec4e65") format("woff2"),',
+            ],
+            [
+                'url' => '/npm/bootstrap-icons@1.1.1/fonts/bootstrap-icons.woff2',
+                'body' => 'woff2 font contents',
+            ],
+        ];
+        $responses = [];
+        foreach ($expectedRequests as $expectedRequest) {
+            $responses[] = function ($method, $url) use ($expectedRequest) {
+                $this->assertSame('GET', $method);
+                $this->assertStringEndsWith($expectedRequest['url'], $url);
+
+                return new MockResponse($expectedRequest['body']);
+            };
+        }
+
+        $httpClient = new MockHttpClient($responses);
+
+        $provider = new JsDelivrEsmResolver($httpClient);
+        $actualReturn = $provider->downloadPackages([
+            'bootstrap-icons/font/bootstrap-icons.min.css' => self::createRemoteEntry('bootstrap-icons/font/bootstrap-icons.min.css', version: '1.1.1', type: ImportMapType::CSS),
+        ]);
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+
+        $packageData = $actualReturn['bootstrap-icons/font/bootstrap-icons.min.css'];
+        $extraFiles = $packageData['extraFiles'];
+        $this->assertCount(2, $extraFiles);
+
+        $this->assertSame($extraFiles, [
+            '/other.css' => '@font-face{font-display:block;font-family:bootstrap-icons;src:url("fonts/bootstrap-icons.woff2?2820a3852bdb9a5832199cc61cec4e65") format("woff2"),',
+            '/fonts/bootstrap-icons.woff2' => 'woff2 font contents',
+        ]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52620
| License       | MIT

Hi!

@tacman found another situation where our "asset downloader" wasn't complete.

If we're downloading a CSS file, it may reference other files via `url()`. In #52620, these were font files, but they could be images or even other CSS Files. Currently, we do NOT download these, so the local references fail. This fixes that. I tried to keep the PR as small as possible, given the late stage of 6.4. But this *is* a bug fix: the downloader currently doesn't work for CSS files with `url()` inside.

Tested locally on ux.symfony.com with the bootstrap-icons package.

Cheers!
