### PR TITLE
[Routing] Revert " Fix removing aliases pointing to removed route in RouteCollection::remove()"

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -157,15 +157,8 @@ class RouteCollection implements \IteratorAggregate, \Countable
      */
     public function remove($name)
     {
-        $names = (array) $name;
-        foreach ($names as $n) {
-            unset($this->routes[$n], $this->priorities[$n]);
-        }
-
-        foreach ($this->aliases as $k => $alias) {
-            if (\in_array($alias->getId(), $names, true)) {
-                unset($this->aliases[$k]);
-            }
+        foreach ((array) $name as $n) {
+            unset($this->routes[$n], $this->priorities[$n], $this->aliases[$n]);
         }
     }
 

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -225,13 +225,11 @@ class RouteCollectionTest extends TestCase
         $collection1->add('bar', $bar = new Route('/bar'));
         $collection->addCollection($collection1);
         $collection->add('last', $last = new Route('/last'));
-        $collection->addAlias('ccc_my_custom_alias', 'foo');
 
         $collection->remove('foo');
         $this->assertSame(['bar' => $bar, 'last' => $last], $collection->all(), '->remove() can remove a single route');
         $collection->remove(['bar', 'last']);
         $this->assertSame([], $collection->all(), '->remove() accepts an array and can remove multiple routes at once');
-        $this->assertNull($collection->getAlias('ccc_my_custom_alias'));
     }
 
     public function testSetHost()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/pull/52806#issuecomment-1832397866
| License       | MIT

We need to find another solution that doesn't change the behavior on 5.4 :confused: