### PR TITLE
[Translation] Remove `@internal` from abstract testcases

### DIFF
--- a/src/Symfony/Component/Translation/Test/ProviderFactoryTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderFactoryTestCase.php
@@ -28,8 +28,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * A test case to ease testing a translation provider factory.
  *
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
- *
- * @internal
  */
 abstract class ProviderFactoryTestCase extends TestCase
 {

--- a/src/Symfony/Component/Translation/Test/ProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderTestCase.php
@@ -25,8 +25,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * A test case to ease testing a translation provider.
  *
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
- *
- * @internal
  */
 abstract class ProviderTestCase extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

The test cases are in the `Test` namespace and therefore under BC promise.
All third-party providers should benefit from it.
We do the same for Mailer and Notifier.

cc @m2mtech as this PR is inspired by your comment in the copied class 😃 in 

https://github.com/m2mtech/weblate-translation-provider/blob/fa38b3c50b5db832e993a0035f516ee0885482b1/tests/ProviderFactoryTestCase.php#L1-L5

@nicolas-grekas or do you want me to target `5.4`?