### PR TITLE
[Serializer] Use `DenormalizerAwareInterface` instead of `SerializerAwareInterface`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+* Let `UnwrappingDenormalizer` implement `DenormalizerAwareInterface` instead of `SerializerAwareInterface`
+* Deprecate method `UnwrappingDenormalizer::setSerializer()`, use `UnwrappingDenormalizer::setDenormalizer()` instead
+
 7.0
 ---
 

--- a/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
@@ -20,9 +20,9 @@ use Symfony\Component\Serializer\SerializerAwareTrait;
 /**
  * @author Eduard Bulava <bulavaeduard@gmail.com>
  */
-final class UnwrappingDenormalizer implements DenormalizerInterface, SerializerAwareInterface
+final class UnwrappingDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
 {
-    use SerializerAwareTrait;
+    use DenormalizerAwareTrait;
 
     public const UNWRAP_PATH = 'unwrap_path';
 
@@ -51,11 +51,7 @@ final class UnwrappingDenormalizer implements DenormalizerInterface, SerializerA
             $data = $this->propertyAccessor->getValue($data, $propertyPath);
         }
 
-        if (!$this->serializer instanceof DenormalizerInterface) {
-            throw new LogicException('Cannot unwrap path because the injected serializer is not a denormalizer.');
-        }
-
-        return $this->serializer->denormalize($data, $type, $format, $context);
+        return $this->denormalizer->denormalize($data, $type, $format, $context);
     }
 
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
@@ -14,8 +14,7 @@ namespace Symfony\Component\Serializer\Normalizer;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\Exception\LogicException;
-use Symfony\Component\Serializer\SerializerAwareInterface;
-use Symfony\Component\Serializer\SerializerAwareTrait;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * @author Eduard Bulava <bulavaeduard@gmail.com>
@@ -57,5 +56,16 @@ final class UnwrappingDenormalizer implements DenormalizerInterface, Denormalize
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return \array_key_exists(self::UNWRAP_PATH, $context) && !isset($context['unwrapped']);
+    }
+
+    public function setSerializer(SerializerInterface $serializer): void
+    {
+        trigger_deprecation('symfony/serializer', '7.1', 'The "%s()" method is deprecated, use "setDenormalizer()" instead.', __METHOD__);
+
+        if (!$serializer instanceof DenormalizerInterface) {
+            throw new LogicException(sprintf('Cannot set denormalizer because the injected serializer does not implement the "%s".', DenormalizerInterface::class));
+        }
+
+        $this->setDenormalizer($serializer);
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
@@ -58,6 +58,9 @@ final class UnwrappingDenormalizer implements DenormalizerInterface, Denormalize
         return \array_key_exists(self::UNWRAP_PATH, $context) && !isset($context['unwrapped']);
     }
 
+    /**
+     * @deprecated Since symfony/serializer 7.1: The "setSerializer()" method is deprecated, use "setDenormalizer()" instead.
+     */
     public function setSerializer(SerializerInterface $serializer): void
     {
         trigger_deprecation('symfony/serializer', '7.1', 'The "%s()" method is deprecated, use "setDenormalizer()" instead.', __METHOD__);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/UnwrappinDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/UnwrappinDenormalizerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectDummy;
@@ -23,13 +24,13 @@ use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectDummy;
 class UnwrappinDenormalizerTest extends TestCase
 {
     private UnwrappingDenormalizer $denormalizer;
-    private MockObject&Serializer $serializer;
+    private MockObject&DenormalizerInterface $baseDenormalizer;
 
     protected function setUp(): void
     {
-        $this->serializer = $this->createMock(Serializer::class);
+        $this->baseDenormalizer = $this->createMock(DenormalizerInterface::class);
         $this->denormalizer = new UnwrappingDenormalizer();
-        $this->denormalizer->setSerializer($this->serializer);
+        $this->denormalizer->setDenormalizer($this->baseDenormalizer);
     }
 
     public function testSupportsNormalization()
@@ -46,7 +47,7 @@ class UnwrappinDenormalizerTest extends TestCase
         $expected->bar = 'bar';
         $expected->setFoo('foo');
 
-        $this->serializer->expects($this->exactly(1))
+        $this->baseDenormalizer->expects($this->exactly(1))
             ->method('denormalize')
             ->with(['foo' => 'foo', 'bar' => 'bar', 'baz' => true])
             ->willReturn($expected);
@@ -65,7 +66,7 @@ class UnwrappinDenormalizerTest extends TestCase
 
     public function testDenormalizeInvalidPath()
     {
-        $this->serializer->expects($this->exactly(1))
+        $this->baseDenormalizer->expects($this->exactly(1))
             ->method('denormalize')
             ->with(null)
             ->willReturn(new ObjectDummy());

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/UnwrappinDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/UnwrappinDenormalizerTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
-use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectDummy;
 
 /**

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/polyfill-ctype": "~1.8"
+        "symfony/polyfill-ctype": "~1.8",
+        "symfony/deprecation-contracts": "^3.4@dev"
     },
     "require-dev": {
         "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/polyfill-ctype": "~1.8",
-        "symfony/deprecation-contracts": "^3.4@dev"
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `UnwrappingDenormalizer` does not depend on the `SerializerInterface`. Using the `DenormalizerInterfacce` is enough, because only `denormalize()` is called. Also, the `SerializerInterface` does not define method `denormalize()` and it currently only works, because at runtime the `serializer` service is injected, which implements the `DenormalizerInterface`.
