### PR TITLE
[DependencyInjection] Add Lazy attribute for classes and arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Lazy.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER)]
+class Lazy
+{
+    public function __construct(
+        public bool|string|null $lazy = true,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add argument `$prepend` to `ContainerConfigurator::extension()` to prepend the configuration instead of appending it
  * Have `ServiceLocator` implement `ServiceCollectionInterface`
+ * Add `#[Lazy]` attribute as shortcut for `#[Autowire(lazy: [bool|string])]` and `#[Autoconfigure(lazy: [bool|string])]`
 
 7.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
 use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+use Symfony\Component\DependencyInjection\Attribute\Lazy;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -299,7 +300,13 @@ class AutowirePass extends AbstractRecursivePass
             };
 
             if ($checkAttributes) {
-                foreach ($parameter->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                $attributes = array_merge($parameter->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF), $parameter->getAttributes(Lazy::class, \ReflectionAttribute::IS_INSTANCEOF));
+
+                if (1 < \count($attributes)) {
+                    throw new AutowiringFailedException($this->currentId, 'Using both attributes #[Lazy] and #[Autowire] on an argument is not allowed; use the "lazy" parameter of #[Autowire] instead.');
+                }
+
+                foreach ($attributes as $attribute) {
                     $attribute = $attribute->newInstance();
                     $invalidBehavior = $parameter->allowsNull() ? ContainerInterface::NULL_ON_INVALID_REFERENCE : ContainerBuilder::EXCEPTION_ON_INVALID_REFERENCE;
 

--- a/src/Symfony/Component/DependencyInjection/Exception/AutoconfigureFailedException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AutoconfigureFailedException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+class AutoconfigureFailedException extends AutowiringFailedException
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LazyAutoconfigured.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LazyAutoconfigured.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\Lazy;
+
+#[Lazy, Autoconfigure(lazy: true)]
+class LazyAutoconfigured
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LazyLoaded.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LazyLoaded.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Lazy;
+
+#[Lazy]
+class LazyLoaded
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/MultipleAutoconfigureAttributed.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/MultipleAutoconfigureAttributed.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(tags: ['foo'])]
+#[Autoconfigure(tags: ['bar'])]
+class MultipleAutoconfigureAttributed
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -5,6 +5,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+use Symfony\Component\DependencyInjection\Attribute\Lazy;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -122,6 +123,20 @@ class AutowireNestedAttributes implements AsDecoratorInterface
             'locator' => new TaggedLocator('foo'),
             'service' => new Autowire(service: 'bar')
         ])] array $options)
+    {
+    }
+}
+
+class LazyServiceAttributeAutowiring
+{
+    public function __construct(#[Lazy] A $a)
+    {
+    }
+}
+
+class LazyAutowireServiceAttributesAutowiring
+{
+    public function __construct(#[Lazy, Autowire(lazy: true)] A $a)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #
| License       | MIT

This commit adds a Lazy attribute shortcut for service definitions. The goal here is simply to improve the DX with a single attribute for lazy loaded services, while adding the strict minimum amount of new code.
This attribute can be used as a replacement for the `Autowire(lazy: bool|string)` attribute on any autowired argument or for the `Autoconfigure(lazy: bool|string)` attribute on an class definition. Both use case support an optional parameter to specify with class/interface should be used for the proxy.

Usage on a class:
```php
use Symfony\Component\DependencyInjection\Attribute\Lazy;

#[Lazy]
class LazyLoaded
{
    // ...
}
```

On a method argument:
```php
use Symfony\Component\DependencyInjection\Attribute\Lazy;

class SuperAwesomeService
{
    public function __construct(#[Lazy] SomeOtherService $service)
    {
        // ...
    }
}

```
