### PR TITLE
[FrameworkBundle] Add missing webhook parsers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2680,7 +2680,9 @@ class FrameworkExtension extends Extension
 
         if ($webhookEnabled) {
             $webhookRequestParsers = [
+                MailerBridge\Brevo\Webhook\BrevoRequestParser::class => 'mailer.webhook.request_parser.brevo',
                 MailerBridge\Mailgun\Webhook\MailgunRequestParser::class => 'mailer.webhook.request_parser.mailgun',
+                MailerBridge\Mailjet\Webhook\MailjetRequestParser::class => 'mailer.webhook.request_parser.mailjet',
                 MailerBridge\Postmark\Webhook\PostmarkRequestParser::class => 'mailer.webhook.request_parser.postmark',
                 MailerBridge\Sendgrid\Webhook\SendgridRequestParser::class => 'mailer.webhook.request_parser.sendgrid',
             ];
@@ -2901,6 +2903,7 @@ class FrameworkExtension extends Extension
 
             $webhookRequestParsers = [
                 NotifierBridge\Twilio\Webhook\TwilioRequestParser::class => 'notifier.webhook.request_parser.twilio',
+                NotifierBridge\Vonage\Webhook\VonageRequestParser::class => 'notifier.webhook.request_parser.vonage',
             ];
 
             foreach ($webhookRequestParsers as $class => $service) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2632,7 +2632,7 @@ class FrameworkExtension extends Extension
             ];
 
             foreach ($webhookRequestParsers as $class => $service) {
-                $package = substr($service, \strlen('mailer.transport_factory.'));
+                $package = substr($service, \strlen('mailer.webhook.request_parser.'));
 
                 if (!ContainerBuilder::willBeAvailable(sprintf('symfony/%s-mailer', 'gmail' === $package ? 'google' : $package), $class, ['symfony/framework-bundle', 'symfony/mailer'])) {
                     $container->removeDefinition($service);
@@ -2839,6 +2839,18 @@ class FrameworkExtension extends Extension
 
         if ($webhookEnabled) {
             $loader->load('notifier_webhook.php');
+
+            $webhookRequestParsers = [
+                NotifierBridge\Twilio\Webhook\TwilioRequestParser::class => 'notifier.webhook.request_parser.twilio',
+            ];
+
+            foreach ($webhookRequestParsers as $class => $service) {
+                $package = substr($service, \strlen('notifier.webhook.request_parser.'));
+
+                if (!ContainerBuilder::willBeAvailable(sprintf('symfony/%s-notifier', $package), $class, ['symfony/framework-bundle', 'symfony/notifier'])) {
+                    $container->removeDefinition($service);
+                }
+            }
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_webhook.php
@@ -12,10 +12,14 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Notifier\Bridge\Twilio\Webhook\TwilioRequestParser;
+use Symfony\Component\Notifier\Bridge\Vonage\Webhook\VonageRequestParser;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('notifier.webhook.request_parser.twilio', TwilioRequestParser::class)
         ->alias(TwilioRequestParser::class, 'notifier.webhook.request_parser.twilio')
+
+        ->set('notifier.webhook.request_parser.vonage', VonageRequestParser::class)
+        ->alias(VonageRequestParser::class, 'notifier.webhook.request_parser.vonage')
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Detected when reviewing this documentation PR: https://github.com/symfony/symfony-docs/pull/19268

Should be merged after #53007, which brings notifier services removal conditionally