### PR TITLE
[Form] Adding `@var` PHPDoc to silence psalm

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -30,6 +30,7 @@ use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\Event\PreSubmitEvent;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper;
 use Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper;
@@ -101,6 +102,7 @@ class ChoiceType extends AbstractType
             // Make sure that scalar, submitted values are converted to arrays
             // which can be submitted to the checkboxes/radio buttons
             $builder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) use ($choiceList, $options, &$unknownValues) {
+                /** @var PreSubmitEvent $event */
                 $form = $event->getForm();
                 $data = $event->getData();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes (kind of)
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52829
| License       | MIT

The goal is to add some PHPDoc to silence the psalm warnings mentioned in the linked issue, without changing the actual type hint (would be a BC break).

I found three ways to achieve this:
* Adding `@var` to the variable *in the next line*. That's what I'm doing in this PR. The idea is taken from https://stackoverflow.com/a/46842721/1668200 . It looks weird, but it's only a small change...
* Adding `@param` above the anonymous function. Would require to move it to a new line and subsequently indent the following ~50 lines:
    ```php
    $builder->addEventListener(FormEvents::PRE_SUBMIT,
        /** @param PreSubmitEvent $event */
        static function (FormEvent $event) use ($choiceList, $options, &$unknownValues) {
            // ...
        }
    );
    ```
* Refactoring by extracting the anonymous callback function to a dedicated method.

Waiting for feedback here, then I'll do the same in [`TimeType`](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php#L64) and [`FileType`](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Form/Extension/Core/Type/FileType.php#L50)