### PR TITLE
[TwigBridge] don't use deprecated and internal Twig functions

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Node;
 
 use Twig\Compiler;
+use Twig\Extension\CoreExtension;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FunctionExpression;
@@ -50,7 +51,7 @@ final class SearchAndRenderBlockNode extends FunctionExpression
                         $labelIsExpression = false;
 
                         // Only insert the label into the array if it is not empty
-                        if (!twig_test_empty($label->getAttribute('value'))) {
+                        if (null !== $label->getAttribute('value') && false !== $label->getAttribute('value') && '' !== (string) $label->getAttribute('value')) {
                             $originalVariables = $variables;
                             $variables = new ArrayExpression([], $lineno);
                             $labelKey = new ConstantExpression('label', $lineno);
@@ -97,7 +98,12 @@ final class SearchAndRenderBlockNode extends FunctionExpression
 
                         // Check at runtime whether the label is empty.
                         // If not, add it to the array at runtime.
-                        $compiler->raw('(twig_test_empty($_label_ = ');
+                        if (method_exists(CoreExtension::class, 'testEmpty')) {
+                            $compiler->raw('(CoreExtension::testEmpty($_label_ = ');
+                        } else {
+                            $compiler->raw('(twig_test_empty($_label_ = ');
+                        }
+
                         $compiler->subcompile($label);
                         $compiler->raw(') ? [] : ["label" => $_label_])');
                     }

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode;
 use Twig\Compiler;
 use Twig\Environment;
+use Twig\Extension\CoreExtension;
 use Twig\Loader\LoaderInterface;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConditionalExpression;
@@ -226,8 +227,9 @@ class SearchAndRenderBlockNodeTest extends TestCase
         // https://github.com/symfony/symfony/issues/5029
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', (twig_test_empty($_label_ = ((true) ? (null) : (null))) ? [] : ["label" => $_label_]))',
-                $this->getVariableGetter('form')
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', (%s($_label_ = ((true) ? (null) : (null))) ? [] : ["label" => $_label_]))',
+                $this->getVariableGetter('form'),
+                method_exists(CoreExtension::class, 'testEmpty') ? 'CoreExtension::testEmpty' : 'twig_test_empty'
             ),
             trim($compiler->compile($node)->getSource())
         );
@@ -263,8 +265,9 @@ class SearchAndRenderBlockNodeTest extends TestCase
         // https://github.com/symfony/symfony/issues/5029
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', ["foo" => "bar", "label" => "value in attributes"] + (twig_test_empty($_label_ = ((true) ? (null) : (null))) ? [] : ["label" => $_label_]))',
-                $this->getVariableGetter('form')
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', ["foo" => "bar", "label" => "value in attributes"] + (%s($_label_ = ((true) ? (null) : (null))) ? [] : ["label" => $_label_]))',
+                $this->getVariableGetter('form'),
+                method_exists(CoreExtension::class, 'testEmpty') ? 'CoreExtension::testEmpty' : 'twig_test_empty'
             ),
             trim($compiler->compile($node)->getSource())
         );

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Twig/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Twig/WebProfilerExtensionTest.php
@@ -15,8 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Twig\Environment;
-use Twig\Extension\CoreExtension;
-use Twig\Extension\EscaperExtension;
 
 class WebProfilerExtensionTest extends TestCase
 {
@@ -25,9 +23,6 @@ class WebProfilerExtensionTest extends TestCase
      */
     public function testDumpHeaderIsDisplayed(string $message, array $context, bool $dump1HasHeader, bool $dump2HasHeader)
     {
-        class_exists(CoreExtension::class); // Load twig_convert_encoding()
-        class_exists(EscaperExtension::class); // Load twig_escape_filter()
-
         $twigEnvironment = $this->mockTwigEnvironment();
         $varCloner = new VarCloner();
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\WebProfilerBundle\Twig;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Twig\Environment;
+use Twig\Extension\EscaperExtension;
 use Twig\Extension\ProfilerExtension;
 use Twig\Profiler\Profile;
 use Twig\TwigFunction;
@@ -60,9 +61,6 @@ class WebProfilerExtension extends ProfilerExtension
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFunctions(): array
     {
         return [
@@ -87,12 +85,12 @@ class WebProfilerExtension extends ProfilerExtension
 
     public function dumpLog(Environment $env, string $message, Data $context = null)
     {
-        $message = twig_escape_filter($env, $message);
+        $message = self::escape($env, $message);
         $message = preg_replace('/&quot;(.*?)&quot;/', '&quot;<b>$1</b>&quot;', $message);
 
         $replacements = [];
         foreach ($context ?? [] as $k => $v) {
-            $k = '{'.twig_escape_filter($env, $k).'}';
+            $k = '{'.self::escape($env, $k).'}';
             if (str_contains($message, $k)) {
                 $replacements[$k] = $v;
             }
@@ -109,11 +107,18 @@ class WebProfilerExtension extends ProfilerExtension
         return '<span class="dump-inline">'.strtr($message, $replacements).'</span>';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return 'profiler';
+    }
+
+    private static function escape(Environment $env, string $s): string
+    {
+        if (method_exists(EscaperExtension::class, 'escape')) {
+            return EscaperExtension::escape($env, $s);
+        }
+
+        // to be removed when support for Twig 3 is dropped
+        return twig_escape_filter($env, $s);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52987
| License       | MIT

`twig_test_empty()` and `twig_escape_filter()` are deprecated since Twig 3.9