### PR TITLE
[Routing] Fix removing aliases pointing to removed route in `RouteCollection::remove()`

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -157,8 +157,15 @@ class RouteCollection implements \IteratorAggregate, \Countable
      */
     public function remove($name)
     {
-        foreach ((array) $name as $n) {
-            unset($this->routes[$n], $this->priorities[$n], $this->aliases[$n]);
+        $names = (array) $name;
+        foreach ($names as $n) {
+            unset($this->routes[$n], $this->priorities[$n]);
+        }
+
+        foreach ($this->aliases as $k => $alias) {
+            if (\in_array($alias->getId(), $names, true)) {
+                unset($this->aliases[$k]);
+            }
         }
     }
 

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -225,11 +225,13 @@ class RouteCollectionTest extends TestCase
         $collection1->add('bar', $bar = new Route('/bar'));
         $collection->addCollection($collection1);
         $collection->add('last', $last = new Route('/last'));
+        $collection->addAlias('ccc_my_custom_alias', 'foo');
 
         $collection->remove('foo');
         $this->assertSame(['bar' => $bar, 'last' => $last], $collection->all(), '->remove() can remove a single route');
         $collection->remove(['bar', 'last']);
         $this->assertSame([], $collection->all(), '->remove() accepts an array and can remove multiple routes at once');
+        $this->assertNull($collection->getAlias('ccc_my_custom_alias'));
     }
 
     public function testSetHost()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | 
| Issues        | https://github.com/symfony/symfony/issues/52802
| License       | MIT

When a route is removed from the collection, we want to remove all aliases pointing to it. The implementation is flawed because the `$aliases` array is indexed by the alias name, and not by the route since several aliases can point to the same route.

It'll fix the related issue because added FQCN aliases will be correctly removed when  `PrefixTrait::addPrefix()` removes the route before reading it for each locale.