### PR TITLE
[Cache] Deprecate `CouchbaseBucketAdapter`, use `CouchbaseCollectionAdapter`

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 7.0 to 7.1
 =======================
 
+Cache
+-----
+
+ * Deprecate `CouchbaseBucketAdapter`, use `CouchbaseCollectionAdapter` instead
+
 Messenger
 ---------
 

--- a/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
@@ -16,8 +16,12 @@ use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
 use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 
+trigger_deprecation('symfony/cache', '7.1', 'The "%s" class is deprecated, use "%s" instead.', CouchbaseBucketAdapter::class, CouchbaseCollectionAdapter::class);
+
 /**
  * @author Antonio Jose Cerezo Aranda <aj.cerezo@gmail.com>
+ *
+ * @deprecated since Symfony 7.1, use {@see CouchbaseCollectionAdapter} instead
  */
 class CouchbaseBucketAdapter extends AbstractAdapter
 {

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add option `sentinel_master` as an alias for `redis_sentinel`
+ * Deprecate `CouchbaseBucketAdapter`, use `CouchbaseCollectionAdapter`
 
 7.0
 ---

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
 
@@ -19,25 +20,25 @@ use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
  * @requires extension couchbase <3.0.0
  * @requires extension couchbase >=2.6.0
  *
- * @group integration
+ * @group integration legacy
  *
  * @author Antonio Jose Cerezo Aranda <aj.cerezo@gmail.com>
  */
 class CouchbaseBucketAdapterTest extends AdapterTestCase
 {
+    use ExpectDeprecationTrait;
+
     protected $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
     ];
 
-    protected static \CouchbaseBucket $client;
+    protected \CouchbaseBucket $client;
 
-    public static function setupBeforeClass(): void
+    protected function setUp(): void
     {
-        if (!CouchbaseBucketAdapter::isSupported()) {
-            self::markTestSkipped('Couchbase >= 2.6.0 < 3.0.0 is required.');
-        }
+        $this->expectDeprecation('Since symfony/cache 7.1: The "Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter" class is deprecated, use "Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter" instead.');
 
-        self::$client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
+        $this->client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
             ['username' => getenv('COUCHBASE_USER'), 'password' => getenv('COUCHBASE_PASS')]
         );
     }
@@ -50,7 +51,7 @@ class CouchbaseBucketAdapterTest extends AdapterTestCase
                 .':'.getenv('COUCHBASE_PASS')
                 .'@'.getenv('COUCHBASE_HOST')
                 .'/cache')
-            : self::$client;
+            : $this->client;
 
         return new CouchbaseBucketAdapter($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

`CouchebaseBucketAdapter` requires Couches 2.x, while the `CouchbaseCollectionAdapter` requires 3.x. This conflicts in the CI where both versions can't be installed. Moreover, the last release of Couchbase extension 2.x was 3 years ago (https://pecl.php.net/package/couchbase). I think it's safe to deprecate the former one and only keep `CouchbaseCollectionAdapter`. Couchbase 4.x support can be added eventually in another PR if someone wants to have a look 🙂 