### PR TITLE
[Messenger Doctrine] Support for `igbinary` serializer and `binary` message `body` column

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -198,6 +198,7 @@ return static function (ContainerConfigurator $container) {
                 service('logger')->nullOnInvalid(),
                 service('messenger.transport.native_php_serializer')->nullOnInvalid(),
                 null,
+                service('messenger.transport.igbinary_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
             ->tag('monolog.logger', ['channel' => 'messenger'])
@@ -207,6 +208,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('Default failure receiver name'),
                 abstract_arg('Receivers'),
                 service('messenger.transport.native_php_serializer')->nullOnInvalid(),
+                service('messenger.transport.igbinary_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
 
@@ -215,6 +217,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('Default failure receiver name'),
                 abstract_arg('Receivers'),
                 service('messenger.transport.native_php_serializer')->nullOnInvalid(),
+                service('messenger.transport.igbinary_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -37,6 +37,7 @@ use Symfony\Component\Messenger\Retry\MultiplierRetryStrategy;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Transport\Serialization\IgbinarySerializer;
 use Symfony\Component\Messenger\Transport\Serialization\Normalizer\FlattenExceptionNormalizer;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
@@ -73,6 +74,8 @@ return static function (ContainerConfigurator $container) {
 
         ->set('serializer.normalizer.flatten_exception', FlattenExceptionNormalizer::class)
             ->tag('serializer.normalizer', ['priority' => -880])
+
+        ->set('messenger.transport.igbinary_serializer', IgbinarySerializer::class)
 
         ->set('messenger.transport.native_php_serializer', PhpSerializer::class)
         ->alias('messenger.default_serializer', 'messenger.transport.native_php_serializer')

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -179,7 +179,7 @@ class ConnectionTest extends TestCase
     /**
      * @dataProvider buildConfigurationProvider
      */
-    public function testBuildConfiguration(string $dsn, array $options, string $expectedConnection, string $expectedTableName, int $expectedRedeliverTimeout, string $expectedQueue, bool $expectedAutoSetup)
+    public function testBuildConfiguration(string $dsn, array $options, string $expectedConnection, string $expectedTableName, int $expectedRedeliverTimeout, string $expectedQueue, bool $expectedAutoSetup, bool $expectedBinaryBody)
     {
         $config = Connection::buildConfiguration($dsn, $options);
         $this->assertEquals($expectedConnection, $config['connection']);
@@ -187,6 +187,7 @@ class ConnectionTest extends TestCase
         $this->assertEquals($expectedRedeliverTimeout, $config['redeliver_timeout']);
         $this->assertEquals($expectedQueue, $config['queue_name']);
         $this->assertEquals($expectedAutoSetup, $config['auto_setup']);
+        $this->assertEquals($expectedBinaryBody, $config['binary_body']);
     }
 
     public static function buildConfigurationProvider(): iterable
@@ -199,6 +200,7 @@ class ConnectionTest extends TestCase
             'expectedRedeliverTimeout' => 3600,
             'expectedQueue' => 'default',
             'expectedAutoSetup' => true,
+            'expectedBinaryBody' => false,
         ];
 
         yield 'test options array' => [
@@ -214,6 +216,7 @@ class ConnectionTest extends TestCase
             'expectedRedeliverTimeout' => 1800,
             'expectedQueue' => 'important',
             'expectedAutoSetup' => false,
+            'expectedBinaryBody' => false,
         ];
 
         yield 'options from dsn' => [
@@ -224,6 +227,7 @@ class ConnectionTest extends TestCase
             'expectedRedeliverTimeout' => 1200,
             'expectedQueue' => 'normal',
             'expectedAutoSetup' => false,
+            'expectedBinaryBody' => false,
         ];
 
         yield 'options from dsn array wins over options from options' => [
@@ -239,6 +243,7 @@ class ConnectionTest extends TestCase
             'expectedRedeliverTimeout' => 1200,
             'expectedQueue' => 'normal',
             'expectedAutoSetup' => true,
+            'expectedBinaryBody' => false,
         ];
 
         yield 'options from dsn with falsey boolean' => [
@@ -249,6 +254,7 @@ class ConnectionTest extends TestCase
             'expectedRedeliverTimeout' => 3600,
             'expectedQueue' => 'default',
             'expectedAutoSetup' => false,
+            'expectedBinaryBody' => false,
         ];
 
         yield 'options from dsn with thruthy boolean' => [
@@ -259,6 +265,7 @@ class ConnectionTest extends TestCase
             'expectedRedeliverTimeout' => 3600,
             'expectedQueue' => 'default',
             'expectedAutoSetup' => true,
+            'expectedBinaryBody' => false,
         ];
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -63,12 +63,14 @@ class Connection implements ResetInterface
     protected ?float $queueEmptiedAt = null;
 
     private bool $autoSetup;
+    private bool $binaryBody;
 
     public function __construct(array $configuration, DBALConnection $driverConnection)
     {
         $this->configuration = array_replace_recursive(static::DEFAULT_OPTIONS, $configuration);
         $this->driverConnection = $driverConnection;
         $this->autoSetup = $this->configuration['auto_setup'];
+        $this->binaryBody = ($this->configuration['binary_body'] ?? false);
     }
 
     public function reset(): void
@@ -92,19 +94,19 @@ class Connection implements ResetInterface
             parse_str($components['query'], $query);
         }
 
-        $configuration = ['connection' => $components['host']];
+        $configuration = ['connection' => $components['host'], 'binary_body' => false];
         $configuration += $query + $options + static::DEFAULT_OPTIONS;
 
         $configuration['auto_setup'] = filter_var($configuration['auto_setup'], \FILTER_VALIDATE_BOOL);
 
         // check for extra keys in options
-        $optionsExtraKeys = array_diff(array_keys($options), array_keys(static::DEFAULT_OPTIONS));
+        $optionsExtraKeys = array_diff(array_keys($options), array_keys(static::DEFAULT_OPTIONS + ['binary_body']));
         if (0 < \count($optionsExtraKeys)) {
             throw new InvalidArgumentException(sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(static::DEFAULT_OPTIONS))));
         }
 
         // check for extra keys in options
-        $queryExtraKeys = array_diff(array_keys($query), array_keys(static::DEFAULT_OPTIONS));
+        $queryExtraKeys = array_diff(array_keys($query), array_keys(static::DEFAULT_OPTIONS + ['binary_body']));
         if (0 < \count($queryExtraKeys)) {
             throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(static::DEFAULT_OPTIONS))));
         }
@@ -141,7 +143,7 @@ class Connection implements ResetInterface
             $now,
             $availableAt,
         ], [
-            Types::STRING,
+            $this->binaryBody ? Types::BINARY : Types::STRING,
             Types::STRING,
             Types::STRING,
             Types::DATETIME_IMMUTABLE,
@@ -431,7 +433,7 @@ class Connection implements ResetInterface
         $table->addColumn('id', Types::BIGINT)
             ->setAutoincrement(true)
             ->setNotnull(true);
-        $table->addColumn('body', Types::TEXT)
+        $table->addColumn('body', $this->binaryBody ? Types::BINARY : Types::TEXT)
             ->setNotnull(true);
         $table->addColumn('headers', Types::TEXT)
             ->setNotnull(true);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\Persistence\ConnectionRegistry;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Serialization\IgbinarySerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -40,10 +42,18 @@ class DoctrineTransportFactory implements TransportFactoryInterface
         $configuration = PostgreSqlConnection::buildConfiguration($dsn, $options);
 
         try {
+            /** @var \Doctrine\DBAL\Connection */
             $driverConnection = $this->registry->getConnection($configuration['connection']);
         } catch (\InvalidArgumentException $e) {
             throw new TransportException('Could not find Doctrine connection from Messenger DSN.', 0, $e);
         }
+
+        $platform = $driverConnection->getDatabasePlatform();
+        if ($platform instanceof SqlitePlatform) {
+            throw new TransportException(sprintf('Sqlite does not support storing binary content. Do not use %s as default Messenger serializer.', IgbinarySerializer::class), 0);
+        }
+
+        $configuration['binary_body'] = $serializer instanceof IgbinarySerializer;
 
         if ($useNotify && $driverConnection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             $connection = new PostgreSqlConnection($configuration, $driverConnection);

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG
  * Add `WrappedExceptionsInterface` interface for exceptions that hold multiple individual exceptions
  * Deprecate `HandlerFailedException::getNestedExceptions()`, `HandlerFailedException::getNestedExceptionsOfClass()`
    and `DelayedMessageHandlingException::getExceptions()` which are replaced by a new `getWrappedExceptions()` method
+ * Add support for `igbinary` serializer for Doctrine transport by setting transport serializer to `messenger.transport.igbinary_serializer`
 
 6.3
 ---

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -28,6 +28,7 @@ use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Serialization\IgbinarySerializer;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\TraceStub;
@@ -47,14 +48,16 @@ abstract class AbstractFailedMessagesCommand extends Command
 
     protected ServiceProviderInterface $failureTransports;
     protected ?PhpSerializer $phpSerializer;
+    protected ?IgbinarySerializer $igbinarySerializer;
 
     private ?string $globalFailureReceiverName;
 
-    public function __construct(?string $globalFailureReceiverName, ServiceProviderInterface $failureTransports, PhpSerializer $phpSerializer = null)
+    public function __construct(?string $globalFailureReceiverName, ServiceProviderInterface $failureTransports, PhpSerializer $phpSerializer = null, IgbinarySerializer $igbinarySerializer = null)
     {
         $this->failureTransports = $failureTransports;
         $this->globalFailureReceiverName = $globalFailureReceiverName;
         $this->phpSerializer = $phpSerializer;
+        $this->igbinarySerializer = $igbinarySerializer;
 
         parent::__construct();
     }

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
@@ -94,10 +94,12 @@ EOF
     {
         foreach ($ids as $id) {
             $this->phpSerializer?->acceptPhpIncompleteClass();
+            $this->igbinarySerializer?->acceptPhpIncompleteClass();
             try {
                 $envelope = $receiver->find($id);
             } finally {
                 $this->phpSerializer?->rejectPhpIncompleteClass();
+                $this->igbinarySerializer?->rejectPhpIncompleteClass();
             }
 
             if (null === $envelope) {

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -97,6 +97,7 @@ EOF
         }
 
         $this->phpSerializer?->acceptPhpIncompleteClass();
+        $this->igbinarySerializer?->acceptPhpIncompleteClass();
         try {
             foreach ($envelopes as $envelope) {
                 $currentClassName = $envelope->getMessage()::class;
@@ -119,6 +120,7 @@ EOF
             }
         } finally {
             $this->phpSerializer?->rejectPhpIncompleteClass();
+            $this->igbinarySerializer?->rejectPhpIncompleteClass();
         }
 
         $rowsCount = \count($rows);
@@ -149,6 +151,7 @@ EOF
         $countPerClass = [];
 
         $this->phpSerializer?->acceptPhpIncompleteClass();
+        $this->igbinarySerializer?->acceptPhpIncompleteClass();
         try {
             foreach ($envelopes as $envelope) {
                 $c = $envelope->getMessage()::class;
@@ -161,6 +164,7 @@ EOF
             }
         } finally {
             $this->phpSerializer?->rejectPhpIncompleteClass();
+            $this->igbinarySerializer?->rejectPhpIncompleteClass();
         }
 
         if (0 === \count($countPerClass)) {
@@ -177,10 +181,12 @@ EOF
         /** @var ListableReceiverInterface $receiver */
         $receiver = $this->getReceiver($failedTransportName);
         $this->phpSerializer?->acceptPhpIncompleteClass();
+        $this->igbinarySerializer?->acceptPhpIncompleteClass();
         try {
             $envelope = $receiver->find($id);
         } finally {
             $this->phpSerializer?->rejectPhpIncompleteClass();
+            $this->igbinarySerializer?->rejectPhpIncompleteClass();
         }
         if (null === $envelope) {
             throw new RuntimeException(sprintf('The message "%s" was not found.', $id));

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/IgbinarySerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/IgbinarySerializerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Serialization\IgbinarySerializer;
+
+class IgbinarySerializerTest extends TestCase
+{
+    public function testEncodedIsDecodable()
+    {
+        $serializer = $this->createIgbinarySerializer();
+
+        $envelope = new Envelope(new DummyMessage('Hello'));
+
+        $encoded = $serializer->encode($envelope);
+        $this->assertEquals($envelope, $serializer->decode($encoded));
+    }
+
+    public function testDecodingFailsWithMissingBodyKey()
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessage('Encoded envelope should have at least a "body", or maybe you should implement your own serializer');
+
+        $serializer = $this->createIgbinarySerializer();
+
+        $serializer->decode([]);
+    }
+
+    public function testDecodingFailsWithBadFormat()
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessageMatches('/Could not decode/');
+
+        $serializer = $this->createIgbinarySerializer();
+
+        $serializer->decode([
+            'body' => '{"message": "bar"}',
+        ]);
+    }
+
+    public function testDecodingFailsWithBadBase64Body()
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessageMatches('/Could not decode/');
+
+        $serializer = $this->createIgbinarySerializer();
+
+        $serializer->decode([
+            'body' => 'x',
+        ]);
+    }
+
+    public function testDecodingFailsWithBadClass()
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessageMatches('/class "ReceivedSt0mp" not found/');
+
+        $serializer = $this->createIgbinarySerializer();
+
+        $serializer->decode([
+            // we need to represent serialized binary here in tests, so we use the help of base64
+            'body' => base64_decode('AAAAAhcNUmVjZWl2ZWRTdDBtcBQA'),
+        ]);
+    }
+
+    public function testNonUtf8IsBase64Encoded()
+    {
+        $serializer = $this->createIgbinarySerializer();
+
+        $envelope = new Envelope(new DummyMessage("\xE9"));
+
+        $encoded = $serializer->encode($envelope);
+        $this->assertEquals($envelope, $serializer->decode($encoded));
+    }
+
+    protected function createIgbinarySerializer(): IgbinarySerializer
+    {
+        return new IgbinarySerializer();
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/IgbinarySerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/IgbinarySerializer.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Serialization;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+/**
+ * @author Rostislav Kaleta<rostislavkaleta@gmail.com>
+ */
+class IgbinarySerializer implements SerializerInterface
+{
+    private bool $acceptPhpIncompleteClass = false;
+
+    /**
+     * @internal
+     */
+    public function acceptPhpIncompleteClass(): void
+    {
+        $this->acceptPhpIncompleteClass = true;
+    }
+
+    /**
+     * @internal
+     */
+    public function rejectPhpIncompleteClass(): void
+    {
+        $this->acceptPhpIncompleteClass = false;
+    }
+
+    public function decode(array $encodedEnvelope): Envelope
+    {
+        if (empty($encodedEnvelope['body'])) {
+            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body", or maybe you should implement your own serializer.');
+        }
+
+        $content = \is_resource($encodedEnvelope['body']) ? stream_get_contents($encodedEnvelope['body']) : $encodedEnvelope['body'];
+        if (empty($content)) {
+            throw new MessageDecodingFailedException('Failed to get encoded envelope content.');
+        }
+
+        return $this->safelyUnserialize($content);
+    }
+
+    public function encode(Envelope $envelope): array
+    {
+        $envelope = $envelope->withoutStampsOfType(NonSendableStampInterface::class);
+
+        return [
+            'body' => igbinary_serialize($envelope),
+        ];
+    }
+
+    private function safelyUnserialize(string $contents): Envelope
+    {
+        if ('' === $contents) {
+            throw new MessageDecodingFailedException('Could not decode an empty message using \igbinary_deserialize.');
+        }
+
+        $signalingException = new MessageDecodingFailedException(sprintf('Could not decode message using \igbinary_deserialize: %s.', $contents));
+
+        if ($this->acceptPhpIncompleteClass) {
+            $prevUnserializeHandler = ini_set('unserialize_callback_func', null);
+        } else {
+            $prevUnserializeHandler = ini_set('unserialize_callback_func', self::class.'::handleUnserializeCallback');
+        }
+        $prevErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler, $signalingException) {
+            if (__FILE__ === $file) {
+                throw $signalingException;
+            }
+
+            return $prevErrorHandler ? $prevErrorHandler($type, $msg, $file, $line, $context) : false;
+        });
+
+        try {
+            /** @var Envelope */
+            $envelope = igbinary_unserialize($contents);
+        } finally {
+            restore_error_handler();
+            ini_set('unserialize_callback_func', $prevUnserializeHandler);
+        }
+
+        if (!$envelope instanceof Envelope) {
+            throw $signalingException;
+        }
+
+        if ($envelope->getMessage() instanceof \__PHP_Incomplete_Class) {
+            $envelope = $envelope->with(new MessageDecodingFailedStamp());
+        }
+
+        return $envelope;
+    }
+
+    /**
+     * @internal
+     */
+    public static function handleUnserializeCallback(string $class): never
+    {
+        throw new MessageDecodingFailedException(sprintf('Message class "%s" not found during decoding.', $class));
+    }
+}


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch       | 7.1, but [here you say that new features should be targetting 6.4](https://symfony.com/doc/current/contributing/code/pull_requests.html#choose-the-right-branch), so I am not sure 
| Bug fix      | no
| New feature  | yes
| Deprecations | no
| Issues        | #52872
| License       | MIT

### Description

This PR introduces alternative Messenger Transport, the [igbinary](https://github.com/igbinary/igbinary) serializer `Symfony\Component\Messenger\Transport\Serialization\IgbinarySerializer` and deepens the support by also modifying `Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection` to support `binary` column type whenever this serializer is enabled.

The `igbinary` serializer is by default 1-5 times faster and it's output is around 30-120% shorter than PHP's build-in `serialize`. Added serializer was also stripped of the `base64` pass both on `encode` and `decode` to further speed up the conversion. To support `binary` message `body` we also need to modify the Doctrine transport connection, so it works with `binary` column type instead of `text`.
 
Every DBAL supported database except Sqlite supports `binary` columns and installing `igbinary` extension is easy as installing alteady built `php-igbinary` package from repos and in other cases `pecl install igbinary` can be used.

With this PR tests might be broken as they now require `ext-igbinary` to be installed - maybe this can be skipped if it's not installed?

### Questions

1. I was not sure how to pass the information to `Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection` so it knows if it should use `binary` or `text` column type for `body` without making BC. Please let me know if the current approach is fine or not. 
2. How do I fix the `psalm` error about non existent `Doctrine\DBAL\Platforms\SqlitePlatform`? Do I need to use `class_implements($platform)` with `in_array()` or is there a better solution? I need to check whenever the used platform is Sqlite to throw exception.