### PR TITLE
[Security] Document BC break with $secret parameter introduction

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -198,7 +198,7 @@ Security
  * [BC break] `UserValueResolver` no longer implements `ArgumentValueResolverInterface`
  * [BC break] Make `PersistentToken` immutable
  * Deprecate accepting only `DateTime` for `TokenProviderInterface::updateToken()`, use `DateTimeInterface` instead
- * Deprecate calling the constructor of `DefaultLoginRateLimiter` with an empty secret
+ * [BC break] Added required `string $secret` parameter to the constructor of `DefaultLoginRateLimiter`
 
 SecurityBundle
 --------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Deprecation was converted to an exception https://github.com/symfony/symfony/pull/52469