### PR TITLE
Use faster hashing algorithms when possible

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -114,6 +114,6 @@ final class TranslationDefaultDomainNodeVisitor extends AbstractNodeVisitor
 
     private function getVarName(): string
     {
-        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+        return sprintf('__internal_%s', hash('xxh128', uniqid(mt_rand(), true)));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
@@ -72,7 +72,7 @@ final class ConsoleProfilerListener implements EventSubscriberInterface
             return;
         }
 
-        $request->attributes->set('_stopwatch_token', substr(hash('sha256', uniqid(mt_rand(), true)), 0, 6));
+        $request->attributes->set('_stopwatch_token', substr(hash('xxh128', uniqid(mt_rand(), true)), 0, 6));
         $this->stopwatch->openSection();
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1693,7 +1693,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
                     ->replaceArgument(0, $expectedSeed)
                     ->replaceArgument(1, 12),
                 (new ChildDefinition('cache.adapter.redis'))
-                    ->replaceArgument(0, new Reference('.cache_connection.kYdiLgf'))
+                    ->replaceArgument(0, new Reference('.cache_connection.U5HliuY'))
                     ->replaceArgument(1, $expectedSeed)
                     ->replaceArgument(2, 12),
             ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
@@ -137,7 +137,7 @@ abstract class CompleteConfigurationTestCase extends TestCase
             [
                 'simple',
                 'security.user_checker',
-                '.security.request_matcher.h5ibf38',
+                '.security.request_matcher.rud_2nr',
                 false,
                 false,
                 '',
@@ -187,7 +187,7 @@ abstract class CompleteConfigurationTestCase extends TestCase
             [
                 'host',
                 'security.user_checker',
-                '.security.request_matcher.bcmu4fb',
+                '.security.request_matcher.ap9sh8g',
                 true,
                 false,
                 'security.user.provider.concrete.default',

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -217,7 +217,7 @@ class CachePoolPass implements CompilerPassInterface
 
     private function getNamespace(string $seed, string $id): string
     {
-        return substr(str_replace('/', '-', base64_encode(hash('sha256', $id.$seed, true))), 0, 10);
+        return substr(str_replace('/', '-', base64_encode(hash('xxh128', $id.$seed, true))), 0, 10);
     }
 
     /**

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
@@ -49,7 +49,7 @@ class CachePoolPassTest extends TestCase
 
         $this->cachePoolPass->process($container);
 
-        $this->assertSame('z3X945Jbf5', $cachePool->getArgument(0));
+        $this->assertSame('cKLcR15Llk', $cachePool->getArgument(0));
     }
 
     public function testNamespaceArgumentIsSeededWithAdapterClassName()
@@ -70,7 +70,7 @@ class CachePoolPassTest extends TestCase
 
         $this->cachePoolPass->process($container);
 
-        $this->assertSame('xmOJ8gqF-Y', $cachePool->getArgument(0));
+        $this->assertSame('mVXLns1cYU', $cachePool->getArgument(0));
     }
 
     public function testNamespaceArgumentIsSeededWithAdapterClassNameWithoutAffectingOtherCachePools()
@@ -97,7 +97,7 @@ class CachePoolPassTest extends TestCase
 
         $this->cachePoolPass->process($container);
 
-        $this->assertSame('xmOJ8gqF-Y', $cachePool->getArgument(0));
+        $this->assertSame('mVXLns1cYU', $cachePool->getArgument(0));
     }
 
     public function testNamespaceArgumentIsNotReplacedIfArrayAdapterIsUsed()
@@ -153,7 +153,7 @@ class CachePoolPassTest extends TestCase
 
         $this->assertInstanceOf(Reference::class, $cachePool->getArgument(0));
         $this->assertSame('foobar', (string) $cachePool->getArgument(0));
-        $this->assertSame('6Ridbw4aMn', $cachePool->getArgument(1));
+        $this->assertSame('ZmalVIjCbI', $cachePool->getArgument(1));
         $this->assertSame(3, $cachePool->getArgument(2));
     }
 
@@ -174,7 +174,7 @@ class CachePoolPassTest extends TestCase
 
         $this->cachePoolPass->process($container);
 
-        $this->assertSame('PeXBWSl6ca', $cachePool->getArgument(1));
+        $this->assertSame('5SvqAqqNBH', $cachePool->getArgument(1));
     }
 
     public function testThrowsExceptionWhenCachePoolTagHasUnknownAttributes()

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1592,7 +1592,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public static function hash(mixed $value): string
     {
-        $hash = substr(base64_encode(hash('sha256', serialize($value), true)), 0, 7);
+        $hash = substr(base64_encode(hash('xxh128', serialize($value), true)), 0, 7);
 
         return str_replace(['/', '+'], ['.', '_'], $hash);
     }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/LazyServiceDumper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/LazyServiceDumper.php
@@ -146,6 +146,6 @@ final class LazyServiceDumper implements DumperInterface
 
         return preg_replace('/^.*\\\\/', '', $definition->getClass())
             .($asGhostObject ? 'Ghost' : 'Proxy')
-            .ucfirst(substr(hash('sha256', $this->salt.'+'.$class->name.'+'.serialize($definition->getTag('proxy'))), -7));
+            .ucfirst(substr(hash('xxh128', $this->salt.'+'.$class->name.'+'.serialize($definition->getTag('proxy'))), -7));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -462,7 +462,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowired', [new Autowire(service: 'service.id')])),
             'autowired.nullable' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'autowired.nullable', [new Autowire(service: 'service.id')])),
             'autowired.parameter' => new ServiceClosureArgument('foobar'),
-            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.oO4rxCy.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
+            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.420ES7z.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'target', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute.php
@@ -78,14 +78,14 @@ class Symfony_DI_PhpDumper_Test_Lazy_Autowire_Attribute extends Container
     protected static function getFoo2Service($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->privates['.lazy.Symfony\\Component\\DependencyInjection\\Tests\\Compiler\\Foo'] = $container->createProxy('FooProxy4048957', static fn () => \FooProxy4048957::createLazyProxy(static fn () => self::getFoo2Service($container, false)));
+            return $container->privates['.lazy.Symfony\\Component\\DependencyInjection\\Tests\\Compiler\\Foo'] = $container->createProxy('FooProxyCd8d23a', static fn () => \FooProxyCd8d23a::createLazyProxy(static fn () => self::getFoo2Service($container, false)));
         }
 
         return ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo());
     }
 }
 
-class FooProxy4048957 extends \Symfony\Component\DependencyInjection\Tests\Compiler\Foo implements \Symfony\Component\VarExporter\LazyObjectInterface
+class FooProxyCd8d23a extends \Symfony\Component\DependencyInjection\Tests\Compiler\Foo implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute_with_intersection.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute_with_intersection.php
@@ -39,7 +39,7 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.lazy.foo.gDmfket' => true,
+            '.lazy.foo.qFdMZVK' => true,
         ];
     }
 
@@ -55,7 +55,7 @@ class ProjectServiceContainer extends Container
      */
     protected static function getFooService($container)
     {
-        $a = ($container->privates['.lazy.foo.gDmfket'] ?? self::get_Lazy_Foo_GDmfketService($container));
+        $a = ($container->privates['.lazy.foo.qFdMZVK'] ?? self::get_Lazy_Foo_QFdMZVKService($container));
 
         if (isset($container->services['foo'])) {
             return $container->services['foo'];
@@ -65,21 +65,21 @@ class ProjectServiceContainer extends Container
     }
 
     /**
-     * Gets the private '.lazy.foo.gDmfket' shared service.
+     * Gets the private '.lazy.foo.qFdMZVK' shared service.
      *
      * @return \object
      */
-    protected static function get_Lazy_Foo_GDmfketService($container, $lazyLoad = true)
+    protected static function get_Lazy_Foo_QFdMZVKService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->privates['.lazy.foo.gDmfket'] = $container->createProxy('objectProxy8ac8e9a', static fn () => \objectProxy8ac8e9a::createLazyProxy(static fn () => self::get_Lazy_Foo_GDmfketService($container, false)));
+            return $container->privates['.lazy.foo.qFdMZVK'] = $container->createProxy('objectProxy1fd6daa', static fn () => \objectProxy1fd6daa::createLazyProxy(static fn () => self::get_Lazy_Foo_QFdMZVKService($container, false)));
         }
 
         return ($container->services['foo'] ?? self::getFooService($container));
     }
 }
 
-class objectProxy8ac8e9a implements \Symfony\Component\DependencyInjection\Tests\Compiler\AInterface, \Symfony\Component\DependencyInjection\Tests\Compiler\IInterface, \Symfony\Component\VarExporter\LazyObjectInterface
+class objectProxy1fd6daa implements \Symfony\Component\DependencyInjection\Tests\Compiler\AInterface, \Symfony\Component\DependencyInjection\Tests\Compiler\IInterface, \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -6,11 +6,11 @@ namespace Container%s;
 
 include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
-class FooClassGhostEe53b95 extends \Bar\FooClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class FooClassGhost1728205 extends \Bar\FooClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 %A
 
-if (!\class_exists('FooClassGhostEe53b95', false)) {
-    \class_alias(__NAMESPACE__.'\\FooClassGhostEe53b95', 'FooClassGhostEe53b95', false);
+if (!\class_exists('FooClassGhost1728205', false)) {
+    \class_alias(__NAMESPACE__.'\\FooClassGhost1728205', 'FooClassGhost1728205', false);
 }
 
     [Container%s/ProjectServiceContainer.php] => <?php
@@ -74,7 +74,7 @@ class ProjectServiceContainer extends Container
     protected static function getLazyFooService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->services['lazy_foo'] = $container->createProxy('FooClassGhostEe53b95', static fn () => \FooClassGhostEe53b95::createLazyGhost(static fn ($proxy) => self::getLazyFooService($container, $proxy)));
+            return $container->services['lazy_foo'] = $container->createProxy('FooClassGhost1728205', static fn () => \FooClassGhost1728205::createLazyGhost(static fn ($proxy) => self::getLazyFooService($container, $proxy)));
         }
 
         include_once $container->targetDir.''.'/Fixtures/includes/foo_lazy.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
@@ -52,7 +52,7 @@ class ProjectServiceContainer extends Container
     protected static function getBarService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->services['bar'] = $container->createProxy('stdClassGhost2fc7938', static fn () => \stdClassGhost2fc7938::createLazyGhost(static fn ($proxy) => self::getBarService($container, $proxy)));
+            return $container->services['bar'] = $container->createProxy('stdClassGhostAa01f12', static fn () => \stdClassGhostAa01f12::createLazyGhost(static fn ($proxy) => self::getBarService($container, $proxy)));
         }
 
         return $lazyLoad;
@@ -66,7 +66,7 @@ class ProjectServiceContainer extends Container
     protected static function getBazService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->services['baz'] = $container->createProxy('stdClassProxy2fc7938', static fn () => \stdClassProxy2fc7938::createLazyProxy(static fn () => self::getBazService($container, false)));
+            return $container->services['baz'] = $container->createProxy('stdClassProxyAa01f12', static fn () => \stdClassProxyAa01f12::createLazyProxy(static fn () => self::getBazService($container, false)));
         }
 
         return \foo_bar();
@@ -80,7 +80,7 @@ class ProjectServiceContainer extends Container
     protected static function getBuzService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->services['buz'] = $container->createProxy('stdClassProxy2fc7938', static fn () => \stdClassProxy2fc7938::createLazyProxy(static fn () => self::getBuzService($container, false)));
+            return $container->services['buz'] = $container->createProxy('stdClassProxyAa01f12', static fn () => \stdClassProxyAa01f12::createLazyProxy(static fn () => self::getBuzService($container, false)));
         }
 
         return \foo_bar();
@@ -94,14 +94,14 @@ class ProjectServiceContainer extends Container
     protected static function getFooService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->services['foo'] = $container->createProxy('stdClassGhost2fc7938', static fn () => \stdClassGhost2fc7938::createLazyGhost(static fn ($proxy) => self::getFooService($container, $proxy)));
+            return $container->services['foo'] = $container->createProxy('stdClassGhostAa01f12', static fn () => \stdClassGhostAa01f12::createLazyGhost(static fn ($proxy) => self::getFooService($container, $proxy)));
         }
 
         return $lazyLoad;
     }
 }
 
-class stdClassGhost2fc7938 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class stdClassGhostAa01f12 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyGhostTrait;
 
@@ -113,7 +113,7 @@ class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
 class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
 class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
 
-class stdClassProxy2fc7938 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class stdClassProxyAa01f12 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_duplicates.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_duplicates.php
@@ -41,7 +41,7 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.mtT6G8y' => true,
+            '.service_locator.lViPm9k' => true,
             'foo' => true,
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_ghost.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_ghost.php
@@ -68,14 +68,14 @@ class ProjectServiceContainer extends Container
         $container->factories['service_container']['foo'] ??= self::getFooService(...);
 
         if (true === $lazyLoad) {
-            return $container->createProxy('stdClassGhost2fc7938', static fn () => \stdClassGhost2fc7938::createLazyGhost(static fn ($proxy) => self::getFooService($container, $proxy)));
+            return $container->createProxy('stdClassGhostAa01f12', static fn () => \stdClassGhostAa01f12::createLazyGhost(static fn ($proxy) => self::getFooService($container, $proxy)));
         }
 
         return $lazyLoad;
     }
 }
 
-class stdClassGhost2fc7938 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class stdClassGhostAa01f12 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyGhostTrait;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_public.php
@@ -51,7 +51,7 @@ class Symfony_DI_PhpDumper_Service_Non_Shared_Lazy extends Container
         $container->factories['foo'] ??= fn () => self::getFooService($container);
 
         if (true === $lazyLoad) {
-            return $container->createProxy('FooLazyClassGhost2108fce', static fn () => \FooLazyClassGhost2108fce::createLazyGhost(static fn ($proxy) => self::getFooService($container, $proxy)));
+            return $container->createProxy('FooLazyClassGhost82ad1a4', static fn () => \FooLazyClassGhost82ad1a4::createLazyGhost(static fn ($proxy) => self::getFooService($container, $proxy)));
         }
 
         static $include = true;
@@ -66,7 +66,7 @@ class Symfony_DI_PhpDumper_Service_Non_Shared_Lazy extends Container
     }
 }
 
-class FooLazyClassGhost2108fce extends \Bar\FooLazyClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class FooLazyClassGhost82ad1a4 extends \Bar\FooLazyClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyGhostTrait;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -43,7 +43,7 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.PWbaRiJ' => true,
+            '.service_locator.DyWBOhJ' => true,
         ];
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
@@ -44,7 +44,7 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.ZP1tNYN' => true,
+            '.service_locator.X7o4UPP' => true,
             'foo2' => true,
             'foo3' => true,
             'foo4' => true,

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -43,9 +43,9 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.2hyyc9y' => true,
-            '.service_locator.KGUGnmw' => true,
-            '.service_locator.KGUGnmw.foo_service' => true,
+            '.service_locator.2x56Fsq' => true,
+            '.service_locator.2x56Fsq.foo_service' => true,
+            '.service_locator.K8KBCZO' => true,
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => true,
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
@@ -56,7 +56,7 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy extends Container
     protected static function getWitherService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->services['wither'] = $container->createProxy('WitherProxy580fe0f', static fn () => \WitherProxy580fe0f::createLazyProxy(static fn () => self::getWitherService($container, false)));
+            return $container->services['wither'] = $container->createProxy('WitherProxy1991f2a', static fn () => \WitherProxy1991f2a::createLazyProxy(static fn () => self::getWitherService($container, false)));
         }
 
         $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\Wither();
@@ -71,7 +71,7 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy extends Container
     }
 }
 
-class WitherProxy580fe0f extends \Symfony\Component\DependencyInjection\Tests\Compiler\Wither implements \Symfony\Component\VarExporter\LazyObjectInterface
+class WitherProxy1991f2a extends \Symfony\Component\DependencyInjection\Tests\Compiler\Wither implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy_non_shared.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy_non_shared.php
@@ -58,7 +58,7 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy_Non_Shared extends Container
         $container->factories['wither'] ??= fn () => self::getWitherService($container);
 
         if (true === $lazyLoad) {
-            return $container->createProxy('WitherProxyDd381be', static fn () => \WitherProxyDd381be::createLazyProxy(static fn () => self::getWitherService($container, false)));
+            return $container->createProxy('WitherProxyE94fdba', static fn () => \WitherProxyE94fdba::createLazyProxy(static fn () => self::getWitherService($container, false)));
         }
 
         $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\Wither();
@@ -73,7 +73,7 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy_Non_Shared extends Container
     }
 }
 
-class WitherProxyDd381be extends \Symfony\Component\DependencyInjection\Tests\Compiler\Wither implements \Symfony\Component\VarExporter\LazyObjectInterface
+class WitherProxyE94fdba extends \Symfony\Component\DependencyInjection\Tests\Compiler\Wither implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 

--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -55,7 +55,7 @@ class FileFormField extends FormField
             $name = $info['basename'];
 
             // copy to a tmp location
-            $tmp = sys_get_temp_dir().'/'.strtr(substr(base64_encode(hash('sha256', uniqid(mt_rand(), true), true)), 0, 7), '/', '_');
+            $tmp = sys_get_temp_dir().'/'.strtr(substr(base64_encode(hash('xxh128', uniqid(mt_rand(), true), true)), 0, 7), '/', '_');
             if (\array_key_exists('extension', $info)) {
                 $tmp .= '.'.$info['extension'];
             }

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -134,7 +134,7 @@ class BinaryFileResponse extends Response
      */
     public function setAutoEtag(): static
     {
-        $this->setEtag(base64_encode(hash_file('sha256', $this->file->getPathname(), true)));
+        $this->setEtag(base64_encode(hash_file('xxh128', $this->file->getPathname(), true)));
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -169,7 +169,7 @@ class MockArraySessionStorage implements SessionStorageInterface
      */
     protected function generateId(): string
     {
-        return hash('sha256', uniqid('ss_mock_', true));
+        return hash('xxh128', uniqid('ss_mock_', true));
     }
 
     protected function loadSession(): void

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -27,7 +27,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     {
         switch ($eventName) {
             case KernelEvents::REQUEST:
-                $event->getRequest()->attributes->set('_stopwatch_token', substr(hash('sha256', uniqid(mt_rand(), true)), 0, 6));
+                $event->getRequest()->attributes->set('_stopwatch_token', substr(hash('xxh128', uniqid(mt_rand(), true)), 0, 6));
                 $this->stopwatch->openSection();
                 break;
             case KernelEvents::VIEW:

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -136,7 +136,7 @@ class Profiler implements ResetInterface
             return null;
         }
 
-        $profile = new Profile(substr(hash('sha256', uniqid(mt_rand(), true)), 0, 6));
+        $profile = new Profile(substr(hash('xxh128', uniqid(mt_rand(), true)), 0, 6));
         $profile->setTime(time());
         $profile->setUrl($request->getUri());
         $profile->setMethod($request->getMethod());

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -75,7 +75,7 @@ class CrowdinProviderTest extends ProviderTestCase
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_en_a</target>
       </trans-unit>
@@ -93,7 +93,7 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="is7pld7" resname="post.num_comments">
+      <trans-unit id="9dF75ai" resname="post.num_comments">
         <source>post.num_comments</source>
         <target>{count, plural, one {# comment} other {# comments}}</target>
       </trans-unit>
@@ -171,7 +171,7 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_en_a</target>
       </trans-unit>
@@ -236,7 +236,7 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_en_a</target>
       </trans-unit>
@@ -308,7 +308,7 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_fr_a</target>
       </trans-unit>
@@ -326,7 +326,7 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_en_a</target>
       </trans-unit>
@@ -415,11 +415,11 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_en_a</target>
       </trans-unit>
-      <trans-unit id="PiPoFgA" resname="b">
+      <trans-unit id="SyIS4xr" resname="b">
         <source>b</source>
         <target>trans_en_b</target>
       </trans-unit>
@@ -489,7 +489,7 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_en_a</target>
       </trans-unit>
@@ -575,7 +575,7 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_fr_a</target>
       </trans-unit>
@@ -602,7 +602,7 @@ XLIFF
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="ypeBEso" resname="a">
+      <trans-unit id="qW_vcFr" resname="a">
         <source>a</source>
         <target>trans_en_gb_a</target>
       </trans-unit>

--- a/src/Symfony/Component/Translation/Bridge/Phrase/Tests/PhraseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/Tests/PhraseProviderTest.php
@@ -797,11 +797,11 @@ class PhraseProviderTest extends TestCase
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="qdGDk9Z" resname="general.back">
+      <trans-unit id="YQ5EBNy" resname="general.back">
         <source>general.back</source>
         <target><![CDATA[back &!]]></target>
       </trans-unit>
-      <trans-unit id="0ESGki9" resname="general.cancel">
+      <trans-unit id="QoyA.iN" resname="general.cancel">
         <source>general.cancel</source>
         <target>Cancel</target>
       </trans-unit>
@@ -837,11 +837,11 @@ XLIFF;
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="qdGDk9Z" resname="general.back">
+      <trans-unit id="YQ5EBNy" resname="general.back">
         <source>general.back</source>
         <target>zurück</target>
       </trans-unit>
-      <trans-unit id="0ESGki9" resname="general.cancel">
+      <trans-unit id="QoyA.iN" resname="general.cancel">
         <source>general.cancel</source>
         <target>Abbrechen</target>
       </trans-unit>

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -93,7 +93,7 @@ class XliffFileDumper extends FileDumper
         foreach ($messages->all($domain) as $source => $target) {
             $translation = $dom->createElement('trans-unit');
 
-            $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
+            $translation->setAttribute('id', strtr(substr(base64_encode(hash('xxh128', $source, true)), 0, 7), '/+', '._'));
             $translation->setAttribute('resname', $source);
 
             $s = $translation->appendChild($dom->createElement('source'));
@@ -167,7 +167,7 @@ class XliffFileDumper extends FileDumper
 
         foreach ($messages->all($domain) as $source => $target) {
             $translation = $dom->createElement('unit');
-            $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
+            $translation->setAttribute('id', strtr(substr(base64_encode(hash('xxh128', $source, true)), 0, 7), '/+', '._'));
 
             if (\strlen($source) <= 80) {
                 $translation->setAttribute('name', $source);

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -93,11 +93,11 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>newFoo</target>
             </trans-unit>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>NOTE</target>
             </trans-unit>
@@ -114,7 +114,7 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="1IHotcu" resname="say_hello">
+            <trans-unit id="Shv46xh" resname="say_hello">
                 <source>say_hello</source>
                 <target>Welcome, {firstname}!</target>
             </trans-unit>
@@ -131,11 +131,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>nouveauFoo</target>
             </trans-unit>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>NOTE</target>
             </trans-unit>
@@ -152,7 +152,7 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="1IHotcu" resname="say_hello">
+            <trans-unit id="Shv46xh" resname="say_hello">
                 <source>say_hello</source>
                 <target>Bonjour, {firstname}!</target>
             </trans-unit>
@@ -199,13 +199,13 @@ XLIFF
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
   <file id="messages.en">
-    <unit id="994ixRL" name="new.foo">
+    <unit id="5pyqChA" name="new.foo">
       <segment>
         <source>new.foo</source>
         <target>newFoo</target>
       </segment>
     </unit>
-    <unit id="7bRlYkK" name="note">
+    <unit id=".DOalbi" name="note">
       <segment>
         <source>note</source>
         <target>NOTE</target>
@@ -219,13 +219,13 @@ XLIFF
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="fr">
   <file id="messages.fr">
-    <unit id="994ixRL" name="new.foo">
+    <unit id="5pyqChA" name="new.foo">
       <segment>
         <source>new.foo</source>
         <target>nouveauFoo</target>
       </segment>
     </unit>
-    <unit id="7bRlYkK" name="note">
+    <unit id=".DOalbi" name="note">
       <segment>
         <source>note</source>
         <target>NOTE</target>
@@ -377,11 +377,11 @@ YAML, file_get_contents($filenameFr));
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>UPDATED NOTE</target>
             </trans-unit>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>newFoo</target>
             </trans-unit>
@@ -398,11 +398,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>NOTE MISE À JOUR</target>
             </trans-unit>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>nouveauFoo</target>
             </trans-unit>
@@ -420,11 +420,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="kA4akVr" resname="foo.error">
+            <trans-unit id="nYScnTy" resname="foo.error">
                 <source>foo.error</source>
                 <target>Bad value</target>
             </trans-unit>
-            <trans-unit id="OcBtn3X" resname="bar.error">
+            <trans-unit id="fe0ouWC" resname="bar.error">
                 <source>bar.error</source>
                 <target>Bar error</target>
             </trans-unit>
@@ -441,11 +441,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="kA4akVr" resname="foo.error">
+            <trans-unit id="nYScnTy" resname="foo.error">
                 <source>foo.error</source>
                 <target>Valeur invalide</target>
             </trans-unit>
-            <trans-unit id="OcBtn3X" resname="bar.error">
+            <trans-unit id="fe0ouWC" resname="bar.error">
                 <source>bar.error</source>
                 <target>Bar erreur</target>
             </trans-unit>
@@ -500,11 +500,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>UPDATED NOTE</target>
             </trans-unit>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>newFoo</target>
             </trans-unit>
@@ -521,11 +521,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>NOTE MISE À JOUR</target>
             </trans-unit>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>nouveauFoo</target>
             </trans-unit>
@@ -576,11 +576,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>newFoo</target>
             </trans-unit>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>NOTE</target>
             </trans-unit>
@@ -597,11 +597,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>nouveauFoo</target>
             </trans-unit>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>NOTE</target>
             </trans-unit>
@@ -653,11 +653,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>newFoo</target>
             </trans-unit>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>NOTE</target>
             </trans-unit>
@@ -674,11 +674,11 @@ XLIFF
             <tool tool-id="symfony" tool-name="Symfony"/>
         </header>
         <body>
-            <trans-unit id="994ixRL" resname="new.foo">
+            <trans-unit id="5pyqChA" resname="new.foo">
                 <source>new.foo</source>
                 <target>newFoo</target>
             </trans-unit>
-            <trans-unit id="7bRlYkK" resname="note">
+            <trans-unit id=".DOalbi" resname="note">
                 <source>note</source>
                 <target>NOTE</target>
             </trans-unit>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0+intl-icu.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0+intl-icu.xlf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
   <file id="messages.en_US">
-    <unit id="LCa0a2j" name="foo">
+    <unit id="ea75LoN" name="foo">
       <segment>
         <source>foo</source>
         <target>bar</target>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0-clean.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0-clean.xlf
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
   <file id="messages.en_US">
-    <unit id="LCa0a2j" name="foo">
+    <unit id="ea75LoN" name="foo">
       <segment>
         <source>foo</source>
         <target>bar</target>
       </segment>
     </unit>
-    <unit id="LHDhK3o" name="key">
+    <unit id="pL305WR" name="key">
       <segment>
         <source>key</source>
         <target order="1"></target>
       </segment>
     </unit>
-    <unit id="2DA_bnh" name="key.with.cdata">
+    <unit id="FrtCNPU" name="key.with.cdata">
       <segment>
         <source>key.with.cdata</source>
         <target><![CDATA[<source> & <target>]]></target>
       </segment>
     </unit>
-    <unit id="aF1tx51">
+    <unit id="UJTTgBF">
       <segment>
         <source>translation.key.that.is.longer.than.eighty.characters.should.not.have.name.attribute</source>
         <target>value</target>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-clean.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-clean.xlf
@@ -5,18 +5,18 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="LCa0a2j" resname="foo">
+      <trans-unit id="ea75LoN" resname="foo">
         <source>foo</source>
         <target>bar</target>
         <note priority="1" from="bar">baz</note>
       </trans-unit>
-      <trans-unit id="LHDhK3o" resname="key">
+      <trans-unit id="pL305WR" resname="key">
         <source>key</source>
         <target></target>
         <note>baz</note>
         <note>qux</note>
       </trans-unit>
-      <trans-unit id="2DA_bnh" resname="key.with.cdata">
+      <trans-unit id="FrtCNPU" resname="key.with.cdata">
         <source>key.with.cdata</source>
         <target><![CDATA[<source> & <target>]]></target>
       </trans-unit>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-clean.xliff
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-clean.xliff
@@ -5,18 +5,18 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="LCa0a2j" resname="foo">
+      <trans-unit id="ea75LoN" resname="foo">
         <source>foo</source>
         <target>bar</target>
         <note priority="1" from="bar">baz</note>
       </trans-unit>
-      <trans-unit id="LHDhK3o" resname="key">
+      <trans-unit id="pL305WR" resname="key">
         <source>key</source>
         <target></target>
         <note>baz</note>
         <note>qux</note>
       </trans-unit>
-      <trans-unit id="2DA_bnh" resname="key.with.cdata">
+      <trans-unit id="FrtCNPU" resname="key.with.cdata">
         <source>key.with.cdata</source>
         <target><![CDATA[<source> & <target>]]></target>
       </trans-unit>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-notes-meta.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-notes-meta.xlf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
   <file id="messages.en_US">
-    <unit id="LCa0a2j" name="foo">
+    <unit id="ea75LoN" name="foo">
       <notes>
         <note category="state">new</note>
         <note category="approved">true</note>
@@ -12,7 +12,7 @@
         <target>bar</target>
       </segment>
     </unit>
-    <unit id="uqWglk0" name="baz">
+    <unit id=".Odr9ig" name="baz">
       <notes>
         <note id="x">x_content</note>
         <note appliesTo="target" category="quality">Fuzzy</note>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-target-attributes.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-target-attributes.xlf
@@ -5,7 +5,7 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="LCa0a2j" resname="foo">
+      <trans-unit id="ea75LoN" resname="foo">
         <source>foo</source>
         <target state="needs-translation">bar</target>
       </trans-unit>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-tool-info.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-tool-info.xlf
@@ -5,7 +5,7 @@
       <tool tool-id="foo" tool-name="foo" tool-version="0.0" tool-company="Foo"/>
     </header>
     <body>
-      <trans-unit id="LCa0a2j" resname="foo">
+      <trans-unit id="ea75LoN" resname="foo">
         <source>foo</source>
         <target>bar</target>
       </trans-unit>

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -324,7 +324,7 @@ EOF
 
     private function getCatalogueCachePath(string $locale): string
     {
-        return $this->cacheDir.'/catalogue.'.$locale.'.'.strtr(substr(base64_encode(hash('sha256', serialize($this->cacheVary), true)), 0, 7), '/', '_').'.php';
+        return $this->cacheDir.'/catalogue.'.$locale.'.'.strtr(substr(base64_encode(hash('xxh128', serialize($this->cacheVary), true)), 0, 7), '/', '_').'.php';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`xxh128` is 60 times faster than `sha256` (source: https://php.watch/versions/8.1/xxHash) but it's not cryptographically secure.

In previous versions we already used `xxh128` in some places. In this PR I propose to use it in all places where we don't need a cryptographically secure hash.

Comments:

* ~I also remove some `base64` encoding of binary hashes, etc. It looks convoluted and to me it looks unnecessary. But I can revert these changes if needed.~ **REVERTED**
* There are some places where we can probably use `xxh128` but I'm not sure, so I didn't. These:
  * https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php#L71
  * https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/HttpKernel/HttpCache/Store.php#L421-L434
  * https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/HttpKernel/HttpCache/Store.php#L421-L434
* And there's this use case, where a function explicitly tells that we're generating a sha256 hash, so I'm not sure if changing it is a BC break: https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php#L42-L65

#SymfonyHackday