### PR TITLE
[HtmlSanitizer] Add functions to handle operations on multiple attributes and/or elements

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/CHANGELOG.md
+++ b/src/Symfony/Component/HtmlSanitizer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add functions to allow operations on arrays of attributes and elements at a time
+
 6.4
 ---
 

--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
@@ -275,6 +275,29 @@ class HtmlSanitizerConfig
     }
 
     /**
+     * Configures the given elements as allowed.
+     *
+     * Allowed elements are elements the sanitizer should retain from the input.
+     *
+     * A list of allowed attributes for this element can be passed as a second argument.
+     * Passing "*" will allow all standard attributes on this element. By default, no
+     * attributes are allowed on the element.
+     *
+     * @param list<string>        $elements
+     * @param list<string>|string $allowedAttributes
+     */
+    public function allowElements(array $elements, array|string $allowedAttributes = []): static
+    {
+        $clone = clone $this;
+
+        foreach ($elements as $element) {
+            $clone = $clone->allowElement($element, $allowedAttributes);
+        }
+
+        return $clone;
+    }
+
+    /**
      * Configures the given element as blocked.
      *
      * Blocked elements are elements the sanitizer should remove from the input, but retain
@@ -293,6 +316,23 @@ class HtmlSanitizerConfig
     }
 
     /**
+     * Configures the given elements as blocked.
+     *
+     * Blocked elements are elements the sanitizer should remove from the input, but retain
+     * their children.
+     */
+    public function blockElements(array $elements): static
+    {
+        $clone = clone $this;
+
+        foreach ($elements as $element) {
+            $clone = $clone->blockElement($element);
+        }
+
+        return $clone;
+    }
+
+    /**
      * Configures the given element as dropped.
      *
      * Dropped elements are elements the sanitizer should remove from the input, including
@@ -306,6 +346,29 @@ class HtmlSanitizerConfig
     {
         $clone = clone $this;
         unset($clone->allowedElements[$element], $clone->blockedElements[$element]);
+
+        return $clone;
+    }
+
+    /**
+     * Configures the given elements as dropped.
+     *
+     * Dropped elements are elements the sanitizer should remove from the input, including
+     * their children.
+     *
+     * Note: when using an empty configuration, all unknown elements are dropped
+     * automatically. This method let you drop elements that were allowed earlier
+     * in the configuration.
+     *
+     * @param list<string> $elements
+     */
+    public function dropElements(array $elements): static
+    {
+        $clone = clone $this;
+
+        foreach ($elements as $element) {
+            $clone = $clone->dropElement($element);
+        }
 
         return $clone;
     }
@@ -340,6 +403,30 @@ class HtmlSanitizerConfig
     }
 
     /**
+     * Configures the given attributes as allowed.
+     *
+     * Allowed attributes are attributes the sanitizer should retain from the input.
+     *
+     * A list of allowed elements for these attributes can be passed as a second argument.
+     * Passing "*" will allow all currently allowed elements to use this attribute.
+     *
+     * To configure each attribute for a specific element, please use the allowAttribute method instead.
+     *
+     * @param list<string>        $attributes
+     * @param list<string>|string $allowedElements
+     */
+    public function allowAttributes(array $attributes, array|string $allowedElements): static
+    {
+        $clone = clone $this;
+
+        foreach ($attributes as $attribute) {
+            $clone = $clone->allowAttribute($attribute, $allowedElements);
+        }
+
+        return $clone;
+    }
+
+    /**
      * Configures the given attribute as dropped.
      *
      * Dropped attributes are attributes the sanitizer should remove from the input.
@@ -362,6 +449,32 @@ class HtmlSanitizerConfig
             if (isset($clone->allowedElements[$element][$attribute])) {
                 unset($clone->allowedElements[$element][$attribute]);
             }
+        }
+
+        return $clone;
+    }
+
+    /**
+     * Configures the given attributes as dropped.
+     *
+     * Dropped attributes are attributes the sanitizer should remove from the input.
+     *
+     * A list of elements on which to drop these attributes can be passed as a second argument.
+     * Passing "*" will drop this attribute from all currently allowed elements.
+     *
+     * Note: when using an empty configuration, all unknown attributes are dropped
+     * automatically. This method let you drop attributes that were allowed earlier
+     * in the configuration.
+     *
+     * @param list<string>        $attributes
+     * @param list<string>|string $droppedElements
+     */
+    public function dropAttributes(array $attributes, array|string $droppedElements): static
+    {
+        $clone = clone $this;
+
+        foreach ($attributes as $attribute) {
+            $clone = $clone->dropAttribute($attribute, $droppedElements);
         }
 
         return $clone;

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerConfigTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerConfigTest.php
@@ -68,6 +68,14 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
+    public function testAllowElements()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section'], ['style']);
+        $this->assertSame(['div' => ['style' => true], 'section' => ['style' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
     public function testAllowElementTwiceOverridesIt()
     {
         $config = new HtmlSanitizerConfig();
@@ -104,12 +112,30 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
+    public function testAllowElementsNoAttributes()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'script'], []);
+        $this->assertSame(['div' => [], 'script' => []], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
     public function testAllowElementStandardAttributes()
     {
         $config = new HtmlSanitizerConfig();
         $config = $config->allowElement('div', '*');
         $this->assertSame(['div'], array_keys($config->getAllowedElements()));
         $this->assertCount(211, $config->getAllowedElements()['div']);
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
+    public function testAllowElementsStandardAttributes()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'script'], '*');
+        $this->assertSame(['div', 'script'], array_keys($config->getAllowedElements()));
+        $this->assertCount(211, $config->getAllowedElements()['div']);
+        $this->assertCount(211, $config->getAllowedElements()['script']);
         $this->assertSame([], $config->getBlockedElements());
     }
 
@@ -121,11 +147,26 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
+    public function testAllowElementsStringAttribute()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'script'], 'width');
+        $this->assertSame(['div' => ['width' => true], 'script' => ['width' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
     public function testBlockElement()
     {
         $config = new HtmlSanitizerConfig();
         $config = $config->blockElement('div');
         $this->assertSame(['div' => true], $config->getBlockedElements());
+    }
+
+    public function testBlockElements()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->blockElements(['iframe', 'script']);
+        $this->assertSame(['iframe' => true, 'script' => true], $config->getBlockedElements());
     }
 
     public function testBlockElementDisallowsIt()
@@ -140,6 +181,18 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame(['div' => true], $config->getBlockedElements());
     }
 
+    public function testBlockElementsDisallowsIt()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['iframe', 'script'], 'width');
+        $this->assertSame(['iframe' => ['width' => true], 'script' => ['width' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+
+        $config = $config->blockElement('iframe');
+        $this->assertSame(['script' => ['width' => true]], $config->getAllowedElements());
+        $this->assertSame(['iframe' => true], $config->getBlockedElements());
+    }
+
     public function testDropAllowedElement()
     {
         $config = new HtmlSanitizerConfig();
@@ -148,6 +201,18 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
 
         $config = $config->dropElement('div');
+        $this->assertSame([], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
+    public function testDropAllowedElements()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section'], 'width');
+        $this->assertSame(['div' => ['width' => true], 'section' => ['width' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+
+        $config = $config->dropElements(['div', 'section']);
         $this->assertSame([], $config->getAllowedElements());
         $this->assertSame([], $config->getBlockedElements());
     }
@@ -164,10 +229,30 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
+    public function testDropBlockedElements()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->blockElements(['div', 'section']);
+        $this->assertSame([], $config->getAllowedElements());
+        $this->assertSame(['div' => true, 'section' => true], $config->getBlockedElements());
+
+        $config = $config->dropElements(['div', 'section']);
+        $this->assertSame([], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
     public function testAllowAttributeNoElement()
     {
         $config = new HtmlSanitizerConfig();
         $config = $config->allowAttribute('width', 'div');
+        $this->assertSame([], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
+    public function testAllowAttributesNoElement()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowAttributes(['width', 'height'], 'div');
         $this->assertSame([], $config->getAllowedElements());
         $this->assertSame([], $config->getBlockedElements());
     }
@@ -181,6 +266,15 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
+    public function testAllowAttributesAllowedElement()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElement('div');
+        $config = $config->allowAttributes(['width', 'height'], 'div');
+        $this->assertSame(['div' => ['width' => true, 'height' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
     public function testAllowAttributeAllElements()
     {
         $config = new HtmlSanitizerConfig();
@@ -188,6 +282,15 @@ class HtmlSanitizerConfigTest extends TestCase
         $config = $config->allowElement('section');
         $config = $config->allowAttribute('width', '*');
         $this->assertSame(['div' => ['width' => true], 'section' => ['width' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
+    public function testAllowAttributesAllElements()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section']);
+        $config = $config->allowAttributes(['width', 'height'], '*');
+        $this->assertSame(['div' => ['width' => true, 'height' => true], 'section' => ['width' => true, 'height' => true]], $config->getAllowedElements());
         $this->assertSame([], $config->getBlockedElements());
     }
 
@@ -201,6 +304,15 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
+    public function testAllowAttributesElementsArray()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section']);
+        $config = $config->allowAttributes(['width', 'height'], ['section']);
+        $this->assertSame(['div' => [], 'section' => ['width' => true, 'height' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
     public function testAllowAttributeElementsString()
     {
         $config = new HtmlSanitizerConfig();
@@ -211,7 +323,16 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
-    public function testAllowAttributeOverridesIt()
+    public function testAllowAttributesElementsString()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section']);
+        $config = $config->allowAttributes(['width', 'height'], 'section');
+        $this->assertSame(['div' => [], 'section' => ['width' => true, 'height' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
+    public function testAllowAttributesOverridesIt()
     {
         $config = new HtmlSanitizerConfig();
         $config = $config->allowElement('div');
@@ -223,6 +344,20 @@ class HtmlSanitizerConfigTest extends TestCase
 
         $config = $config->allowAttribute('width', 'section');
         $this->assertSame(['div' => [], 'section' => ['width' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
+    public function testAllowAttributeArraysOverridesIt()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section']);
+
+        $config = $config->allowAttributes(['width', 'height'], 'div');
+        $this->assertSame(['div' => ['width' => true, 'height' => true], 'section' => []], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+
+        $config = $config->allowAttributes(['width', 'height'], 'section');
+        $this->assertSame(['div' => [], 'section' => ['width' => true, 'height' => true]], $config->getAllowedElements());
         $this->assertSame([], $config->getBlockedElements());
     }
 
@@ -239,6 +374,18 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
+    public function testDropAllowedAttributeArrayAllowedElementsArray()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section', 'main'], 'width');
+        $this->assertSame(['div' => ['width' => true], 'section' => ['width' => true], 'main' => ['width' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+
+        $config = $config->dropAttribute('width', ['div', 'section']);
+        $this->assertSame(['div' => [], 'section' => [], 'main' => ['width' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
     public function testDropAllowedAttributeAllowedElementString()
     {
         $config = new HtmlSanitizerConfig();
@@ -252,6 +399,18 @@ class HtmlSanitizerConfigTest extends TestCase
         $this->assertSame([], $config->getBlockedElements());
     }
 
+    public function testDropAllowedAttributesAllowedElementString()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section'], ['width', 'height']);
+        $this->assertSame(['div' => ['width' => true, 'height' => true], 'section' => ['width' => true, 'height' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+
+        $config = $config->dropAttributes(['width'], 'section');
+        $this->assertSame(['div' => ['width' => true, 'height' => true], 'section' => ['height' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
     public function testDropAllowedAttributeAllElements()
     {
         $config = new HtmlSanitizerConfig();
@@ -262,6 +421,18 @@ class HtmlSanitizerConfigTest extends TestCase
 
         $config = $config->dropAttribute('width', '*');
         $this->assertSame(['div' => [], 'section' => []], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+    }
+
+    public function testDropAllowedAttributesAllElements()
+    {
+        $config = new HtmlSanitizerConfig();
+        $config = $config->allowElements(['div', 'section'], ['width', 'height']);
+        $this->assertSame(['div' => ['width' => true, 'height' => true], 'section' => ['width' => true, 'height' => true]], $config->getAllowedElements());
+        $this->assertSame([], $config->getBlockedElements());
+
+        $config = $config->dropAttribute('width', '*');
+        $this->assertSame(['div' => ['height' => true], 'section' => ['height' => true]], $config->getAllowedElements());
         $this->assertSame([], $config->getBlockedElements());
     }
 


### PR DESCRIPTION
Add functions to handle operations on multiple attributes or elements at the same time

| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | None
| License       | MIT

This branch brings supports for array parameters to handle mass allow / block / drop of elements and/or attributes.

Here is a code screenshot that shows how these news methods work:

```php
$config = new HtmlSanitizerConfig();

$attributes = ['height', 'width', 'src'];
$elements = ['img',' iframe'];

/* Current way */
        
foreach ($elements as $element) {
    $config = $config->allowElement($element, $attributes);
}

/* New way */

$config = $config->allowElements($elements, $attributes);
```
