### PR TITLE
[Routing] Add redirection.io as sponsor of versions 6.4/7.0/7.1

### DIFF
--- a/src/Symfony/Component/Routing/README.md
+++ b/src/Symfony/Component/Routing/README.md
@@ -41,6 +41,17 @@ $url = $generator->generate('blog_show', [
 // $url = '/blog/my-blog-post'
 ```
 
+Sponsor
+-------
+
+The Routing component for Symfony 6.4 is [backed][1] by [redirection.io][2].
+
+redirection.io logs all your website’s HTTP traffic, and lets you fix errors
+with redirect rules in seconds. Give your marketing, SEO and IT teams the
+right tool to manage your website traffic efficiently!
+
+Help Symfony by [sponsoring][3] its development!
+
 Resources
 ---------
 
@@ -49,3 +60,7 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
+
+[1]: https://symfony.com/backers
+[2]: https://redirection.io
+[3]: https://symfony.com/sponsor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Add https://github.com/redirectionio as sponsor of the Routing component for versions 6.4, 7.0 and 7.1.
Thanks to them! :pray: 

/cc @xavierlacot @lyrixx @bastnic @Korbeil @joelwurtz et al.