### PR TITLE
[Mailer] Changed the region in the tests to the (default) `eu-west-1`

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -39,7 +39,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
         return [
             [
                 new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY']))),
-                'ses+api://ACCESS_KEY@us-east-1',
+                'ses+api://ACCESS_KEY@eu-west-1',
             ],
             [
                 new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1']))),
@@ -55,7 +55,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             ],
             [
                 new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'sessionToken' => 'SESSION_TOKEN']))),
-                'ses+api://ACCESS_KEY@us-east-1',
+                'ses+api://ACCESS_KEY@eu-west-1',
             ],
             [
                 new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1', 'sessionToken' => 'SESSION_TOKEN']))),
@@ -76,7 +76,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://email.us-east-1.amazonaws.com/v2/email/outbound-emails', $url);
+            $this->assertSame('https://email.eu-west-1.amazonaws.com/v2/email/outbound-emails', $url);
 
             $content = json_decode($options['body'], true);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -39,7 +39,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
         return [
             [
                 new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY']))),
-                'ses+https://ACCESS_KEY@us-east-1',
+                'ses+https://ACCESS_KEY@eu-west-1',
             ],
             [
                 new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1']))),
@@ -55,7 +55,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             ],
             [
                 new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'sessionToken' => 'SESSION_TOKEN']))),
-                'ses+https://ACCESS_KEY@us-east-1',
+                'ses+https://ACCESS_KEY@eu-west-1',
             ],
             [
                 new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1', 'sessionToken' => 'SESSION_TOKEN']))),
@@ -76,7 +76,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://email.us-east-1.amazonaws.com/v2/email/outbound-emails', $url);
+            $this->assertSame('https://email.eu-west-1.amazonaws.com/v2/email/outbound-emails', $url);
 
             $body = json_decode($options['body'], true);
             $content = base64_decode($body['Content']['Raw']['Data']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

```shell
./phpunit src/Symfony/Component/Mailer
```

**Before**

<details>
    <summary>PHPUnit output</summary>

```shell
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Testing /symfony/symfony/src/Symfony/Component/Mailer
F...F...F.F...F...F............................................  63 / 495 ( 12%)
............................................................... 126 / 495 ( 25%)
............................................................... 189 / 495 ( 38%)
............................................................... 252 / 495 ( 50%)
............................................................... 315 / 495 ( 63%)
............................................................... 378 / 495 ( 76%)
.......................................SSS...SS.............S.. 441 / 495 ( 89%)
..................SS..................................          495 / 495 (100%)

Time: 00:02.082, Memory: 24.00 MB

There were 6 failures:

1) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesApiAsyncAwsTransportTest::testToString with data set #0 (Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport Object (...), 'ses+api://ACCESS_KEY@us-east-1')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'ses+api://ACCESS_KEY@us-east-1'
+'ses+api://ACCESS_KEY@eu-west-1'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php:34

2) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesApiAsyncAwsTransportTest::testToString with data set #4 (Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport Object (...), 'ses+api://ACCESS_KEY@us-east-1')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'ses+api://ACCESS_KEY@us-east-1'
+'ses+api://ACCESS_KEY@eu-west-1'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php:34

3) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesApiAsyncAwsTransportTest::testSend
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'https://email.us-east-1.amazonaws.com/v2/email/outbound-emails'
+'https://email.eu-west-1.amazonaws.com/v2/email/outbound-emails'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php:79
/symfony/symfony/src/Symfony/Component/HttpClient/MockHttpClient.php:70
/symfony/symfony/vendor/async-aws/core/src/AbstractApi.php:161
/symfony/symfony/vendor/async-aws/ses/src/SesClient.php:67
/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php:55
/symfony/symfony/src/Symfony/Component/Mailer/Transport/AbstractTransport.php:69
/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php:119

4) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesHttpAsyncAwsTransportTest::testToString with data set #0 (Symfony\Component\Mailer\Bridge\Amazon\Transport\SesHttpAsyncAwsTransport Object (...), 'ses+https://ACCESS_KEY@us-east-1')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'ses+https://ACCESS_KEY@us-east-1'
+'ses+https://ACCESS_KEY@eu-west-1'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php:34

5) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesHttpAsyncAwsTransportTest::testToString with data set #4 (Symfony\Component\Mailer\Bridge\Amazon\Transport\SesHttpAsyncAwsTransport Object (...), 'ses+https://ACCESS_KEY@us-east-1')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'ses+https://ACCESS_KEY@us-east-1'
+'ses+https://ACCESS_KEY@eu-west-1'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php:34

6) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesHttpAsyncAwsTransportTest::testSend
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'https://email.us-east-1.amazonaws.com/v2/email/outbound-emails'
+'https://email.eu-west-1.amazonaws.com/v2/email/outbound-emails'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php:79
/symfony/symfony/src/Symfony/Component/HttpClient/MockHttpClient.php:70
/symfony/symfony/vendor/async-aws/core/src/AbstractApi.php:161
/symfony/symfony/vendor/async-aws/ses/src/SesClient.php:67
/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php:55
/symfony/symfony/src/Symfony/Component/Mailer/Transport/AbstractTransport.php:69
/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php:112

FAILURES!
Tests: 495, Assertions: 923, Failures: 6, Skipped: 8.
```

</details>

**After**

<details>
    <summary>PHPUnit output</summary>


```shell
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Testing /symfony/symfony/src/Symfony/Component/Mailer
...............................................................  63 / 495 ( 12%)
............................................................... 126 / 495 ( 25%)
............................................................... 189 / 495 ( 38%)
............................................................... 252 / 495 ( 50%)
............................................................... 315 / 495 ( 63%)
............................................................... 378 / 495 ( 76%)
.......................................SSS...SS.............S.. 441 / 495 ( 89%)
..................SS..................................          495 / 495 (100%)

Time: 00:02.387, Memory: 24.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 495, Assertions: 943, Skipped: 8.
```

</details>
