### PR TITLE
[AssetMapper] Fix URL pattern when importing es-module-shims

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -30,6 +30,8 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
 
     public const IMPORT_REGEX = '#(?:import\s*(?:\w+,)?(?:(?:\{[^}]*\}|\w+|\*\s*as\s+\w+)\s*\bfrom\s*)?|export\s*(?:\{[^}]*\}|\*)\s*from\s*)("/npm/((?:@[^/]+/)?[^@]+?)(?:@([^/]+))?((?:/[^/]+)*?)/\+esm")#';
 
+    private const ES_MODULE_SHIMS = 'es-module-shims';
+
     private HttpClientInterface $httpClient;
 
     public function __construct(
@@ -78,7 +80,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 throw new RuntimeException(sprintf('Unable to find the latest version for package "%s" - try specifying the version manually.', $packageName));
             }
 
-            $pattern = str_ends_with($filePath, '.css') ? self::URL_PATTERN_DIST_CSS : self::URL_PATTERN_DIST;
+            $pattern = $this->resolveUrlPattern($packageName, $filePath);
             $requiredPackages[$i][1] = $this->httpClient->request('GET', sprintf($pattern, $packageName, $version, $filePath));
             $requiredPackages[$i][4] = $version;
 
@@ -169,7 +171,11 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 throw new \InvalidArgumentException(sprintf('The entry "%s" is not a remote package.', $entry->importName));
             }
 
-            $pattern = ImportMapType::CSS === $entry->type ? self::URL_PATTERN_DIST_CSS : self::URL_PATTERN_DIST;
+            $pattern = $this->resolveUrlPattern(
+                $entry->getPackageName(),
+                $entry->getPackagePathString(),
+                $entry->type,
+            );
             $url = sprintf($pattern, $entry->getPackageName(), $entry->version, $entry->getPackagePathString());
 
             $responses[$package] = [$this->httpClient->request('GET', $url), $entry];
@@ -325,5 +331,20 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         }
 
         return preg_replace('{/\*# sourceMappingURL=[^ ]*+ \*/}', '', $content);
+    }
+
+    /**
+     * Determine the URL pattern to be used by the HTTP Client.
+     */
+    private function resolveUrlPattern(string $packageName, string $path, ImportMapType $type = null): string
+    {
+        // The URL for the es-module-shims polyfill package uses the CSS pattern to
+        // prevent a syntax error in the browser console, so check the package name
+        // as part of the condition.
+        if (self::ES_MODULE_SHIMS === $packageName || str_ends_with($path, '.css') || ImportMapType::CSS === $type) {
+            return self::URL_PATTERN_DIST_CSS;
+        }
+
+        return self::URL_PATTERN_DIST;
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -439,9 +439,9 @@ class JsDelivrEsmResolverTest extends TestCase
             ],
             [
                 [
-                    'url' => '/es-module-shims@1.8.2/+esm',
+                    'url' => '/es-module-shims@1.8.2',
                     'body' => <<<'EOF'
-const je="\n//# sourceURL=",Ue="\n//# sourceMappingURL=",Me=/^(text|application)\/(x-)?javascript(;|$)/,_e=/^(application)\/wasm(;|$)/,Ie=/^(text|application)\/json(;|$)/,Re=/^(text|application)\/css(;|$)/,Te=/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g;export{t as default};
+const je="\n//# sourceURL=",Ue="\n//# sourceMappingURL=",Me=/^(text|application)\/(x-)?javascript(;|$)/,_e=/^(application)\/wasm(;|$)/,Ie=/^(text|application)\/json(;|$)/,Re=/^(text|application)\/css(;|$)/,Te=/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g;
 //# sourceMappingURL=/sm/ef3916de598f421a779ba0e69af94655b2043095cde2410cc01893452d893338.map
 EOF
                 ],
@@ -449,7 +449,7 @@ EOF
             [
                 'es-module-shims' => [
                     'content' => <<<'EOF'
-const je="\n//# sourceURL=",Ue="\n//# sourceMappingURL=",Me=/^(text|application)\/(x-)?javascript(;|$)/,_e=/^(application)\/wasm(;|$)/,Ie=/^(text|application)\/json(;|$)/,Re=/^(text|application)\/css(;|$)/,Te=/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g;export{t as default};
+const je="\n//# sourceURL=",Ue="\n//# sourceMappingURL=",Me=/^(text|application)\/(x-)?javascript(;|$)/,_e=/^(application)\/wasm(;|$)/,Ie=/^(text|application)\/json(;|$)/,Re=/^(text|application)\/css(;|$)/,Te=/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g;
 EOF,
                     'dependencies' => [],
                     'extraFiles' => [],


### PR DESCRIPTION
This fixes a JS console syntax error when importing the `es-module-shims` polyfills package

| Q             | A
| ------------- | ---
| Branch?       | 6.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #52783  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Requiring `es-module-shims` using AssetMapper causes a trailing `export {t as default};` in the downloaded file. The recommendation in #52783 is to be explicit about checking if the package is the shims/polyfill, and, if so, to use the CSS URL pattern when building the HTTP request for the package. This PR adds a new method for handling this case, and it centralizes the logic for determining if the URL pattern should be `URL_PATTERN_DIST`|`URL_PATTERN_DIST_CSS`
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
