### PR TITLE
[Routing] Fixed priority getting lost when setting localized prefix

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/PrefixTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/PrefixTrait.php
@@ -29,6 +29,7 @@ trait PrefixTrait
             }
             foreach ($routes->all() as $name => $route) {
                 if (null === $locale = $route->getDefault('_locale')) {
+                    $priority = $routes->getPriority($name) ?? 0;
                     $routes->remove($name);
                     foreach ($prefix as $locale => $localePrefix) {
                         $localizedRoute = clone $route;
@@ -36,13 +37,13 @@ trait PrefixTrait
                         $localizedRoute->setRequirement('_locale', preg_quote($locale));
                         $localizedRoute->setDefault('_canonical_route', $name);
                         $localizedRoute->setPath($localePrefix.(!$trailingSlashOnRoot && '/' === $route->getPath() ? '' : $route->getPath()));
-                        $routes->add($name.'.'.$locale, $localizedRoute);
+                        $routes->add($name.'.'.$locale, $localizedRoute, $priority);
                     }
                 } elseif (!isset($prefix[$locale])) {
                     throw new \InvalidArgumentException(sprintf('Route "%s" with locale "%s" is missing a corresponding prefix in its parent collection.', $name, $locale));
                 } else {
                     $route->setPath($prefix[$locale].(!$trailingSlashOnRoot && '/' === $route->getPath() ? '' : $route->getPath()));
-                    $routes->add($name, $route);
+                    $routes->add($name, $route, $routes->getPriority($name) ?? 0);
                 }
             }
 

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -395,4 +395,9 @@ class RouteCollection implements \IteratorAggregate, \Countable
     {
         return $this->aliases[$name] ?? null;
     }
+
+    public function getPriority(string $name): ?int
+    {
+        return $this->priorities[$name] ?? null;
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/RouteWithPriorityController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/RouteWithPriorityController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class RouteWithPriorityController
+{
+    /**
+     * @Route("/important", name="important", priority=2)
+     */
+    public function important()
+    {
+    }
+
+    /**
+     * @Route("/also-important", name="also_important", priority=1, defaults={"_locale": "cs"})
+     */
+    public function alsoImportant()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/localized-prefix.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/localized-prefix.yml
@@ -1,0 +1,6 @@
+important_controllers:
+  resource: Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\RouteWithPriorityController
+  type: annotation
+  prefix:
+    cs: /cs
+    en: /en


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52912
| License       | MIT

When a route prefix is an array, the original route is removed from the collection and then re-added with a new name and path. During this process, the route's priority is lost as it's not preserved during the removal and re-addition.

Current state of `PrefixTrait.php`
```php
 $routes->remove($name);
 ...
  $routes->add($name.'.'.$locale, $localizedRoute);
 ```

To resolve this issue, I implemented a change where the priority of the route is stored before removal. This stored priority is then reassigned to the route when it's added back to the collection.