### PR TITLE
[TwigBridge][TwigBundle][VarDumper] Remove legacy Twig_ namespace support

### DIFF
--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -131,7 +131,7 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
 
     public function getProfile(): Profile
     {
-        return $this->profile ??= unserialize($this->data['profile'], ['allowed_classes' => ['Twig_Profiler_Profile', Profile::class]]);
+        return $this->profile ??= unserialize($this->data['profile'], ['allowed_classes' => [Profile::class]]);
     }
 
     private function getComputedData(string $index): mixed

--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -50,10 +50,6 @@ class TransNodeTest extends TestCase
 
     protected function getVariableGetterWithStrictCheck($name)
     {
-        if (Environment::MAJOR_VERSION >= 2) {
-            return sprintf('(isset($context["%1$s"]) || array_key_exists("%1$s", $context) ? $context["%1$s"] : (function () { throw new %2$s(\'Variable "%1$s" does not exist.\', 0, $this->source); })())', $name, Environment::VERSION_ID >= 20700 ? 'RuntimeError' : 'Twig_Error_Runtime');
-        }
-
-        return sprintf('($context["%s"] ?? $this->getContext($context, "%1$s"))', $name);
+        return sprintf('(isset($context["%1$s"]) || array_key_exists("%1$s", $context) ? $context["%1$s"] : (function () { throw new RuntimeError(\'Variable "%1$s" does not exist.\', 0, $this->source); })())', $name);
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -170,8 +170,6 @@ class TwigExtension extends Extension
             'optimizations' => true,
         ]));
 
-        $container->registerForAutoconfiguration(\Twig_ExtensionInterface::class)->addTag('twig.extension');
-        $container->registerForAutoconfiguration(\Twig_LoaderInterface::class)->addTag('twig.loader');
         $container->registerForAutoconfiguration(ExtensionInterface::class)->addTag('twig.extension');
         $container->registerForAutoconfiguration(LoaderInterface::class)->addTag('twig.loader');
         $container->registerForAutoconfiguration(RuntimeExtensionInterface::class)->addTag('twig.runtime');

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add argument `$label` to `VarDumper::dump()`
  * Require explicit argument when calling `VarDumper::setHandler()`
+ * Remove display of backtrace in `Twig_Template`, only `Twig\Template` are supported
 
 6.4
 ---

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -214,7 +214,7 @@ class ExceptionCaster
                 $ellipsis = $ellipsis->attr['ellipsis'] ?? 0;
 
                 if (is_file($f['file']) && 0 <= self::$srcContext) {
-                    if (!empty($f['class']) && (is_subclass_of($f['class'], 'Twig\Template') || is_subclass_of($f['class'], 'Twig_Template')) && method_exists($f['class'], 'getDebugInfo')) {
+                    if (!empty($f['class']) && is_subclass_of($f['class'], 'Twig\Template') && method_exists($f['class'], 'getDebugInfo')) {
                         $template = null;
                         if (isset($f['object'])) {
                             $template = $f['object'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Twig 3.0 is required by Symfony 7.0+, support for legacy class names is not necessary.
Nothing added to TwigBundle changelog as "Drop support for Twig 2" is already mentionned.

For VarDumper, since there is no version constraint for `twig/twig`, I added a line to the changelog.