### PR TITLE
[VarDumper] Fix CSS alignment in HtmlDumper

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -663,7 +663,7 @@ pre.sf-dump:after {
    clear: both;
 }
 pre.sf-dump span {
-    display: inline;
+    display: inline-flex;
 }
 pre.sf-dump a {
     text-decoration: none;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53103
| License       | MIT

Bottom alignment seems the right one here:

![image](https://github.com/symfony/symfony/assets/2144837/dee6ea23-0e95-4d08-a7f6-f20c013be061)
