### PR TITLE
[Security][SecurityBundle] Add `LogoutUrlGeneratorInterface` and autowiring alias

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/LogoutUrlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/LogoutUrlExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Extension;
 
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
+use Symfony\Component\Security\Http\Logout\LogoutUrlGeneratorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -22,9 +23,9 @@ use Twig\TwigFunction;
  */
 final class LogoutUrlExtension extends AbstractExtension
 {
-    private LogoutUrlGenerator $generator;
+    private LogoutUrlGenerator|LogoutUrlGeneratorInterface $generator;
 
-    public function __construct(LogoutUrlGenerator $generator)
+    public function __construct(LogoutUrlGenerator|LogoutUrlGeneratorInterface $generator)
     {
         $this->generator = $generator;
     }

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `Symfony\Component\Security\Http\Logout\LogoutUrlGeneratorInterface` as autowiring alias for `security.logout_url_generator`
+
 7.0
 ---
 

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -26,6 +26,7 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 use Symfony\Component\Security\Http\FirewallMapInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
+use Symfony\Component\Security\Http\Logout\LogoutUrlGeneratorInterface;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Cloner\Data;
 
@@ -38,13 +39,13 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 {
     private ?TokenStorageInterface $tokenStorage;
     private ?RoleHierarchyInterface $roleHierarchy;
-    private ?LogoutUrlGenerator $logoutUrlGenerator;
+    private LogoutUrlGenerator|LogoutUrlGeneratorInterface|null $logoutUrlGenerator;
     private ?AccessDecisionManagerInterface $accessDecisionManager;
     private ?FirewallMapInterface $firewallMap;
     private ?TraceableFirewallListener $firewall;
     private bool $hasVarDumper;
 
-    public function __construct(TokenStorageInterface $tokenStorage = null, RoleHierarchyInterface $roleHierarchy = null, LogoutUrlGenerator $logoutUrlGenerator = null, AccessDecisionManagerInterface $accessDecisionManager = null, FirewallMapInterface $firewallMap = null, TraceableFirewallListener $firewall = null)
+    public function __construct(TokenStorageInterface $tokenStorage = null, RoleHierarchyInterface $roleHierarchy = null, LogoutUrlGenerator|LogoutUrlGeneratorInterface $logoutUrlGenerator = null, AccessDecisionManagerInterface $accessDecisionManager = null, FirewallMapInterface $firewallMap = null, TraceableFirewallListener $firewall = null)
     {
         $this->tokenStorage = $tokenStorage;
         $this->roleHierarchy = $roleHierarchy;

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -50,6 +50,7 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Impersonate\ImpersonateUrlGenerator;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
+use Symfony\Component\Security\Http\Logout\LogoutUrlGeneratorInterface;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 
@@ -226,6 +227,7 @@ return static function (ContainerConfigurator $container) {
                 service('router')->nullOnInvalid(),
                 service('security.token_storage')->nullOnInvalid(),
             ])
+        ->alias(LogoutUrlGeneratorInterface::class, 'security.logout_url_generator')
 
         ->set('security.route_loader.logout', LogoutRouteLoader::class)
             ->args([

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `LogoutUrlGeneratorInterface` to generate logout URLs and Paths
+
 7.0
 ---
 

--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jeremy Mikola <jmikola@gmail.com>
  */
-class LogoutUrlGenerator
+class LogoutUrlGenerator implements LogoutUrlGeneratorInterface
 {
     private ?RequestStack $requestStack;
     private ?UrlGeneratorInterface $router;

--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGeneratorInterface.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGeneratorInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Logout;
+
+/**
+ * Generate the absolute logout path and URL for a firewall.
+ */
+interface LogoutUrlGeneratorInterface
+{
+    /**
+     * Generates the absolute logout path for the firewall.
+     *
+     * @param string|null $key The firewall name (null to generate a path for the current firewall)
+     */
+    public function getLogoutPath(string $key = null): string;
+
+    /**
+     * Generates the absolute logout URL for the firewall.
+     *
+     * @param string|null $key The firewall name (null to generate a URL for the current firewall)
+     */
+    public function getLogoutUrl(string $key = null): string;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | https://github.com/symfony/demo/pull/1461#discussion_r1410550115
| License       | MIT

The `LogoutUrlGenerator` is useful to be used in a controller as seen in the demo: https://github.com/symfony/demo/blob/72040e73b3deed4281706bb5dda1ff1321f00396/src/Controller/UserController.php#L65
I'm not sure about our strategy for autowiring bundle-provided services. In this case, this service can't be redefined with a different class as it doesn't implement any interface.