### PR TITLE
[Dotenv] Properly handle `SYMFONY_DOTENV_VARS` being the empty string

### DIFF
--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -82,7 +82,13 @@ final class DebugCommand extends Command
 
     private function getVariables(array $envFiles): array
     {
-        $vars = explode(',', $_SERVER['SYMFONY_DOTENV_VARS'] ?? '');
+        $dotenvVars = $_SERVER['SYMFONY_DOTENV_VARS'] ?? '';
+
+        if ('' === $dotenvVars) {
+            return [];
+        }
+
+        $vars = explode(',', $dotenvVars);
         sort($vars);
 
         $output = [];

--- a/src/Symfony/Component/Dotenv/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DebugCommandTest.php
@@ -25,6 +25,8 @@ class DebugCommandTest extends TestCase
      */
     public function testErrorOnUninitializedDotenv()
     {
+        unset($_SERVER['SYMFONY_DOTENV_VARS']);
+
         $command = new DebugCommand('dev', __DIR__.'/Fixtures/Scenario1');
         $command->setHelperSet(new HelperSet([new FormatterHelper()]));
         $tester = new CommandTester($command);
@@ -32,6 +34,30 @@ class DebugCommandTest extends TestCase
         $output = $tester->getDisplay();
 
         $this->assertStringContainsString('[ERROR] Dotenv component is not initialized', $output);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testEmptyDotEnvVarsList()
+    {
+        $_SERVER['SYMFONY_DOTENV_VARS'] = '';
+
+        $command = new DebugCommand('dev', __DIR__.'/Fixtures/Scenario1');
+        $command->setHelperSet(new HelperSet([new FormatterHelper()]));
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+        $expectedFormat = <<<'OUTPUT'
+%a
+ ---------- ------- ------------ ------%S
+  Variable   Value   .env.local   .env%S
+ ---------- ------- ------------ ------%S
+
+ // Note real values might be different between web and CLI.%S
+%a
+OUTPUT;
+
+        $this->assertStringMatchesFormat($expectedFormat, $tester->getDisplay());
     }
 
     public function testScenario1InDevEnv()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT