### PR TITLE
[HttpClient] Add `NoRetryStrategy` to help testing errors going through `RetryableHttpClient`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `NoRetryStrategy` to simplify testing errors going through `RetryableHttpClient`
+
 7.0
 ---
 

--- a/src/Symfony/Component/HttpClient/Test/Retry/NoRetryStrategy.php
+++ b/src/Symfony/Component/HttpClient/Test/Retry/NoRetryStrategy.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Test\Retry;
+
+use Symfony\Component\HttpClient\Response\AsyncContext;
+use Symfony\Component\HttpClient\Retry\RetryStrategyInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class NoRetryStrategy implements RetryStrategyInterface
+{
+    public function shouldRetry(AsyncContext $context, ?string $responseContent, ?TransportExceptionInterface $exception): ?bool
+    {
+        return false;
+    }
+
+    public function getDelay(AsyncContext $context, ?string $responseContent, ?TransportExceptionInterface $exception): int
+    {
+        throw new \LogicException();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

A very small test-related DX feature again.

When I test how my code reacts to a 500 error (`new MockResponse('', ['http_code' => 500])`) and it goes through `RetryableHttpClient`, I don't want to retry anything at all (or I'd have to provide several responses to the `MockHttpClient`), so I always create a `NoRetryStrategy`. I'd like this code to be part of Symfony directly so it can be reused by anyone more easily :smile: