### PR TITLE
[Translation] Allow `translation:extract` to sort messages with `--force`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -277,7 +277,14 @@ EOF
                 $bundleTransPath = end($transPaths);
             }
 
-            $this->writer->write($operation->getResult(), $format, ['path' => $bundleTransPath, 'default_locale' => $this->defaultLocale, 'xliff_version' => $xliffVersion, 'as_tree' => $input->getOption('as-tree'), 'inline' => $input->getOption('as-tree') ?? 0]);
+            $this->writer->write($operation->getResult(), $format, [
+                'path' => $bundleTransPath,
+                'default_locale' => $this->defaultLocale,
+                'xliff_version' => $xliffVersion,
+                'as_tree' => $input->getOption('as-tree'),
+                'inline' => $input->getOption('as-tree') ?? 0,
+                'sort' => $input->getOption('sort'),
+            ]);
 
             if (true === $input->getOption('dump-messages')) {
                 $resultMessage .= ' and translation files were updated';

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -87,7 +87,7 @@ class TranslationUpdateCommand extends Command
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Should the extract be done'),
                 new InputOption('clean', null, InputOption::VALUE_NONE, 'Should clean not found messages'),
                 new InputOption('domain', null, InputOption::VALUE_OPTIONAL, 'Specify the domain to extract'),
-                new InputOption('sort', null, InputOption::VALUE_OPTIONAL, 'Return list of messages sorted alphabetically (only works with --dump-messages)', 'asc'),
+                new InputOption('sort', null, InputOption::VALUE_OPTIONAL, 'Return list of messages sorted alphabetically', 'asc'),
                 new InputOption('as-tree', null, InputOption::VALUE_OPTIONAL, 'Dump the messages as a tree-like structure: The given value defines the level where to switch to inline YAML'),
             ])
             ->setHelp(<<<'EOF'
@@ -116,6 +116,7 @@ You can sort the output with the <comment>--sort</> flag:
 You can dump a tree-like structure using the yaml format with <comment>--as-tree</> flag:
 
     <info>php %command.full_name% --force --format=yaml --as-tree=3 en AcmeBundle</info>
+    <info>php %command.full_name% --force --format=yaml --sort=asc --as-tree=3 fr</info>
 
 EOF
             )

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -87,7 +87,7 @@ class TranslationUpdateCommand extends Command
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Should the extract be done'),
                 new InputOption('clean', null, InputOption::VALUE_NONE, 'Should clean not found messages'),
                 new InputOption('domain', null, InputOption::VALUE_OPTIONAL, 'Specify the domain to extract'),
-                new InputOption('sort', null, InputOption::VALUE_OPTIONAL, 'Return list of messages sorted alphabetically', 'asc'),
+                new InputOption('sort', null, InputOption::VALUE_OPTIONAL, 'Return list of messages sorted alphabetically'),
                 new InputOption('as-tree', null, InputOption::VALUE_OPTIONAL, 'Dump the messages as a tree-like structure: The given value defines the level where to switch to inline YAML'),
             ])
             ->setHelp(<<<'EOF'
@@ -235,19 +235,22 @@ EOF
 
                 $domainMessagesCount = \count($list);
 
-                if ($sort = $input->getOption('sort')) {
-                    $sort = strtolower($sort);
-                    if (!\in_array($sort, self::SORT_ORDERS, true)) {
-                        $errorIo->error(['Wrong sort order', 'Supported formats are: '.implode(', ', self::SORT_ORDERS).'.']);
+                $sort = $input->getOption('sort');
+                if (null === $sort) {
+                    $sort = 'asc';
+                }
 
-                        return 1;
-                    }
+                $sort = strtolower($sort);
+                if (!\in_array($sort, self::SORT_ORDERS, true)) {
+                    $errorIo->error(['Wrong sort order', 'Supported formats are: '.implode(', ', self::SORT_ORDERS).'.']);
 
-                    if (self::DESC === $sort) {
-                        rsort($list);
-                    } else {
-                        sort($list);
-                    }
+                    return 1;
+                }
+
+                if (self::DESC === $sort) {
+                    rsort($list);
+                } else {
+                    sort($list);
                 }
 
                 $io->section(sprintf('Messages extracted for domain "<info>%s</info>" (%d message%s)', $domain, $domainMessagesCount, $domainMessagesCount > 1 ? 's' : ''));

--- a/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
@@ -27,7 +27,9 @@ class CsvFileDumper extends FileDumper
     {
         $handle = fopen('php://memory', 'r+');
 
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        $sort = $options['sort'] ?? null;
+
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             fputcsv($handle, [$source, $target], $this->delimiter, $this->enclosure);
         }
 

--- a/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
@@ -27,7 +27,7 @@ class CsvFileDumper extends FileDumper
     {
         $handle = fopen('php://memory', 'r+');
 
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             fputcsv($handle, [$source, $target], $this->delimiter, $this->enclosure);
         }
 

--- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
@@ -44,6 +44,8 @@ abstract class FileDumper implements DumperInterface
             throw new InvalidArgumentException('The file dumper needs a path option.');
         }
 
+        $sort = $options['sort'] ?? null;
+
         // save a file for each domain
         foreach ($messages->getDomains() as $domain) {
             $fullpath = $options['path'].'/'.$this->getRelativePath($domain, $messages->getLocale());
@@ -55,7 +57,7 @@ abstract class FileDumper implements DumperInterface
             }
 
             $intlDomain = $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX;
-            $intlMessages = $messages->all($intlDomain, $options['sort']);
+            $intlMessages = $messages->all($intlDomain, $sort);
 
             if ($intlMessages) {
                 $intlPath = $options['path'].'/'.$this->getRelativePath($intlDomain, $messages->getLocale());
@@ -64,7 +66,7 @@ abstract class FileDumper implements DumperInterface
                 $messages->replace([], $intlDomain);
 
                 try {
-                    if ($messages->all($domain, $options['sort'])) {
+                    if ($messages->all($domain, $sort)) {
                         file_put_contents($fullpath, $this->formatCatalogue($messages, $domain, $options));
                     }
                     continue;

--- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
@@ -55,7 +55,7 @@ abstract class FileDumper implements DumperInterface
             }
 
             $intlDomain = $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX;
-            $intlMessages = $messages->all($intlDomain);
+            $intlMessages = $messages->all($intlDomain, $options['sort']);
 
             if ($intlMessages) {
                 $intlPath = $options['path'].'/'.$this->getRelativePath($intlDomain, $messages->getLocale());
@@ -64,7 +64,7 @@ abstract class FileDumper implements DumperInterface
                 $messages->replace([], $intlDomain);
 
                 try {
-                    if ($messages->all($domain)) {
+                    if ($messages->all($domain, $options['sort'])) {
                         file_put_contents($fullpath, $this->formatCatalogue($messages, $domain, $options));
                     }
                     continue;

--- a/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
@@ -25,8 +25,9 @@ class IcuResFileDumper extends FileDumper
     public function formatCatalogue(MessageCatalogue $messages, string $domain, array $options = []): string
     {
         $data = $indexes = $resources = '';
+        $sort = $options['sort'] ?? null;
 
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             $indexes .= pack('v', \strlen($data) + 28);
             $data .= $source."\0";
         }
@@ -35,7 +36,7 @@ class IcuResFileDumper extends FileDumper
 
         $keyTop = $this->getPosition($data);
 
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             $resources .= pack('V', $this->getPosition($data));
 
             $data .= pack('V', \strlen($target))
@@ -46,7 +47,7 @@ class IcuResFileDumper extends FileDumper
 
         $resOffset = $this->getPosition($data);
 
-        $data .= pack('v', \count($messages->all($domain, $options['sort'])))
+        $data .= pack('v', \count($messages->all($domain, $sort)))
             .$indexes
             .$this->writePadding($data)
             .$resources

--- a/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
@@ -26,7 +26,7 @@ class IcuResFileDumper extends FileDumper
     {
         $data = $indexes = $resources = '';
 
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             $indexes .= pack('v', \strlen($data) + 28);
             $data .= $source."\0";
         }
@@ -35,7 +35,7 @@ class IcuResFileDumper extends FileDumper
 
         $keyTop = $this->getPosition($data);
 
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             $resources .= pack('V', $this->getPosition($data));
 
             $data .= pack('V', \strlen($target))
@@ -46,7 +46,7 @@ class IcuResFileDumper extends FileDumper
 
         $resOffset = $this->getPosition($data);
 
-        $data .= pack('v', \count($messages->all($domain)))
+        $data .= pack('v', \count($messages->all($domain, $options['sort'])))
             .$indexes
             .$this->writePadding($data)
             .$resources

--- a/src/Symfony/Component/Translation/Dumper/IniFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IniFileDumper.php
@@ -24,7 +24,7 @@ class IniFileDumper extends FileDumper
     {
         $output = '';
 
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             $escapeTarget = str_replace('"', '\"', $target);
             $output .= $source.'="'.$escapeTarget."\"\n";
         }

--- a/src/Symfony/Component/Translation/Dumper/IniFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IniFileDumper.php
@@ -24,7 +24,9 @@ class IniFileDumper extends FileDumper
     {
         $output = '';
 
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        $sort = $options['sort'] ?? null;
+
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             $escapeTarget = str_replace('"', '\"', $target);
             $output .= $source.'="'.$escapeTarget."\"\n";
         }

--- a/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
@@ -23,8 +23,9 @@ class JsonFileDumper extends FileDumper
     public function formatCatalogue(MessageCatalogue $messages, string $domain, array $options = []): string
     {
         $flags = $options['json_encoding'] ?? \JSON_PRETTY_PRINT;
+        $sort = $options['sort'] ?? null;
 
-        return json_encode($messages->all($domain, $options['sort']), $flags);
+        return json_encode($messages->all($domain, $sort), $flags);
     }
 
     protected function getExtension(): string

--- a/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
@@ -24,7 +24,7 @@ class JsonFileDumper extends FileDumper
     {
         $flags = $options['json_encoding'] ?? \JSON_PRETTY_PRINT;
 
-        return json_encode($messages->all($domain), $flags);
+        return json_encode($messages->all($domain, $options['sort']), $flags);
     }
 
     protected function getExtension(): string

--- a/src/Symfony/Component/Translation/Dumper/MoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/MoFileDumper.php
@@ -27,7 +27,7 @@ class MoFileDumper extends FileDumper
         $offsets = [];
         $size = 0;
 
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             $offsets[] = array_map('strlen', [$sources, $source, $targets, $target]);
             $sources .= "\0".$source;
             $targets .= "\0".$target;

--- a/src/Symfony/Component/Translation/Dumper/MoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/MoFileDumper.php
@@ -27,7 +27,9 @@ class MoFileDumper extends FileDumper
         $offsets = [];
         $size = 0;
 
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        $sort = $options['sort'] ?? null;
+
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             $offsets[] = array_map('strlen', [$sources, $source, $targets, $target]);
             $sources .= "\0".$source;
             $targets .= "\0".$target;

--- a/src/Symfony/Component/Translation/Dumper/PhpFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PhpFileDumper.php
@@ -22,7 +22,9 @@ class PhpFileDumper extends FileDumper
 {
     public function formatCatalogue(MessageCatalogue $messages, string $domain, array $options = []): string
     {
-        return "<?php\n\nreturn ".var_export($messages->all($domain, $options['sort']), true).";\n";
+        $sort = $options['sort'] ?? null;
+
+        return "<?php\n\nreturn ".var_export($messages->all($domain, $sort), true).";\n";
     }
 
     protected function getExtension(): string

--- a/src/Symfony/Component/Translation/Dumper/PhpFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PhpFileDumper.php
@@ -22,7 +22,7 @@ class PhpFileDumper extends FileDumper
 {
     public function formatCatalogue(MessageCatalogue $messages, string $domain, array $options = []): string
     {
-        return "<?php\n\nreturn ".var_export($messages->all($domain), true).";\n";
+        return "<?php\n\nreturn ".var_export($messages->all($domain, $options['sort']), true).";\n";
     }
 
     protected function getExtension(): string

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -29,8 +29,10 @@ class PoFileDumper extends FileDumper
         $output .= '"Language: '.$messages->getLocale().'\n"'."\n";
         $output .= "\n";
 
+        $sort = $options['sort'] ?? null;
+
         $newLine = false;
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             if ($newLine) {
                 $output .= "\n";
             } else {

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -30,7 +30,7 @@ class PoFileDumper extends FileDumper
         $output .= "\n";
 
         $newLine = false;
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             if ($newLine) {
                 $output .= "\n";
             } else {

--- a/src/Symfony/Component/Translation/Dumper/QtFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/QtFileDumper.php
@@ -28,7 +28,9 @@ class QtFileDumper extends FileDumper
         $context = $ts->appendChild($dom->createElement('context'));
         $context->appendChild($dom->createElement('name', $domain));
 
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        $sort = $options['sort'] ?? null;
+
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             $message = $context->appendChild($dom->createElement('message'));
             $metadata = $messages->getMetadata($source, $domain);
             if (isset($metadata['sources'])) {

--- a/src/Symfony/Component/Translation/Dumper/QtFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/QtFileDumper.php
@@ -28,7 +28,7 @@ class QtFileDumper extends FileDumper
         $context = $ts->appendChild($dom->createElement('context'));
         $context->appendChild($dom->createElement('name', $domain));
 
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             $message = $context->appendChild($dom->createElement('message'));
             $metadata = $messages->getMetadata($source, $domain);
             if (isset($metadata['sources'])) {

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -90,7 +90,7 @@ class XliffFileDumper extends FileDumper
         }
 
         $xliffBody = $xliffFile->appendChild($dom->createElement('body'));
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             $translation = $dom->createElement('trans-unit');
 
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
@@ -165,7 +165,7 @@ class XliffFileDumper extends FileDumper
             }
         }
 
-        foreach ($messages->all($domain) as $source => $target) {
+        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
             $translation = $dom->createElement('unit');
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
 

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -43,7 +43,7 @@ class XliffFileDumper extends FileDumper
             return $this->dumpXliff1($defaultLocale, $messages, $domain, $options);
         }
         if ('2.0' === $xliffVersion) {
-            return $this->dumpXliff2($defaultLocale, $messages, $domain);
+            return $this->dumpXliff2($defaultLocale, $messages, $domain, $options);
         }
 
         throw new InvalidArgumentException(sprintf('No support implemented for dumping XLIFF version "%s".', $xliffVersion));
@@ -56,6 +56,8 @@ class XliffFileDumper extends FileDumper
 
     private function dumpXliff1(string $defaultLocale, MessageCatalogue $messages, ?string $domain, array $options = []): string
     {
+        $sort = $options['sort'] ?? null;
+
         $toolInfo = ['tool-id' => 'symfony', 'tool-name' => 'Symfony'];
         if (\array_key_exists('tool_info', $options)) {
             $toolInfo = array_merge($toolInfo, $options['tool_info']);
@@ -90,7 +92,7 @@ class XliffFileDumper extends FileDumper
         }
 
         $xliffBody = $xliffFile->appendChild($dom->createElement('body'));
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             $translation = $dom->createElement('trans-unit');
 
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
@@ -137,8 +139,10 @@ class XliffFileDumper extends FileDumper
         return $dom->saveXML();
     }
 
-    private function dumpXliff2(string $defaultLocale, MessageCatalogue $messages, ?string $domain): string
+    private function dumpXliff2(string $defaultLocale, MessageCatalogue $messages, ?string $domain, array $options = []): string
     {
+        $sort = $options['sort'] ?? null;
+
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = true;
 
@@ -165,7 +169,7 @@ class XliffFileDumper extends FileDumper
             }
         }
 
-        foreach ($messages->all($domain, $options['sort']) as $source => $target) {
+        foreach ($messages->all($domain, $sort) as $source => $target) {
             $translation = $dom->createElement('unit');
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
 

--- a/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
@@ -36,7 +36,7 @@ class YamlFileDumper extends FileDumper
             throw new LogicException('Dumping translations in the YAML format requires the Symfony Yaml component.');
         }
 
-        $data = $messages->all($domain);
+        $data = $messages->all($domain, $options['sort']);
 
         if (isset($options['as_tree']) && $options['as_tree']) {
             $data = ArrayConverter::expandToTree($data);

--- a/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
@@ -36,7 +36,9 @@ class YamlFileDumper extends FileDumper
             throw new LogicException('Dumping translations in the YAML format requires the Symfony Yaml component.');
         }
 
-        $data = $messages->all($domain, $options['sort']);
+        $sort = $options['sort'] ?? null;
+
+        $data = $messages->all($domain, $sort);
 
         if (isset($options['as_tree']) && $options['as_tree']) {
             $data = ArrayConverter::expandToTree($data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #37918 <br>Fix #49250<br>Similar to #52337 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

I've started to work on https://github.com/symfony/symfony/issues/37918 in order to sort the translations when using the `--force` argument of the command `translation:extract` (previously `translation:update`).

Actually, sorting only works when using `--dump-messages`. However, it's pretty common that developers want to keep their translations sorted by alphabetical order in order to navigate more easily in the translations files. Actually, this has to be done manually, increasing the risk of mistakes.

~~At the moment, my PR only adds sorting to the `MessageCatalogue::all()` method. I'm not sure how to pass the option from the command down to the MessageCatalogue and I'll need help on that. My best guess is to pass the sort value as a new option to the writer in [the `TranslationUpdateCommand` class](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php#L280). Then, the writer pass the options to the dumper, which is in charge of calling `MessageCatalogue::all()` with the sort option. It means making sure to amend all the different dumpers, but it seems doable.~~ Implemented, see my message below :)

Does this solution look correct to you?