### PR TITLE
[Serializer] Add discriminator map to debug commmand output

### DIFF
--- a/src/Symfony/Component/Serializer/Command/DebugCommand.php
+++ b/src/Symfony/Component/Serializer/Command/DebugCommand.php
@@ -97,6 +97,9 @@ class DebugCommand extends Command
     {
         $data = [];
 
+        $mapping = $classMetadata->getClassDiscriminatorMapping();
+        $typeProperty = $mapping?->getTypeProperty();
+
         foreach ($classMetadata->getAttributesMetadata() as $attributeMetadata) {
             $data[$attributeMetadata->getName()] = [
                 'groups' => $attributeMetadata->getGroups(),
@@ -107,6 +110,10 @@ class DebugCommand extends Command
                 'normalizationContexts' => $attributeMetadata->getNormalizationContexts(),
                 'denormalizationContexts' => $attributeMetadata->getDenormalizationContexts(),
             ];
+
+            if ($mapping && $typeProperty === $attributeMetadata->getName()) {
+                $data[$attributeMetadata->getName()]['discriminatorMap'] = $mapping->getTypesMapping();
+            }
         }
 
         return $data;

--- a/src/Symfony/Component/Serializer/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Command/DebugCommandTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Command\DebugCommand;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Tests\Dummy\DummyClassWithDiscriminatorMap;
 use Symfony\Component\Serializer\Tests\Dummy\DummyClassOne;
 
 /**
@@ -73,6 +74,41 @@ class DebugCommandTest extends TestCase
             |          |   "denormalizationContexts" => []     |
             |          | ]                                     |
             +----------+---------------------------------------+
+
+            TXT,
+            $tester->getDisplay(true),
+        );
+    }
+
+    public function testOutputWithDiscriminatorMapClass()
+    {
+        $command = new DebugCommand(new ClassMetadataFactory(new AttributeLoader()));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['class' => DummyClassWithDiscriminatorMap::class], ['decorated' => false]);
+
+        $this->assertSame(<<<TXT
+
+            Symfony\Component\Serializer\Tests\Dummy\DummyClassWithDiscriminatorMap
+            -----------------------------------------------------------------------
+
+            +----------+------------------------------------------------------------------------+
+            | Property | Options                                                                |
+            +----------+------------------------------------------------------------------------+
+            | type     | [                                                                      |
+            |          |   "groups" => [],                                                      |
+            |          |   "maxDepth" => null,                                                  |
+            |          |   "serializedName" => null,                                            |
+            |          |   "serializedPath" => null,                                            |
+            |          |   "ignore" => false,                                                   |
+            |          |   "normalizationContexts" => [],                                       |
+            |          |   "denormalizationContexts" => [],                                     |
+            |          |   "discriminatorMap" => [                                              |
+            |          |     "one" => "Symfony\Component\Serializer\Tests\Dummy\DummyClassOne", |
+            |          |     "two" => "Symfony\Component\Serializer\Tests\Dummy\DummyClassTwo"  |
+            |          |   ]                                                                    |
+            |          | ]                                                                      |
+            +----------+------------------------------------------------------------------------+
 
             TXT,
             $tester->getDisplay(true),

--- a/src/Symfony/Component/Serializer/Tests/Dummy/DummyClassTwo.php
+++ b/src/Symfony/Component/Serializer/Tests/Dummy/DummyClassTwo.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Dummy;
+
+class DummyClassTwo
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/Dummy/DummyClassWithDiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Tests/Dummy/DummyClassWithDiscriminatorMap.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Dummy;
+
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'one' => DummyClassOne::class,
+    'two' => DummyClassTwo::class,
+])]
+class DummyClassWithDiscriminatorMap
+{
+    public string $type;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | little addition
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

The discriminator mapping was missing in the `debug:serializer` output. 

In case a `#[DiscriminatorMap]` is configured the output will now look like this: 

https://github.com/symfony/symfony/pull/52749/files#diff-d5830f2c54bb89f9819ca3c7c357a2f8df9319cf4d82f71b0704e693a2bfe9ceR106-R109