### PR TITLE
[Messenger] Deprecate `HandleTrait` in favor of a new `SingleHandlingTrait`

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -10,6 +10,7 @@ Messenger
 ---------
 
  * Make `#[AsMessageHandler]` final
+ * Deprecate `HandleTrait`, use `SingleHandlingTrait` instead
 
 Workflow
 --------

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add option `redis_sentinel` as an alias for `sentinel_master`
  * Add `--all` option to the `messenger:consume` command
  * Make `#[AsMessageHandler]` final
+ * Deprecate `HandleTrait`, use `SingleHandlingTrait` instead
 
 7.0
 ---

--- a/src/Symfony/Component/Messenger/HandleTrait.php
+++ b/src/Symfony/Component/Messenger/HandleTrait.php
@@ -14,10 +14,14 @@ namespace Symfony\Component\Messenger;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 
+trigger_deprecation('symfony/messenger', '7.1', 'The "%s" class is deprecated, use "%s" instead.', HandleTrait::class, SingleHandlingTrait::class);
+
 /**
  * Leverages a message bus to expect a single, synchronous message handling and return its result.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @deprecated since Symfony 7.1, use SingleHandlingTrait instead.
  */
 trait HandleTrait
 {

--- a/src/Symfony/Component/Messenger/SingleHandlingTrait.php
+++ b/src/Symfony/Component/Messenger/SingleHandlingTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger;
+
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+trait SingleHandlingTrait
+{
+    private readonly MessageBusInterface $messageBus;
+
+    /**
+     * Dispatches the given message, expecting to be handled by a single handler
+     * and returns the result from the handler returned value.
+     * This behavior is useful for both synchronous command & query buses,
+     * the last one usually returning the handler result.
+     *
+     * @param object|Envelope $message The message or the message pre-wrapped in an envelope
+     * @param StampInterface[] $stamps
+     */
+    private function handle(object $message, array $stamps = []): mixed
+    {
+        if (!isset($this->messageBus)) {
+            throw new LogicException(sprintf('You must provide a "%s" instance in the "%s::$messageBus" property, but that property has not been initialized yet.', MessageBusInterface::class, static::class));
+        }
+
+        $exceptions = [];
+
+        try {
+            $envelope = $this->messageBus->dispatch($message, $stamps);
+        } catch (HandlerFailedException $exception) {
+            $envelope = $exception->getEnvelope();
+            $exceptions = $exception->getWrappedExceptions();
+        }
+
+        /** @var HandledStamp[] $handledStamps */
+        $handledStamps = $envelope->all(HandledStamp::class);
+
+        $handlers = array_merge(
+            array_map(static fn (HandledStamp $stamp) => $stamp->getHandlerName(), $handledStamps),
+            array_keys($exceptions),
+        );
+
+        if (!$handlers) {
+            throw new LogicException(sprintf('Message of type "%s" was handled zero times. Exactly one handler is expected when using "%s::%s()".', $envelope->getMessage()::class, static::class, __FUNCTION__));
+        }
+
+        if (\count($handlers) > 1) {
+            throw new LogicException(sprintf('Message of type "%s" was handled multiple times. Only one handler is expected when using "%s::%s()", got %d: "%s".', $envelope->getMessage()::class, static::class, __FUNCTION__, \count($handlers), implode('", "', $handlers)));
+        }
+
+        if ($exceptions) {
+            throw reset($exceptions);
+        }
+
+        return $handledStamps[0]->getResult();
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/TestTracesWithSingleHandlingTraitAction.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/TestTracesWithSingleHandlingTraitAction.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\SingleHandlingTrait;
+
+/**
+ * @see \Symfony\Component\Messenger\Tests\TraceableMessageBusTest::testItTracesDispatchWhenSingleHandlingTraitIsUsed
+ */
+class TestTracesWithSingleHandlingTraitAction
+{
+    use SingleHandlingTrait;
+
+    public function __construct(MessageBusInterface $messageBus)
+    {
+        $this->messageBus = $messageBus;
+    }
+
+    public function __invoke($message)
+    {
+        $this->handle($message);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/HandleTraitTest.php
+++ b/src/Symfony/Component/Messenger/Tests/HandleTraitTest.php
@@ -20,6 +20,9 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
+/**
+ * @group legacy
+ */
 class HandleTraitTest extends TestCase
 {
     public function testItThrowsOnNoMessageBusInstance()

--- a/src/Symfony/Component/Messenger/Tests/SingleHandlingTraitTest.php
+++ b/src/Symfony/Component/Messenger/Tests/SingleHandlingTraitTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\SingleHandlingTrait;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class SingleHandlingTraitTest extends TestCase
+{
+    public function testItThrowsOnNoMessageBusInstance()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('You must provide a "Symfony\Component\Messenger\MessageBusInterface" instance in the "Symfony\Component\Messenger\Tests\SingleHandlerBus::$messageBus" property, but that property has not been initialized yet.');
+        $singleHandlerBus = new SingleHandlerBus(null);
+        $message = new DummyMessage('Hello');
+
+        $singleHandlerBus->dispatch($message);
+    }
+
+    public function testHandleReturnsHandledStampResult()
+    {
+        $bus = $this->createMock(MessageBus::class);
+        $singleHandlerBus = new SingleHandlerBus($bus);
+
+        $message = new DummyMessage('Hello');
+        $bus->expects($this->once())->method('dispatch')->willReturn(
+            new Envelope($message, [new HandledStamp('result', 'DummyHandler::__invoke')])
+        );
+
+        $this->assertSame('result', $singleHandlerBus->dispatch($message));
+    }
+
+    public function testHandleAcceptsEnvelopes()
+    {
+        $bus = $this->createMock(MessageBus::class);
+        $singleHandlerBus = new SingleHandlerBus($bus);
+
+        $envelope = new Envelope(new DummyMessage('Hello'), [new HandledStamp('result', 'DummyHandler::__invoke')]);
+        $bus->expects($this->once())->method('dispatch')->willReturn($envelope);
+
+        $this->assertSame('result', $singleHandlerBus->dispatch($envelope));
+    }
+
+    public function testHandleThrowsOnNoHandledStamp()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Message of type "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage" was handled zero times. Exactly one handler is expected when using "Symfony\Component\Messenger\Tests\SingleHandlerBus::handle()".');
+        $bus = $this->createMock(MessageBus::class);
+        $singleHandlerBus = new SingleHandlerBus($bus);
+
+        $message = new DummyMessage('Hello');
+        $bus->expects($this->once())->method('dispatch')->willReturn(new Envelope($message));
+
+        $singleHandlerBus->dispatch($message);
+    }
+
+    public function testHandleThrowsOnMultipleHandledStamps()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Message of type "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage" was handled multiple times. Only one handler is expected when using "Symfony\Component\Messenger\Tests\SingleHandlerBus::handle()", got 2: "FirstDummyHandler::__invoke", "SecondDummyHandler::__invoke".');
+        $bus = $this->createMock(MessageBus::class);
+        $singleHandlerBus = new SingleHandlerBus($bus);
+
+        $message = new DummyMessage('Hello');
+        $bus->expects($this->once())->method('dispatch')->willThrowException(
+            new HandlerFailedException(
+                new Envelope($message, [new HandledStamp('first_result', 'FirstDummyHandler::__invoke')]),
+                ['SecondDummyHandler::__invoke' => new \RuntimeException('SecondDummyHandler failed.')]
+            )
+        );
+
+        $singleHandlerBus->dispatch($message);
+    }
+
+    public function testHandleThrowsWrappedException()
+    {
+        $bus = $this->createMock(MessageBus::class);
+        $singleHandlerBus = new SingleHandlerBus($bus);
+
+        $message = new DummyMessage('Hello');
+        $wrappedException = new \RuntimeException('Handler failed.');
+        $bus->expects($this->once())->method('dispatch')->willThrowException(
+            new HandlerFailedException(
+                new Envelope($message),
+                ['DummyHandler::__invoke' => new \RuntimeException('Handler failed.')]
+            )
+        );
+
+        $this->expectException($wrappedException::class);
+        $this->expectExceptionMessage($wrappedException->getMessage());
+
+        $singleHandlerBus->dispatch($message);
+    }
+}
+
+class SingleHandlerBus
+{
+    use SingleHandlingTrait;
+
+    public function __construct(?MessageBusInterface $messageBus)
+    {
+        if ($messageBus) {
+            $this->messageBus = $messageBus;
+        }
+    }
+
+    public function dispatch($message): string
+    {
+        return $this->handle($message);
+    }
+}

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -63,9 +63,10 @@ class TraceableMessageBus implements MessageBusInterface
         $line = $trace[1]['line'] ?? null;
 
         $handleTraitFile = (new \ReflectionClass(HandleTrait::class))->getFileName();
+        $singleHandlingTraitFile = (new \ReflectionClass(SingleHandlingTrait::class))->getFileName();
         $found = false;
         for ($i = 1; $i < 8; ++$i) {
-            if (isset($trace[$i]['file'], $trace[$i + 1]['file'], $trace[$i + 1]['line']) && $trace[$i]['file'] === $handleTraitFile) {
+            if (isset($trace[$i]['file'], $trace[$i + 1]['file'], $trace[$i + 1]['line']) && ($trace[$i]['file'] === $singleHandlingTraitFile || $trace[$i]['file'] === $handleTraitFile)) {
                 $file = $trace[$i + 1]['file'];
                 $line = $trace[$i + 1]['line'];
                 $found = true;

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=8.2",
         "psr/log": "^1|^2|^3",
-        "symfony/clock": "^6.4|^7.0"
+        "symfony/clock": "^6.4|^7.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "psr/cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #52300
| License       | MIT

In competition with #52949

When using [the `HandleTrait`](https://symfony.com/doc/current/messenger.html#getting-results-when-working-with-command-query-buses), the `HandlerFailedException` just adds noise as the wrapped exception is the one we would expect to be thrown.

This PR aims to replace the `HandleTrait` by a new `SingleHandlingTrait`, the latter throwing any single exception wrapped in a `HandlerFailedException`. In addition, it checks for a single handler even if one failed.