### PR TITLE
[Uid] Add `UuidV1::toV6()`, `UuidV1::toV7()` and `UuidV6::toV7()`

### DIFF
--- a/src/Symfony/Component/Uid/BinaryUtil.php
+++ b/src/Symfony/Component/Uid/BinaryUtil.php
@@ -118,8 +118,10 @@ class BinaryUtil
 
     /**
      * @param string $time Count of 100-nanosecond intervals since the UUID epoch 1582-10-15 00:00:00 in hexadecimal
+     *
+     * @return string Count of 100-nanosecond intervals since the UUID epoch 1582-10-15 00:00:00 as a numeric string
      */
-    public static function hexToDateTime(string $time): \DateTimeImmutable
+    public static function hexToNumericString(string $time): string
     {
         if (\PHP_INT_SIZE >= 8) {
             $time = (string) (hexdec($time) - self::TIME_OFFSET_INT);
@@ -140,7 +142,17 @@ class BinaryUtil
             $time = '-' === $time[0] ? '-'.str_pad(substr($time, 1), 8, '0', \STR_PAD_LEFT) : str_pad($time, 8, '0', \STR_PAD_LEFT);
         }
 
-        return \DateTimeImmutable::createFromFormat('U.u?', substr_replace($time, '.', -7, 0));
+        return $time;
+    }
+
+    /**
+     * Sub-microseconds are lost since they are not handled by \DateTimeImmutable.
+     *
+     * @param string $time Count of 100-nanosecond intervals since the UUID epoch 1582-10-15 00:00:00 in hexadecimal
+     */
+    public static function hexToDateTime(string $time): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromFormat('U.u?', substr_replace(self::hexToNumericString($time), '.', -7, 0));
     }
 
     /**

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.1
 ---
 
- * Add `UuidV6::fromV1()` and `UuidV7::fromV1()`
+ * Add `UuidV1::toV6()`, `UuidV1::toV7()` and `UuidV6::toV7()`
 
 6.2
 ---

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `UuidV6::fromV1()` and `UuidV7::fromV1()`
+
 6.2
 ---
 

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -427,4 +427,33 @@ class UuidTest extends TestCase
     {
         $this->assertInstanceOf(Uuid::class, Uuid::fromString('111111111u9QRyVM94rdmZ'));
     }
+
+    public function testV6FromV1()
+    {
+        $uuidV1 = new UuidV1('8189d3de-9670-11ee-b9d1-0242ac120002');
+        $uuidV6 = UuidV6::fromV1($uuidV1);
+
+        $this->assertEquals($uuidV1->getDateTime(), $uuidV6->getDateTime());
+        $this->assertSame($uuidV1->getNode(), $uuidV6->getNode());
+        $this->assertEquals($uuidV6, UuidV6::fromV1($uuidV1));
+    }
+
+    public function testV7FromV1BeforeUnixEpochThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('UUIDv1 with a timestamp before Unix epoch cannot be converted to UUIDv7');
+
+        UuidV7::fromV1(new UuidV1('9aba8000-ff00-11b0-b3db-3b3fc83afdfc')); // Timestamp is 1969-01-01 00:00:00.0000000
+    }
+
+    public function testV7FromV1()
+    {
+        $uuidV1 = new UuidV1('eb248d80-ea4f-11ec-9d2a-839425e6fb88');
+        $sameUuidV1100NanosecondsLater = new UuidV1('eb248d81-ea4f-11ec-9d2a-839425e6fb88');
+        $uuidV7 = UuidV7::fromV1($uuidV1);
+
+        $this->assertEquals($uuidV1->getDateTime(), $uuidV7->getDateTime());
+        $this->assertEquals($uuidV7, UuidV7::fromV1($uuidV1));
+        $this->assertNotEquals($uuidV7, UuidV7::fromV1($sameUuidV1100NanosecondsLater));
+    }
 }

--- a/src/Symfony/Component/Uid/UuidV1.php
+++ b/src/Symfony/Component/Uid/UuidV1.php
@@ -41,6 +41,18 @@ class UuidV1 extends Uuid implements TimeBasedUidInterface
         return uuid_mac($this->uid);
     }
 
+    public function toV6(): UuidV6
+    {
+        $uuid = $this->uid;
+
+        return new UuidV6(substr($uuid, 15, 3).substr($uuid, 9, 4).$uuid[0].'-'.substr($uuid, 1, 4).'-6'.substr($uuid, 5, 3).substr($uuid, 18, 6).substr($uuid, 24));
+    }
+
+    public function toV7(): UuidV7
+    {
+        return $this->toV6()->toV7();
+    }
+
     public static function generate(\DateTimeInterface $time = null, Uuid $node = null): string
     {
         $uuid = !$time || !$node ? uuid_create(static::TYPE) : parent::NIL;

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -43,11 +43,31 @@ class UuidV6 extends Uuid implements TimeBasedUidInterface
         return substr($this->uid, 24);
     }
 
-    public static function fromV1(UuidV1 $uuidV1): self
+    public function toV7(): UuidV7
     {
-        $uuidV1 = $uuidV1->toRfc4122();
+        $uuid = $this->uid;
+        $time = BinaryUtil::hexToNumericString('0'.substr($uuid, 0, 8).substr($uuid, 9, 4).substr($uuid, 15, 3));
+        if ('-' === $time[0]) {
+            throw new \InvalidArgumentException('Cannot convert UUID to v7: its timestamp is before the Unix epoch.');
+        }
 
-        return new self(substr($uuidV1, 15, 3).substr($uuidV1, 9, 4).$uuidV1[0].'-'.substr($uuidV1, 1, 4).'-6'.substr($uuidV1, 5, 3).substr($uuidV1, 18, 6).substr($uuidV1, 24));
+        $ms = \strlen($time) > 4 ? substr($time, 0, -4) : '0';
+        $time = dechex(10000 * hexdec(substr($uuid, 20, 3)) + substr($time, -4));
+
+        if (\strlen($time) > 6) {
+            $uuid[29] = dechex(hexdec($uuid[29]) ^ hexdec($time[0]));
+            $time = substr($time, 1);
+        }
+
+        return new UuidV7(substr_replace(sprintf(
+            '%012s-7%s-%s%s-%s%06s',
+            \PHP_INT_SIZE >= 8 ? dechex($ms) : bin2hex(BinaryUtil::fromBase($ms, BinaryUtil::BASE10)),
+            substr($uuid, -6, 3),
+            $uuid[19],
+            substr($uuid, -3),
+            substr($uuid, -12, 6),
+            $time
+        ), '-', 8, 0));
     }
 
     public static function generate(\DateTimeInterface $time = null, Uuid $node = null): string

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -43,6 +43,13 @@ class UuidV6 extends Uuid implements TimeBasedUidInterface
         return substr($this->uid, 24);
     }
 
+    public static function fromV1(UuidV1 $uuidV1): self
+    {
+        $uuidV1 = $uuidV1->toRfc4122();
+
+        return new self(substr($uuidV1, 15, 3).substr($uuidV1, 9, 4).$uuidV1[0].'-'.substr($uuidV1, 1, 4).'-6'.substr($uuidV1, 5, 3).substr($uuidV1, 18, 6).substr($uuidV1, 24));
+    }
+
     public static function generate(\DateTimeInterface $time = null, Uuid $node = null): string
     {
         $uuidV1 = UuidV1::generate($time, $node);

--- a/src/Symfony/Component/Uid/UuidV7.php
+++ b/src/Symfony/Component/Uid/UuidV7.php
@@ -49,28 +49,6 @@ class UuidV7 extends Uuid implements TimeBasedUidInterface
         return \DateTimeImmutable::createFromFormat('U.v', substr_replace($time, '.', -3, 0));
     }
 
-    /**
-     * Sub-millisecond timestamp precision is lost since UUIDv7 don't support it.
-     */
-    public static function fromV1(UuidV1 $uuidV1): self
-    {
-        $uuidV1 = $uuidV1->toRfc4122();
-        $time = '0'.substr($uuidV1, 15, 3).substr($uuidV1, 9, 4).substr($uuidV1, 0, 8);
-        $time = BinaryUtil::hexToNumericString($time);
-        if ('-' === $time[0]) {
-            throw new \InvalidArgumentException('UUIDv1 with a timestamp before Unix epoch cannot be converted to UUIDv7');
-        }
-
-        $time = str_pad($time, 5, '0', \STR_PAD_LEFT);
-
-        return new self(substr_replace(sprintf(
-            '%012s-7%03s-%s',
-            \PHP_INT_SIZE >= 8 ? dechex(substr($time, 0, -4)) : bin2hex(BinaryUtil::fromBase(substr($time, 0, -4), BinaryUtil::BASE10)),
-            dechex((int) substr($time, -4, 3)),
-            substr($uuidV1, 19)
-        ), '-', 8, 0));
-    }
-
     public static function generate(\DateTimeInterface $time = null): string
     {
         if (null === $mtime = $time) {

--- a/src/Symfony/Component/Uid/UuidV7.php
+++ b/src/Symfony/Component/Uid/UuidV7.php
@@ -49,6 +49,28 @@ class UuidV7 extends Uuid implements TimeBasedUidInterface
         return \DateTimeImmutable::createFromFormat('U.v', substr_replace($time, '.', -3, 0));
     }
 
+    /**
+     * Sub-millisecond timestamp precision is lost since UUIDv7 don't support it.
+     */
+    public static function fromV1(UuidV1 $uuidV1): self
+    {
+        $uuidV1 = $uuidV1->toRfc4122();
+        $time = '0'.substr($uuidV1, 15, 3).substr($uuidV1, 9, 4).substr($uuidV1, 0, 8);
+        $time = BinaryUtil::hexToNumericString($time);
+        if ('-' === $time[0]) {
+            throw new \InvalidArgumentException('UUIDv1 with a timestamp before Unix epoch cannot be converted to UUIDv7');
+        }
+
+        $time = str_pad($time, 5, '0', \STR_PAD_LEFT);
+
+        return new self(substr_replace(sprintf(
+            '%012s-7%03s-%s',
+            \PHP_INT_SIZE >= 8 ? dechex(substr($time, 0, -4)) : bin2hex(BinaryUtil::fromBase(substr($time, 0, -4), BinaryUtil::BASE10)),
+            dechex((int) substr($time, -4, 3)),
+            substr($uuidV1, 19)
+        ), '-', 8, 0));
+    }
+
     public static function generate(\DateTimeInterface $time = null): string
     {
         if (null === $mtime = $time) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | false
| Issues        | -
| License       | MIT

The goal is to help working with new UUIDv6 & v7 versions when you receive legacy UUIDv1.

UUIDv6 and v1 are 100% compatible since v6 is just a "reordering" of v1.

UUIDv7 and v1 are not strictly compatible for several reasons: the timestamp precision is not the same. Also, there is no clock seq or variant or node in v7 but full randomness instead. And maybe others?
However, I believe we can still technically do the conversion (timestamp -> timestamp, clock seq + variant + node -> randomness) with at least one concession: the sub-milliseconds v1 timestamp precision is lost since v7 doesn't support it. 

My proposed v1 to v7 implementation has 2 issues:
* sub-microsecond entropy is entirely lost
* monotonicity is lost?

I'm opening this PR so that @nicolas-grekas gets triggered by the inefficiency of my code and finds a better solution :grin:
I'm kidding, I actually know he already has an idea because he explained it to me during the Brussels HackDay but I couldn't understand it well enough to be able to implement it :sweat_smile:
