### PR TITLE
[Serializer] Fix using deserialization path 5.4

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -414,7 +414,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         sprintf('Failed to create object because the class misses the "%s" property.', $constructorParameter->name),
                         $data,
                         ['unknown'],
-                        $objectDeserializationPath,
+                        $context['deserialization_path'],
                         true
                     );
                     $context['not_normalizable_value_exceptions'][] = $exception;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -437,7 +437,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     sprintf('Failed to denormalize attribute "%s" value for class "%s": '.$e->getMessage(), $attribute, $type),
                     $data,
                     ['unknown'],
-                    $context['deserialization_path'] ?? null,
+                    $attributeContext['deserialization_path'] ?? null,
                     false,
                     $e->getCode(),
                     $e

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1049,7 +1049,7 @@ class SerializerTest extends TestCase
                 'expectedTypes' => [
                     'unknown',
                 ],
-                'path' => 'php74FullWithConstructor',
+                'path' => 'php74FullWithConstructor.constructorArgument',
                 'useMessageForUser' => true,
                 'message' => 'Failed to create object because the class misses the "constructorArgument" property.',
             ],
@@ -1187,6 +1187,75 @@ class SerializerTest extends TestCase
     }
 
     /**
+     * @requires PHP 7.4
+     */
+    public function testCollectDenormalizationErrorsWithoutTypeExtractor()
+    {
+        $json = '
+        {
+            "string": [],
+            "int": [],
+            "float": []
+        }';
+
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+
+        try {
+            $serializer->deserialize($json, Php74Full::class, 'json', [
+                DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+            ]);
+
+            $this->fail();
+        } catch (\Throwable $th) {
+            $this->assertInstanceOf(PartialDenormalizationException::class, $th);
+        }
+
+        $this->assertInstanceOf(Php74Full::class, $th->getData());
+
+        $exceptionsAsArray = array_map(function (NotNormalizableValueException $e): array {
+            return [
+                'currentType' => $e->getCurrentType(),
+                'expectedTypes' => $e->getExpectedTypes(),
+                'path' => $e->getPath(),
+                'useMessageForUser' => $e->canUseMessageForUser(),
+                'message' => $e->getMessage(),
+            ];
+        }, $th->getErrors());
+
+        $expected = [
+            [
+                'currentType' => 'array',
+                'expectedTypes' => [
+                    'unknown',
+                ],
+                'path' => 'string',
+                'useMessageForUser' => false,
+                'message' => 'Failed to denormalize attribute "string" value for class "Symfony\\Component\\Serializer\\Tests\\Fixtures\\Php74Full": Expected argument of type "string", "array" given at property path "string".',
+            ],
+            [
+                'currentType' => 'array',
+                'expectedTypes' => [
+                    'unknown',
+                ],
+                'path' => 'int',
+                'useMessageForUser' => false,
+                'message' => 'Failed to denormalize attribute "int" value for class "Symfony\\Component\\Serializer\\Tests\\Fixtures\\Php74Full": Expected argument of type "int", "array" given at property path "int".',
+            ],
+            [
+                'currentType' => 'array',
+                'expectedTypes' => [
+                    'unknown',
+                ],
+                'path' => 'float',
+                'useMessageForUser' => false,
+                'message' => 'Failed to denormalize attribute "float" value for class "Symfony\\Component\\Serializer\\Tests\\Fixtures\\Php74Full": Expected argument of type "float", "array" given at property path "float".',
+            ],
+        ];
+
+        $this->assertSame($expected, $exceptionsAsArray);
+    }
+
+    /**
      * @dataProvider provideCollectDenormalizationErrors
      *
      * @requires PHP 8.0
@@ -1241,7 +1310,7 @@ class SerializerTest extends TestCase
                 'expectedTypes' => [
                     'unknown',
                 ],
-                'path' => null,
+                'path' => 'string',
                 'useMessageForUser' => true,
                 'message' => 'Failed to create object because the class misses the "string" property.',
             ],
@@ -1250,7 +1319,7 @@ class SerializerTest extends TestCase
                 'expectedTypes' => [
                     'unknown',
                 ],
-                'path' => null,
+                'path' => 'int',
                 'useMessageForUser' => true,
                 'message' => 'Failed to create object because the class misses the "int" property.',
             ],
@@ -1300,7 +1369,7 @@ class SerializerTest extends TestCase
             [
                 'currentType' => 'string',
                 'expectedTypes' => [
-                    0 => 'bool',
+                    'bool',
                 ],
                 'path' => 'bool',
                 'useMessageForUser' => false,
@@ -1309,7 +1378,7 @@ class SerializerTest extends TestCase
             [
                 'currentType' => 'bool',
                 'expectedTypes' => [
-                    0 => 'int',
+                    'int',
                 ],
                 'path' => 'int',
                 'useMessageForUser' => false,
@@ -1481,7 +1550,7 @@ class SerializerTest extends TestCase
                 'expectedTypes' => [
                     'unknown',
                 ],
-                'path' => null,
+                'path' => 'two',
                 'useMessageForUser' => true,
                 'message' => 'Failed to create object because the class misses the "two" property.',
             ],

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -33,7 +33,7 @@
         "symfony/http-foundation": "^4.4|^5.0|^6.0",
         "symfony/http-kernel": "^4.4|^5.0|^6.0",
         "symfony/mime": "^4.4|^5.0|^6.0",
-        "symfony/property-access": "^5.4|^6.0",
+        "symfony/property-access": "^5.4.26|^6.3",
         "symfony/property-info": "^5.4.24|^6.2.11",
         "symfony/uid": "^5.3|^6.0",
         "symfony/validator": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I've noticed this while working on #53107.

Sometimes, the `path` provided to the `NotNormalizableValueException` is incorrect.