### PR TITLE
[Contracts] Allow psr/container 1.1 again

### DIFF
--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "psr/container": "^2.0"
+        "psr/container": "^1.1|^2.0"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The only difference between psr/container 1.1 and 2.0 is one additional return type on the `ContainerInterface::has()` method, see https://github.com/php-fig/container/compare/1.1.2...2.0.2

This means that if a package is compatible with 2.0 already (== all implementations already have that return type), it remains compatible with 1.1. However, in #42088 we changed the composer.json of our service-contracts package and replaced `^1.1` with `^2.0`, dropping support for 1.1 although there was no need to do so.

I'm migrating a larger application to Symfony 7 at the moment which also consumes various Laminas packages. Due to Laminas still being stuck on psr/container 1.1, I cannot upgrade to service-contracts 3 which in turn blocks my Symfony 7 upgrade.

It would smoothen the upgrade path a lot for me, if we released a service-contracts 3.x that allows the installation of psr/container 1.1 again.