### PR TITLE
[VarExporter] Fix lazy ghost trait when using nullsafe operator

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -175,8 +175,9 @@ trait LazyGhostTrait
             if ($state && (null === $scope || isset($propertyScopes["\0$scope\0$name"]))) {
                 if (LazyObjectState::STATUS_INITIALIZED_FULL === $state->status) {
                     // Work around php/php-src#12695
-                    $property = $propertyScopes[null === $scope ? $name : "\0$scope\0$name"][3]
-                        ?? (Hydrator::$propertyScopes[$this::class] = Hydrator::getPropertyScopes($this::class))[3];
+                    $property = null === $scope ? $name : "\0$scope\0$name";
+                    $property = $propertyScopes[$property][3]
+                        ?? Hydrator::$propertyScopes[$this::class][$property][3] = new \ReflectionProperty($scope ?? $class, $name);
                 } else {
                     $property = null;
                 }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ChildMagicClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ChildMagicClass.php
@@ -18,5 +18,14 @@ class ChildMagicClass extends MagicClass implements LazyObjectInterface
 {
     use LazyGhostTrait;
 
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [
+        "\0".self::class."\0".'data' => [self::class, 'data', null],
+        "\0".self::class."\0".'lazyObjectState' => [self::class, 'lazyObjectState', null],
+        "\0".parent::class."\0".'data' => [parent::class, 'data', null],
+        'cloneCounter' => [self::class, 'cloneCounter', null],
+        'data' => [self::class, 'data', null],
+        'lazyObjectState' => [self::class, 'lazyObjectState', null],
+    ];
+
     private int $data = 123;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52793
| License       | MIT

My bad. Tests coming.

The issue happens only when using the nullsafe operator so the short-term workaround is using isset + ternary instead.