### PR TITLE
[CI] Show exit code when job fails

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -155,12 +155,13 @@ jobs:
             local ok=0
             local title="$1$FLIP"
             local start=$(date -u +%s)
-            OUTPUT=$(bash -xc "$2" 2>&1) || ok=1
+            OUTPUT=$(bash -xc "$2" 2>&1) || ok=$?
             local end=$(date -u +%s)
 
             if [[ $ok -ne 0 ]]; then
               printf "\n%-70s%10s\n" $title $(($end-$start))s
               echo "$OUTPUT"
+              echo "Job exited with: $ok"
               echo -e "\n::error::KO $title\\n"
             else
               printf "::group::%-68s%10s\n" $title $(($end-$start))s


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This is just a small small PR to show what exit code the job failed with. 