### PR TITLE
[VarDumper] Test intl formatter broken since dumper does not replace the nnbsp character by standard space

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/IntlCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/IntlCasterTest.php
@@ -234,7 +234,7 @@ EOTXT;
         $var = new \IntlDateFormatter('en', \IntlDateFormatter::TRADITIONAL, \IntlDateFormatter::TRADITIONAL);
 
         $expectedLocale = $var->getLocale();
-        $expectedPattern = $var->getPattern();
+        $expectedPattern = $this->normalizeNarrowNoBreakSpaceCharacter($var->getPattern());
         $expectedCalendar = $var->getCalendar();
         $expectedTimeZoneId = $var->getTimeZoneId();
         $expectedTimeType = $var->getTimeType();
@@ -293,5 +293,10 @@ IntlDateFormatter {
 }
 EOTXT;
         $this->assertDumpEquals($expected, $var);
+    }
+
+    private function normalizeNarrowNoBreakSpaceCharacter(string $input): string
+    {
+        return str_replace("\u{202F}", '\\u{202F}', $input);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| Issues        |  I don't know, saw the problem on my machine
| License       | MIT

Fix the \Symfony\Component\VarDumper\Tests\Caster\IntlCasterTest::testCastDateFormatter failure on machines that have Intl >= 72.1 :

Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
'IntlDateFormatter {
locale: "en"
-  pattern: "EEEE, MMMM d, y 'at' h:mm:ss a zzzz"  <--- Notice that between 'ss' and 'a', it look's like a space, but it is an invisible \u{202F} character
+  pattern: "EEEE, MMMM d, y 'at' h:mm:ss\u{202F}a zzzz"
   

Commit 69368454 says 'display invisible characters'. Since Intl 72.1 version, the getPattern method of IntlDateFormatter returns a string containing an invisible character \u{202F} (alia NNBSP).
I replaced it by \\u{202F} in the expected output, but I guess maybe we could go further and do this replacement in the assertDumpEquals method


For example, here is a piece of code I wrote when debugging the problem :

```
        // Check what happens with Unicode caracters
        $u202F = "\u{202F}";
        $escapedU202F = "\\u{202F}";
        // Obviously those two strings are not equals
        $this->assertNotEquals($u202F, $escapedU202F);

        // this test fails :
        // $this->assertDumpEquals('"' . $u202F . '"', $u202F);
        // Output :
        /// Failed asserting that two strings are identical.
        // -'" "'
        // +'"\u{202F}"'

        // the dump of the first one \u{202F} is equal to the second one \\u{202F}
        // this test passes :
        $this->assertDumpEquals('"' . $escapedU202F . '"', $u202F);

        // since Intl 72, $var->getPatterns returns EEEE, MMMM d, y 'at' h:mm:ss\u{202F}a zzzz
        // The test fails as :
        // - it expects "EEEE, MMMM d, y 'at' h:mm:ss\u{202F}a zzzz" (\u{202F} is invisible, so in the console output it look's like "EEEE, MMMM d, y 'at' h:mm:ss a zzzz"
        // - but gets "EEEE, MMMM d, y 'at' h:mm:ss\\u{202F}a zzzz" (escaped version produced by dump since commit 69368454)
        // $expectedPattern = str_replace("\u{202F}", "\\u{202F}", $var->getPattern());
        $expectedPattern = $this->normalizeU202F($var->getPattern());
```
