### PR TITLE
[HttpKernel] Catch `TypeError` if the wrong type is used in `BackedEnumValueResolver`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/BackedEnumValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/BackedEnumValueResolver.php
@@ -86,7 +86,7 @@ class BackedEnumValueResolver implements ArgumentValueResolverInterface, ValueRe
 
         try {
             return [$enumType::from($value)];
-        } catch (\ValueError $e) {
+        } catch (\ValueError|\TypeError $e) {
             throw new NotFoundHttpException(sprintf('Could not resolve the "%s $%s" controller argument: ', $argument->getType(), $argument->getName()).$e->getMessage(), $e);
         }
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/BackedEnumValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/BackedEnumValueResolverTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Tests\Fixtures\IntEnum;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Suit;
 
 class BackedEnumValueResolverTest extends TestCase
@@ -130,6 +131,18 @@ class BackedEnumValueResolverTest extends TestCase
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Could not resolve the "Symfony\Component\HttpKernel\Tests\Fixtures\Suit $suit" controller argument: expecting an int or string, got "bool".');
+
+        $resolver->resolve($request, $metadata);
+    }
+
+    public function testResolveThrowsOnTypeError()
+    {
+        $resolver = new BackedEnumValueResolver();
+        $request = self::createRequest(['suit' => 'value']);
+        $metadata = self::createArgumentMetadata('suit', IntEnum::class);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Could not resolve the "Symfony\Component\HttpKernel\Tests\Fixtures\IntEnum $suit" controller argument: Symfony\Component\HttpKernel\Tests\Fixtures\IntEnum::from(): Argument #1 ($value) must be of type int, string given');
 
         $resolver->resolve($request, $metadata);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/IntEnum.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/IntEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+enum IntEnum: int
+{
+    case One = 1;
+    case Two = 2;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52053
| License       | MIT
