### PR TITLE
[Validator] Only trigger deprecation when Validator annotations are used

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -118,13 +118,13 @@ class AnnotationLoader implements LoaderInterface
         $annotations = [];
 
         if ($reflection instanceof \ReflectionClass && $annotations = $this->reader->getClassAnnotations($reflection)) {
-            trigger_deprecation('symfony/validator', '6.4', 'Class "%s" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.', $reflection->getName());
+            $this->triggerDeprecationIfAnnotationIsUsed($annotations, sprintf('Class "%s"', $reflection->getName()));
         }
         if ($reflection instanceof \ReflectionMethod && $annotations = $this->reader->getMethodAnnotations($reflection)) {
-            trigger_deprecation('symfony/validator', '6.4', 'Method "%s::%s()" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.', $reflection->getDeclaringClass()->getName(), $reflection->getName());
+            $this->triggerDeprecationIfAnnotationIsUsed($annotations, sprintf('Method "%s::%s()"', $reflection->getDeclaringClass()->getName(), $reflection->getName()));
         }
         if ($reflection instanceof \ReflectionProperty && $annotations = $this->reader->getPropertyAnnotations($reflection)) {
-            trigger_deprecation('symfony/validator', '6.4', 'Property "%s::$%s" uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.', $reflection->getDeclaringClass()->getName(), $reflection->getName());
+            $this->triggerDeprecationIfAnnotationIsUsed($annotations, sprintf('Property "%s::$%s"', $reflection->getDeclaringClass()->getName(), $reflection->getName()));
         }
 
         foreach ($dedup as $annotation) {
@@ -139,6 +139,20 @@ class AnnotationLoader implements LoaderInterface
             }
             if (!\in_array($annotation, $dedup, false)) {
                 yield $annotation;
+            }
+        }
+    }
+
+    private function triggerDeprecationIfAnnotationIsUsed(array $annotations, string $messagePrefix): void
+    {
+        foreach ($annotations as $annotation) {
+            if (
+                $annotation instanceof Constraint
+                || $annotation instanceof GroupSequence
+                || $annotation instanceof GroupSequenceProvider
+            ) {
+                trigger_deprecation('symfony/validator', '6.4', sprintf('%s uses Doctrine Annotations to configure validation constraints, which is deprecated. Use PHP attributes instead.', $messagePrefix));
+                break;
             }
         }
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderWithHybridAnnotationsTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderWithHybridAnnotationsTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Validator\Tests\Mapping\Loader;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 
 /**
@@ -46,6 +48,14 @@ class AnnotationLoaderWithHybridAnnotationsTest extends AttributeLoaderTest
         parent::testLoadClassMetadataAndMerge();
     }
 
+    public function testLoadClassMetadataWithOtherAnnotations()
+    {
+        $loader = $this->createAnnotationLoader();
+        $metadata = new ClassMetadata(EntityWithOtherAnnotations::class);
+
+        $this->assertTrue($loader->loadClassMetadata($metadata));
+    }
+
     protected function createAnnotationLoader(): AnnotationLoader
     {
         return new AnnotationLoader(new AnnotationReader());
@@ -55,4 +65,21 @@ class AnnotationLoaderWithHybridAnnotationsTest extends AttributeLoaderTest
     {
         return 'Symfony\Component\Validator\Tests\Fixtures\Attribute';
     }
+}
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ */
+class SomeAnnotation
+{
+}
+
+class EntityWithOtherAnnotations
+{
+    /**
+     * @SomeAnnotation
+     */
+    #[NotBlank]
+    public ?string $name = null;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52828
| License       | MIT

The deprecations are now triggered only if one of the annotations is from the validator component.