### PR TITLE
[Clock] Return Symfony ClockInterface in ClockSensitiveTrait

### DIFF
--- a/src/Symfony/Component/Clock/Test/ClockSensitiveTrait.php
+++ b/src/Symfony/Component/Clock/Test/ClockSensitiveTrait.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Clock\Test;
 
-use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
 use Symfony\Component\Clock\MockClock;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

@nicolas-grekas I don't understand why the ClockSensitiveTrait::mockTime returns a PSR ClockInterface, instead of a Symfony ClockInterface. Is this done on purpose? Or was this a mistake?