### PR TITLE
[Messenger] Avoid reconnecting active Redis connections.

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -117,6 +117,10 @@ class Connection
      */
     private static function initializeRedis(\Redis $redis, string $host, int $port, $auth, int $serializer, int $dbIndex): \Redis
     {
+        if ($redis->isConnected()) {
+            return $redis;
+        }
+
         $redis->connect($host, $port);
         $redis->setOption(\Redis::OPT_SERIALIZER, $serializer);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #45057
| License       | MIT

With the Messenger component's internal Redis Connection class, if you pass it a \Redis or \Relay instance that's already connected, it will still try to reconnect that instance using the host/port/etc. that's passed to the connection object's "options" array in the constructor.

Not only does this cause problems when the Redis instance is already connected, but it also prevents you from, say, using socket connections instead (as the only connection method supported by the class itself is IP-based connections) and just passing in a ready-to-go Redis instance.

This PR is a resubmission of #52811 targeting 5.4 as it's a bug fix.
