### PR TITLE
Release v6.4.0-RC2

### DIFF
--- a/CHANGELOG-6.4.md
+++ b/CHANGELOG-6.4.md
@@ -7,6 +7,38 @@ in 6.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.4.0...v6.4.1
 
+* 6.4.0-RC2 (2023-11-26)
+
+ * bug #52724 [Security] make secret required for DefaultLoginRateLimiter (RobertMe)
+ * bug #52617 [AssetMapper] Fix resolving jsdeliver default + other exports from modules (ogizanagi)
+ * feature #52712 [AssetMapper] Exclude dot files (weaverryan)
+ * bug #52725 [AssetMapper] Fix: also download files referenced by url() in CSS (weaverryan)
+ * bug #52702 [AssetMapper] Fix eager imports are not deduplicated (smnandre)
+ * bug #52719 [Mime] Add `TemplatedEmail::$locale` to the serialized props (mkrauser)
+ * bug #52677 [Translation] [Lokalise] Fix language format on Lokalise Provider (welcoMattic)
+ * bug #52715 [Cache] fix detecting the database server version (xabbuh)
+ * bug #52688 [Cache] Add url decoding of password in `RedisTrait` DSN (alexandre-daubois)
+ * bug #52172 [Serializer] Fix denormalizing empty string into `object|null` parameter (Jeroeny)
+ * bug #52693 [Messenger] Fix message handlers with multiple `from_transports` (valtzu)
+ * bug #52684 [PropertyInfo] Fixed promoted property type detection for `PhpStanExtractor` (LastDragon-ru)
+ * bug #52681 [Serializer] Fix support for DiscriminatorMap in PropertyNormalizer (mtarld)
+ * bug #52680 [Serializer] Fix access to private properties/getters when using the ``@Ignore`` annotation (mtarld)
+ * bug #52713 [Serializer] Fix deserialization_path missing using contructor (mtarld)
+ * bug #52683 [Serializer] Fix constructor deserialization path (mtarld)
+ * bug #52707 [HttpKernel] Fix logging deprecations to the "php" channel when channel "deprecation" is not defined (nicolas-grekas)
+ * bug #52589 [Serializer] Fix XML attributes not added on empty node (mtarld)
+ * bug #52686 [Cache] fix detecting the server version with Doctrine DBAL 4 (xabbuh)
+ * bug #52629 [Messenger] Fix support for Redis Sentinel using php-redis 6.0.0 (pepeh)
+ * bug #52656 [FrameworkBundle] Add TemplateController to the list of allowed controllers for fragments (nicolas-grekas)
+ * bug #52459 [Cache][HttpFoundation][Lock] Fix PDO store not creating table + add tests (HypeMC)
+ * bug #52626 [Serializer] Fix denormalizing date intervals having both weeks and days (oneNevan)
+ * bug #52578 [Serializer] Fix denormalize constructor arguments (mtarld)
+ * bug #52526 Add some more non-countable English nouns (paullallier)
+ * bug #52604 [FrameworkBundle] register the virtual request stack together with common profiling services (xabbuh)
+ * bug #52039 [Scheduler] Continue with stored `Checkpoint::$time` on lock (Jeroeny)
+ * bug #52631 [DomCrawler] Revert "bug #52579 UriResolver support path with colons" (lyrixx)
+ * bug #52618 [VarExporter] Fix handling mangled property names returned by __sleep() (nicolas-grekas)
+
 * 6.4.0-RC1 (2023-11-15)
 
  * bug #52588 [Messenger] Use extension_loaded call to check if pcntl extension is loaded, as SIGTERM might be set be swoole (Sergii Dolgushev)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.4.0-DEV';
+    public const VERSION = '6.4.0-RC2';
     public const VERSION_ID = 60400;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = 'RC2';
 
     public const END_OF_MAINTENANCE = '11/2026';
     public const END_OF_LIFE = '11/2027';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.4.0-RC1...v6.4.0-RC2)

 * bug #52724 [Security] make secret required for DefaultLoginRateLimiter (@RobertMe)
 * bug #52617 [AssetMapper] Fix resolving jsdeliver default + other exports from modules (@ogizanagi)
 * feature #52712 [AssetMapper] Exclude dot files (@weaverryan)
 * bug #52725 [AssetMapper] Fix: also download files referenced by url() in CSS (@weaverryan)
 * bug #52702 [AssetMapper] Fix eager imports are not deduplicated (@smnandre)
 * bug #52719 [Mime] Add `TemplatedEmail::$locale` to the serialized props (@mkrauser)
 * bug #52677 [Translation] [Lokalise] Fix language format on Lokalise Provider (@welcoMattic)
 * bug #52715 [Cache] fix detecting the database server version (@xabbuh)
 * bug #52688 [Cache] Add url decoding of password in `RedisTrait` DSN (@alexandre-daubois)
 * bug #52172 [Serializer] Fix denormalizing empty string into `object|null` parameter (@Jeroeny)
 * bug #52693 [Messenger] Fix message handlers with multiple `from_transports` (@valtzu)
 * bug #52684 [PropertyInfo] Fixed promoted property type detection for `PhpStanExtractor` (@LastDragon-ru)
 * bug #52681 [Serializer] Fix support for DiscriminatorMap in PropertyNormalizer (@mtarld)
 * bug #52680 [Serializer] Fix access to private properties/getters when using the ``@Ignore`` annotation (@mtarld)
 * bug #52713 [Serializer] Fix deserialization_path missing using contructor (@mtarld)
 * bug #52683 [Serializer] Fix constructor deserialization path (@mtarld)
 * bug #52707 [HttpKernel] Fix logging deprecations to the "php" channel when channel "deprecation" is not defined (@nicolas-grekas)
 * bug #52589 [Serializer] Fix XML attributes not added on empty node (@mtarld)
 * bug #52686 [Cache] fix detecting the server version with Doctrine DBAL 4 (@xabbuh)
 * bug #52629 [Messenger] Fix support for Redis Sentinel using php-redis 6.0.0 (@pepeh)
 * bug #52656 [FrameworkBundle] Add TemplateController to the list of allowed controllers for fragments (@nicolas-grekas)
 * bug #52459 [Cache][HttpFoundation][Lock] Fix PDO store not creating table + add tests (@HypeMC)
 * bug #52626 [Serializer] Fix denormalizing date intervals having both weeks and days (@oneNevan)
 * bug #52578 [Serializer] Fix denormalize constructor arguments (@mtarld)
 * bug #52526 Add some more non-countable English nouns (@paullallier)
 * bug #52604 [FrameworkBundle] register the virtual request stack together with common profiling services (@xabbuh)
 * bug #52039 [Scheduler] Continue with stored `Checkpoint::$time` on lock (@Jeroeny)
 * bug #52631 [DomCrawler] Revert "bug #52579 UriResolver support path with colons" (@lyrixx)
 * bug #52618 [VarExporter] Fix handling mangled property names returned by __sleep() (@nicolas-grekas)
