### PR TITLE
[Messenger] Add `UnwrapHandlerExceptionMiddleware`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -32,6 +32,7 @@ use Symfony\Component\Messenger\Middleware\RejectRedeliveredMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
 use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\TraceableMiddleware;
+use Symfony\Component\Messenger\Middleware\UnwrapHandlerExceptionMiddleware;
 use Symfony\Component\Messenger\Middleware\ValidationMiddleware;
 use Symfony\Component\Messenger\Retry\MultiplierRetryStrategy;
 use Symfony\Component\Messenger\RoutableMessageBus;
@@ -110,6 +111,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('router'),
             ])
+
+        ->set('messenger.middleware.unwrap_handler_exception', UnwrapHandlerExceptionMiddleware::class)
 
         // Discovery
         ->set('messenger.receiver_locator', ServiceLocator::class)

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add option `redis_sentinel` as an alias for `sentinel_master`
  * Add `--all` option to the `messenger:consume` command
  * Make `#[AsMessageHandler]` final
+ * Add `UnwrapHandlerExceptionMiddleware`
 
 7.0
 ---

--- a/src/Symfony/Component/Messenger/Middleware/UnwrapHandlerExceptionMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/UnwrapHandlerExceptionMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\LogicException;
+
+class UnwrapHandlerExceptionMiddleware implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } catch (HandlerFailedException $exception) {
+            $wrappedExceptions = $exception->getWrappedExceptions();
+
+            if (1 !== \count($wrappedExceptions)) {
+                throw new LogicException(sprintf('"%s" can only unwrap a single exception, but got %d.', __CLASS__, \count($wrappedExceptions)));
+            }
+
+            throw reset($wrappedExceptions);
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/UnwrapHandlerExceptionMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/UnwrapHandlerExceptionMiddleware.php
@@ -25,7 +25,7 @@ class UnwrapHandlerExceptionMiddleware implements MiddlewareInterface
             $wrappedExceptions = $exception->getWrappedExceptions();
 
             if (1 !== \count($wrappedExceptions)) {
-                throw new LogicException(sprintf('"%s" can only unwrap a single exception, but got %d.', __CLASS__, \count($wrappedExceptions)));
+                throw new LogicException(sprintf('%s can only unwrap a single exception, but got %d.', __CLASS__, \count($wrappedExceptions)));
             }
 
             throw reset($wrappedExceptions);

--- a/src/Symfony/Component/Messenger/Tests/Middleware/UnwrapHandlerExceptionMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/UnwrapHandlerExceptionMiddlewareTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Middleware\UnwrapHandlerExceptionMiddleware;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class UnwrapHandlerExceptionMiddlewareTest extends MiddlewareTestCase
+{
+    public function testItThrowTheWrappedException()
+    {
+        $middleware = new UnwrapHandlerExceptionMiddleware();
+        $envelope = new Envelope(new \stdClass());
+        $wrappedException = new \RuntimeException('Wrapped exception.');
+        $exception = new HandlerFailedException($envelope, ['single handler' => $wrappedException]);
+
+        $this->expectException($wrappedException::class);
+        $this->expectExceptionMessage($wrappedException->getMessage());
+
+        $middleware->handle($envelope, $this->getThrowingStackMock($exception));
+    }
+
+    public function testItFailsWhenThereIsManyWrappedExceptions()
+    {
+        $middleware = new UnwrapHandlerExceptionMiddleware();
+        $envelope = new Envelope(new \stdClass());
+        $exception = new HandlerFailedException($envelope, [
+            'first handler' => new \RuntimeException('Wrapped exception.'),
+            'second handler' => new \RuntimeException('Wrapped exception.'),
+        ]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('"Symfony\Component\Messenger\Middleware\UnwrapHandlerExceptionMiddleware" can only unwrap a single exception, but got 2.');
+
+        $middleware->handle($envelope, $this->getThrowingStackMock($exception));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52300
| License       | MIT

In competition with #52952

When using [the `HandleTrait`](https://symfony.com/doc/current/messenger.html#getting-results-when-working-with-command-query-buses), the `HandlerFailedException` just adds noise as the wrapped exception is the one we would expect to be thrown.

This PR adds an `UnwrapHandlerExceptionMiddleware` (idea stolen from [Sulu’s `UnpackExceptionMiddleware`](https://github.com/sulu/messenger#unpackexceptionmiddleware)): added to a bus before the `HandleMessageMiddleware`, it will throw the single exception wrapped in a `HandlerFailedException`.