### PR TITLE
[Console] Fix xterm detection

### DIFF
--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -64,9 +64,6 @@ class StreamOutput extends Output
         return $this->stream;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function doWrite(string $message, bool $newline)
     {
         if ($newline) {
@@ -103,7 +100,7 @@ class StreamOutput extends Output
                 && @sapi_windows_vt100_support($this->stream))
                 || false !== getenv('ANSICON')
                 || 'ON' === getenv('ConEmuANSI')
-                || 'xterm' === getenv('TERM');
+                || str_starts_with((string) getenv('TERM'), 'xterm');
         }
 
         return 'Hyper' === getenv('TERM_PROGRAM')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None reported
| License       | MIT

Currently `StreamOutput::hasColorSupport()` returns `true` if `TERM=xterm`. However xterm may have different values such as `xterm-256color`.

Technically I think it would be more correct to check `xterm` or starts with `xterm-`, but I am not convinced there is a need to do so and one may prefer the (tiny) performance advantage? This can easily be changed though.