### PR TITLE
[WebProfilerBundle] Don't expect collector.compilerLogs to be defined

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -409,7 +409,7 @@
         <script>Sfjs.initializeLogsTable();</script>
     {% endif %}
 
-    {% set compilerLogTotal = collector.compilerLogs|reduce((total, logs) => total + logs|length, 0) %}
+    {% set compilerLogTotal = collector.compilerLogs|default([])|reduce((total, logs) => total + logs|length, 0) %}
     <details class="container-compilation-logs">
         <summary>
             <h4>Container Compilation Logs <span class="text-muted">({{ compilerLogTotal }})</span></h4>


### PR DESCRIPTION
collector.compilerLogs is not always available and since reduce expects an array, it will cause a php-error.

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In my environment the debug toolbar's logs-panel would occasionally give a fatal error at the changed line:
```
The "reduce" filter only works with arrays or "Traversable", got "NULL" as first argument.
```

So apparently compilerLogs is null. Since there is a 'is not empty' test a bit later on, that is clearly expected behavior. So this is is probably broken since the for-loop that preceded this reduce-change was replaced a few months back.

There are probably more elegant fixes possible, like doing that empty test much earlier. But this is a much less invasive fix :)