### PR TITLE
[HttpClient] Add HttpOptions->addHeader as a shortcut to add an header in an existing options object

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -66,6 +66,17 @@ class HttpOptions
     /**
      * @return $this
      */
+    public function addHeader(string $key, string $value): static
+    {
+        $this->options['headers'] ??= [];
+        $this->options['headers'][$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function setHeaders(iterable $headers): static
     {
         $this->options['headers'] = $headers;

--- a/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
@@ -39,4 +39,15 @@ class HttpOptionsTest extends TestCase
     {
         $this->assertSame('foobar', (new HttpOptions())->setAuthBearer('foobar')->toArray()['auth_bearer']);
     }
+
+    public function testAddHeader()
+    {
+        $options = new HttpOptions();
+        $options->addHeader('Accept', 'application/json');
+        $this->assertSame(['Accept' => 'application/json'], $options->toArray()['headers']);
+        $options->addHeader('Accept-Language', 'en-US,en;q=0.5');
+        $this->assertSame(['Accept' => 'application/json', 'Accept-Language' => 'en-US,en;q=0.5'], $options->toArray()['headers']);
+        $options->addHeader('Accept', 'application/html');
+        $this->assertSame(['Accept' => 'application/html', 'Accept-Language' => 'en-US,en;q=0.5'], $options->toArray()['headers']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Currently, the HttpOptions object only provide a ->setHeaders option that override every existing headers. When we are provided an HttpOptions to customize a request, adding a request header requires to get the whole headers array, update it, and then set it back in the HttpOptions object. This DX improvement brings an addHeader option, allowing to add an header to the set without having to manage the existing ones.

When the header option is not yet provided, the ??= operator makes sure the headers is initialized with an empty array (PHP >= 7.4) When a header is already provided, it is overwritten.