### PR TITLE
[Cache] Fix expiration time for CouchbaseCollection

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
@@ -35,7 +35,7 @@ class CouchbaseCollectionAdapter extends AbstractAdapter
     public function __construct(Collection $connection, string $namespace = '', int $defaultLifetime = 0, MarshallerInterface $marshaller = null)
     {
         if (!static::isSupported()) {
-            throw new CacheException('Couchbase >= 3.0.0 < 4.0.0 is required.');
+            throw new CacheException('Couchbase >= 3.0.5 < 4.0.0 is required.');
         }
 
         $this->maxIdLength = static::MAX_KEY_LENGTH;
@@ -54,7 +54,7 @@ class CouchbaseCollectionAdapter extends AbstractAdapter
         }
 
         if (!static::isSupported()) {
-            throw new CacheException('Couchbase >= 3.0.0 < 4.0.0 is required.');
+            throw new CacheException('Couchbase >= 3.0.5 < 4.0.0 is required.');
         }
 
         set_error_handler(function ($type, $msg, $file, $line): bool { throw new \ErrorException($msg, 0, $type, $file, $line); });
@@ -183,7 +183,7 @@ class CouchbaseCollectionAdapter extends AbstractAdapter
         }
 
         $upsertOptions = new UpsertOptions();
-        $upsertOptions->expiry($lifetime);
+        $upsertOptions->expiry(time() + $lifetime);
 
         $ko = [];
         foreach ($values as $key => $value) {

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
 
 /**
  * @requires extension couchbase <4.0.0
- * @requires extension couchbase >=3.0.0
+ * @requires extension couchbase >=3.0.5
  *
  * @group integration
  *
@@ -36,7 +36,7 @@ class CouchbaseCollectionAdapterTest extends AdapterTestCase
     public static function setupBeforeClass(): void
     {
         if (!CouchbaseCollectionAdapter::isSupported()) {
-            self::markTestSkipped('Couchbase >= 3.0.0 < 4.0.0 is required.');
+            self::markTestSkipped('Couchbase >= 3.0.5 < 4.0.0 is required.');
         }
 
         self::$client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
@@ -47,7 +47,7 @@ class CouchbaseCollectionAdapterTest extends AdapterTestCase
     public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         if (!CouchbaseCollectionAdapter::isSupported()) {
-            self::markTestSkipped('Couchbase >= 3.0.0 < 4.0.0 is required.');
+            self::markTestSkipped('Couchbase >= 3.0.5 < 4.0.0 is required.');
         }
 
         $client = $defaultLifetime


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A refactoring has been done in Couchbase extension 3.0.5 about expiry time: https://github.com/couchbase/php-couchbase/releases/tag/v3.0.5 (see PCBC-715)

In order to put things together, let's constantly use an absolute time point here. This also fixes a failing test of integration tests in 6.3.

Tests skipping messages have been updated to match `CouchbaseCollectionAdapter::isSupported()`.
