### PR TITLE
[String] Skip a test when an issue is detected in PCRE2

### DIFF
--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -94,14 +94,21 @@ END'],
 
     public static function provideCodePointsAt(): array
     {
-        return [
+        $data = [
             [[], '', 0],
             [[], 'a', 1],
             [[0x53], 'Späßchen', 0],
             [[0xE4], 'Späßchen', 2],
             [[0xDF], 'Späßchen', -5],
-            [[0x260E], '☢☎❄', 1],
         ];
+
+        // Skip this set if we encounter an issue in PCRE2
+        // @see https://github.com/PCRE2Project/pcre2/issues/361
+        if (3 === grapheme_strlen('☢☎❄')) {
+            $data[] = [[0x260E], '☢☎❄', 1];
+        }
+
+        return $data;
     }
 
     public static function provideLength(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #52206
| License       | MIT

I propose to ignore this test when [this issue of PCRE2](https://github.com/PCRE2Project/pcre2/issues/361) is detected until it's resolved and the polyfill updated.