### PR TITLE
[WebProfilerBundle] Fix JS error when evaluating scripts

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -547,7 +547,9 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
                         /* Evaluate in global scope scripts embedded inside the toolbar */
                         var i, scripts = [].slice.call(el.querySelectorAll('script'));
                         for (i = 0; i < scripts.length; ++i) {
-                            eval.call({}, scripts[i].firstChild.nodeValue);
+                            if (scripts[i].firstChild) {
+                                eval.call({}, scripts[i].firstChild.nodeValue);
+                            }
                         }
 
                         el.style.display = -1 !== xhr.responseText.indexOf('sf-toolbarreset') ? 'block' : 'none';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

When a script tag without body (ie <script src="..."/>) is injected in the toolbar (this happened to me with some browser extension), the toolbar crashes with 
```
Cannot read properties of null (reading 'nodeValue')
```

This PR asserts the script has a body before evaluating its content.