### PR TITLE
[Clock] Add static `DatePoint::create` constructor

### DIFF
--- a/src/Symfony/Component/Clock/CHANGELOG.md
+++ b/src/Symfony/Component/Clock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add static `create` method to `DatePoint` to allow chaining of methods
+
 6.4
 ---
 

--- a/src/Symfony/Component/Clock/DatePoint.php
+++ b/src/Symfony/Component/Clock/DatePoint.php
@@ -49,6 +49,14 @@ final class DatePoint extends \DateTimeImmutable
     }
 
     /**
+     * @throws \DateMalformedStringException
+     */
+    public static function create(string $datetime = 'now', \DateTimeZone $timezone = null, parent $reference = null): self
+    {
+        return new self($datetime, $timezone, $reference);
+    }
+
+    /**
      * @throws \DateMalformedStringException When $format or $datetime are invalid
      */
     public static function createFromFormat(string $format, string $datetime, \DateTimeZone $timezone = null): static

--- a/src/Symfony/Component/Clock/Tests/DatePointTest.php
+++ b/src/Symfony/Component/Clock/Tests/DatePointTest.php
@@ -57,4 +57,16 @@ class DatePointTest extends TestCase
         $this->expectExceptionMessage('Failed to parse time string (Bad Date)');
         $date->modify('Bad Date');
     }
+
+    public function testCreate()
+    {
+        $date = DatePoint::create('2010-01-28 15:00:00');
+
+        $this->assertInstanceOf(DatePoint::class, $date);
+        $this->assertSame('2010-01-28 15:00:00', $date->format('Y-m-d H:i:s'));
+
+        $this->expectException(\DateMalformedStringException::class);
+        $this->expectExceptionMessage('Failed to parse time string (Bad Date)');
+        DatePoint::create('Bad Date');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | 
| License       | MIT

This makes it easier to do things like `DatePoint::create('now')->format('Y-m-d')` instead of having to type `(new DatePoint('now'))->format('Y-m-d')`.