### PR TITLE
[EventDispatcher] Enable the possibility of deprecating events

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -34,12 +34,14 @@ class EventDispatcher implements EventDispatcherInterface
     private array $listeners = [];
     private array $sorted = [];
     private array $optimized;
+    private array $deprecated;
 
-    public function __construct()
+    public function __construct(array $deprecated = [])
     {
         if (__CLASS__ === static::class) {
             $this->optimized = [];
         }
+        $this->deprecated = $deprecated;
     }
 
     public function dispatch(object $event, string $eventName = null): object
@@ -125,6 +127,10 @@ class EventDispatcher implements EventDispatcherInterface
 
     public function addListener(string $eventName, callable|array $listener, int $priority = 0): void
     {
+        if (isset($this->deprecated[$eventName])) {
+            trigger_deprecation(...array_values($this->deprecated[$eventName]));
+        }
+
         $this->listeners[$eventName][$priority][] = $listener;
         unset($this->sorted[$eventName], $this->optimized[$eventName]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Currently there is no way to deprecate events in the framework used by the EventDispatcher. It's probably not even desired to enable this possibility, but I wanted to have a go at it anyway. 

The changes in `RegisterListenersPass` might be reverted if throwing the deprecation in `addListener`. Though if users are DI-configuring there own `EventDispatcher`, they might not have set the `$deprecated` argument and won't get the deprecation notices. 

#SymfonyHackday