### PR TITLE
[HttpClient][Mailer][Process] always pass microseconds to usleep as integers

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncContext.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncContext.php
@@ -92,7 +92,7 @@ final class AsyncContext
         if (\is_callable($pause = $this->response->getInfo('pause_handler'))) {
             $pause($duration);
         } elseif (0 < $duration) {
-            usleep(1E6 * $duration);
+            usleep((int) (1E6 * $duration));
         }
     }
 

--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -303,7 +303,7 @@ trait TransportResponseTrait
             }
 
             if (-1 === self::select($multi, min($timeoutMin, $timeoutMax - $elapsedTimeout))) {
-                usleep(min(500, 1E6 * $timeoutMin));
+                usleep((int) min(500, 1E6 * $timeoutMin));
             }
 
             $elapsedTimeout = microtime(true) - $lastActivity;

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -104,7 +104,7 @@ abstract class AbstractTransport implements TransportInterface
         $sleep = (1 / $this->rate) - (microtime(true) - $this->lastSent);
         if (0 < $sleep) {
             $this->logger->debug(sprintf('Email transport "%s" sleeps for %.2f seconds', __CLASS__, $sleep));
-            usleep($sleep * 1000000);
+            usleep((int) ($sleep * 1000000));
         }
         $this->lastSent = microtime(true);
     }

--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -149,7 +149,7 @@ class WindowsPipes extends AbstractPipes
             if ($w) {
                 @stream_select($r, $w, $e, 0, Process::TIMEOUT_PRECISION * 1E6);
             } elseif ($this->fileHandles) {
-                usleep(Process::TIMEOUT_PRECISION * 1E6);
+                usleep((int) (Process::TIMEOUT_PRECISION * 1E6));
             }
         }
         foreach ($this->fileHandles as $type => $fileHandle) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52856
| License       | MIT