### PR TITLE
[Webhook] [Framework] Added missing XML attribute in config XSD

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -976,6 +976,7 @@
             <xsd:element name="service" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="secret" type="xsd:string" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
+        <xsd:attribute name="type" type="xsd:string" use="required" />
     </xsd:complexType>
 
     <xsd:complexType name="remote-event">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The XML schema definition was missing the type attribute for the webhook routing.

This attribute is necessary to identify the correct parser and remote event consumers.


In YAML and PHP, it exists and works:
```yaml
framework:
    webhook:
        routing:
            mailer: # <-- this identifier
                service: #...
                secret: #...
```

```php
        use App\Webhook\MailerWebhookParser;
        use Symfony\Config\FrameworkConfig;

        return static function (FrameworkConfig $frameworkConfig): void {
            $webhookConfig = $frameworkConfig->webhook();
            $webhookConfig
                ->routing('mailer') // <-- this parameter
                ->service('mailer.webhook.request_parser.mailgun')
                ->secret('%env(MAILER_MAILGUN_SECRET)%')
            ;
        };
```

#SymfonyHackday