### PR TITLE
[Routing] Fix conflicting FQCN aliases with route name

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -144,7 +144,9 @@ abstract class AttributeClassLoader implements LoaderInterface
 
                 if (1 === $collection->count() - \count($routeNamesBefore)) {
                     $newRouteName = current(array_diff(array_keys($collection->all()), $routeNamesBefore));
-                    $collection->addAlias(sprintf('%s::%s', $class->name, $method->name), $newRouteName);
+                    if ($newRouteName !== $aliasName = sprintf('%s::%s', $class->name, $method->name)) {
+                        $collection->addAlias($aliasName, $newRouteName);
+                    }
                 }
             }
             if (0 === $collection->count() && $class->hasMethod('__invoke')) {
@@ -155,8 +157,14 @@ abstract class AttributeClassLoader implements LoaderInterface
                 }
             }
             if ($fqcnAlias && 1 === $collection->count()) {
-                $collection->addAlias($class->name, $invokeRouteName = key($collection->all()));
-                $collection->addAlias(sprintf('%s::__invoke', $class->name), $invokeRouteName);
+                $invokeRouteName = key($collection->all());
+                if ($invokeRouteName !== $class->name) {
+                    $collection->addAlias($class->name, $invokeRouteName);
+                }
+
+                if ($invokeRouteName !== $aliasName = sprintf('%s::__invoke', $class->name)) {
+                    $collection->addAlias($aliasName, $invokeRouteName);
+                }
             }
 
             if ($this->hasDeprecatedAnnotations) {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableFQCNAliasConflictController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableFQCNAliasConflictController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * @Route("/foobarccc", name="Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\InvokableFQCNAliasConflictController")
+ */
+class InvokableFQCNAliasConflictController
+{
+    public function __invoke()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/InvokableFQCNAliasConflictController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/InvokableFQCNAliasConflictController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(path: '/foobarccc', name: self::class)]
+class InvokableFQCNAliasConflictController
+{
+    public function __invoke()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTestCase.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTestCase.php
@@ -86,6 +86,15 @@ abstract class AttributeClassLoaderTestCase extends TestCase
         $this->assertEquals(new Alias('lol'), $routes->getAlias($this->getNamespace().'\InvokableController::__invoke'));
     }
 
+    public function testInvokableFQCNAliasConflictController()
+    {
+        $routes = $this->loader->load($this->getNamespace().'\InvokableFQCNAliasConflictController');
+        $this->assertCount(1, $routes);
+        $this->assertEquals('/foobarccc', $routes->get($this->getNamespace().'\InvokableFQCNAliasConflictController')->getPath());
+        $this->assertNull($routes->getAlias($this->getNamespace().'\InvokableFQCNAliasConflictController'));
+        $this->assertEquals(new Alias($this->getNamespace().'\InvokableFQCNAliasConflictController'), $routes->getAlias($this->getNamespace().'\InvokableFQCNAliasConflictController::__invoke'));
+    }
+
     public function testInvokableMethodControllerLoader()
     {
         $routes = $this->loader->load($this->getNamespace().'\InvokableMethodController');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/52801
| License       | MIT

When the route name === the FQCN alias we want to add, `addAlias()` throws. In this case, we can safely ignore the exception and move on.