### PR TITLE
Fix legacy class palceholder definitions for static analysis

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/AnnotatedRouteControllerLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/AnnotatedRouteControllerLoader.php
@@ -19,7 +19,7 @@ if (false) {
     /**
      * @deprecated since Symfony 6.4, to be removed in 7.0, use {@link AttributeRouteControllerLoader} instead
      */
-    class AnnotatedRouteControllerLoader
+    class AnnotatedRouteControllerLoader extends AttributeRouteControllerLoader
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -25,7 +25,7 @@ if (false) {
     /**
      * @deprecated since Symfony 6.4, use FileLinkFormatter from the ErrorHandler component instead
      */
-    class FileLinkFormatter
+    class FileLinkFormatter extends ErrorHandlerFileLinkFormatter
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -21,7 +21,7 @@ if (false) {
     /**
      * @deprecated since Symfony 6.4, to be removed in 7.0, use {@link HttpFoundationUriSigner} instead
      */
-    class UriSigner
+    class UriSigner extends HttpFoundationUriSigner
     {
     }
 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -19,7 +19,7 @@ if (false) {
     /**
      * @deprecated since Symfony 6.4, to be removed in 7.0, use {@link AttributeClassLoader} instead
      */
-    class AnnotationClassLoader
+    abstract class AnnotationClassLoader extends AttributeClassLoader
     {
     }
 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -19,7 +19,7 @@ if (false) {
     /**
      * @deprecated since Symfony 6.4, to be removed in 7.0, use {@link AttributeDirectoryLoader} instead
      */
-    class AnnotationDirectoryLoader
+    class AnnotationDirectoryLoader extends AttributeDirectoryLoader
     {
     }
 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -19,7 +19,7 @@ if (false) {
     /**
      * @deprecated since Symfony 6.4, to be removed in 7.0, use {@link AttributeFileLoader} instead
      */
-    class AnnotationFileLoader
+    class AnnotationFileLoader extends AttributeFileLoader
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -19,7 +19,7 @@ if (false) {
     /**
      * @deprecated since Symfony 6.4, to be removed in 7.0, use {@link AttributeLoader} instead
      */
-    class AnnotationLoader
+    class AnnotationLoader extends AttributeLoader
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In #50392 the `UriSigner` class was moved from HttpKernel to HttpFoundation. The empty definition `class UriSigner {}` causes many issues with static analysis tools like PHPStan.

As this code is wrapped in an `if (false)` changing it to `class UriSigner extends HttpFoundationUriSigner` should not cause any behavior change while fixing most static analysis issues.