### PR TITLE
[DomCrawler] set select by text content

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -68,7 +68,7 @@ class ChoiceFormField extends FormField
 
     /**
      * Sets the value of a select field by it's text content.
-     * 
+     *
      * @throws \LogicException When the type provided is not correct
      */
     public function selectByTextContent(string $value): void
@@ -78,8 +78,9 @@ class ChoiceFormField extends FormField
         }
 
         foreach ($this->node->childNodes as $option) {
-            if($value === $option->textContent) {
+            if ($value === $option->textContent) {
                 $this->select($option->getAttribute('value'));
+
                 return;
             }
         }

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -67,6 +67,27 @@ class ChoiceFormField extends FormField
     }
 
     /**
+     * Sets the value of a select field by it's text content.
+     * 
+     * @throws \LogicException When the type provided is not correct
+     */
+    public function selectByTextContent(string $value): void
+    {
+        if ('select' !== $this->type) {
+            throw new \LogicException(sprintf('You cannot select "%s" by text content as it is not a select (%s).', $this->name, $this->type));
+        }
+
+        foreach ($this->node->childNodes as $option) {
+            if($value === $option->textContent) {
+                $this->select($option->getAttribute('value'));
+                return;
+            }
+        }
+
+        $this->select($value);
+    }
+
+    /**
      * Ticks a checkbox.
      *
      * @throws \LogicException When the type provided is not correct

--- a/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
@@ -323,6 +323,35 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $this->assertEquals('foo', $field->getValue(), '->select() changes the selected option');
     }
 
+    public function testSelectByText()
+    {
+        $node = $this->createNode('input', '', ['type' => 'checkbox', 'name' => 'name']);
+        $field = new ChoiceFormField($node);
+
+        try {
+            $field->selectByTextContent('');
+            $this->fail('->selectByTextContent() throws a \LogicException for checkbox');
+        } catch (\LogicException $e) {
+            $this->assertTrue(true, '->selectByTextContent() throws a \LogicException for checkbox');
+        }
+
+        $node = $this->createNode('input', '', ['type' => 'radio', 'name' => 'name']);
+        $field = new ChoiceFormField($node);
+
+        try {
+            $field->selectByTextContent('');
+            $this->fail('->selectByTextContent() throws a \LogicException for radio');
+        } catch (\LogicException $e) {
+            $this->assertTrue(true, '->selectByTextContent() throws a \LogicException for radio');
+        }
+
+        $node = $this->createSelectNode(['foo' => false, 'bar' => false]);
+        $field = new ChoiceFormField($node);
+
+        $field->selectByTextContent('bar');
+        $this->assertEquals('bar', $field->getValue(), '->selectByTextContent() changes the selected option');
+    }
+
     public function testOptionWithNoValue()
     {
         $node = $this->createSelectNodeWithEmptyOption(['foo' => false, 'bar' => false]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | Fix #51423
| License       | MIT

Adding possibility to select a `select option` by its text Content. Only available on a `select` field, not `checkbox` or `radio` inputs. 

I have doubt about `$this->select($value);` fallback on this new method, maybe an `\InvalidArgumentException` might be better ?

If this functionality seems good for you, i will update the CHANGELOG and make a doc PR as fast as possible !