### PR TITLE
[AssetMapper] Upgrade asset mapper to 6.4 fails due to invalid entries "downloaded_to" and "preload"

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -41,7 +41,7 @@ class ImportMapConfigReader
 
         $entries = new ImportMapEntries();
         foreach ($importMapConfig ?? [] as $importName => $data) {
-            $validKeys = ['path', 'version', 'type', 'entrypoint', 'url', 'package_specifier'];
+            $validKeys = ['path', 'version', 'type', 'entrypoint', 'url', 'package_specifier', 'downloaded_to', 'preload'];
             if ($invalidKeys = array_diff(array_keys($data), $validKeys)) {
                 throw new \InvalidArgumentException(sprintf('The following keys are not valid for the importmap entry "%s": "%s". Valid keys are: "%s".', $importName, implode('", "', $invalidKeys), implode('", "', $validKeys)));
             }
@@ -49,6 +49,20 @@ class ImportMapConfigReader
             // should solve itself when the config is written again
             if (isset($data['url'])) {
                 trigger_deprecation('symfony/asset-mapper', '6.4', 'The "url" option is deprecated, use "version" instead.');
+            }
+
+            // should solve itself when the config is written again
+            if (isset($data['downloaded_to'])) {
+                trigger_deprecation('symfony/asset-mapper', '6.4', 'The "downloaded_to" option is deprecated and will be removed.');
+                // remove deprecated downloaded_to
+                unset($data['downloaded_to']);
+            }
+
+            // should solve itself when the config is written again
+            if (isset($data['preload'])) {
+                trigger_deprecation('symfony/asset-mapper', '6.4', 'The "preload" option is deprecated, preloading is automatically done.');
+                // remove deprecated preload
+                unset($data['preload']);
             }
 
             $type = isset($data['type']) ? ImportMapType::tryFrom($data['type']) : ImportMapType::JS;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes and no, entries were deprecated, but upgrade did not handle these
| Issues        | Fix #52810
| License       | MIT

Fixes errors that arise from deprecated entries "downloaded_to" and "preload" after upgrade to Symfony 6.4.
Deprecated parameters are ignored and removed whenever importmap.php is rewritten during importmap:update for example.
Tested with my personal symfony project, and resolved the issue #52810 

