### PR TITLE
[DependencyInjection] Do not autowire private and protected properties

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
@@ -42,7 +42,7 @@ class AutowireRequiredPropertiesPass extends AbstractRecursivePass
         }
 
         $properties = $value->getProperties();
-        foreach ($reflectionClass->getProperties() as $reflectionProperty) {
+        foreach ($reflectionClass->getProperties(\ReflectionProperty::IS_PUBLIC) as $reflectionProperty) {
             if (!($type = $reflectionProperty->getType()) instanceof \ReflectionNamedType) {
                 continue;
             }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
@@ -24,9 +24,6 @@ use Symfony\Contracts\Service\Attribute\Required;
  */
 class AutowireRequiredPropertiesPass extends AbstractRecursivePass
 {
-    /**
-     * {@inheritdoc}
-     */
     protected function processValue($value, bool $isRoot = false)
     {
         if (\PHP_VERSION_ID < 70400) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredPropertiesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredPropertiesPassTest.php
@@ -43,6 +43,9 @@ class AutowireRequiredPropertiesPassTest extends TestCase
 
         $this->assertArrayHasKey('plop', $properties);
         $this->assertEquals(Bar::class, (string) $properties['plop']);
+
+        $this->assertArrayNotHasKey('plopProtected', $properties);
+        $this->assertArrayNotHasKey('plopPrivate', $properties);
     }
 
     /**
@@ -67,5 +70,8 @@ class AutowireRequiredPropertiesPassTest extends TestCase
 
         $this->assertArrayHasKey('foo', $properties);
         $this->assertEquals(Foo::class, (string) $properties['foo']);
+
+        $this->assertArrayNotHasKey('fooProtected', $properties);
+        $this->assertArrayNotHasKey('fooPrivate', $properties);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_74.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_74.php
@@ -14,6 +14,16 @@ class PropertiesInjection
      */
     public $plip;
 
+    /**
+     * @required
+     */
+    protected Bar $plopProtected;
+
+    /**
+     * @required
+     */
+    private Bar $plopPrivate;
+
     public function __construct(A $a)
     {
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -25,4 +25,10 @@ class AutowireProperty
 {
     #[Required]
     public Foo $foo;
+
+    #[Required]
+    protected Foo $fooProtected;
+
+    #[Required]
+    private Foo $fooPrivate;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The [https://symfony.com/doc/5.4/service_container/autowiring.html#autowiring-other-methods-e-g-setters-and-public-typed-properties](documentation) says that only public properties are autowired. Nevertheless not only public, but also protected and private properties are handled by `\Symfony\Component\DependencyInjection\Compiler\AutowireRequiredPropertiesPass`. With this change only public properties are handled.