### PR TITLE
[Validator] Fix using known option names as field names

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
@@ -41,9 +42,10 @@ class Collection extends Composite
      */
     public function __construct($fields = null, array $groups = null, $payload = null, bool $allowExtraFields = null, bool $allowMissingFields = null, string $extraFieldsMessage = null, string $missingFieldsMessage = null)
     {
-        // no known options set? $fields is the fields array
         if (\is_array($fields)
-            && !array_intersect(array_keys($fields), ['groups', 'fields', 'allowExtraFields', 'allowMissingFields', 'extraFieldsMessage', 'missingFieldsMessage'])) {
+            && (($firstField = reset($fields)) instanceof Constraint
+                || ($firstField[0] ?? null) instanceof Constraint
+            )) {
             $fields = ['fields' => $fields];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52993
| License       | MIT

Instead of assuming `$fields` is not the fields array when any of the keys is a known option, let's assume it is the fields array if all keys are known options. Of course, this approach won't work if someone names all their fields after known options, but I don't believe that will actually happen.