### PR TITLE
[Mailer] Stop using the (local) AWS shared configuration in PHPUnit

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -37,35 +37,35 @@ class SesApiAsyncAwsTransportTest extends TestCase
     {
         return [
             [
-                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY']))),
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY']))),
                 'ses+api://ACCESS_KEY@us-east-1',
             ],
             [
-                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1']))),
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1']))),
                 'ses+api://ACCESS_KEY@us-west-1',
             ],
             [
-                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com']))),
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com']))),
                 'ses+api://ACCESS_KEY@example.com',
             ],
             [
-                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99']))),
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99']))),
                 'ses+api://ACCESS_KEY@example.com:99',
             ],
             [
-                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'sessionToken' => 'SESSION_TOKEN']))),
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'sessionToken' => 'SESSION_TOKEN']))),
                 'ses+api://ACCESS_KEY@us-east-1',
             ],
             [
-                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1', 'sessionToken' => 'SESSION_TOKEN']))),
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1', 'sessionToken' => 'SESSION_TOKEN']))),
                 'ses+api://ACCESS_KEY@us-west-1',
             ],
             [
-                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com', 'sessionToken' => 'SESSION_TOKEN']))),
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com', 'sessionToken' => 'SESSION_TOKEN']))),
                 'ses+api://ACCESS_KEY@example.com',
             ],
             [
-                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99', 'sessionToken' => 'SESSION_TOKEN']))),
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99', 'sessionToken' => 'SESSION_TOKEN']))),
                 'ses+api://ACCESS_KEY@example.com:99',
             ],
         ];
@@ -97,7 +97,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             ]);
         });
 
-        $transport = new SesApiAsyncAwsTransport(new SesClient(Configuration::create([]), new NullProvider(), $client));
+        $transport = new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false]), new NullProvider(), $client));
 
         $mail = new Email();
         $mail->subject('Hello!')

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -37,35 +37,35 @@ class SesHttpAsyncAwsTransportTest extends TestCase
     {
         return [
             [
-                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY']))),
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY']))),
                 'ses+https://ACCESS_KEY@us-east-1',
             ],
             [
-                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1']))),
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1']))),
                 'ses+https://ACCESS_KEY@us-west-1',
             ],
             [
-                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com']))),
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com']))),
                 'ses+https://ACCESS_KEY@example.com',
             ],
             [
-                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99']))),
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99']))),
                 'ses+https://ACCESS_KEY@example.com:99',
             ],
             [
-                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'sessionToken' => 'SESSION_TOKEN']))),
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'sessionToken' => 'SESSION_TOKEN']))),
                 'ses+https://ACCESS_KEY@us-east-1',
             ],
             [
-                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1', 'sessionToken' => 'SESSION_TOKEN']))),
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1', 'sessionToken' => 'SESSION_TOKEN']))),
                 'ses+https://ACCESS_KEY@us-west-1',
             ],
             [
-                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com', 'sessionToken' => 'SESSION_TOKEN']))),
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com', 'sessionToken' => 'SESSION_TOKEN']))),
                 'ses+https://ACCESS_KEY@example.com',
             ],
             [
-                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99', 'sessionToken' => 'SESSION_TOKEN']))),
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false, 'accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99', 'sessionToken' => 'SESSION_TOKEN']))),
                 'ses+https://ACCESS_KEY@example.com:99',
             ],
         ];
@@ -94,7 +94,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             ]);
         });
 
-        $transport = new SesHttpAsyncAwsTransport(new SesClient(Configuration::create([]), new NullProvider(), $client));
+        $transport = new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false]), new NullProvider(), $client));
 
         $mail = new Email();
         $mail->subject('Hello!')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Replaces https://github.com/symfony/symfony/pull/52958

Found an (other) way to stop using the (local) [AWS shared configuration](https://async-aws.com/authentication/credentials-file.html) in the Composer package [async-aws/core](https://github.com/async-aws/core) in the PHPUnit tests. 🥳 

_This was an great Symfony hackday pair session with @TmEuMail-2020._

Also big shout out to @xabbuh and @OskarStark for the heads up in the right direction! 👍 

```shell
./phpunit src/Symfony/Component/Mailer
```

**Before**

<details>
    <summary>PHPUnit output</summary>

```shell
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Testing /symfony/symfony/src/Symfony/Component/Mailer
F...F...F.F...F...F............................................  63 / 495 ( 12%)
............................................................... 126 / 495 ( 25%)
............................................................... 189 / 495 ( 38%)
............................................................... 252 / 495 ( 50%)
............................................................... 315 / 495 ( 63%)
............................................................... 378 / 495 ( 76%)
.......................................SSS...SS.............S.. 441 / 495 ( 89%)
..................SS..................................          495 / 495 (100%)

Time: 00:02.082, Memory: 24.00 MB

There were 6 failures:

1) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesApiAsyncAwsTransportTest::testToString with data set #0 (Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport Object (...), 'ses+api://ACCESS_KEY@us-east-1')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'ses+api://ACCESS_KEY@us-east-1'
+'ses+api://ACCESS_KEY@eu-west-1'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php:34

2) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesApiAsyncAwsTransportTest::testToString with data set #4 (Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport Object (...), 'ses+api://ACCESS_KEY@us-east-1')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'ses+api://ACCESS_KEY@us-east-1'
+'ses+api://ACCESS_KEY@eu-west-1'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php:34

3) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesApiAsyncAwsTransportTest::testSend
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'https://email.us-east-1.amazonaws.com/v2/email/outbound-emails'
+'https://email.eu-west-1.amazonaws.com/v2/email/outbound-emails'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php:79
/symfony/symfony/src/Symfony/Component/HttpClient/MockHttpClient.php:70
/symfony/symfony/vendor/async-aws/core/src/AbstractApi.php:161
/symfony/symfony/vendor/async-aws/ses/src/SesClient.php:67
/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php:55
/symfony/symfony/src/Symfony/Component/Mailer/Transport/AbstractTransport.php:69
/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php:119

4) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesHttpAsyncAwsTransportTest::testToString with data set #0 (Symfony\Component\Mailer\Bridge\Amazon\Transport\SesHttpAsyncAwsTransport Object (...), 'ses+https://ACCESS_KEY@us-east-1')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'ses+https://ACCESS_KEY@us-east-1'
+'ses+https://ACCESS_KEY@eu-west-1'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php:34

5) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesHttpAsyncAwsTransportTest::testToString with data set #4 (Symfony\Component\Mailer\Bridge\Amazon\Transport\SesHttpAsyncAwsTransport Object (...), 'ses+https://ACCESS_KEY@us-east-1')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'ses+https://ACCESS_KEY@us-east-1'
+'ses+https://ACCESS_KEY@eu-west-1'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php:34

6) Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport\SesHttpAsyncAwsTransportTest::testSend
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'https://email.us-east-1.amazonaws.com/v2/email/outbound-emails'
+'https://email.eu-west-1.amazonaws.com/v2/email/outbound-emails'

/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php:79
/symfony/symfony/src/Symfony/Component/HttpClient/MockHttpClient.php:70
/symfony/symfony/vendor/async-aws/core/src/AbstractApi.php:161
/symfony/symfony/vendor/async-aws/ses/src/SesClient.php:67
/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php:55
/symfony/symfony/src/Symfony/Component/Mailer/Transport/AbstractTransport.php:69
/symfony/symfony/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php:112

FAILURES!
Tests: 495, Assertions: 923, Failures: 6, Skipped: 8.
```

</details>

**After**

<details>
    <summary>PHPUnit output</summary>


```shell
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Testing /symfony/symfony/src/Symfony/Component/Mailer
...............................................................  63 / 495 ( 12%)
............................................................... 126 / 495 ( 25%)
............................................................... 189 / 495 ( 38%)
............................................................... 252 / 495 ( 50%)
............................................................... 315 / 495 ( 63%)
............................................................... 378 / 495 ( 76%)
.......................................SSS...SS.............S.. 441 / 495 ( 89%)
..................SS..................................          495 / 495 (100%)

Time: 00:02.387, Memory: 24.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 495, Assertions: 943, Skipped: 8.
```

</details>
