### PR TITLE
[Serializer] Do not instantiate object if it is not instantiable

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -458,6 +458,15 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
         unset($context['has_constructor']);
 
+        if (!$reflectionClass->isInstantiable()) {
+            throw NotNormalizableValueException::createForUnexpectedDataType(
+                sprintf('Failed to create object because the class "%s" is not instantiable.', $class),
+                $data,
+                ['unknown'],
+                $context['deserialization_path'] ?? null,
+            );
+        }
+
         return new $class();
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
@@ -32,6 +33,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\NullableConstructorArgumentDummy
 use Symfony\Component\Serializer\Tests\Fixtures\NullableOptionalConstructorArgumentDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorNormalizer;
+use Symfony\Component\Serializer\Tests\Fixtures\UnitEnumDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\VariadicConstructorTypedArgsDummy;
 
 /**
@@ -278,5 +280,17 @@ class AbstractNormalizerTest extends TestCase
         $normalizer = new PropertyNormalizer($this->classMetadata);
 
         $this->assertSame([], $normalizer->normalize($dummy));
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testDenormalizeWhenObjectNotInstantiable()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+
+        $normalizer = new ObjectNormalizer();
+
+        $normalizer->denormalize('{}', UnitEnumDummy::class);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

If you pass an object that can't be instantiable such as enum to deserialize then you get the following
error `Error: Cannot instantiate enum` as the object is tried to be created without checking if it's instantiable
