### PR TITLE
[HttpKernel] Move `@internal` from `AbstractSessionListener` class to its methods and properties

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -36,13 +36,15 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Tobias Schultze <http://tobion.de>
- *
- * @internal
  */
 abstract class AbstractSessionListener implements EventSubscriberInterface, ResetInterface
 {
     public const NO_AUTO_CACHE_CONTROL_HEADER = 'Symfony-Session-NoAutoCacheControl';
 
+
+    /**
+     * @internal
+     */
     protected $container;
     private $sessionUsageStack = [];
     private $debug;
@@ -52,6 +54,9 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
      */
     private $sessionOptions;
 
+    /**
+     * @internal
+     */
     public function __construct(ContainerInterface $container = null, bool $debug = false, array $sessionOptions = [])
     {
         $this->container = $container;
@@ -59,6 +64,9 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
         $this->sessionOptions = $sessionOptions;
     }
 
+    /**
+     * @internal
+     */
     public function onKernelRequest(RequestEvent $event)
     {
         if (!$event->isMainRequest()) {
@@ -94,6 +102,9 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
         $this->sessionUsageStack[] = $session instanceof Session ? $session->getUsageIndex() : 0;
     }
 
+    /**
+     * @internal
+     */
     public function onKernelResponse(ResponseEvent $event)
     {
         if (!$event->isMainRequest() || (!$this->container->has('initialized_session') && !$event->getRequest()->hasSession())) {
@@ -222,6 +233,9 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
         }
     }
 
+    /**
+     * @internal
+     */
     public function onFinishRequest(FinishRequestEvent $event)
     {
         if ($event->isMainRequest()) {
@@ -229,6 +243,9 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
         }
     }
 
+    /**
+     * @internal
+     */
     public function onSessionUsage(): void
     {
         if (!$this->debug) {
@@ -264,6 +281,9 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
         throw new UnexpectedSessionUsageException('Session was used while the request was declared stateless.');
     }
 
+    /**
+     * @internal
+     */
     public static function getSubscribedEvents(): array
     {
         return [
@@ -274,6 +294,9 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
         ];
     }
 
+    /**
+     * @internal
+     */
     public function reset(): void
     {
         if (\PHP_SESSION_ACTIVE === session_status()) {
@@ -290,6 +313,8 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
 
     /**
      * Gets the session object.
+     *
+     * @internal
      *
      * @return SessionInterface|null
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

The `AbstractSessionListener` being marked as internal, its public constant `NO_AUTO_CACHE_CONTROL_HEADER` should not be used while the documentation [states it can](https://symfony.com/doc/current/http_cache.html#http-caching-and-user-sessions).

In fact, static analysis tools like psalm says there is an error with code using this constant.
```
ERROR: InternalClass - xxx.php:32:33 - Symfony\Component\HttpKernel\EventListener\AbstractSessionListener is internal to Symfony but called from xxx (see https://psalm.dev/174)
        $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 'true');
```

~~Another solution is to make every method of the `AbstractSessionListener`  internal but this means the class could be extended.~~
~~Also, maybe the class `AbstractSessionListener` should not be internal, but I don't think so.~~
~~This is why I introduced a new interface that is not internal and allows to not introduce BC.~~

~~The documentation will need to be updated if this pull request is merged, I'd be happy to do it later.~~

As discussed, I made public/protected properties and methods internal and removed the original internal mark on the class.
This solves the issue and allows us to use the `AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER` const just like the documentation says we can.