### PR TITLE
[WebProfilerBundle] Set `XDEBUG_IGNORE` option for all XHR

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Set `XDEBUG_IGNORE` query parameter when sending toolbar XHR
+
 6.4
 ---
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -78,6 +78,9 @@
             }
 
             var request = function(url, onSuccess, onError, payload, options, tries) {
+                url = new URL(url);
+                url.searchParams.set('XDEBUG_IGNORE', '1');
+                url = url.toString();
                 var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
                 options = options || {};
                 options.retry = options.retry || false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

When using an Xdebug browser extension with Symfony, toolbar requests are also processed by Xdebug because the browser extension has set an `XDEBUG_*` cookie on the page. This leads to superfluous breakpoint triggering when debugging at lower levels of the codebase, as well as a performance hit with no gain for every toolbar request, junk profiler/trace output blobs, etc.

The only sane way to prevent this behavior seems to be for the cookie to never be sent, as Xdebug has no mechanism for ignoring requests to certain URIs, and detecting this condition at the webserver and rewriting the request before passing it off to PHP is also non-trivial.

This PR detects the `XDEBUG_*` cookie and removes it before conducting XHR, then re-sets it after the fact.

Thanks!
