### PR TITLE
[DoctrineBridge] Add check for lazy object interface

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -16,6 +16,7 @@ use ProxyManager\Proxy\GhostObjectInterface;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 
 /**
  * References Doctrine connections and entity/document managers.
@@ -51,6 +52,13 @@ abstract class ManagerRegistry extends AbstractManagerRegistry
         }
         $manager = $this->container->get($name);
 
+        if ($manager instanceof LazyObjectInterface) {
+            if (!$manager->resetLazyObject()) {
+                throw new \LogicException(sprintf('Resetting a non-lazy manager service is not supported. Declare the "%s" service as lazy.', $name));
+            }
+
+            return;
+        }
         if (!$manager instanceof LazyLoadingInterface) {
             throw new \LogicException('Resetting a non-lazy manager service is not supported. '.(interface_exists(LazyLoadingInterface::class) && class_exists(RuntimeInstantiator::class) ? sprintf('Declare the "%s" service as lazy.', $name) : 'Try running "composer require symfony/proxy-manager-bridge".'));
         }


### PR DESCRIPTION
In Symfony 6.4 lazy loading of ghost proxies is used out of the box.

This means if using 6.4 components with the 5.4 version of the doctrine
bridge you get the following error when trying to reset the entity manager:

```
Resetting a non-lazy manager service is not supported.
Declare the "doctrine.orm.default_entity_manager" service as lazy.
```

The entity manager is set as lazy
already in our case but it extends `\Symfony\Component\VarExporter\LazyObjectInterface` instead of the `LazyLoadingInterface` that's expected

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | 
| License       | MIT
