### PR TITLE
[String] Fix Inflector for 'icon'

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -253,6 +253,9 @@ final class EnglishInflector implements InflectorInterface
         // seasons (season), treasons (treason), poisons (poison), lessons (lesson)
         ['nos', 3, true, true, 'sons'],
 
+        // icons (icon)
+        ['noc', 3, true, true, 'cons'],
+
         // bacteria (bacterium), criteria (criterion), phenomena (phenomenon)
         ['no', 2, true, true, 'a'],
 

--- a/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
@@ -295,6 +295,7 @@ class EnglishInflectorTest extends TestCase
             ['tree', 'trees'],
             ['waltz', 'waltzes'],
             ['wife', 'wives'],
+            ['icon', 'icons'],
 
             // test casing: if the first letter was uppercase, it should remain so
             ['Man', 'Men'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Hello,
this PR fixes problem when inflecting `icon` word into `icons`. Currently it returns wrong result `ica`

Please make someone review because I'm not 100% sure if this is the right way how to fix it.

Thank you.

Btw: older versions are also affected and it should be possible to merge it there