### PR TITLE
[Contracts][DependencyInjection] Add `ServiceCollectionInterface`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "psr/http-message": "^1.0|^2.0",
         "psr/link": "^1.1|^2.0",
         "psr/log": "^1|^2|^3",
-        "symfony/contracts": "^2.5|^3.0",
+        "symfony/contracts": "^3.5",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-grapheme": "~1.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -206,7 +206,7 @@
             "url": "src/Symfony/Contracts",
             "options": {
                 "versions": {
-                    "symfony/contracts": "3.4.x-dev"
+                    "symfony/contracts": "3.5.x-dev"
                 }
             }
         },

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add argument `$prepend` to `ContainerConfigurator::extension()` to prepend the configuration instead of appending it
+ * Have `ServiceLocator` implement `ServiceCollectionInterface`
 
 7.0
 ---

--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -16,8 +16,8 @@ use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Contracts\Service\ServiceCollectionInterface;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
-use Symfony\Contracts\Service\ServiceProviderInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
 /**
@@ -26,9 +26,9 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
  *
  * @template-covariant T of mixed
  *
- * @implements ServiceProviderInterface<T>
+ * @implements ServiceCollectionInterface<T>
  */
-class ServiceLocator implements ServiceProviderInterface, \Countable
+class ServiceLocator implements ServiceCollectionInterface
 {
     use ServiceLocatorTrait {
         get as private doGet;
@@ -80,6 +80,13 @@ class ServiceLocator implements ServiceProviderInterface, \Countable
     public function count(): int
     {
         return \count($this->getProvidedServices());
+    }
+
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->getProvidedServices() as $id => $config) {
+            yield $id => $this->get($id);
+        }
     }
 
     private function createNotFoundException(string $id): NotFoundExceptionInterface

--- a/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
@@ -101,6 +101,17 @@ class ServiceLocatorTest extends ServiceLocatorTestCase
             'baz' => '?string',
         ]);
     }
+
+    public function testIsCountableAndIterable()
+    {
+        $locator = $this->getServiceLocator([
+            'foo' => fn () => 'bar',
+            'bar' => fn () => 'baz',
+        ]);
+
+        $this->assertCount(2, $locator);
+        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], iterator_to_array($locator));
+    }
 }
 
 class SomeServiceSubscriber implements ServiceSubscriberInterface

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "psr/container": "^1.1|^2.0",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/service-contracts": "^3.3",
+        "symfony/service-contracts": "^3.5",
         "symfony/var-exporter": "^6.4|^7.0"
     },
     "require-dev": {

--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.5
+---
+
+ * Add `ServiceCollectionInterface`
+
 3.4
 ---
 

--- a/src/Symfony/Contracts/Cache/composer.json
+++ b/src/Symfony/Contracts/Cache/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "3.4-dev"
+            "dev-main": "3.5-dev"
         },
         "thanks": {
             "name": "symfony/contracts",

--- a/src/Symfony/Contracts/Deprecation/composer.json
+++ b/src/Symfony/Contracts/Deprecation/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "3.4-dev"
+            "dev-main": "3.5-dev"
         },
         "thanks": {
             "name": "symfony/contracts",

--- a/src/Symfony/Contracts/EventDispatcher/composer.json
+++ b/src/Symfony/Contracts/EventDispatcher/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "3.4-dev"
+            "dev-main": "3.5-dev"
         },
         "thanks": {
             "name": "symfony/contracts",

--- a/src/Symfony/Contracts/HttpClient/composer.json
+++ b/src/Symfony/Contracts/HttpClient/composer.json
@@ -27,7 +27,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "3.4-dev"
+            "dev-main": "3.5-dev"
         },
         "thanks": {
             "name": "symfony/contracts",

--- a/src/Symfony/Contracts/Service/ServiceCollectionInterface.php
+++ b/src/Symfony/Contracts/Service/ServiceCollectionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Service;
+
+/**
+ * A ServiceProviderInterface that is also countable and iterable.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @template-covariant T of mixed
+ *
+ * @extends ServiceProviderInterface<T>
+ * @extends \IteratorAggregate<string, T>
+ */
+interface ServiceCollectionInterface extends ServiceProviderInterface, \Countable, \IteratorAggregate
+{
+}

--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "3.4-dev"
+            "dev-main": "3.5-dev"
         },
         "thanks": {
             "name": "symfony/contracts",

--- a/src/Symfony/Contracts/Translation/composer.json
+++ b/src/Symfony/Contracts/Translation/composer.json
@@ -27,7 +27,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "3.4-dev"
+            "dev-main": "3.5-dev"
         },
         "thanks": {
             "name": "symfony/contracts",

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -45,7 +45,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "3.4-dev"
+            "dev-main": "3.5-dev"
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

I commonly require a service locator which is also an iterator. I noticed during @weaverryan's most recent livestream he could have benefited from this as well. There are currently three ways to achieve:

1. Decorate a `ServiceLocator` and use `ServiceLocator::getProvidedServices()` in the decorator's `getIterator()`
2. Decorate a service iterable and add your own `ContainerInterface::get()` method which iterates over all items until it finds a match (this is what Ryan did in his livestream)
3. Inject a tagged iterator in addition to your locator.

This PR proposes a new `ServiceCollectionInterface` which is a countable, iterable, `ContainerInterface`.

I'm implemented on the current `ServiceLocator` so any place this is used in your code, you can now type-hint `ServiceCollectionInterface`:

```php
public function someAction(
    #[TaggedLocator('some.tag')]
    ServiceCollectionInterface $container,
) {
    foreach ($container as $id => $item) {
        // do something with each service/id
    }

    $container->count(); // # of services
    
    $container->get('some.id');
}
``` 