### PR TITLE
[Routing] Restore aliases removal in `RouteCollection::remove()`

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -157,13 +157,21 @@ class RouteCollection implements \IteratorAggregate, \Countable
      */
     public function remove($name)
     {
-        $names = (array) $name;
-        foreach ($names as $n) {
-            unset($this->routes[$n], $this->priorities[$n]);
+        $routes = [];
+        foreach ((array) $name as $n) {
+            if (isset($this->routes[$n])) {
+                $routes[] = $n;
+            }
+
+            unset($this->routes[$n], $this->priorities[$n], $this->aliases[$n]);
+        }
+
+        if (!$routes) {
+            return;
         }
 
         foreach ($this->aliases as $k => $alias) {
-            if (\in_array($alias->getId(), $names, true)) {
+            if (\in_array($alias->getId(), $routes, true)) {
                 unset($this->aliases[$k]);
             }
         }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -219,19 +219,22 @@ class RouteCollectionTest extends TestCase
     public function testRemove()
     {
         $collection = new RouteCollection();
-        $collection->add('foo', $foo = new Route('/foo'));
+        $collection->add('foo', new Route('/foo'));
 
         $collection1 = new RouteCollection();
         $collection1->add('bar', $bar = new Route('/bar'));
         $collection->addCollection($collection1);
         $collection->add('last', $last = new Route('/last'));
-        $collection->addAlias('ccc_my_custom_alias', 'foo');
+        $collection->addAlias('alias_removed_when_removing_route_foo', 'foo');
+        $collection->addAlias('alias_directly_removed', 'bar');
 
         $collection->remove('foo');
         $this->assertSame(['bar' => $bar, 'last' => $last], $collection->all(), '->remove() can remove a single route');
+        $collection->remove('alias_directly_removed');
+        $this->assertNull($collection->getAlias('alias_directly_removed'));
         $collection->remove(['bar', 'last']);
         $this->assertSame([], $collection->all(), '->remove() accepts an array and can remove multiple routes at once');
-        $this->assertNull($collection->getAlias('ccc_my_custom_alias'));
+        $this->assertNull($collection->getAlias('alias_removed_when_removing_route_foo'));
     }
 
     public function testSetHost()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/pull/52806#issuecomment-1832397866
| License       | MIT

As suggested in https://github.com/symfony/symfony/pull/52831#discussion_r1410982751

It's still a small behavior change on 5.4, let's see what people think :smiley: 