### PR TITLE
[VarExporter] Work around php/php-src#12695 for lazy objects, fixing nullsafe-related behavior

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Internal/Hydrator.php
@@ -271,10 +271,10 @@ class Hydrator
             $name = $property->name;
 
             if (\ReflectionProperty::IS_PRIVATE & $flags) {
-                $propertyScopes["\0$class\0$name"] = $propertyScopes[$name] = [$class, $name, $flags & \ReflectionProperty::IS_READONLY ? $class : null];
+                $propertyScopes["\0$class\0$name"] = $propertyScopes[$name] = [$class, $name, $flags & \ReflectionProperty::IS_READONLY ? $class : null, $property];
                 continue;
             }
-            $propertyScopes[$name] = [$class, $name, $flags & \ReflectionProperty::IS_READONLY ? $property->class : null];
+            $propertyScopes[$name] = [$class, $name, $flags & \ReflectionProperty::IS_READONLY ? $property->class : null, $property];
 
             if (\ReflectionProperty::IS_PROTECTED & $flags) {
                 $propertyScopes["\0*\0$name"] = $propertyScopes[$name];
@@ -288,8 +288,8 @@ class Hydrator
                 if (!$property->isStatic()) {
                     $name = $property->name;
                     $readonlyScope = $property->isReadOnly() ? $class : null;
-                    $propertyScopes["\0$class\0$name"] = [$class, $name, $readonlyScope];
-                    $propertyScopes[$name] ??= [$class, $name, $readonlyScope];
+                    $propertyScopes["\0$class\0$name"] = [$class, $name, $readonlyScope, $property];
+                    $propertyScopes[$name] ??= [$class, $name, $readonlyScope, $property];
                 }
             }
         }

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
@@ -65,29 +65,32 @@ class LazyObjectState
                 return $this->status = self::STATUS_INITIALIZED_PARTIAL;
             }
 
-            $status = self::STATUS_UNINITIALIZED_PARTIAL;
-
             if ($initializer = $this->initializer["\0"] ?? null) {
                 if (!\is_array($values = $initializer($instance, LazyObjectRegistry::$defaultProperties[$class]))) {
                     throw new \TypeError(sprintf('The lazy-initializer defined for instance of "%s" must return an array, got "%s".', $class, get_debug_type($values)));
                 }
                 $properties = (array) $instance;
                 foreach ($values as $key => $value) {
-                    if ($k === $key) {
-                        $status = self::STATUS_INITIALIZED_PARTIAL;
-                    }
                     if (!\array_key_exists($key, $properties) && [$scope, $name, $readonlyScope] = $propertyScopes[$key] ?? null) {
                         $scope = $readonlyScope ?? ('*' !== $scope ? $scope : $class);
                         $accessor = LazyObjectRegistry::$classAccessors[$scope] ??= LazyObjectRegistry::getClassAccessors($scope);
                         $accessor['set']($instance, $name, $value);
+
+                        if ($k === $key) {
+                            $this->status = self::STATUS_INITIALIZED_PARTIAL;
+                        }
                     }
                 }
             }
 
-            return $status;
+            return $this->status;
         }
 
-        $this->status = self::STATUS_INITIALIZED_FULL;
+        if (self::STATUS_INITIALIZED_PARTIAL === $this->status) {
+            return self::STATUS_INITIALIZED_PARTIAL;
+        }
+
+        $this->status = self::STATUS_INITIALIZED_PARTIAL;
 
         try {
             if ($defaultProperties = array_diff_key(LazyObjectRegistry::$defaultProperties[$instance::class], $this->skippedProperties)) {
@@ -102,7 +105,7 @@ class LazyObjectState
             throw $e;
         }
 
-        return self::STATUS_INITIALIZED_FULL;
+        return $this->status = self::STATUS_INITIALIZED_FULL;
     }
 
     public function reset($instance): void

--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -322,6 +322,9 @@ final class ProxyHelper
     {
         $propertyScopes = Hydrator::$propertyScopes[$parent] ??= Hydrator::getPropertyScopes($parent);
         uksort($propertyScopes, 'strnatcmp');
+        foreach ($propertyScopes as $k => $v) {
+            unset($propertyScopes[$k][3]);
+        }
         $propertyScopes = VarExporter::export($propertyScopes);
         $propertyScopes = str_replace(VarExporter::export($parent), 'parent::class', $propertyScopes);
         $propertyScopes = preg_replace("/(?|(,)\n( )       |\n        |,\n    (\]))/", '$1$2', $propertyScopes);

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -65,8 +65,10 @@ class LazyGhostTraitTest extends TestCase
 
         $this->assertSame(["\0".TestClass::class."\0lazyObjectState"], array_keys((array) $instance));
         unset($instance->public);
-        $this->assertFalse(isset($instance->public));
         $this->assertSame(4, $instance->publicReadonly);
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('__isset(public)');
+        isset($instance->public);
     }
 
     public function testSetPublic()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #52753
| License       | MIT

This PR fixes another issue discovered with @arnaud-lb while working on lazy-objects.
The root of the issue is described in php/php-src#12695 and this PR implements a fix based on a suggestion by @iluuu1994 

Only ghost objects are affected; proxy objects are OK.

