### PR TITLE
[RateLimiter] Fix results on last token consume

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -63,21 +63,35 @@ final class FixedWindowLimiter implements LimiterInterface
 
             $now = microtime(true);
             $availableTokens = $window->getAvailableTokens($now);
-            if ($availableTokens >= $tokens) {
+            if (0 !== $tokens && $availableTokens > $tokens) {
                 $window->add($tokens, $now);
 
                 $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->limit));
             } else {
+                if ($availableTokens === $tokens) {
+                    $window->add($tokens, $now);
+                }
+
                 $waitDuration = $window->calculateTimeForTokens($tokens, $now);
 
-                if (null !== $maxTime && $waitDuration > $maxTime) {
+                if ($availableTokens !== $tokens && 0 !== $tokens && null !== $maxTime && $waitDuration > $maxTime) {
                     // process needs to wait longer than set interval
                     throw new MaxWaitDurationExceededException(sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
                 }
 
-                $window->add($tokens, $now);
+                if ($availableTokens !== $tokens) {
+                    $window->add($tokens, $now);
+                }
 
-                $reservation = new Reservation($now + $waitDuration, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
+                if ($availableTokens === $tokens || 0 === $tokens) {
+                    $accepted = true;
+                    $timeToAct = $now;
+                } else {
+                    $accepted = false;
+                    $timeToAct = $now + $waitDuration;
+                }
+
+                $reservation = new Reservation($timeToAct, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), $accepted, $this->limit));
             }
             $this->storage->save($window);
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| License       | MIT

This PR is a result of the discussion in PR https://github.com/symfony/symfony/pull/52835 (@wouterj)

It fixes wrong `retryAfter` values for `fixed_window` and `token_bucket` policies and some related things.

PS: Also seems there is one more bug with the `token_bucket` - I'm sure that the `TokenBucket::$timer` should be used somehow in the `Rate::calculateTimeForTokens()` - it calculates time from `now` at this moment.
