### PR TITLE
[Mailer] Fix Azure bridge double encoding attachments' content

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
@@ -67,12 +67,19 @@ class AzureApiTransportTest extends TestCase
 
             $message = $body['content'];
             $this->assertSame('normal', $body['importance']);
-            // $this->assertSame('Fabien', $message['from_name']);
             $this->assertSame('fabpot@symfony.com', $body['senderAddress']);
             $this->assertSame('Saif Eddin', $body['recipients']['to'][0]['displayName']);
             $this->assertSame('saif.gmati@symfony.com', $body['recipients']['to'][0]['address']);
             $this->assertSame('Hello!', $message['subject']);
             $this->assertSame('Hello There!', $message['plainText']);
+
+            $this->assertSame([
+                [
+                    'name' => 'Hello There!',
+                    'contentInBase64' => base64_encode('content'),
+                    'contentType' => 'text/plain',
+                ],
+            ], $body['attachments']);
 
             return new JsonMockResponse([
                 'id' => 'foobar',
@@ -87,7 +94,8 @@ class AzureApiTransportTest extends TestCase
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
-            ->text('Hello There!');
+            ->text('Hello There!')
+            ->attach('content', 'Hello There!', 'text/plain');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
@@ -148,7 +148,7 @@ final class AzureApiTransport extends AbstractApiTransport
 
             $att = [
                 'name' => $filename,
-                'contentInBase64' => base64_encode(str_replace("\r\n", '', $attachment->bodyToString())),
+                'contentInBase64' => base64_encode($attachment->getBody()),
                 'contentType' => $headers->get('Content-Type')->getBody(),
             ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53132
| License       | MIT
