### PR TITLE
[Messenger] Fix using negative delay

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -67,10 +67,10 @@ class DoctrineIntegrationTest extends TestCase
         // DBAL 2 compatibility
         $result = method_exists($qb, 'executeQuery') ? $qb->executeQuery() : $qb->execute();
 
-        $available_at = new \DateTimeImmutable($result->fetchOne());
+        $availableAt = new \DateTimeImmutable($result->fetchOne());
 
         $now = new \DateTimeImmutable('now + 60 seconds');
-        $this->assertGreaterThan($now, $available_at);
+        $this->assertGreaterThan($now, $availableAt);
     }
 
     public function testSendWithNegativeDelay()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -73,6 +73,25 @@ class DoctrineIntegrationTest extends TestCase
         $this->assertGreaterThan($now, $available_at);
     }
 
+    public function testSendWithNegativeDelay()
+    {
+        $this->connection->send('{"message": "Hi, I am not actually delayed"}', ['type' => DummyMessage::class], -600000);
+
+        $qb = $this->driverConnection->createQueryBuilder()
+            ->select('m.available_at')
+            ->from('messenger_messages', 'm')
+            ->where('m.body = :body')
+            ->setParameter('body', '{"message": "Hi, I am not actually delayed"}');
+
+        // DBAL 2 compatibility
+        $result = method_exists($qb, 'executeQuery') ? $qb->executeQuery() : $qb->execute();
+
+        $available_at = new \DateTimeImmutable($result->fetchOne());
+
+        $now = new \DateTimeImmutable('now - 60 seconds');
+        $this->assertLessThan($now, $available_at);
+    }
+
     public function testItRetrieveTheFirstAvailableMessage()
     {
         $this->connection->setup();

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -89,7 +89,7 @@ class DoctrineIntegrationTest extends TestCase
         $availableAt = new \DateTimeImmutable($result->fetchOne());
 
         $now = new \DateTimeImmutable('now - 60 seconds');
-        $this->assertLessThan($now, $available_at);
+        $this->assertLessThan($now, $availableAt);
     }
 
     public function testItRetrieveTheFirstAvailableMessage()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -86,7 +86,7 @@ class DoctrineIntegrationTest extends TestCase
         // DBAL 2 compatibility
         $result = method_exists($qb, 'executeQuery') ? $qb->executeQuery() : $qb->execute();
 
-        $available_at = new \DateTimeImmutable($result->fetchOne());
+        $availableAt = new \DateTimeImmutable($result->fetchOne());
 
         $now = new \DateTimeImmutable('now - 60 seconds');
         $this->assertLessThan($now, $available_at);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -127,7 +127,7 @@ class Connection implements ResetInterface
     public function send(string $body, array $headers, int $delay = 0): string
     {
         $now = new \DateTimeImmutable('UTC');
-        $availableAt = $now->modify(sprintf('+%d seconds', $delay / 1000));
+        $availableAt = $now->modify(sprintf('%+d seconds', $delay / 1000));
 
         $queryBuilder = $this->driverConnection->createQueryBuilder()
             ->insert($this->configuration['table_name'])

--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
@@ -85,6 +85,15 @@ class InMemoryTransportTest extends TestCase
         $this->assertSame([$envelope1], $this->transport->get());
     }
 
+    public function testQueueWithNegativeDelay()
+    {
+        $envelope1 = new Envelope(new \stdClass());
+        $envelope1 = $this->transport->send($envelope1);
+        $envelope2 = (new Envelope(new \stdClass()))->with(new DelayStamp(-10_000));
+        $envelope2 = $this->transport->send($envelope2);
+        $this->assertSame([$envelope1, $envelope2], $this->transport->get());
+    }
+
     public function testQueueWithSerialization()
     {
         $envelope = new Envelope(new \stdClass());

--- a/src/Symfony/Component/Messenger/Transport/InMemory/InMemoryTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/InMemory/InMemoryTransport.php
@@ -102,7 +102,7 @@ class InMemoryTransport implements TransportInterface, ResetInterface
         /** @var DelayStamp|null $delayStamp */
         if ($delayStamp = $envelope->last(DelayStamp::class)) {
             $now = $this->clock?->now() ?? new \DateTimeImmutable();
-            $this->availableAt[$id] = $now->modify(sprintf('+%d seconds', $delayStamp->getDelay() / 1000));
+            $this->availableAt[$id] = $now->modify(sprintf('%+d seconds', $delayStamp->getDelay() / 1000));
         }
 
         return $envelope;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50833
| License       | MIT

Fixes using negative delays when sending messages.