### PR TITLE
Release v6.3.9

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -7,6 +7,38 @@ in 6.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.3.0...v6.3.1
 
+* 6.3.9 (2023-11-29)
+
+ * bug #52786 [Serializer] Revert allowed attributes fix (mtarld)
+ * bug #52780 [DependencyInjection] don't check parameter values if they are not set (xabbuh)
+ * bug #52762 [VarExporter] Work around php/php-src#12695 for lazy objects, fixing nullsafe-related behavior (nicolas-grekas)
+ * bug #52759 [VarExporter] Fix serializing objects that implement __sleep() and that are made lazy (nicolas-grekas)
+ * bug #52767 [Serializer] Fix normalization relying on allowed attributes only (mtarld)
+ * bug #52727 [String] Fix Inflector for 'icon' (podhy)
+ * bug #52677 [Translation] [Lokalise] Fix language format on Lokalise Provider (welcoMattic)
+ * bug #52715 [Cache] fix detecting the database server version (xabbuh)
+ * bug #52688 [Cache] Add url decoding of password in `RedisTrait` DSN (alexandre-daubois)
+ * bug #52172 [Serializer] Fix denormalizing empty string into `object|null` parameter (Jeroeny)
+ * bug #52693 [Messenger] Fix message handlers with multiple `from_transports` (valtzu)
+ * bug #52684 [PropertyInfo] Fixed promoted property type detection for `PhpStanExtractor` (LastDragon-ru)
+ * bug #52681 [Serializer] Fix support for DiscriminatorMap in PropertyNormalizer (mtarld)
+ * bug #52680 [Serializer] Fix access to private properties/getters when using the ``@Ignore`` annotation (mtarld)
+ * bug #52713 [Serializer] Fix deserialization_path missing using contructor (mtarld)
+ * bug #52683 [Serializer] Fix constructor deserialization path (mtarld)
+ * bug #52707 [HttpKernel] Fix logging deprecations to the "php" channel when channel "deprecation" is not defined (nicolas-grekas)
+ * bug #52589 [Serializer] Fix XML attributes not added on empty node (mtarld)
+ * bug #52686 [Cache] fix detecting the server version with Doctrine DBAL 4 (xabbuh)
+ * bug #52629 [Messenger] Fix support for Redis Sentinel using php-redis 6.0.0 (pepeh)
+ * bug #52459 [Cache][HttpFoundation][Lock] Fix PDO store not creating table + add tests (HypeMC)
+ * bug #52626 [Serializer] Fix denormalizing date intervals having both weeks and days (oneNevan)
+ * bug #52578 [Serializer] Fix denormalize constructor arguments (mtarld)
+ * bug #52526 Add some more non-countable English nouns (paullallier)
+ * bug #52631 [DomCrawler] Revert "bug #52579 UriResolver support path with colons" (lyrixx)
+ * bug #52618 [VarExporter] Fix handling mangled property names returned by __sleep() (nicolas-grekas)
+ * bug #52588 [Messenger] Use extension_loaded call to check if pcntl extension is loaded, as SIGTERM might be set be swoole (Sergii Dolgushev)
+ * bug #52579 [DomCrawler] UriResolver support path with colons (vdauchy)
+ * bug #52581 [Messenger] attach all required parameters to query (xabbuh)
+
 * 6.3.8 (2023-11-10)
 
  * bug #51666 [RateLimiter] CompoundLimiter was accepting requests even when some limiters already consumed all tokens (10n)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.3.9-DEV';
+    public const VERSION = '6.3.9';
     public const VERSION_ID = 60309;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 3;
     public const RELEASE_VERSION = 9;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2024';
     public const END_OF_LIFE = '01/2024';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.3.8...v6.3.9)

 * bug #52786 [Serializer] Revert allowed attributes fix (@mtarld)
 * bug #52780 [DependencyInjection] don't check parameter values if they are not set (@xabbuh)
 * bug #52762 [VarExporter] Work around php/php-src#12695 for lazy objects, fixing nullsafe-related behavior (@nicolas-grekas)
 * bug #52759 [VarExporter] Fix serializing objects that implement __sleep() and that are made lazy (@nicolas-grekas)
 * bug #52767 [Serializer] Fix normalization relying on allowed attributes only (@mtarld)
 * bug #52727 [String] Fix Inflector for 'icon' (@podhy)
 * bug #52677 [Translation] [Lokalise] Fix language format on Lokalise Provider (@welcoMattic)
 * bug #52715 [Cache] fix detecting the database server version (@xabbuh)
 * bug #52688 [Cache] Add url decoding of password in `RedisTrait` DSN (@alexandre-daubois)
 * bug #52172 [Serializer] Fix denormalizing empty string into `object|null` parameter (@Jeroeny)
 * bug #52693 [Messenger] Fix message handlers with multiple `from_transports` (@valtzu)
 * bug #52684 [PropertyInfo] Fixed promoted property type detection for `PhpStanExtractor` (@LastDragon-ru)
 * bug #52681 [Serializer] Fix support for DiscriminatorMap in PropertyNormalizer (@mtarld)
 * bug #52680 [Serializer] Fix access to private properties/getters when using the ``@Ignore`` annotation (@mtarld)
 * bug #52713 [Serializer] Fix deserialization_path missing using contructor (@mtarld)
 * bug #52683 [Serializer] Fix constructor deserialization path (@mtarld)
 * bug #52707 [HttpKernel] Fix logging deprecations to the "php" channel when channel "deprecation" is not defined (@nicolas-grekas)
 * bug #52589 [Serializer] Fix XML attributes not added on empty node (@mtarld)
 * bug #52686 [Cache] fix detecting the server version with Doctrine DBAL 4 (@xabbuh)
 * bug #52629 [Messenger] Fix support for Redis Sentinel using php-redis 6.0.0 (@pepeh)
 * bug #52459 [Cache][HttpFoundation][Lock] Fix PDO store not creating table + add tests (@HypeMC)
 * bug #52626 [Serializer] Fix denormalizing date intervals having both weeks and days (@oneNevan)
 * bug #52578 [Serializer] Fix denormalize constructor arguments (@mtarld)
 * bug #52526 Add some more non-countable English nouns (@paullallier)
 * bug #52631 [DomCrawler] Revert "bug #52579 UriResolver support path with colons" (@lyrixx)
 * bug #52618 [VarExporter] Fix handling mangled property names returned by __sleep() (@nicolas-grekas)
 * bug #52588 [Messenger] Use extension_loaded call to check if pcntl extension is loaded, as SIGTERM might be set be swoole (Sergii Dolgushev)
 * bug #52579 [DomCrawler] UriResolver support path with colons (@vdauchy)
 * bug #52581 [Messenger] attach all required parameters to query (@xabbuh)
