### PR TITLE
[Messenger] Fix Redis messenger scheme comparison

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransportFactory.php
@@ -32,6 +32,6 @@ class RedisTransportFactory implements TransportFactoryInterface
 
     public function supports(#[\SensitiveParameter] string $dsn, array $options): bool
     {
-        return str_starts_with($dsn, 'redis://') || str_starts_with($dsn, 'rediss://');
+        return str_starts_with($dsn, 'redis:') || str_starts_with($dsn, 'rediss:');
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #52899 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Commit 3380518b88f8303ad9428f26c103e6b3b64a9fc5 introduced a new Redis Sentinel DSN for the redis messenger transport which uses a scheme syntax like `redis:?host[rs:1234]&host[rs2:1234]`.
Though, the coresponding factory only supports schemes which start with `redis://` or `rediss://` which renders the redis sentinel features for the messenger unusable. This commit fixes the supported schemes by removing the `//` portion of them.

fixes #52899