### PR TITLE
[SecurityBundle] Fix redeclaration of `InternalSecurity` class when opcache preload is active

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -30,6 +30,9 @@ use Symfony\Component\Security\Http\ParameterBagUtils;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
+if (class_exists(InternalSecurity::class, false)) {
+    return;
+}
 if (class_exists(LegacySecurity::class)) {
     class_alias(LegacySecurity::class, InternalSecurity::class);
 } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | 
| License       | MIT

When opcache.preload is active the `InternalSecurity` gets aliased twice.

I have security voter in project that injects `Symfony\Bundle\SecurityBundle\Security` and the `opcache.preload` php config is set.


Stack trace:
```
ErrorException:
Warning: Cannot declare class Symfony\Bundle\SecurityBundle\InternalSecurity, because the name is already in use

  at vendor/symfony/security-bundle/Security.php:34
  at include_once('/var/www/vendor/symfony/security-bundle/Security.php')
     (var/cache/dev/ContainerSgUiPaP/App_KernelDevDebugContainer.php:6191)
  at ContainerSgUiPaP\App_KernelDevDebugContainer::getSecurity_HelperService(object(App_KernelDevDebugContainer))
     (var/cache/dev/ContainerSgUiPaP/App_KernelDevDebugContainer.php:3537)
  at ContainerSgUiPaP\App_KernelDevDebugContainer::getImageVoter2Service(object(App_KernelDevDebugContainer))
     (var/cache/dev/ContainerSgUiPaP/App_KernelDevDebugContainer.php:2198)
  at ContainerSgUiPaP\App_KernelDevDebugContainer::getImageVoterService(object(App_KernelDevDebugContainer))
     (var/cache/dev/ContainerSgUiPaP/App_KernelDevDebugContainer.php:4671)
  at ContainerSgUiPaP\App_KernelDevDebugContainer::ContainerSgUiPaP\{closure}()
     (vendor/symfony/security-bundle/DataCollector/SecurityDataCollector.php:135)
  at Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector->collect(object(Request), object(Response), null)
     (vendor/symfony/http-kernel/Profiler/Profiler.php:169)
  at Symfony\Component\HttpKernel\Profiler\Profiler->collect(object(Request), object(Response), null)
     (vendor/symfony/http-kernel/EventListener/ProfilerListener.php:108)
  at Symfony\Component\HttpKernel\EventListener\ProfilerListener->onKernelResponse(object(ResponseEvent), 'kernel.response', object(TraceableEventDispatcher))
     (vendor/symfony/event-dispatcher/Debug/WrappedListener.php:116)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(object(ResponseEvent), 'kernel.response', object(TraceableEventDispatcher))
     (vendor/symfony/event-dispatcher/EventDispatcher.php:220)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners(array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'kernel.response', object(ResponseEvent))
     (vendor/symfony/event-dispatcher/EventDispatcher.php:56)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch(object(ResponseEvent), 'kernel.response')
     (vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:139)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(object(ResponseEvent), 'kernel.response')
     (vendor/symfony/http-kernel/HttpKernel.php:214)
  at Symfony\Component\HttpKernel\HttpKernel->filterResponse(object(Response), object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:202)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35)
  at Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
     (vendor/autoload_runtime.php:29)
  at require_once('/var/www/vendor/autoload_runtime.php')
     (public/index.php:5)
```