### PR TITLE
[Serializer] Fix DebugCommandTest

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Command/DebugCommandTest.php
@@ -36,43 +36,43 @@ class DebugCommandTest extends TestCase
             Symfony\Component\Serializer\Tests\Dummy\DummyClassOne
             ------------------------------------------------------
 
-            +----------+-------------------------------------+
-            | Property | Options                             |
-            +----------+-------------------------------------+
-            | code     | [                                   |
-            |          |   "groups" => [                     |
-            |          |     "book:read",                    |
-            |          |     "book:write"                    |
-            |          |   ],                                |
-            |          |   "maxDepth" => 1,                  |
-            |          |   "serializedName" => "identifier", |
-            |          |   "serializedPath" => null,         |
-            |          |   "ignore" => true,                 |
-            |          |   "normalizationContexts" => [      |
-            |          |     "*" => [                        |
-            |          |       "groups" => [                 |
-            |          |         "book:read"                 |
-            |          |       ]                             |
-            |          |     ]                               |
-            |          |   ],                                |
-            |          |   "denormalizationContexts" => [    |
-            |          |     "*" => [                        |
-            |          |       "groups" => [                 |
-            |          |         "book:write"                |
-            |          |       ]                             |
-            |          |     ]                               |
-            |          |   ]                                 |
-            |          | ]                                   |
-            | name     | [                                   |
-            |          |   "groups" => [],                   |
-            |          |   "maxDepth" => null,               |
-            |          |   "serializedName" => null,         |
-            |          |   "serializedPath" => [data][name], |
-            |          |   "ignore" => false,                |
-            |          |   "normalizationContexts" => [],    |
-            |          |   "denormalizationContexts" => []   |
-            |          | ]                                   |
-            +----------+-------------------------------------+
+            +----------+---------------------------------------+
+            | Property | Options                               |
+            +----------+---------------------------------------+
+            | code     | [                                     |
+            |          |   "groups" => [                       |
+            |          |     "book:read",                      |
+            |          |     "book:write"                      |
+            |          |   ],                                  |
+            |          |   "maxDepth" => 1,                    |
+            |          |   "serializedName" => "identifier",   |
+            |          |   "serializedPath" => null,           |
+            |          |   "ignore" => true,                   |
+            |          |   "normalizationContexts" => [        |
+            |          |     "*" => [                          |
+            |          |       "groups" => [                   |
+            |          |         "book:read"                   |
+            |          |       ]                               |
+            |          |     ]                                 |
+            |          |   ],                                  |
+            |          |   "denormalizationContexts" => [      |
+            |          |     "*" => [                          |
+            |          |       "groups" => [                   |
+            |          |         "book:write"                  |
+            |          |       ]                               |
+            |          |     ]                                 |
+            |          |   ]                                   |
+            |          | ]                                     |
+            | name     | [                                     |
+            |          |   "groups" => [],                     |
+            |          |   "maxDepth" => null,                 |
+            |          |   "serializedName" => null,           |
+            |          |   "serializedPath" => "[data][name]", |
+            |          |   "ignore" => false,                  |
+            |          |   "normalizationContexts" => [],      |
+            |          |   "denormalizationContexts" => []     |
+            |          | ]                                     |
+            +----------+---------------------------------------+
 
             TXT,
             $tester->getDisplay(true),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | -
| New feature?  | -
| Deprecations? | -
| Issues        | -
| License       | MIT

This will fix the `DebugCommandTest`, which I broke in https://github.com/symfony/symfony/commit/24cdc43bc154e767372a6df00ac70d856dd1ccd4 :-(