### PR TITLE
[DoctrineBridge] Global query time always at 0.00 ms on profiler

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -146,7 +146,7 @@ class DoctrineDataCollector extends DataCollector
     }
 
     /**
-     * @return int
+     * @return float
      */
     public function getTime()
     {

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -183,7 +183,7 @@ class DoctrineDataCollectorTest extends TestCase
             $debugDataHolder->addQuery('default', $query);
 
             if (isset($queryData['executionMS'])) {
-                sleep($queryData['executionMS']);
+                usleep($queryData['executionMS'] * 1000000);
             }
             $query->stop();
         }

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTestTrait.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTestTrait.php
@@ -73,6 +73,36 @@ trait DoctrineDataCollectorTestTrait
         $this->assertEquals(3, $c->getTime());
     }
 
+    public function testCollectTimeWithFloatExecutionMS()
+    {
+        $queries = [
+            ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 0.23],
+        ];
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEqualsWithDelta(0.23, $c->getTime(), .01);
+
+        $queries = [
+            ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 1.02],
+            ['sql' => 'SELECT * FROM table2', 'params' => [], 'types' => [], 'executionMS' => 0.75],
+        ];
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEqualsWithDelta(1.77, $c->getTime(), .01);
+
+        $queries = [
+            ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 0.15],
+            ['sql' => 'SELECT * FROM table2', 'params' => [], 'types' => [], 'executionMS' => 0.32],
+            ['sql' => 'SELECT * FROM table3', 'params' => [], 'types' => [], 'executionMS' => 0.07],
+        ];
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEqualsWithDelta(0.54, $c->getTime(), .01);
+    }
+
     public function testCollectQueryWithNoTypes()
     {
         $queries = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52880
| License       | MIT

(original explanation made from 7.0 branch, now targeting 6.4 cf comments)

The related issue, when i explained the possible solution : https://github.com/symfony/symfony/issues/52880

On `Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector`, updated the native return type from `int` to `float` for the method `getTime`.

Context : 
```
    public function getTime(): int
    {
        $time = 0;
        foreach ($this->data['queries'] as $queries) {
            foreach ($queries as $query) {
                $time += $query['executionMS'];
            }
        }

        return $time;
    }
```

Inside this method, the value of `$time` was always a float smaller than 0. The transition to native return type (which was correct regarding to old phpdoc type) made the return cast int to the floating value, hence returning always 0.

I updated the return type to float and updated the test to check for the calculus on floating values.
I had to switch to usleep instead of sleep, since the value might not be an int.