### PR TITLE
[MonologBridge] Fix context data and display extra data

### DIFF
--- a/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
+++ b/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
@@ -164,7 +164,8 @@ EOF
                 $record['channel'],
                 Level::fromValue($record['level']),
                 $record['message'],
-                $record['context']->getContext(),
+                $record['context']->getValue(true),
+                $record['extra']->getValue(true),
             );
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | ->
| License       | MIT


Fix the compatibility with Monolog 3. In the PR #52222 we had the compatibility with Monolog 3 but context parameter is incorrect and extra parameter is missing.

No test can be added because testing this command is not possible at this time. Another PR (#53518) was opened to add test on this command.