### PR TITLE
[Messenger] Fix missing `@throws` phpdoc on MiddlewareInterface, MessageBusInterface and SenderInterface

### DIFF
--- a/src/Symfony/Component/Messenger/MessageBusInterface.php
+++ b/src/Symfony/Component/Messenger/MessageBusInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger;
 
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
@@ -23,6 +24,8 @@ interface MessageBusInterface
      *
      * @param object|Envelope  $message The message or the message pre-wrapped in an envelope
      * @param StampInterface[] $stamps
+     *
+     * @throws ExceptionInterface
      */
     public function dispatch(object $message, array $stamps = []): Envelope;
 }

--- a/src/Symfony/Component/Messenger/Middleware/MiddlewareInterface.php
+++ b/src/Symfony/Component/Messenger/Middleware/MiddlewareInterface.php
@@ -12,11 +12,15 @@
 namespace Symfony\Component\Messenger\Middleware;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
 interface MiddlewareInterface
 {
+    /**
+     * @throws ExceptionInterface
+     */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope;
 }

--- a/src/Symfony/Component/Messenger/Transport/Sender/SenderInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SenderInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\Sender;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -25,6 +26,8 @@ interface SenderInterface
      * like delivery delay.
      *
      * If applicable, the returned Envelope should contain a TransportMessageIdStamp.
+     *
+     * @throws ExceptionInterface
      */
     public function send(Envelope $envelope): Envelope;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes (kinda, it's missing phpdoc)
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

`@throws` phpdoc help the developper to know those methods can throw an exception and to have a contract about which exception can be thrown.

I recently got an exception in production because of the call `$messageBus->dispatch()` without knowing it could throw an exception. Seems like it's because it iterable on every Middleware and a lot of middleware are throwing exception.

As an example:
- https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Messenger/Middleware/RejectRedeliveredMessageMiddleware.php#L38
- Almost every sender are throwing `TransportException` in case of errors, which happen in the SendMessageMiddleware.