### PR TITLE
[Notifier] [Bridges] Provide EventDispatcher and HttpClient to the transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2594,7 +2594,9 @@ class FrameworkExtension extends Extension
 
         if (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', MercureTransportFactory::class, $parentPackages, true) && ContainerBuilder::willBeAvailable('symfony/mercure-bundle', MercureBundle::class, $parentPackages, true) && \in_array(MercureBundle::class, $container->getParameter('kernel.bundles'), true)) {
             $container->getDefinition($classToServices[MercureTransportFactory::class])
-                ->replaceArgument('$registry', new Reference(HubRegistry::class));
+                ->replaceArgument('$registry', new Reference(HubRegistry::class))
+                ->replaceArgument('$client', new Reference('http_client'))
+                ->replaceArgument('$dispatcher', new Reference('event_dispatcher'));
         } elseif (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', MercureTransportFactory::class, $parentPackages, true)) {
             $container->removeDefinition($classToServices[MercureTransportFactory::class]);
         }
@@ -2602,13 +2604,17 @@ class FrameworkExtension extends Extension
         if (ContainerBuilder::willBeAvailable('symfony/fake-chat-notifier', FakeChatTransportFactory::class, ['symfony/framework-bundle', 'symfony/notifier', 'symfony/mailer'], true)) {
             $container->getDefinition($classToServices[FakeChatTransportFactory::class])
                 ->replaceArgument('$mailer', new Reference('mailer'))
-                ->replaceArgument('$logger', new Reference('logger'));
+                ->replaceArgument('$logger', new Reference('logger'))
+                ->replaceArgument('$client', new Reference('http_client'))
+                ->replaceArgument('$dispatcher', new Reference('event_dispatcher'));
         }
 
         if (ContainerBuilder::willBeAvailable('symfony/fake-sms-notifier', FakeSmsTransportFactory::class, ['symfony/framework-bundle', 'symfony/notifier', 'symfony/mailer'], true)) {
             $container->getDefinition($classToServices[FakeSmsTransportFactory::class])
                 ->replaceArgument('$mailer', new Reference('mailer'))
-                ->replaceArgument('$logger', new Reference('logger'));
+                ->replaceArgument('$logger', new Reference('logger'))
+                ->replaceArgument('$client', new Reference('http_client'))
+                ->replaceArgument('$dispatcher', new Reference('event_dispatcher'));
         }
 
         if (isset($config['admin_recipients'])) {

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/MercureTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/MercureTransportFactory.php
@@ -18,6 +18,8 @@ use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
 use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
@@ -26,9 +28,9 @@ final class MercureTransportFactory extends AbstractTransportFactory
 {
     private $registry;
 
-    public function __construct(HubRegistry $registry)
+    public function __construct(HubRegistry $registry, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null)
     {
-        parent::__construct();
+        parent::__construct($dispatcher, $client);
 
         $this->registry = $registry;
     }
@@ -51,7 +53,7 @@ final class MercureTransportFactory extends AbstractTransportFactory
             throw new IncompleteDsnException(sprintf('Hub "%s" not found. Did you mean one of: "%s"?', $hubId, implode('", "', array_keys($this->registry->all()))));
         }
 
-        return new MercureTransport($hub, $hubId, $topic);
+        return new MercureTransport($hub, $hubId, $topic, $this->client, $this->dispatcher);
     }
 
     protected function getSupportedSchemes(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52997 
| License       | MIT

Some Notifier transport factories are redefining the class constructor, but aren't passing the HttpClient nor the EventDispatcher.
As a result, those transports are not providing Notifier event hooks.

This PR adds those dependencies.