### PR TITLE
[HttpClient] Allow mocking `start_time` info in `MockResponse`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Allow mocking `start_time` info in `MockResponse`
+
 7.0
 ---
 

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -217,6 +217,9 @@ class MockResponse implements ResponseInterface, StreamableInterface
     {
         $onProgress = $options['on_progress'] ?? static function () {};
         $response->info += $mock->getInfo() ?: [];
+        if (null !== $mock->getInfo('start_time')) {
+            $response->info['start_time'] = $mock->getInfo('start_time');
+        }
 
         // simulate "size_upload" if it is set
         if (isset($response->info['size_upload'])) {

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -573,4 +573,14 @@ class MockHttpClientTest extends HttpClientTestCase
         $client->request('GET', 'https://example.com');
         $client->request('GET', 'https://example.com');
     }
+
+    public function testMockStartTimeInfo()
+    {
+        $client = new MockHttpClient(new MockResponse('foobarccc', [
+            'start_time' => 1701187598.313123,
+        ]));
+
+        $response = $client->request('GET', 'https://example.com');
+        $this->assertSame(1701187598.313123, $response->getInfo('start_time'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Let's honor the custom `start_time` passed to `MockResponse`.

My use case is that the current behavior prevents me from easily testing code using this info.