### PR TITLE
[AssetMapper] require scss files

### DIFF
--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add Sass require support to the `importmap:require` command
+
 6.4
 ---
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -200,12 +200,11 @@ class ImportMapManager
 
     private static function getImportMapTypeFromFilename(string $path): ImportMapType
     {
-        if (str_ends_with($path, '.css')) {
-            return ImportMapType::CSS;
-        } else if (str_ends_with($path, '.scss')) {
-            return ImportMapType::SCSS;
-        }
-        return ImportMapType::JS;
+        return match (true) {
+            str_ends_with($path, '.css') => ImportMapType::CSS,
+            str_ends_with($path, '.scss') => ImportMapType::SCSS,
+            default => ImportMapType::JS,
+        };
     }
 
     /**

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -200,7 +200,12 @@ class ImportMapManager
 
     private static function getImportMapTypeFromFilename(string $path): ImportMapType
     {
-        return str_ends_with($path, '.css') ? ImportMapType::CSS : ImportMapType::JS;
+        if (str_ends_with($path, '.css')) {
+            return ImportMapType::CSS;
+        } else if (str_ends_with($path, '.scss')) {
+            return ImportMapType::SCSS;
+        }
+        return ImportMapType::JS;
     }
 
     /**

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapType.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapType.php
@@ -15,4 +15,5 @@ enum ImportMapType: string
 {
     case JS = 'js';
     case CSS = 'css';
+    case SCSS = 'scss';
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -78,7 +78,10 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 throw new RuntimeException(sprintf('Unable to find the latest version for package "%s" - try specifying the version manually.', $packageName));
             }
 
-            $pattern = str_ends_with($filePath, '.css') || str_ends_with($filePath, '.scss') ? self::URL_PATTERN_DIST_STYLE : self::URL_PATTERN_DIST;
+            $pattern = match (true) {
+                str_ends_with($filePath, '.css'), str_ends_with($filePath, '.scss') => self::URL_PATTERN_DIST_STYLE,
+                default => self::URL_PATTERN_DIST,
+            };
             $requiredPackages[$i][1] = $this->httpClient->request('GET', sprintf($pattern, $packageName, $version, $filePath));
             $requiredPackages[$i][4] = $version;
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -175,11 +175,10 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 throw new \InvalidArgumentException(sprintf('The entry "%s" is not a remote package.', $entry->importName));
             }
 
-            if (ImportMapType::CSS === $entry->type || ImportMapType::SCSS === $entry->type) {
-                $pattern = self::URL_PATTERN_DIST_STYLE;
-            } else {
-                $pattern = self::URL_PATTERN_DIST;
-            }
+            $pattern = match ($entry->type) {
+                ImportMapType::CSS, ImportMapType::SCSS => self::URL_PATTERN_DIST_STYLE,
+                default => self::URL_PATTERN_DIST,
+            };
             $url = sprintf($pattern, $entry->getPackageName(), $entry->version, $entry->getPackagePathString());
 
             $responses[$package] = [$this->httpClient->request('GET', $url), $entry];

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -106,13 +106,11 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
             }
 
             $contentType = $response->getHeaders()['content-type'][0] ?? '';
-            if (str_starts_with($contentType, 'text/css')) {
-                $type = ImportMapType::CSS;
-            } else if (str_starts_with($contentType, 'text/x-scss')) {
-                $type = ImportMapType::SCSS;
-            } else {
-                $type = ImportMapType::JS;
-            }
+            $type = match (true) {
+                str_starts_with($contentType, 'text/css') => ImportMapType::CSS,
+                str_starts_with($contentType, 'text/x-scss') => ImportMapType::SCSS,
+                default => ImportMapType::JS,
+            };
             $resolvedPackages[$options->packageModuleSpecifier] = new ResolvedImportMapPackage($options, $version, $type);
 
             $packagesToRequire = array_merge($packagesToRequire, $this->fetchPackageRequirementsFromImports($response->getContent()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52957 
| License       | MIT

Modification of the AssetMapper `importmap:require` command to support importing Sass `.scss` files in the same way as CSS.

#SymfonyHackday