### PR TITLE
[Validator] Add `ThisableMessage`

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ThisableMessage.php
+++ b/src/Symfony/Component/Validator/Constraints/ThisableMessage.php
@@ -26,8 +26,10 @@ class ThisableMessage extends Composite
 
     public $addRootParameters = [];
 
-    public function __construct(mixed $constraints = null, array $groups = null, mixed $payload = null)
+    public function __construct(mixed $constraints = null, array $addThisParameters = [],  array $addRootParameters = [], array $groups = null, mixed $payload = null)
     {
+        $this->addThisParameters = $addThisParameters;
+        $this->addRootParameters = $addRootParameters;
         parent::__construct($constraints ?? [], $groups, $payload);
     }
 

--- a/src/Symfony/Component/Validator/Constraints/ThisableMessage.php
+++ b/src/Symfony/Component/Validator/Constraints/ThisableMessage.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Émile PRÉVOT <emile@level21.io>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class ThisableMessage extends Composite
+{
+    public $constraints = [];
+
+    public $addThisParameters = [];
+
+    public $addRootParameters = [];
+
+    public function __construct(mixed $constraints = null, array $groups = null, mixed $payload = null)
+    {
+        parent::__construct($constraints ?? [], $groups, $payload);
+    }
+
+    public function getDefaultOption(): ?string
+    {
+        return 'constraints';
+    }
+
+    public function getRequiredOptions(): array
+    {
+        return ['constraints'];
+    }
+
+    protected function getCompositeOption(): string
+    {
+        return 'constraints';
+    }
+
+    public function getTargets(): string|array
+    {
+        return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/ThisableMessageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ThisableMessageValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @author Émile PRÉVOT <emile@level21.io>
+ */
+class ThisableMessageValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof ThisableMessage) {
+            throw new UnexpectedTypeException($constraint, ThisableMessage::class);
+        }
+
+        $context = $this->context;
+
+        $validator = $context->getValidator();
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        $object = $context->getObject();
+        $root = $context->getRoot();
+
+        if (null === $root) {
+            throw new ConstraintDefinitionException('The current root is not accessible');
+        }
+        if (null === $object) {
+            throw new ConstraintDefinitionException('The current object is not accessible');
+        }
+
+        foreach ($constraint->constraints as $subConstraint) {
+            $violationList = $validator->validate($value, $subConstraint);
+            foreach ($violationList as $oldViolation) {
+                $matches = [];
+                preg_match_all('/{{ this\.(.*?) }}/s', $oldViolation->getMessage(), $matches);
+                $newViolation = $this->context->buildViolation($oldViolation->getMessage(), $oldViolation->getParameters());
+                $keys = $matches[1] ?? [];
+                $keys = array_merge($keys, $constraint->addThisParameters);
+                foreach ($keys as $key) {
+                    $newViolation->setParameter('{{ this.'.$key.' }}', $propertyAccessor->getValue($object, $key));
+                }
+
+                $matches = [];
+                preg_match_all('/{{ root\.(.*?) }}/s', $oldViolation->getMessage(), $matches);
+                $keys = $matches[1] ?? [];
+                $keys = array_merge($keys, $constraint->addRootParameters);
+                foreach ($keys as $key) {
+                    $newViolation->setParameter('{{ root.'.$key.' }}', $propertyAccessor->getValue($root, $key));
+                }
+                $newViolation->addViolation();
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/ThisableMessageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ThisableMessageValidator.php
@@ -46,9 +46,10 @@ class ThisableMessageValidator extends ConstraintValidator
         foreach ($constraint->constraints as $subConstraint) {
             $violationList = $validator->validate($value, $subConstraint);
             foreach ($violationList as $oldViolation) {
+                $newViolation = $this->context->buildViolation($oldViolation->getMessage(), $oldViolation->getParameters());
+
                 $matches = [];
                 preg_match_all('/{{ this\.(.*?) }}/s', $oldViolation->getMessage(), $matches);
-                $newViolation = $this->context->buildViolation($oldViolation->getMessage(), $oldViolation->getParameters());
                 $keys = $matches[1] ?? [];
                 $keys = array_merge($keys, $constraint->addThisParameters);
                 foreach ($keys as $key) {
@@ -62,6 +63,8 @@ class ThisableMessageValidator extends ConstraintValidator
                 foreach ($keys as $key) {
                     $newViolation->setParameter('{{ root.'.$key.' }}', $propertyAccessor->getValue($root, $key));
                 }
+
+                $newViolation->setCode($oldViolation->getCode());
                 $newViolation->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ThisableMessageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ThisableMessageValidatorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\EqualTo;
+use Symfony\Component\Validator\Constraints\ThisableMessage;
+use Symfony\Component\Validator\Constraints\ThisableMessageValidator;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Validation;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ThisableMessageValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): ThisableMessageValidator
+    {
+        return new ThisableMessageValidator();
+    }
+
+    public function testWalkSingleConstraint()
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->any())->method('trans')->willReturnArgument(0);
+
+        $validator = Validation::createValidator();
+
+        $root = new ThisableMessageRoot();
+        $child = new ThisableMessageChild();
+        $root->childs[] = $child;
+
+        $this->setRoot($root);
+        $this->setObject($child);
+
+        $context = new ExecutionContext($validator, $root, $translator);
+        $context->setGroup($this->group);
+        $context->setNode($child->val, $child, new ClassMetadata(ThisableMessageRoot::class), 'list[0].val');
+
+        $this->root = $root;
+        $this->setObject($child);
+
+        $equal = new EqualTo(2);
+        $equal->message = '{{ root.who }} and {{ this.who }}';
+
+        $constraint = new ThisableMessage([$equal]);
+        $constraint->addRootParameters = ['val2'];
+        $constraint->addThisParameters = ['who2'];
+        $violations = $validator->inContext($context)
+            ->validate($child->val, $constraint, 'Default')
+            ->getViolations();
+
+        $parameters = $violations->get(0)->getParameters();
+        $this->assertEquals('21', $parameters['{{ value }}']);
+        $this->assertEquals('2', $parameters['{{ compared_value }}']);
+        $this->assertEquals('int', $parameters['{{ compared_value_type }}']);
+
+        $this->assertEquals('child', $parameters['{{ this.who }}']);
+        $this->assertEquals('parent', $parameters['{{ root.who }}']);
+
+        $this->assertEquals('child2', $parameters['{{ this.who2 }}']);
+        $this->assertEquals('123', $parameters['{{ root.val2 }}']);
+    }
+}
+
+class ThisableMessageRoot
+{
+    public string $who = 'parent';
+    public int $val = 42;
+    public int $val2 = 123;
+
+    #[Valid()]
+    public array $childs;
+}
+
+class ThisableMessageChild
+{
+    public string $who = 'child';
+    public string $who2 = 'child2';
+
+    #[ThisableMessage([
+        new EqualTo(2, '{{ root.who }} {{ this.who }}'),
+    ])]
+    public int $val = 21;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Hello !
I really like the way you can place assertions on Symfony :
```php
class Person
{
    protected string $firstName;

    #[Assert\EqualTo(
       value: 20,
       message: 'This value should be equal to {{ compared_value }}.'
    )]
    protected int $age;
}
```

But if our need becomes a little more complex, as when we want to validate several Person at once :

```php
class GroupOfPersons
{
    #[Assert\Valid]
    protected array $persons;
}
```

If we validate this object with some valid Persons and others not, we'll have a large list of exceptions containing "This value should be equal to 20" with the value path. That's enough to meet many needs, and twig with the form component displays them correctly.

But my need was simply to display "This value should be equal to 20 for the person whose first name is Émile." and I couldn't find any elegant way of doing it.

So I've coded this Assertion which makes it possible to do :
```php
class Person
{
    protected string $firstName;

    
    #[Assert\ThisableMessage([
        new Assert\EqualTo(
           value: 20,
           message: 'This value should be equal to {{ compared_value }} for the person whose first name is {{ this.firstName }}.'
       )
    ])]
    protected int $age;
}
```

If you find this feature interesting, I'd be happy to write the documentation and the changelog, but I might need a little help to improve the test and source code. And maybe "ThisableMessage" is a name that can evolve.

I use it to validate CSVs containing hundreds of rows over dozens of columns, and adding this assertion had no noticeable effect on performance.

Thank you,