### PR TITLE
[Serializer] fix nullable int cannot be serialized

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -524,7 +524,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                             }
                             break;
                         case Type::BUILTIN_TYPE_INT:
-                            if (ctype_digit($data) || '-' === $data[0] && ctype_digit(substr($data, 1))) {
+                            if (ctype_digit($data) || isset($data[0]) && '-' === $data[0] && ctype_digit(substr($data, 1))) {
                                 $data = (int) $data;
                             } else {
                                 throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('The type of the "%s" attribute for class "%s" must be int ("%s" given).', $attribute, $currentClass, $data), $data, [Type::BUILTIN_TYPE_INT], $context['deserialization_path'] ?? null);

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyNullableInt.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyNullableInt.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+class DummyNullableInt
+{
+    public int|null $value = null;
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -61,6 +62,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberThree;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyNullableInt;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumConstructor;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumProperty;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyWithObjectOrNull;
@@ -738,6 +740,19 @@ class SerializerTest extends TestCase
         $serializer = new Serializer([new UnwrappingDenormalizer()], ['json' => new JsonEncoder()]);
 
         $this->assertSame(42, $serializer->deserialize('{"wrapper": 42}', 'int', 'json', [UnwrappingDenormalizer::UNWRAP_PATH => '[wrapper]']));
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testDeserializeNullableIntInXml()
+    {
+        $extractor = new PropertyInfoExtractor([], [new ReflectionExtractor()]);
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, $extractor)], ['xml' => new XmlEncoder()]);
+
+        $obj = $serializer->deserialize('<?xml version="1.0" encoding="UTF-8"?><DummyNullableInt><value/></DummyNullableInt>', DummyNullableInt::class, 'xml');
+        $this->assertInstanceOf(DummyNullableInt::class, $obj);
+        $this->assertNull($obj->value);
     }
 
     public function testUnionTypeDeserializable()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello,

previous to [this PR](https://github.com/symfony/symfony/pull/52172) such XML could be deserialized correctly, setting null in the value:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<DummyNullableInt>
	<value/>
</DummyNullableInt>
```
```php
class DummyNullableInt
{
    public function __construct(
        public int|null $value = null
    )
    {}
}
```

but now it creates the following error:
```
Uninitialized string offset 0

/home/nikophil/works/symfony/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php:495
/home/nikophil/works/symfony/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php:630
/home/nikophil/works/symfony/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php:377
/home/nikophil/works/symfony/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php:246
/home/nikophil/works/symfony/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php:346
```

I looked for any issue or PR mentioning this problem, but couldn't find it. So here is a fix 

ping @Jeroeny
