### PR TITLE
[Messenger] Avoid reconnecting an already-connected Redis instance.

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -166,9 +166,11 @@ class Connection
      */
     private static function initializeRedis(\Redis|Relay $redis, string $host, int $port, string|array|null $auth, array $params): \Redis|Relay
     {
-        $connect = isset($params['persistent_id']) ? 'pconnect' : 'connect';
-        $redis->{$connect}($host, $port, $params['timeout'], $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...(\defined('Redis::SCAN_PREFIX') || \extension_loaded('relay')) ? [['stream' => $params['ssl'] ?? null]] : []);
-
+        if (!$redis->isConnected()) {
+            $connect = isset($params['persistent_id']) ? 'pconnect' : 'connect';
+            $redis->{$connect}($host, $port, $params['timeout'], $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...(\defined('Redis::SCAN_PREFIX') || \extension_loaded('relay')) ? [['stream' => $params['ssl'] ?? null]] : []);
+        }
+        
         $redis->setOption($redis instanceof \Redis ? \Redis::OPT_SERIALIZER : Relay::OPT_SERIALIZER, $params['serializer']);
 
         if (null !== $auth && !$redis->auth($auth)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes?
| New feature?  | yes?
| Deprecations? | no
| Issues        | Fix #45057
| License       | MIT

With the Messenger component's internal Redis `Connection` class, if you pass it a `\Redis` or `\Relay` instance that's already connected, it will still try to reconnect that instance using the host/port/etc. that's passed to the connection object's "options" array in the constructor.

Not only does this cause problems when the Redis instance is already connected, but it also prevents you from, say, using socket connections instead (as the only connection method supported by the class itself is IP-based connections) and just passing in a ready-to-go Redis instance.

While I personally use this class heavily in my own applications, I'm not aware of every possible implication of making a change like this, i.e. if there are other parts of the application that are counting on this working as-is (even though I can't imagine that unnecessarily reconnecting is a desired feature in this case). While it's intended to fix a bug in my specific use-case, I'd consider it also arguably "new" functionality that the class can now handle pre-connected instances being passed to it.

Basically, I'm new to contributing to Symfony so I'm a little shaky on my legs here, but the reported issue above mentioned needing a PR, and we're running into the issue ourselves, so here's the PR!