### PR TITLE
[Console] Fix color support check on non-Windows platforms

### DIFF
--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -95,15 +95,17 @@ class StreamOutput extends Output
             return false;
         }
 
-        if (\DIRECTORY_SEPARATOR === '\\') {
-            return (\function_exists('sapi_windows_vt100_support')
-                && @sapi_windows_vt100_support($this->stream))
-                || false !== getenv('ANSICON')
-                || 'ON' === getenv('ConEmuANSI')
-                || str_starts_with((string) getenv('TERM'), 'xterm');
+        if (\DIRECTORY_SEPARATOR === '\\'
+            && \function_exists('sapi_windows_vt100_support')
+            && @sapi_windows_vt100_support($this->stream)
+        ) {
+            return true;
         }
 
         return 'Hyper' === getenv('TERM_PROGRAM')
+            || false !== getenv('ANSICON')
+            || 'ON' === getenv('ConEmuANSI')
+            || str_starts_with((string) getenv('TERM'), 'xterm')
             || stream_isatty($this->stream);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #45917
| License       | MIT

Currently checking the color support based on `ANSICON`, `ConEmuANSI=ON` or `TERM=xTerm` is done only for Widows. I could not find any reason as to why and it does not make much sense as it is. Especially if we consider that `TERM=xTerm` is a term check and we do another one (not Widows specific) which is `TERM_PROGRAM=Hyper`.

This potentially fixes #45917.

This also looks more in line with the intent (based on the title) of #27831 and #27794.