### PR TITLE
[WebProfilerBundle] Fix "Copy as cURL" dark style

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -186,12 +186,10 @@
 
                     copyToClipboardElement.textContent = `✅ Copied!`;
                     copyToClipboardElement.disabled = true;
-                    copyToClipboardElement.classList.add('status-success');
 
                     setTimeout(() => {
                         copyToClipboardElement.textContent = oldContent;
                         copyToClipboardElement.disabled = false;
-                        copyToClipboardElement.classList.remove('status-success');
                     }, 7000);
                 });
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/52937#discussion_r1421369704
| License       | MIT

Followup to #52937, addresses @javiereguiluz's comment.

The button no longer changes color when using the dark theme:
![dark](https://github.com/symfony/symfony/assets/2445045/dc1dc267-a541-4ab7-8be9-db152d48dc12)

Nothing changed when using the light theme:
![light](https://github.com/symfony/symfony/assets/2445045/13a60002-d02e-42e9-8e08-e967bae4ef6e)
