### PR TITLE
[Serializer] Denormalize support for `stdClass`

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -139,6 +139,12 @@ class ObjectNormalizer extends AbstractObjectNormalizer
      */
     protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = [])
     {
+        if (\stdClass::class === $object::class) {
+            $object->{$attribute} = $value;
+
+            return;
+        }
+
         try {
             $this->propertyAccessor->setValue($object, $attribute, $value);
         } catch (NoSuchPropertyException) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -265,6 +265,22 @@ class ObjectNormalizerTest extends TestCase
         $this->assertEquals('bar', $obj->bar);
     }
 
+    public function testConstructorWithObjectDenormalizeForStdClass()
+    {
+        $data = [
+            'foo' => ['bar' => 'baz'],
+            'oof' => 'rab',
+        ];
+
+        $obj = $this->normalizer->denormalize($data, \stdClass::class, 'any');
+
+        $expected = new \stdClass();
+        $expected->foo = ['bar' => 'baz'];
+        $expected->oof = 'rab';
+
+        self::assertEquals($expected, $obj);
+    }
+
     public function testConstructorWithObjectTypeHintDenormalize()
     {
         $data = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Add support for denormalizing stdClass objects in Symfony serializer
