### PR TITLE
[Workflow] Add `getEnabledTransition()` to TraceableWorkflow

### DIFF
--- a/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
+++ b/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
@@ -16,6 +16,7 @@ use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
+use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\TransitionBlockerList;
 use Symfony\Component\Workflow\WorkflowInterface;
 
@@ -53,6 +54,11 @@ class TraceableWorkflow implements WorkflowInterface
     }
 
     public function getEnabledTransitions(object $subject): array
+    {
+        return $this->callInner(__FUNCTION__, \func_get_args());
+    }
+
+    public function getEnabledTransition(object $subject, string $name): ?Transition
     {
         return $this->callInner(__FUNCTION__, \func_get_args());
     }

--- a/src/Symfony/Component/Workflow/Tests/Debug/TraceableWorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Debug/TraceableWorkflowTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Tests\Debug;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\Workflow\Debug\TraceableWorkflow;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\TransitionBlockerList;
+use Symfony\Component\Workflow\Workflow;
+
+class TraceableWorkflowTest extends TestCase
+{
+    private MockObject|Workflow $innerWorkflow;
+
+    private StopWatch $stopwatch;
+
+    private TraceableWorkflow $traceableWorkflow;
+
+    protected function setUp(): void
+    {
+        $this->innerWorkflow = $this->createMock(Workflow::class);
+        $this->stopwatch = new Stopwatch();
+
+        $this->traceableWorkflow = new TraceableWorkflow(
+            $this->innerWorkflow,
+            $this->stopwatch
+        );
+    }
+
+    /**
+     * @dataProvider provideFunctionNames
+     */
+    public function testCallsInner(string $function, array $args, mixed $returnValue)
+    {
+        $this->innerWorkflow->expects($this->once())
+            ->method($function)
+            ->willReturn($returnValue);
+
+        $this->assertSame($returnValue, $this->traceableWorkflow->{$function}(...$args));
+
+        $calls = $this->traceableWorkflow->getCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertSame($function, $calls[0]['method']);
+        $this->assertArrayHasKey('duration', $calls[0]);
+        $this->assertSame($returnValue, $calls[0]['return']);
+    }
+
+    public function testCallsInnerCatchesException()
+    {
+        $exception = new \Exception('foo');
+        $this->innerWorkflow->expects($this->once())
+            ->method('can')
+            ->willThrowException($exception);
+
+        try {
+            $this->traceableWorkflow->can(new \stdClass(), 'foo');
+
+            $this->fail('An exception should have been thrown.');
+        } catch (\Exception $e) {
+            $this->assertSame($exception, $e);
+
+            $calls = $this->traceableWorkflow->getCalls();
+
+            $this->assertCount(1, $calls);
+            $this->assertSame('can', $calls[0]['method']);
+            $this->assertArrayHasKey('duration', $calls[0]);
+            $this->assertArrayHasKey('exception', $calls[0]);
+            $this->assertSame($exception, $calls[0]['exception']);
+        }
+    }
+
+    public static function provideFunctionNames(): \Generator
+    {
+        $subject = new \stdClass();
+
+        yield ['getMarking', [$subject], new Marking(['place' => 1])];
+
+        yield ['can', [$subject, 'foo'], true];
+
+        yield ['buildTransitionBlockerList', [$subject, 'foo'], new TransitionBlockerList()];
+
+        yield ['apply', [$subject, 'foo'], new Marking(['place' => 1])];
+
+        yield ['getEnabledTransitions', [$subject], []];
+
+        yield ['getEnabledTransition', [$subject, 'foo'], null];
+    }
+}

--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -31,6 +31,7 @@
         "symfony/expression-language": "^5.4|^6.0|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/security-core": "^5.4|^6.0|^7.0",
+        "symfony/stopwatch": "^5.4|^6.0|^7.0",
         "symfony/validator": "^5.4|^6.0|^7.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52812
| License       | MIT

I added an annotation to `WorkflowInterface` to not break BC. I think it could deserve an additional `not implementing this method is deprecated since Symfony 7.1` while upmerging (I guess ?).

Added the tests while at it.