### PR TITLE
[Serializer] Add `DateTimeNormalizer::CAST_KEY` context option

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `DateTimeNormalizer::CAST_KEY` context option
+
 7.0
 ---
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
@@ -61,4 +61,12 @@ final class DateTimeNormalizerContextBuilder implements ContextBuilderInterface
 
         return $this->with(DateTimeNormalizer::TIMEZONE_KEY, $timezone);
     }
+
+    /**
+     * @param 'int'|'float'|null $cast
+     */
+    public function withCast(?string $cast): static
+    {
+        return $this->with(DateTimeNormalizer::CAST_KEY, $cast);
+    }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -25,10 +25,12 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
 {
     public const FORMAT_KEY = 'datetime_format';
     public const TIMEZONE_KEY = 'datetime_timezone';
+    public const CAST_KEY = 'datetime_cast';
 
     private array $defaultContext = [
         self::FORMAT_KEY => \DateTimeInterface::RFC3339,
         self::TIMEZONE_KEY => null,
+        self::CAST_KEY => null,
     ];
 
     private const SUPPORTED_TYPES = [
@@ -59,7 +61,7 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * @throws InvalidArgumentException
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): int|float|string
     {
         if (!$object instanceof \DateTimeInterface) {
             throw new InvalidArgumentException('The object must implement the "\DateTimeInterface".');
@@ -73,7 +75,11 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
             $object = $object->setTimezone($timezone);
         }
 
-        return $object->format($dateTimeFormat);
+        return match ($context[self::CAST_KEY] ?? $this->defaultContext[self::CAST_KEY] ?? false) {
+            'int' => (int) $object->format($dateTimeFormat),
+            'float' => (float) $object->format($dateTimeFormat),
+            default => $object->format($dateTimeFormat),
+        };
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateTimeNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateTimeNormalizerContextBuilderTest.php
@@ -38,6 +38,7 @@ class DateTimeNormalizerContextBuilderTest extends TestCase
         $context = $this->contextBuilder
             ->withFormat($values[DateTimeNormalizer::FORMAT_KEY])
             ->withTimezone($values[DateTimeNormalizer::TIMEZONE_KEY])
+            ->withCast($values[DateTimeNormalizer::CAST_KEY])
             ->toArray();
 
         $this->assertEquals($values, $context);
@@ -51,11 +52,13 @@ class DateTimeNormalizerContextBuilderTest extends TestCase
         yield 'With values' => [[
             DateTimeNormalizer::FORMAT_KEY => 'format',
             DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('GMT'),
+            DateTimeNormalizer::CAST_KEY => 'int',
         ]];
 
         yield 'With null values' => [[
             DateTimeNormalizer::FORMAT_KEY => null,
             DateTimeNormalizer::TIMEZONE_KEY => null,
+            DateTimeNormalizer::CAST_KEY => null,
         ]];
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -154,6 +154,72 @@ class DateTimeNormalizerTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideNormalizeUsingCastCases
+     */
+    public function testNormalizeUsingCastPassedInConstructor(\DateTimeInterface $value, string $format, ?string $cast, string|int|float $expectedResult)
+    {
+        $normalizer = new DateTimeNormalizer([DateTimeNormalizer::CAST_KEY => $cast]);
+
+        $this->assertSame($normalizer->normalize($value, null, [DateTimeNormalizer::FORMAT_KEY => $format]), $expectedResult);
+    }
+
+    /**
+     * @dataProvider provideNormalizeUsingCastCases
+     */
+    public function testNormalizeUsingCastPassedInContext(\DateTimeInterface $value, string $format, ?string $cast, string|int|float $expectedResult)
+    {
+        $this->assertSame($this->normalizer->normalize($value, null, [DateTimeNormalizer::FORMAT_KEY => $format, DateTimeNormalizer::CAST_KEY => $cast]), $expectedResult);
+    }
+
+    /**
+     * @return iterable<array{0: \DateTimeImmutable, 1: non-empty-string, 2: 'int'|'float'|null, 3: 'int'|'float'|'string'}>
+     */
+    public static function provideNormalizeUsingCastCases(): iterable
+    {
+        yield [
+            \DateTimeImmutable::createFromFormat('U', '1703071202'),
+            'Y',
+            null,
+            '2023',
+        ];
+
+        yield [
+            \DateTimeImmutable::createFromFormat('U', '1703071202'),
+            'Y',
+            'int',
+            2023,
+        ];
+
+        yield [
+            \DateTimeImmutable::createFromFormat('U', '1703071202'),
+            'Ymd',
+            'int',
+            20231220,
+        ];
+
+        yield [
+            \DateTimeImmutable::createFromFormat('U', '1703071202'),
+            'Y',
+            'int',
+            2023,
+        ];
+
+        yield [
+            \DateTimeImmutable::createFromFormat('U.v', '1703071202.388'),
+            'U.v',
+            'float',
+            1703071202.388,
+        ];
+
+        yield [
+            \DateTimeImmutable::createFromFormat('U.u', '1703071202.388811'),
+            'U.u',
+            'float',
+            1703071202.388811,
+        ];
+    }
+
     public function testNormalizeInvalidObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53055
| License       | MIT

This adds `DateTimeNormalizer::CAST_KEY` context option allowing to cast the formatted result to `int` or `float`.
