### PR TITLE
[Cache] Fix failing test

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
  * @requires extension couchbase <3.0.0
  * @requires extension couchbase >=2.6.0
  *
- * @group integration legacy
+ * @group legacy integration
  *
  * @author Antonio Jose Cerezo Aranda <aj.cerezo@gmail.com>
  */

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
@@ -20,8 +20,7 @@ use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
  * @requires extension couchbase <4.0.0
  * @requires extension couchbase >=3.0.0
  *
- * @group integration
- * @group legacy
+ * @group legacy integration
  *
  * @author Antonio Jose Cerezo Aranda <aj.cerezo@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix CI
| License       | MIT

Unfortunately, [this change](https://github.com/symfony/symfony/compare/a385bc474836fc41bb8afd523a2d87caca71e143..578eb296ce98edb2896a70c8e32382f77b5937c1) didn't work as expected and makes [the integration suite fail](https://github.com/symfony/symfony/actions/runs/7249814282/job/19748627840). I suggest reverting the annotation to one line to fix this. 