### PR TITLE
Release v6.3.10

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -7,6 +7,16 @@ in 6.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.3.0...v6.3.1
 
+* 6.3.10 (2023-12-01)
+
+ * bug #52804 [Serializer] Fix support of plain object types denormalization (andersonamuller)
+ * bug #52845 [Routing] Restore aliases removal in RouteCollection::remove() (fancyweb)
+ * bug #52846 [PhpUnitBridge]  run composer update for compatibility with PHPUnit versions shipping composer.lock (xabbuh)
+ * bug #52823 add parameter types in query builder (javiercno)
+ * bug #52808 [DependencyInjection] Fix dumping containers with null-referenced services (nicolas-grekas)
+ * bug #52797 [VarExporter] Fix lazy ghost trait when using nullsafe operator (nicolas-grekas)
+ * bug #52806 [Routing] Fix removing aliases pointing to removed route in `RouteCollection::remove()` (fancyweb)
+
 * 6.3.9 (2023-11-29)
 
  * bug #52786 [Serializer] Revert allowed attributes fix (mtarld)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.3.10-DEV';
+    public const VERSION = '6.3.10';
     public const VERSION_ID = 60310;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 3;
     public const RELEASE_VERSION = 10;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2024';
     public const END_OF_LIFE = '01/2024';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.3.9...v6.3.10)

 * bug #52804 [Serializer] Fix support of plain object types denormalization (@andersonamuller)
 * bug #52845 [Routing] Restore aliases removal in RouteCollection::remove() (@fancyweb)
 * bug #52846 [PhpUnitBridge]  run composer update for compatibility with PHPUnit versions shipping composer.lock (@xabbuh)
 * bug #52823 add parameter types in query builder (@javiercno)
 * bug #52808 [DependencyInjection] Fix dumping containers with null-referenced services (@nicolas-grekas)
 * bug #52797 [VarExporter] Fix lazy ghost trait when using nullsafe operator (@nicolas-grekas)
 * bug #52806 [Routing] Fix removing aliases pointing to removed route in `RouteCollection::remove()` (@fancyweb)
