### PR TITLE
Avoid incompatibility with symfony/console 7

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -75,7 +75,7 @@
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",
         "symfony/asset": "<5.3",
-        "symfony/console": "<5.2.5",
+        "symfony/console": "<5.2.5|>=7.0",
         "symfony/dotenv": "<5.1",
         "symfony/dom-crawler": "<4.4",
         "symfony/http-client": "<4.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The FrameworkBundle has no constraint on the `symfony/console` component.

So a project can have a `composer.json` similar to this one:

```php
{
    "require": {
        "php": ">=8.1",
        "ext-ctype": "*",
        "ext-iconv": "*",
        "symfony/console": "^7.0",
        "symfony/framework-bundle": "5.4.*"
    },
}
```

Using this configuration, it will install the console component in version 7.0.1 and the framework in 5.4.32.

But this error will occur:

```text
!!
!!  Fatal error: Declaration of Symfony\Bundle\FrameworkBundle\Console\Application::doRun(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Application::doRun(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /Users/jeremy/Workspace/personnal/bug-test/vendor/symfony/framework-bundle/Console/Application.php on line 72
!!  PHP Fatal error:  Declaration of Symfony\Bundle\FrameworkBundle\Console\Application::doRun(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Application::doRun(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /Users/jeremy/Workspace/personnal/bug-test/vendor/symfony/framework-bundle/Console/Application.php on line 72
!!  Symfony\Component\ErrorHandler\Error\FatalError {#16
!!    #message: "Compile Error: Declaration of Symfony\Bundle\FrameworkBundle\Console\Application::doRun(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Application::doRun(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int"
!!    #code: 0
!!    #file: "./vendor/symfony/framework-bundle/Console/Application.php"
!!    #line: 72
!!    -error: array:4 [
!!      "type" => 64
!!      "message" => "Declaration of Symfony\Bundle\FrameworkBundle\Console\Application::doRun(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Application::doRun(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int"
!!      "file" => "/Users/jeremy/Workspace/personnal/bug-test/vendor/symfony/framework-bundle/Console/Application.php"
!!      "line" => 72
!!    ]
!!  }
!!
```

So I suggest to add a `conflict` to avoid this issue.