### PR TITLE
Release v7.0.1

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -7,6 +7,21 @@ in 7.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.0.0...v7.0.1
 
+* 7.0.1 (2023-12-01)
+
+ * bug #52814 [Workflow] Add `getEnabledTransition()` to TraceableWorkflow (alexandre-daubois)
+ * bug #52852 [Serializer] Fix TranslatableNormalizer when the Translator is disabled (Jean-Beru)
+ * bug #52836 [DependencyInjection] Fix parsing named autowiring aliases that contain underscores (nicolas-grekas)
+ * bug #52804 [Serializer] Fix support of plain object types denormalization (andersonamuller)
+ * bug #52845 [Routing] Restore aliases removal in RouteCollection::remove() (fancyweb)
+ * bug #52846 [PhpUnitBridge]  run composer update for compatibility with PHPUnit versions shipping composer.lock (xabbuh)
+ * bug #52823 add parameter types in query builder (javiercno)
+ * bug #52825 [AssetMapper] Upgrade asset mapper to 6.4 fails due to invalid entries "downloaded_to" and "preload" (redflo)
+ * bug #52808 [DependencyInjection] Fix dumping containers with null-referenced services (nicolas-grekas)
+ * bug #52797 [VarExporter] Fix lazy ghost trait when using nullsafe operator (nicolas-grekas)
+ * bug #52806 [Routing] Fix removing aliases pointing to removed route in `RouteCollection::remove()` (fancyweb)
+ * bug #52805 [Routing] Fix conflicting FQCN aliases with route name (fancyweb)
+
 * 7.0.0 (2023-11-29)
 
  * bug #52786 [Serializer] Revert allowed attributes fix (mtarld)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.0.1-DEV';
+    public const VERSION = '7.0.1';
     public const VERSION_ID = 70001;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 1;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2024';
     public const END_OF_LIFE = '07/2024';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.0.0...v7.0.1)

 * bug #52814 [Workflow] Add `getEnabledTransition()` to TraceableWorkflow (@alexandre-daubois)
 * bug #52852 [Serializer] Fix TranslatableNormalizer when the Translator is disabled (@Jean-Beru)
 * bug #52836 [DependencyInjection] Fix parsing named autowiring aliases that contain underscores (@nicolas-grekas)
 * bug #52804 [Serializer] Fix support of plain object types denormalization (@andersonamuller)
 * bug #52845 [Routing] Restore aliases removal in RouteCollection::remove() (@fancyweb)
 * bug #52846 [PhpUnitBridge]  run composer update for compatibility with PHPUnit versions shipping composer.lock (@xabbuh)
 * bug #52823 add parameter types in query builder (@javiercno)
 * bug #52825 [AssetMapper] Upgrade asset mapper to 6.4 fails due to invalid entries "downloaded_to" and "preload" (@redflo)
 * bug #52808 [DependencyInjection] Fix dumping containers with null-referenced services (@nicolas-grekas)
 * bug #52797 [VarExporter] Fix lazy ghost trait when using nullsafe operator (@nicolas-grekas)
 * bug #52806 [Routing] Fix removing aliases pointing to removed route in `RouteCollection::remove()` (@fancyweb)
 * bug #52805 [Routing] Fix conflicting FQCN aliases with route name (@fancyweb)
