### PR TITLE
[Validator] Update Luhn validation message

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Luhn.php
+++ b/src/Symfony/Component/Validator/Constraints/Luhn.php
@@ -31,7 +31,7 @@ class Luhn extends Constraint
         self::CHECKSUM_FAILED_ERROR => 'CHECKSUM_FAILED_ERROR',
     ];
 
-    public string $message = 'Invalid card number.';
+    public string $message = 'Invalid number.';
 
     public function __construct(
         array $options = null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

Current invalid message of LuhnValidator `Invalid card number.` is confusing. Luhn algorithm has much more use cases than credit card validation, see https://en.wikipedia.org/wiki/Luhn_algorithm#Uses for examples.

I don't know if I need to edit all validators.xx.xlf files or if there is a bot/script who can deal with it, please let me know.
If PR if accepted, I will do a separate PR to improve current docs for this validator.