### PR TITLE
[Cache] Fix CI failing tests

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use Couchbase\Collection;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
 
@@ -21,41 +21,32 @@ use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
  * @requires extension couchbase >=3.0.0
  *
  * @group integration
+ * @group legacy
  *
  * @author Antonio Jose Cerezo Aranda <aj.cerezo@gmail.com>
  */
 class CouchbaseCollectionAdapterTest extends AdapterTestCase
 {
+    use ExpectDeprecationTrait;
+
     protected $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
     ];
 
-    protected static Collection $client;
-
-    public static function setupBeforeClass(): void
+    public static function setUpBeforeClass(): void
     {
         if (!CouchbaseCollectionAdapter::isSupported()) {
             self::markTestSkipped('Couchbase >= 3.0.0 < 4.0.0 is required.');
         }
-
-        self::$client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
-            ['username' => getenv('COUCHBASE_USER'), 'password' => getenv('COUCHBASE_PASS')]
-        );
     }
 
     public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
-        if (!CouchbaseCollectionAdapter::isSupported()) {
-            self::markTestSkipped('Couchbase >= 3.0.0 < 4.0.0 is required.');
-        }
+        $this->expectDeprecation('Since symfony/cache 7.1: The "Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter" class is deprecated, use "Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter" instead.');
 
-        $client = $defaultLifetime
-            ? AbstractAdapter::createConnection('couchbase://'
-                .getenv('COUCHBASE_USER')
-                .':'.getenv('COUCHBASE_PASS')
-                .'@'.getenv('COUCHBASE_HOST')
-                .'/cache')
-            : self::$client;
+        $client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
+            ['username' => getenv('COUCHBASE_USER'), 'password' => getenv('COUCHBASE_PASS')]
+        );
 
         return new CouchbaseCollectionAdapter($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -25,6 +25,7 @@
         "psr/cache": "^2.0|^3.0",
         "psr/log": "^1.1|^2|^3",
         "symfony/cache-contracts": "^2.5|^3",
+        "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/var-exporter": "^6.4|^7.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes CI, `AbstractAdapter::createConnection` checks the bucket support before falling back to Collection when the DSN starts with `couchbase`. Should fix CI in all versions with #53054