### PR TITLE
[VarDumper] Exclude some chars from user selection

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -905,12 +905,12 @@ EOHTML
         $v = "<span class=sf-dump-{$style}>".preg_replace_callback(static::$controlCharsRx, function ($c) use ($map) {
             $s = $b = '<span class="sf-dump-default';
             $c = $c[$i = 0];
-            if ($ns = "\r" === $c[$i] || "\n" === $c[$i]) {
+            if ($ns = \in_array($c[$i], ["\t", "\n", "\v", "\f", "\r"], true)) {
                 $s .= ' sf-dump-ns';
             }
             $s .= '">';
             do {
-                if (("\r" === $c[$i] || "\n" === $c[$i]) !== $ns) {
+                if (\in_array($c[$i], ["\t", "\n", "\v", "\f", "\r"], true) !== $ns) {
                     $s .= '</span>'.$b;
                     if ($ns = !$ns) {
                         $s .= ' sf-dump-ns';

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -66,7 +66,7 @@ class HtmlDumperTest extends TestCase
   <span class=sf-dump-key>6</span> => <span class=sf-dump-num>{$intMax}</span>
   "<span class=sf-dump-key>str</span>" => "<span class=sf-dump-str title="5 characters">d&%s;j&%s;<span class="sf-dump-default sf-dump-ns">\\n</span></span>"
   <span class=sf-dump-key>7</span> => b"""
-    <span class=sf-dump-str title="11 binary or non-UTF-8 characters">&#233;<span class="sf-dump-default">\\x01</span>test<span class="sf-dump-default">\\t</span><span class="sf-dump-default sf-dump-ns">\\n</span></span>
+    <span class=sf-dump-str title="11 binary or non-UTF-8 characters">&#233;<span class="sf-dump-default">\\x01</span>test<span class="sf-dump-default sf-dump-ns">\\t\\n</span></span>
     <span class=sf-dump-str title="11 binary or non-UTF-8 characters">ing</span>
     """
   "<span class=sf-dump-key>[]</span>" => []


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #53002 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Exclude `\t` `\v` and `\f` from user selection.