### PR TITLE
Change ProxyCacheWarmer::warmUp signature

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -96,6 +96,7 @@ DependencyInjection
 DoctrineBridge
 --------------
 
+ * [BC Break] Add argument `$buildDir` to `ProxyCacheWarmer::warmUp()` 
  * [BC Break] Add return type-hints to `EntityFactory`
  * Deprecate `DbalLogger`, use a middleware instead
  * Deprecate not constructing `DoctrineDataCollector` with an instance of `DebugDataHolder`

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * [BC BREAK] Add argument `$buildDir` to `ProxyCacheWarmer::warmUp()` 
  * [BC BREAK] Add return type-hints to `EntityFactory`
  * Deprecate `DbalLogger`, use a middleware instead
  * Deprecate not constructing `DoctrineDataCollector` with an instance of `DebugDataHolder`

--- a/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
@@ -37,10 +37,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
-    /**
-     * @param string|null $buildDir
-     */
-    public function warmUp(string $cacheDir /* , string $buildDir = null */): array
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         $files = [];
         foreach ($this->registry->getManagers() as $em) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none exists
| License       | MIT

I ended up with a composer.lock that has `"symfony/doctrine-bridge:v6.4.0"` and `"symfony/http-kernel:v7.0.1"`, this combination results in a fatal syntax error: 

```php
Compile Error:
 Declaration of Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer::warmUp(string $cacheDir): array 
 must be compatible with 
 Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface::warmUp(string $cacheDir, ?string $buildDir = null): array
```

I opened this PR as a starting point to "fix" this, I already wondered if the conflict should also be put over `doctrine-bridge`. Happy to do changes as needed.