### PR TITLE
[Serializer] Make sure Serializer::denormalize() shows what exception it throws

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -197,6 +197,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
      * {@inheritdoc}
      *
      * @throws NotNormalizableValueException
+     * @throws PartialDenormalizationException Occurs when one or more properties of $type fails to denormalize
      */
     public function denormalize($data, string $type, string $format = null, array $context = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

This was missing from #42502. We have no contract that explains that this exceptions should be thrown. 

With this addition, we technically make this a "sometimes" feature of the Serializer class. 