### PR TITLE
[Console] Add env var to disable direct output

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -67,6 +67,9 @@ class ApplicationTest extends TestCase
         putenv('SHELL_VERBOSITY');
         unset($_ENV['SHELL_VERBOSITY']);
         unset($_SERVER['SHELL_VERBOSITY']);
+        putenv('SYMFONY_CONSOLE_OUTPUT');
+        unset($_ENV['SYMFONY_CONSOLE_OUTPUT']);
+        unset($_SERVER['SYMFONY_CONSOLE_OUTPUT']);
 
         if (\function_exists('pcntl_signal')) {
             // We reset all signals to their default value to avoid side effects
@@ -1126,6 +1129,22 @@ class ApplicationTest extends TestCase
         $input = new ArgvInput(['cli.php', '--foo', 'bar']);
 
         $this->assertSame(0, $application->run($input, $output));
+    }
+
+    public function testDisableOutput()
+    {
+        $_ENV['SYMFONY_CONSOLE_OUTPUT'] = '0';
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->add($command = new \Foo1Command());
+        $_SERVER['argv'] = ['cli.php', 'foo:bar1'];
+
+        ob_start();
+        $application->run();
+        ob_end_clean();
+
+        $this->assertInstanceOf(NullOutput::class, $command->output);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52777 
| License       | MIT

This is useful when running in a containerized application and you've configured Monolog to write to stdout (probably using a JSON format).

Alternatively, we can also introduce a `LoggerOutput` that writes each line to an INFO log message. This can result in double messages, but has the benefit that commands don't have to be written so that useful information is logged. What do you think of this?