### PR TITLE
Allow custom query string parameters in the login link

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
@@ -38,9 +38,9 @@ class FirewallAwareLoginLinkHandler implements LoginLinkHandlerInterface
         $this->requestStack = $requestStack;
     }
 
-    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null): LoginLinkDetails
+    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null, array $parameters = []): LoginLinkDetails
     {
-        return $this->getForFirewall()->createLoginLink($user, $request, $lifetime);
+        return $this->getForFirewall()->createLoginLink($user, $request, $lifetime, $parameters);
     }
 
     public function consumeLoginLink(Request $request): UserInterface

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LoginLinkAuthenticationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LoginLinkAuthenticationTest.php
@@ -33,9 +33,9 @@ class LoginLinkAuthenticationTest extends AbstractWebTestCase
         $loginLinkHandler = self::getContainer()->get(LoginLinkHandlerInterface::class);
         $user = new InMemoryUser('weaverryan', 'foo');
         $loginLink = $loginLinkHandler->createLoginLink($user);
-        $this->assertStringContainsString('user=weaverryan', $loginLink);
-        $this->assertStringContainsString('hash=', $loginLink);
-        $this->assertStringContainsString('expires=', $loginLink);
+        $this->assertStringContainsString('_user=weaverryan', $loginLink);
+        $this->assertStringContainsString('_hash=', $loginLink);
+        $this->assertStringContainsString('_expires=', $loginLink);
         $client->request('GET', $loginLink->getUrl());
         $response = $client->getResponse();
 

--- a/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
@@ -148,8 +148,6 @@ class SignatureHasher
             return $result;
         }
 
-        ksort($parameters);
-
         foreach ($parameters as $key => $value) {
             if ($value instanceof \DateTimeInterface) {
                 $value = $value->format('c');

--- a/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
@@ -54,9 +54,9 @@ class SignatureHasher
      *
      * This method must be called before the user object is loaded from a provider.
      *
-     * @param int    $expires The expiry time as a unix timestamp
-     * @param string $hash    The plaintext hash provided by the request
-     * @param array<string, mixed> $parameters  Additional key-value pairs that should be part of the signature
+     * @param int                  $expires    The expiry time as a unix timestamp
+     * @param string               $hash       The plaintext hash provided by the request
+     * @param array<string, mixed> $parameters Additional key-value pairs that should be part of the signature
      *
      * @throws InvalidSignatureException If the signature does not match the provided parameters
      * @throws ExpiredSignatureException If the signature is no longer valid
@@ -78,9 +78,9 @@ class SignatureHasher
     /**
      * Verifies the hash using the provided user and expire time.
      *
-     * @param int    $expires The expiry time as a unix timestamp
-     * @param string $hash    The plaintext hash provided by the request
-     * @param array<string, mixed> $parameters  Additional key-value pairs that should be part of the signature
+     * @param int                  $expires    The expiry time as a unix timestamp
+     * @param string               $hash       The plaintext hash provided by the request
+     * @param array<string, mixed> $parameters Additional key-value pairs that should be part of the signature
      *
      * @throws InvalidSignatureException If the signature does not match the provided parameters
      * @throws ExpiredSignatureException If the signature is no longer valid
@@ -107,7 +107,7 @@ class SignatureHasher
     /**
      * Computes the secure hash for the provided user and expire time.
      *
-     * @param int $expires The expiry time as a unix timestamp
+     * @param int                  $expires    The expiry time as a unix timestamp
      * @param array<string, mixed> $parameters Additional key-value pairs that should be part of the signature
      */
     public function computeSignatureHash(UserInterface $user, int $expires, array $parameters = []): string
@@ -138,7 +138,6 @@ class SignatureHasher
      * Produces a single string of supplied key-value pairs usable during the hashing process.
      *
      * @param array<string, mixed> $parameters
-     * @return string
      */
     private function squashParameters(array $parameters): string
     {

--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -54,8 +54,12 @@ final class LoginLinkAuthenticator extends AbstractAuthenticator implements Inte
 
     public function authenticate(Request $request): Passport
     {
-        if (!$username = $request->get('user')) {
-            throw new InvalidLoginLinkAuthenticationException('Missing user from link.');
+        if ($fallbackUsername = $request->get('user')) {
+            trigger_deprecation('symfony/security', '7.1', 'Login link parameters "user", "hash" and "expires" were renamed to include an underscore prefix: "_user", "_hash" and "_expires". Update your login link to reflect this.');
+        }
+
+        if (!$username = $request->get('_user', $fallbackUsername)) {
+            throw new InvalidLoginLinkAuthenticationException('Missing _user from link.');
         }
 
         $userBadge = new UserBadge($username, function () use ($request) {

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add argument `$parameters` to `LoginLinkHandlerInterface::createLoginLink()`
+
 7.0
 ---
 

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -110,10 +110,10 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         $hashParametersList = $request->query->get('_hash_parameters');
         if (!empty($hashParametersList)) {
             $hashParameters = [
-                '_hash_parameters' => $hashParametersList
+                '_hash_parameters' => $hashParametersList,
             ];
 
-            foreach(explode(',', $hashParametersList) as $hashParameterName) {
+            foreach (explode(',', $hashParametersList) as $hashParameterName) {
                 if (!$request->query->has($hashParameterName)) {
                     throw new InvalidLoginLinkException(sprintf('Missing "%s" parameter.', $hashParameterName));
                 }

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -44,9 +44,6 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         ], $options);
     }
 
-    /**
-     * @param array<string, \Stringable|scalar> $parameters A list of additional query string parameters that should be part of the login link
-     */
     public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null, array $parameters = []): LoginLinkDetails
     {
         $expires = time() + ($lifetime ?: $this->options['lifetime']);

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -44,12 +44,12 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         ], $options);
     }
 
-    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null): LoginLinkDetails
+    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null, array $parameters = []): LoginLinkDetails
     {
         $expires = time() + ($lifetime ?: $this->options['lifetime']);
         $expiresAt = new \DateTimeImmutable('@'.$expires);
 
-        $parameters = [
+        $parameters += [
             'user' => $user->getUserIdentifier(),
             'expires' => $expires,
             'hash' => $this->signatureHasher->computeSignatureHash($user, $expires),

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -24,9 +24,10 @@ interface LoginLinkHandlerInterface
     /**
      * Generate a link that can be used to authenticate as the given user.
      *
-     * @param int|null $lifetime When not null, the argument overrides any default lifetime previously set
+     * @param int|null                          $lifetime   When not null, the argument overrides any default lifetime previously set
+     * @param array<string, \Stringable|scalar> $parameters A list of additional query string parameters that should be part of the login link URL
      */
-    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null): LoginLinkDetails;
+    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null/* , array $parameters = [] */): LoginLinkDetails;
 
     /**
      * Validates if this request contains a login link and returns the associated User.

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -128,7 +128,7 @@ class LoginLinkHandlerTest extends TestCase
             new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'),
             ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'],
             null,
-            ['_target_path' => '/welcome']
+            ['_target_path' => '/welcome'],
         ];
     }
 

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/polyfill-mbstring": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | No
| New feature?  | Yes, signature change recorded in `src/Symfony/Component/Security/Http/CHANGELOG.md`
| Deprecations? | No
| Issues        | None
| License       | MIT

This change allows the user to generate a login link with additional attributes, not just `user`, `expiry` and `hash`. The key reason is to allow passing things to the success handler through the URL of the login link.

This effectively adds support for the `_target_path` mechanism, which was the missing capability triggering my work on this PR: I use the magic link as the only authentication method, and I want to redirect the user to the URL requested before being redirected to the login page. This works well for password-driven form-based authentication scenarios, but in case of a magic link, neither the HTTP referrer nor a hidden input field is usable.

Another option would be to store the URL in session, but that assumes a stateless firewall and the willingness to start a session just to save this value. Also, the login link could be valid and opened after the session expires, or from a different browser or even different machine. So session doesn't really work. In my opinion, including `&_target_path=/welcome` is much simpler way to do it. 

If this gets merged, I'm happy to update docs as well. 