### PR TITLE
[Messenger] Fix Redis integration tests data provider

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -221,7 +221,7 @@ class RedisExtIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider
+     * @dataProvider sentinelOptionNames
      */
     public function testSentinel(string $sentinelOptionName)
     {
@@ -252,10 +252,10 @@ class RedisExtIntegrationTest extends TestCase
         $connection->cleanup();
     }
 
-    public function sentinelOptionNames(): iterable
+    public static function sentinelOptionNames(): \Generator
     {
-        yield 'redis_sentinel';
-        yield 'sentinel_master';
+        yield ['redis_sentinel'];
+        yield ['sentinel_master'];
     }
 
     public function testLazySentinel()

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -47,6 +47,7 @@ class Connection
         'auth' => null,
         'serializer' => 1, // see \Redis::SERIALIZER_PHP,
         'sentinel_master' => null, // String, master to look for (optional, default is NULL meaning Sentinel support is disabled)
+        'redis_sentinel' => null, // String, alias for 'sentinel_master'
         'timeout' => 0.0, // Float, value in seconds (optional, default is 0 meaning unlimited)
         'read_timeout' => 0.0, //  Float, value in seconds (optional, default is 0 meaning unlimited)
         'retry_interval' => 0, //  Int, value in milliseconds (optional, default is 0)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This fixes the data provider for `RedisExtIntegrationTest` and add `redis_sentinel` as a valid option