### PR TITLE
[FrameworkBundle] Prevent silenced warning by checking if `/proc/mount` exists

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -200,7 +200,7 @@ EOF
 
         if (null === $mounts) {
             $mounts = [];
-            if ('/' === \DIRECTORY_SEPARATOR && $files = @file('/proc/mounts')) {
+            if ('/' === \DIRECTORY_SEPARATOR && is_readable('/proc/mounts') && $files = @file('/proc/mounts')) {
                 foreach ($files as $mount) {
                     $mount = \array_slice(explode(' ', $mount), 1, -3);
                     if (!\in_array(array_pop($mount), ['vboxsf', 'nfs'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When running `bin/console cache:clear -vvv` on Mac OS, I get the following warning:

```
12:40:51 DEBUG     [php] Warning: file(/proc/mounts): Failed to open stream: No such file or directory
[
  "exception" => Symfony\Component\ErrorHandler\Exception\SilencedErrorContext {
    +count: 1
    -severity: E_WARNING
    trace: {
      ./vendor/symfony/framework-bundle/Command/CacheClearCommand.php:203 { …}
      ./vendor/symfony/framework-bundle/Command/CacheClearCommand.php:156 { …}
    }
  }
]
```

This warning can be avoided by checking whether the file exists. Maybe the `@` can be removed also.

I'm not sure about the branch to target as this is not really a bug.