### PR TITLE
[Form] Fix DateTypeTest

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -169,7 +169,7 @@ class DateTypeTest extends BaseTypeTestCase
             'input' => 'timestamp',
         ]);
 
-        $form->submit('2.6.2010');
+        $form->submit('02.06.2010');
 
         $dateTime = new \DateTime('2010-06-02 UTC');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -102,7 +102,7 @@ class DateTypeTest extends BaseTypeTestCase
             'input' => 'datetime',
         ]);
 
-        $form->submit('2.6.2010');
+        $form->submit('02.06.2010');
 
         $this->assertEquals(new \DateTime('2010-06-02 UTC'), $form->getData());
         $this->assertEquals('02.06.2010', $form->getViewData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -124,7 +124,7 @@ class DateTypeTest extends BaseTypeTestCase
             'input' => 'datetime_immutable',
         ]);
 
-        $form->submit('2.6.2010');
+        $form->submit('02.06.2010');
 
         $this->assertInstanceOf(\DateTimeImmutable::class, $form->getData());
         $this->assertEquals(new \DateTimeImmutable('2010-06-02 UTC'), $form->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -147,7 +147,7 @@ class DateTypeTest extends BaseTypeTestCase
             'input' => 'string',
         ]);
 
-        $form->submit('2.6.2010');
+        $form->submit('02.06.2010');
 
         $this->assertEquals('2010-06-02', $form->getData());
         $this->assertEquals('02.06.2010', $form->getViewData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -193,7 +193,7 @@ class DateTypeTest extends BaseTypeTestCase
             'input' => 'array',
         ]);
 
-        $form->submit('2.6.2010');
+        $form->submit('02.06.2010');
 
         $output = [
             'day' => '2',


### PR DESCRIPTION
The date submitted cause an unexcpected Intl date parse error exception.

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |  None
| License       | MIT

I've fixed a test related to DateType that failed because submit an invalid format expected throwing a Intl parse exception.
