### PR TITLE
[HttpKernel] Fix request attribute value ignored with pinned resolvers

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -73,6 +73,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
 
                     $argumentValueResolvers = [
                         $this->namedResolvers->get($resolverName),
+                        new RequestAttributeValueResolver(),
                         new DefaultValueResolver(),
                     ];
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52875
| License       | MIT

This is similar to #50458. When pinned resolvers are used, values already resolved in the request attributes bag are ignored.