### PR TITLE
docs: how to get the Slack message and channel IDs when the Messenger component is installed

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/README.md
@@ -29,7 +29,7 @@ SLACK_DSN=slack://xoxb-......@default?channel=fabien
 Adding Interactions to a Message
 --------------------------------
 
-With a Slack message, you can use the `SlackOptions` class to add some 
+With a Slack message, you can use the `SlackOptions` class to add some
 interactive options called [Block elements](https://api.slack.com/reference/block-kit/block-elements).
 
 ```php
@@ -226,6 +226,55 @@ $options = new UpdateMessageSlackOptions($channelId, $messageId);
 $chatter->send(new ChatMessage('Updated message', $options));
 ```
 
+Note that if you are using the Messenger component, the value of `$sentMessage` will be `null`. This is due to the implementation of `ChatterInterface` which dispatches a message and doesn't return a result, as messages can be asynchronous.
+
+To get the message ID and channel ID from the sent message, create an event subscriber as follows:
+
+```php
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Notifier\Bridge\Slack\SlackSentMessage;
+use Symfony\Component\Notifier\Event\SentMessageEvent;
+
+class SlackSentMessageSubscriber implements EventSubscriberInterface
+{
+    public function onSentMessageEvent(SentMessageEvent $event): void
+    {
+        $sentMessage = $event->getMessage();
+
+        // Make sure that Slack transport was used
+        if ($sentMessage instanceof SlackSentMessage) {
+            $messageId = $sentMessage->getMessageId();
+            $channelId = $sentMessage->getChannelId();
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SentMessageEvent::class => 'onSentMessageEvent',
+        ];
+    }
+}
+```
+
+If you need the ID of an entity, put it into your `ChatMessage` subject (which doesn't show in Slack if the message is sent with `SlackOptions`):
+
+```php
+$chatMessage = new ChatMessage('MyCustomEntity ID: ' . $id);
+$chatMessage->options($slackOptions);
+$sentMessage = $chatter->send($chatMessage);
+```
+
+and access it in `SlackSentMessageSubscriber`:
+
+```php
+$subject = $sentMessage->getOriginalMessage()->getSubject();
+$id = (int) substr($subject, strlen('MyCustomEntity ID: '));
+```
+
+****
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52701
| License       | MIT

Document how to get the Slack message and channel IDs when the Messenger component is installed.