### PR TITLE
Set `strict` parameter of `in_array` to true where possible

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -223,8 +223,8 @@ EOF
                     }
                 }
 
-                if (!\in_array(self::MESSAGE_UNUSED, $states) && $input->getOption('only-unused')
-                    || !\in_array(self::MESSAGE_MISSING, $states) && $input->getOption('only-missing')
+                if (!\in_array(self::MESSAGE_UNUSED, $states, true) && $input->getOption('only-unused')
+                    || !\in_array(self::MESSAGE_MISSING, $states, true) && $input->getOption('only-missing')
                 ) {
                     continue;
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -110,7 +110,7 @@ class UnusedTagsPass implements CompilerPassInterface
 
         foreach ($container->findUnusedTags() as $tag) {
             // skip known tags
-            if (\in_array($tag, self::KNOWN_TAGS)) {
+            if (\in_array($tag, self::KNOWN_TAGS, true)) {
                 continue;
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -435,7 +435,7 @@ class Configuration implements ConfigurationInterface
                                                     if (!\is_string($value)) {
                                                         return true;
                                                     }
-                                                    if (class_exists(WorkflowEvents::class) && !\in_array($value, WorkflowEvents::ALIASES)) {
+                                                    if (class_exists(WorkflowEvents::class) && !\in_array($value, WorkflowEvents::ALIASES, true)) {
                                                         return true;
                                                     }
                                                 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2179,7 +2179,7 @@ class FrameworkExtension extends Extension
                 ->setArguments([$transport['dsn'], $transport['options'] + ['transport_name' => $name], new Reference($serializerId)])
                 ->addTag('messenger.receiver', [
                         'alias' => $name,
-                        'is_failure_transport' => \in_array($name, $failureTransports),
+                        'is_failure_transport' => \in_array($name, $failureTransports, true),
                     ]
                 )
             ;

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -64,7 +64,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->defaultValue('form_div_layout.html.twig')->end()
                     ->example(['@My/form.html.twig'])
                     ->validate()
-                        ->ifTrue(fn ($v) => !\in_array('form_div_layout.html.twig', $v))
+                        ->ifTrue(fn ($v) => !\in_array('form_div_layout.html.twig', $v, true))
                         ->then(fn ($v) => array_merge(['form_div_layout.html.twig'], $v))
                     ->end()
                 ->end()

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -716,7 +716,7 @@ class Application implements ResetInterface
 
                 $aliases[$nameOrAlias] = $commandName;
 
-                return $commandName === $nameOrAlias || !\in_array($commandName, $commands);
+                return $commandName === $nameOrAlias || !\in_array($commandName, $commands, true);
             }));
         }
 

--- a/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
@@ -226,7 +226,7 @@ class ReStructuredTextDescriptor extends Descriptor
         $nonDefaultOptions = [];
         foreach ($definition->getOptions() as $option) {
             // Skip global options.
-            if (!\in_array($option->getName(), $globalOptions)) {
+            if (!\in_array($option->getName(), $globalOptions, true)) {
                 $nonDefaultOptions[] = $option;
             }
         }

--- a/src/Symfony/Component/Console/Helper/TableCellStyle.php
+++ b/src/Symfony/Component/Console/Helper/TableCellStyle.php
@@ -67,7 +67,7 @@ class TableCellStyle
     {
         return array_filter(
             $this->getOptions(),
-            fn ($key) => \in_array($key, self::TAG_OPTIONS) && isset($this->options[$key]),
+            fn ($key) => \in_array($key, self::TAG_OPTIONS, true) && isset($this->options[$key]),
             \ARRAY_FILTER_USE_KEY
         );
     }

--- a/src/Symfony/Component/CssSelector/Parser/Token.php
+++ b/src/Symfony/Component/CssSelector/Parser/Token.php
@@ -72,7 +72,7 @@ class Token
             return true;
         }
 
-        return \in_array($this->value, $values);
+        return \in_array($this->value, $values, true);
     }
 
     public function isWhitespace(): bool

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
@@ -65,7 +65,7 @@ class RegisterEnvVarProcessorsPass implements CompilerPassInterface
         $types = explode('|', $types);
 
         foreach ($types as $type) {
-            if (!\in_array($type, self::ALLOWED_TYPES)) {
+            if (!\in_array($type, self::ALLOWED_TYPES, true)) {
                 throw new InvalidArgumentException(sprintf('Invalid type "%s" returned by "%s::getProvidedTypes()", expected one of "%s".', $type, $class, implode('", "', self::ALLOWED_TYPES)));
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -127,7 +127,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 foreach ($tags as $k => $v) {
                     if (null === $definition->getDecoratedService() || $interface === $definition->getClass() || \in_array($k, $tagsToKeep, true)) {
                         foreach ($v as $v) {
-                            if ($definition->hasTag($k) && \in_array($v, $definition->getTag($k))) {
+                            if ($definition->hasTag($k) && \in_array($v, $definition->getTag($k), true)) {
                                 continue;
                             }
                             $definition->addTag($k, $v);

--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -668,7 +668,7 @@ final class Path
             }
 
             // Only add slash if previous part didn't end with '/' or '\'
-            if (!\in_array(substr($finalPath, -1), ['/', '\\'])) {
+            if (!\in_array(substr($finalPath, -1), ['/', '\\'], true)) {
                 $finalPath .= '/';
             }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -167,7 +167,7 @@ class FilesystemTest extends FilesystemTestCase
      */
     public function testCopyForOriginUrlsAndExistingLocalFileDefaultsToCopy()
     {
-        if (!\in_array('https', stream_get_wrappers())) {
+        if (!\in_array('https', stream_get_wrappers(), true)) {
             $this->markTestSkipped('"https" stream wrapper is not enabled.');
         }
         $sourceFilePath = 'https://symfony.com/images/common/logo/logo_symfony_header.png';

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -120,7 +120,7 @@ class FormValidator extends ConstraintValidator
                     // Otherwise validate a constraint only once for the first
                     // matching group
                     foreach ($groups as $group) {
-                        if (\in_array($group, $constraint->groups)) {
+                        if (\in_array($group, $constraint->groups, true)) {
                             $groupedConstraints[$group][] = $constraint;
 
                             // Prevent duplicate validation

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -32,7 +32,7 @@ abstract class TypeTestCase extends FormIntegrationTestCase
     {
         $extensions = [];
 
-        if (\in_array(ValidatorExtensionTrait::class, class_uses($this))) {
+        if (\in_array(ValidatorExtensionTrait::class, class_uses($this), true)) {
             $extensions[] = $this->getValidatorExtension();
         }
 

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -532,11 +532,11 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
                 throw new InvalidArgumentException(sprintf('Cannot set "%s" with "extra.curl", use option "%s" instead.', $constName, $curloptsToConfig[$opt]));
             }
 
-            if (\in_array($opt, $methodOpts)) {
+            if (\in_array($opt, $methodOpts, true)) {
                 throw new InvalidArgumentException('The HTTP method cannot be overridden using "extra.curl".');
             }
 
-            if (\in_array($opt, $curloptsToCheck)) {
+            if (\in_array($opt, $curloptsToCheck, true)) {
                 $constName = $this->findConstantName($opt) ?? $opt;
                 throw new InvalidArgumentException(sprintf('Cannot set "%s" with "extra.curl".', $constName));
             }

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -165,7 +165,7 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
      */
     public function contains(string $key, string $value): bool
     {
-        return \in_array($value, $this->all($key));
+        return \in_array($value, $this->all($key), true);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -254,7 +254,7 @@ class Request
         $request = self::createRequestFromFactory($_GET, $_POST, [], $_COOKIE, $_FILES, $_SERVER);
 
         if (str_starts_with($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')
-            && \in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), ['PUT', 'DELETE', 'PATCH'])
+            && \in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), ['PUT', 'DELETE', 'PATCH'], true)
         ) {
             parse_str($request->getContent(), $data);
             $request->request = new InputBag($data);
@@ -1090,7 +1090,7 @@ class Request
         if (\count(self::$trustedHostPatterns) > 0) {
             // to avoid host header injection attacks, you should provide a list of trusted host patterns
 
-            if (\in_array($host, self::$trustedHosts)) {
+            if (\in_array($host, self::$trustedHosts, true)) {
                 return $host;
             }
 
@@ -1221,10 +1221,10 @@ class Request
         }
 
         foreach (static::$formats as $format => $mimeTypes) {
-            if (\in_array($mimeType, (array) $mimeTypes)) {
+            if (\in_array($mimeType, (array) $mimeTypes, true)) {
                 return $format;
             }
-            if (null !== $canonicalMimeType && \in_array($canonicalMimeType, (array) $mimeTypes)) {
+            if (null !== $canonicalMimeType && \in_array($canonicalMimeType, (array) $mimeTypes, true)) {
                 return $format;
             }
         }
@@ -1541,7 +1541,7 @@ class Request
             $extendedPreferredLanguages[] = $language;
             if (false !== $position = strpos($language, '_')) {
                 $superLanguage = substr($language, 0, $position);
-                if (!\in_array($superLanguage, $preferredLanguages)) {
+                if (!\in_array($superLanguage, $preferredLanguages, true)) {
                     $extendedPreferredLanguages[] = $superLanguage;
                 }
             }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -62,7 +62,7 @@ class Esi extends AbstractSurrogate
         }
 
         $parts = explode(';', $type);
-        if (!\in_array($parts[0], $this->contentTypes)) {
+        if (!\in_array($parts[0], $this->contentTypes, true)) {
             return $response;
         }
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -390,7 +390,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
             // return the response and not the cache entry if the response is valid but not cached
             $etag = $response->getEtag();
-            if ($etag && \in_array($etag, $requestEtags) && !\in_array($etag, $cachedEtags)) {
+            if ($etag && \in_array($etag, $requestEtags, true) && !\in_array($etag, $cachedEtags, true)) {
                 return $response;
             }
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -46,7 +46,7 @@ class Ssi extends AbstractSurrogate
         }
 
         $parts = explode(';', $type);
-        if (!\in_array($parts[0], $this->contentTypes)) {
+        if (!\in_array($parts[0], $this->contentTypes, true)) {
             return $response;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -264,7 +264,7 @@ class HttpCacheTest extends HttpCacheTestCase
             if ($request->cookies->has('authenticated')) {
                 $response->headers->set('Cache-Control', 'private, no-store');
                 $response->setETag('"private tag"');
-                if (\in_array('"private tag"', $etags)) {
+                if (\in_array('"private tag"', $etags, true)) {
                     $response->setStatusCode(304);
                 } else {
                     $response->setStatusCode(200);
@@ -274,7 +274,7 @@ class HttpCacheTest extends HttpCacheTestCase
             } else {
                 $response->headers->set('Cache-Control', 'public');
                 $response->setETag('"public tag"');
-                if (\in_array('"public tag"', $etags)) {
+                if (\in_array('"public tag"', $etags, true)) {
                     $response->setStatusCode(304);
                 } else {
                     $response->setStatusCode(200);

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -242,7 +242,7 @@ class RegionDataGenerator extends AbstractDataGenerator
                 continue;
             }
 
-            if (\in_array($alias, self::WITHDRAWN_CODES)) {
+            if (\in_array($alias, self::WITHDRAWN_CODES, true)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailTransportFactory.php
@@ -23,7 +23,7 @@ final class GmailTransportFactory extends AbstractTransportFactory
 {
     public function create(Dsn $dsn): TransportInterface
     {
-        if (\in_array($dsn->getScheme(), $this->getSupportedSchemes())) {
+        if (\in_array($dsn->getScheme(), $this->getSupportedSchemes(), true)) {
             return new GmailSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $this->dispatcher, $this->logger);
         }
 

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransportFactory.php
@@ -34,7 +34,7 @@ abstract class AbstractTransportFactory implements TransportFactoryInterface
 
     public function supports(Dsn $dsn): bool
     {
-        return \in_array($dsn->getScheme(), $this->getSupportedSchemes());
+        return \in_array($dsn->getScheme(), $this->getSupportedSchemes(), true);
     }
 
     abstract protected function getSupportedSchemes(): array;

--- a/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
@@ -47,7 +47,7 @@ class HandlersLocator implements HandlersLocatorInterface
                 }
 
                 $name = $handlerDescriptor->getName();
-                if (\in_array($name, $seen)) {
+                if (\in_array($name, $seen, true)) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Mime/Tests/Encoder/QpMimeHeaderEncoderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Encoder/QpMimeHeaderEncoderTest.php
@@ -99,7 +99,7 @@ class QpMimeHeaderEncoderTest extends TestCase
         foreach (range(0x00, 0xFF) as $byte) {
             $char = pack('C', $byte);
             $encodedChar = $encoder->encodeString($char, 'iso-8859-1');
-            if (\in_array($byte, $allowedBytes)) {
+            if (\in_array($byte, $allowedBytes, true)) {
                 $this->assertEquals($char, $encodedChar, 'Character '.$char.' should not be encoded.');
             } elseif (0x20 == $byte) {
                 // special case

--- a/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
@@ -139,7 +139,7 @@ class DataPartTest extends TestCase
      */
     public function testFromPathWithUrl()
     {
-        if (!\in_array('https', stream_get_wrappers())) {
+        if (!\in_array('https', stream_get_wrappers(), true)) {
             $this->markTestSkipped('"https" stream wrapper is not enabled.');
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Share/LifecycleStateShare.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Share/LifecycleStateShare.php
@@ -40,7 +40,7 @@ final class LifecycleStateShare extends AbstractLinkedInShare
 
     public function __construct(string $lifecycleState = self::PUBLISHED)
     {
-        if (!\in_array($lifecycleState, self::AVAILABLE_LIFECYCLE)) {
+        if (!\in_array($lifecycleState, self::AVAILABLE_LIFECYCLE, true)) {
             throw new LogicException(sprintf('"%s" is not a valid value, available lifecycle are "%s".', $lifecycleState, implode(', ', self::AVAILABLE_LIFECYCLE)));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Share/ShareContentShare.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Share/ShareContentShare.php
@@ -72,7 +72,7 @@ final class ShareContentShare extends AbstractLinkedInShare
         }
 
         if ($shareMediaCategory) {
-            if (!\in_array($shareMediaCategory, self::ALL)) {
+            if (!\in_array($shareMediaCategory, self::ALL, true)) {
                 throw new LogicException(sprintf('"%s" is not valid option, available options are "%s".', $shareMediaCategory, implode(', ', self::ALL)));
             }
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Share/ShareMediaShare.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Share/ShareMediaShare.php
@@ -54,7 +54,7 @@ class ShareMediaShare extends AbstractLinkedInShare
         }
 
         if (null !== $landingPageTitle) {
-            if (!\in_array($landingPageTitle, self::ALL)) {
+            if (!\in_array($landingPageTitle, self::ALL, true)) {
                 throw new LogicException(sprintf('"%s" is not valid option, available options are "%s".', $landingPageTitle, implode(', ', self::ALL)));
             }
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Share/VisibilityShare.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Share/VisibilityShare.php
@@ -39,11 +39,11 @@ final class VisibilityShare extends AbstractLinkedInShare
 
     public function __construct(string $visibility = self::MEMBER_NETWORK_VISIBILITY, string $value = 'PUBLIC')
     {
-        if (!\in_array($visibility, self::AVAILABLE_VISIBILITY)) {
+        if (!\in_array($visibility, self::AVAILABLE_VISIBILITY, true)) {
             throw new LogicException(sprintf('"%s" is not a valid visibility, available visibility are "%s".', $visibility, implode(', ', self::AVAILABLE_VISIBILITY)));
         }
 
-        if (self::MEMBER_NETWORK_VISIBILITY === $visibility && !\in_array($value, self::MEMBER_NETWORK)) {
+        if (self::MEMBER_NETWORK_VISIBILITY === $visibility && !\in_array($value, self::MEMBER_NETWORK, true)) {
             throw new LogicException(sprintf('"%s" is not a valid value, available value for visibility "%s" are "%s".', $value, $visibility, implode(', ', self::MEMBER_NETWORK)));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Action/Input/MultiChoiceInput.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Action/Input/MultiChoiceInput.php
@@ -53,7 +53,7 @@ final class MultiChoiceInput extends AbstractInput
      */
     public function style(string $style): static
     {
-        if (!\in_array($style, self::STYLES)) {
+        if (!\in_array($style, self::STYLES, true)) {
             throw new InvalidArgumentException(sprintf('Supported styles for "%s" method are: "%s".', __METHOD__, implode('", "', self::STYLES)));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Action/OpenUriAction.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Action/OpenUriAction.php
@@ -45,7 +45,7 @@ final class OpenUriAction implements ActionCardCompatibleActionInterface
      */
     public function target(string $uri, string $os = 'default'): static
     {
-        if (!\in_array($os, self::OPERATING_SYSTEMS)) {
+        if (!\in_array($os, self::OPERATING_SYSTEMS, true)) {
             throw new InvalidArgumentException(sprintf('Supported operating systems for "%s" method are: "%s".', __METHOD__, implode('", "', self::OPERATING_SYSTEMS)));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransportFactory.php
@@ -30,7 +30,7 @@ final class NtfyTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $topic = substr($dsn->getPath(), 1);
 
-        if (\in_array($dsn->getOption('secureHttp', true), [0, false, 'false', 'off', 'no'])) {
+        if (\in_array($dsn->getOption('secureHttp', true), [0, false, 'false', 'off', 'no'], true)) {
             $secureHttp = false;
         } else {
             $secureHttp = true;

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
@@ -99,7 +99,7 @@ final class NtfyTransportTest extends TransportTestCase
             $expectedBody = json_encode(['topic' => 'test', 'title' => 'Hello', 'message' => 'World']);
             $expectedAuthorization = 'Authorization: Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ';
             $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
-            $this->assertTrue(\in_array($expectedAuthorization, $options['headers']));
+            $this->assertTrue(\in_array($expectedAuthorization, $options['headers'], true));
 
             return $response;
         });

--- a/src/Symfony/Component/Notifier/Transport/AbstractTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Transport/AbstractTransportFactory.php
@@ -32,7 +32,7 @@ abstract class AbstractTransportFactory implements TransportFactoryInterface
 
     public function supports(Dsn $dsn): bool
     {
-        return \in_array($dsn->getScheme(), $this->getSupportedSchemes());
+        return \in_array($dsn->getScheme(), $this->getSupportedSchemes(), true);
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -158,7 +158,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             return null;
         }
 
-        if (!\in_array($prefix, $this->arrayMutatorPrefixes)) {
+        if (!\in_array($prefix, $this->arrayMutatorPrefixes, true)) {
             return $types;
         }
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -424,7 +424,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
         $type = $this->extractFromReflectionType($reflectionType, $reflectionMethod->getDeclaringClass());
 
-        if (1 === \count($type) && \in_array($prefix, $this->arrayMutatorPrefixes)) {
+        if (1 === \count($type) && \in_array($prefix, $this->arrayMutatorPrefixes, true)) {
             $type = [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), $type[0])];
         }
 
@@ -631,7 +631,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         foreach ($mutatorPrefixes as $prefix) {
             $names = [$ucProperty];
-            if (\in_array($prefix, $this->arrayMutatorPrefixes)) {
+            if (\in_array($prefix, $this->arrayMutatorPrefixes, true)) {
                 $names = array_merge($names, $ucSingulars);
             }
 
@@ -660,7 +660,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $pattern = implode('|', array_merge($this->accessorPrefixes, $this->mutatorPrefixes));
 
         if ('' !== $pattern && preg_match('/^('.$pattern.')(.+)$/i', $methodName, $matches)) {
-            if (!\in_array($matches[1], $this->arrayMutatorPrefixes)) {
+            if (!\in_array($matches[1], $this->arrayMutatorPrefixes, true)) {
                 return $matches[2];
             }
 

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -78,7 +78,7 @@ class Type
      */
     public function __construct(string $builtinType, bool $nullable = false, string $class = null, bool $collection = false, array|self $collectionKeyType = null, array|self $collectionValueType = null)
     {
-        if (!\in_array($builtinType, self::$builtinTypes)) {
+        if (!\in_array($builtinType, self::$builtinTypes, true)) {
             throw new \InvalidArgumentException(sprintf('"%s" is not a valid PHP type.', $builtinType));
         }
 

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -178,7 +178,7 @@ final class PhpDocTypeHelper
 
     private function getPhpTypeAndClass(string $docType): array
     {
-        if (\in_array($docType, Type::$builtinTypes)) {
+        if (\in_array($docType, Type::$builtinTypes, true)) {
             return [$docType, null];
         }
 

--- a/src/Symfony/Component/PropertyInfo/Util/PhpStanTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpStanTypeHelper.php
@@ -165,8 +165,8 @@ final class PhpStanTypeHelper
             return [new Type(Type::BUILTIN_TYPE_OBJECT, false, $nameScope->resolveRootClass())];
         }
         if ($node instanceof IdentifierTypeNode) {
-            if (\in_array($node->name, Type::$builtinTypes)) {
-                return [new Type($node->name, false, null, \in_array($node->name, Type::$builtinCollectionTypes))];
+            if (\in_array($node->name, Type::$builtinTypes, true)) {
+                return [new Type($node->name, false, null, \in_array($node->name, Type::$builtinCollectionTypes, true))];
             }
 
             return match ($node->name) {

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -125,7 +125,7 @@ class TraceableUrlMatcher extends UrlMatcher
             }
 
             if ('/' !== $pathinfo && !$hasTrailingVar && $hasTrailingSlash === ($trimmedPathinfo === $pathinfo)) {
-                if ($supportsTrailingSlash && (!$requiredMethods || \in_array('GET', $requiredMethods))) {
+                if ($supportsTrailingSlash && (!$requiredMethods || \in_array('GET', $requiredMethods, true))) {
                     $this->addTrace('Route matches!', self::ROUTE_MATCHES, $name, $route);
 
                     return $this->allow = $this->allowSchemes = [];
@@ -140,7 +140,7 @@ class TraceableUrlMatcher extends UrlMatcher
                 continue;
             }
 
-            if ($requiredMethods && !\in_array($method, $requiredMethods)) {
+            if ($requiredMethods && !\in_array($method, $requiredMethods, true)) {
                 $this->allow = array_merge($this->allow, $requiredMethods);
                 $this->addTrace(sprintf('Method "%s" does not match any of the required methods (%s)', $this->context->getMethod(), implode(', ', $requiredMethods)), self::ROUTE_ALMOST_MATCHES, $name, $route);
                 continue;

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -163,7 +163,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
             }
 
             if ('/' !== $pathinfo && !$hasTrailingVar && $hasTrailingSlash === ($trimmedPathinfo === $pathinfo)) {
-                if ($supportsTrailingSlash && (!$requiredMethods || \in_array('GET', $requiredMethods))) {
+                if ($supportsTrailingSlash && (!$requiredMethods || \in_array('GET', $requiredMethods, true))) {
                     return $this->allow = $this->allowSchemes = [];
                 }
                 continue;
@@ -174,7 +174,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
                 continue;
             }
 
-            if ($requiredMethods && !\in_array($method, $requiredMethods)) {
+            if ($requiredMethods && !\in_array($method, $requiredMethods, true)) {
                 $this->allow = array_merge($this->allow, $requiredMethods);
                 continue;
             }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -197,7 +197,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
             ->expects($this->any())
             ->method('vote')
             ->willReturnCallback(function (TokenInterface $token, $subject, array $attributes) use ($sut, $voter1) {
-                $vote = \in_array('attr1', $attributes) ? VoterInterface::ACCESS_GRANTED : VoterInterface::ACCESS_ABSTAIN;
+                $vote = \in_array('attr1', $attributes, true) ? VoterInterface::ACCESS_GRANTED : VoterInterface::ACCESS_ABSTAIN;
                 $sut->addVoterVote($voter1, $attributes, $vote);
 
                 return $vote;
@@ -207,7 +207,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
             ->expects($this->any())
             ->method('vote')
             ->willReturnCallback(function (TokenInterface $token, $subject, array $attributes) use ($sut, $voter2) {
-                if (\in_array('attr2', $attributes)) {
+                if (\in_array('attr2', $attributes, true)) {
                     $vote = null == $subject ? VoterInterface::ACCESS_GRANTED : VoterInterface::ACCESS_DENIED;
                 } else {
                     $vote = VoterInterface::ACCESS_ABSTAIN;
@@ -222,7 +222,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
             ->expects($this->any())
             ->method('vote')
             ->willReturnCallback(function (TokenInterface $token, $subject, array $attributes) use ($sut, $voter3) {
-                if (\in_array('attr2', $attributes) && $subject) {
+                if (\in_array('attr2', $attributes, true) && $subject) {
                     $vote = $sut->decide($token, $attributes) ? VoterInterface::ACCESS_GRANTED : VoterInterface::ACCESS_DENIED;
                 } else {
                     $vote = VoterInterface::ACCESS_ABSTAIN;

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -90,7 +90,7 @@ class AttributeMetadata implements AttributeMetadataInterface
 
     public function addGroup(string $group): void
     {
-        if (!\in_array($group, $this->groups)) {
+        if (!\in_array($group, $this->groups, true)) {
             $this->groups[] = $group;
         }
     }

--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -30,7 +30,7 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
 
     public function normalize(string $propertyName): string
     {
-        if (null === $this->attributes || \in_array($propertyName, $this->attributes)) {
+        if (null === $this->attributes || \in_array($propertyName, $this->attributes, true)) {
             return strtolower(preg_replace('/[A-Z]/', '_\\0', lcfirst($propertyName)));
         }
 
@@ -45,7 +45,7 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
             $camelCasedName = lcfirst($camelCasedName);
         }
 
-        if (null === $this->attributes || \in_array($camelCasedName, $this->attributes)) {
+        if (null === $this->attributes || \in_array($camelCasedName, $this->attributes, true)) {
             return $camelCasedName;
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -253,7 +253,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     protected function isAllowedAttribute(object|string $classOrObject, string $attribute, string $format = null, array $context = []): bool
     {
         $ignoredAttributes = $context[self::IGNORED_ATTRIBUTES] ?? $this->defaultContext[self::IGNORED_ATTRIBUTES];
-        if (\in_array($attribute, $ignoredAttributes)) {
+        if (\in_array($attribute, $ignoredAttributes, true)) {
             return false;
         }
 
@@ -326,7 +326,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                 $attributeContext = $this->getAttributeDenormalizationContext($class, $paramName, $context);
                 $key = $this->nameConverter ? $this->nameConverter->normalize($paramName, $class, $format, $context) : $paramName;
 
-                $allowed = false === $allowedAttributes || \in_array($paramName, $allowedAttributes);
+                $allowed = false === $allowedAttributes || \in_array($paramName, $allowedAttributes, true);
                 $ignored = !$this->isAllowedAttribute($class, $paramName, $format, $context);
                 if ($constructorParameter->isVariadic()) {
                     if ($allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data))) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -334,7 +334,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             $attributeContext = $this->getAttributeDenormalizationContext($resolvedClass, $attribute, $context);
 
-            if ((false !== $allowedAttributes && !\in_array($attribute, $allowedAttributes)) || !$this->isAllowedAttribute($resolvedClass, $attribute, $format, $context)) {
+            if ((false !== $allowedAttributes && !\in_array($attribute, $allowedAttributes, true)) || !$this->isAllowedAttribute($resolvedClass, $attribute, $format, $context)) {
                 if (!($context[self::ALLOW_EXTRA_ATTRIBUTES] ?? $this->defaultContext[self::ALLOW_EXTRA_ATTRIBUTES])) {
                     $extraAttributes[] = $attribute;
                 }

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -67,7 +67,7 @@ final class LocoProvider implements ProviderInterface
         foreach ($translatorBag->getCatalogues() as $catalogue) {
             $locale = $catalogue->getLocale();
 
-            if (!\in_array($locale, $this->getLocales())) {
+            if (!\in_array($locale, $this->getLocales(), true)) {
                 $this->createLocale($locale);
             }
 

--- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
@@ -96,7 +96,7 @@ abstract class AbstractOperation implements OperationInterface
 
     public function getMessages(string $domain): array
     {
-        if (!\in_array($domain, $this->getDomains())) {
+        if (!\in_array($domain, $this->getDomains(), true)) {
             throw new InvalidArgumentException(sprintf('Invalid domain: "%s".', $domain));
         }
 
@@ -109,7 +109,7 @@ abstract class AbstractOperation implements OperationInterface
 
     public function getNewMessages(string $domain): array
     {
-        if (!\in_array($domain, $this->getDomains())) {
+        if (!\in_array($domain, $this->getDomains(), true)) {
             throw new InvalidArgumentException(sprintf('Invalid domain: "%s".', $domain));
         }
 
@@ -122,7 +122,7 @@ abstract class AbstractOperation implements OperationInterface
 
     public function getObsoleteMessages(string $domain): array
     {
-        if (!\in_array($domain, $this->getDomains())) {
+        if (!\in_array($domain, $this->getDomains(), true)) {
             throw new InvalidArgumentException(sprintf('Invalid domain: "%s".', $domain));
         }
 

--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -76,7 +76,7 @@ class PoFileLoader extends FileLoader
 
             if ('' === $line) {
                 // Whitespace indicated current item is done
-                if (!\in_array('fuzzy', $flags)) {
+                if (!\in_array('fuzzy', $flags, true)) {
                     $this->addMessage($messages, $item);
                 }
                 $item = $defaults;
@@ -108,7 +108,7 @@ class PoFileLoader extends FileLoader
             }
         }
         // save last item
-        if (!\in_array('fuzzy', $flags)) {
+        if (!\in_array('fuzzy', $flags, true)) {
             $this->addMessage($messages, $item);
         }
         fclose($stream);

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -112,7 +112,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 
         $this->resources[$locale][] = [$format, $resource, $domain];
 
-        if (\in_array($locale, $this->fallbackLocales)) {
+        if (\in_array($locale, $this->fallbackLocales, true)) {
             $this->catalogues = [];
         } else {
             unset($this->catalogues[$locale]);

--- a/src/Symfony/Component/Uid/Command/GenerateUlidCommand.php
+++ b/src/Symfony/Component/Uid/Command/GenerateUlidCommand.php
@@ -79,7 +79,7 @@ EOF
 
         $formatOption = $input->getOption('format');
 
-        if (\in_array($formatOption, $this->getAvailableFormatOptions())) {
+        if (\in_array($formatOption, $this->getAvailableFormatOptions(), true)) {
             $format = 'to'.ucfirst($formatOption);
         } else {
             $io->error(sprintf('Invalid format "%s", supported formats are "%s".', $formatOption, implode('", "', $this->getAvailableFormatOptions())));

--- a/src/Symfony/Component/Uid/Command/GenerateUuidCommand.php
+++ b/src/Symfony/Component/Uid/Command/GenerateUuidCommand.php
@@ -168,7 +168,7 @@ EOF
 
         $formatOption = $input->getOption('format');
 
-        if (\in_array($formatOption, $this->getAvailableFormatOptions())) {
+        if (\in_array($formatOption, $this->getAvailableFormatOptions(), true)) {
             $format = 'to'.ucfirst($formatOption);
         } else {
             $io->error(sprintf('Invalid format "%s", supported formats are "%s".', $formatOption, implode('", "', $this->getAvailableFormatOptions())));

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -228,7 +228,7 @@ abstract class Constraint
             throw new \LogicException(sprintf('"%s::$groups" is set to null. Did you forget to call "%s::__construct()"?', static::class, self::class));
         }
 
-        if (\in_array(self::DEFAULT_GROUP, $this->groups) && !\in_array($group, $this->groups)) {
+        if (\in_array(self::DEFAULT_GROUP, $this->groups) && !\in_array($group, $this->groups, true)) {
             $this->groups[] = $group;
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/CssColor.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColor.php
@@ -77,7 +77,7 @@ class CssColor extends Constraint
 
             $options['value'] = $formats;
         } elseif (\is_string($formats)) {
-            if (!\in_array($formats, self::$validationModes)) {
+            if (!\in_array($formats, self::$validationModes, true)) {
                 throw new InvalidArgumentException(sprintf('The "formats" parameter value is not valid. It must contain one or more of the following values: "%s".', $validationModesAsString));
             }
 

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -107,7 +107,7 @@ class Length extends Constraint
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
 
-        if (!\in_array($this->countUnit, self::VALID_COUNT_UNITS)) {
+        if (!\in_array($this->countUnit, self::VALID_COUNT_UNITS, true)) {
             throw new InvalidArgumentException(sprintf('The "countUnit" option must be one of the "%s"::COUNT_* constants ("%s" given).', __CLASS__, $this->countUnit));
         }
     }

--- a/src/Symfony/Component/WebLink/GenericLinkProvider.php
+++ b/src/Symfony/Component/WebLink/GenericLinkProvider.php
@@ -45,7 +45,7 @@ class GenericLinkProvider implements EvolvableLinkProviderInterface
         $links = [];
 
         foreach ($this->links as $link) {
-            if (\in_array($rel, $link->getRels())) {
+            if (\in_array($rel, $link->getRels(), true)) {
                 $links[] = $link;
             }
         }

--- a/src/Symfony/Component/WebLink/Tests/LinkTest.php
+++ b/src/Symfony/Component/WebLink/Tests/LinkTest.php
@@ -45,7 +45,7 @@ class LinkTest extends TestCase
             ->withoutRel('next');
 
         $this->assertEquals('http://www.google.com', $link->getHref());
-        $this->assertFalse(\in_array('next', $link->getRels()));
+        $this->assertFalse(\in_array('next', $link->getRels(), true));
         $this->assertArrayNotHasKey('me', $link->getAttributes());
     }
 

--- a/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
@@ -72,7 +72,7 @@ class MermaidDumper implements DumperInterface
                 $placeId,
                 $place,
                 $meta->getPlaceMetadata($place),
-                \in_array($place, $definition->getInitialPlaces()),
+                \in_array($place, $definition->getInitialPlaces(), true),
                 $marking?->has($place) ?? false
             );
 

--- a/src/Symfony/Component/Workflow/Validator/WorkflowValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/WorkflowValidator.php
@@ -33,7 +33,7 @@ class WorkflowValidator implements DefinitionValidatorInterface
         $places = array_fill_keys($definition->getPlaces(), []);
         foreach ($definition->getTransitions() as $transition) {
             foreach ($transition->getFroms() as $from) {
-                if (\in_array($transition->getName(), $places[$from])) {
+                if (\in_array($transition->getName(), $places[$from], true)) {
                     throw new InvalidDefinitionException(sprintf('All transitions for a place must have an unique name. Multiple transitions named "%s" where found for place "%s" in workflow "%s".', $transition->getName(), $from, $name));
                 }
                 $places[$from][] = $transition->getName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This pull request introduces a comprehensive update where the `in_array` function is now consistently invoked with the `strict` parameter set to `true`. This change is implemented across various components of the framework to enhance type safety and reliability.

To me, this update is a step towards more explicit and error-resistant code.