### PR TITLE
[Serializer] Keep stack trace for enum value denormalizer error

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -65,7 +65,7 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
             return $type::from($data);
         } catch (\ValueError $e) {
             if (isset($context['has_constructor'])) {
-                throw new InvalidArgumentException('The data must belong to a backed enumeration of type '.$type);
+                throw new InvalidArgumentException('The data must belong to a backed enumeration of type '.$type, 0, $e);
             }
 
             throw NotNormalizableValueException::createForUnexpectedDataType('The data must belong to a backed enumeration of type '.$type, $data, [$type], $context['deserialization_path'] ?? null, true, 0, $e);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Simple `previous: $exception` added not to loose track of the error origin.