### PR TITLE
[SecurityBundle] Prevent to login/logout without a request context

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
@@ -201,6 +201,28 @@ class SecurityTest extends TestCase
         $security->login($user);
     }
 
+    public function testLoginWithoutRequestContext()
+    {
+        $requestStack = new RequestStack();
+        $user = $this->createMock(UserInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->willReturnMap([
+                ['request_stack', $requestStack],
+            ])
+        ;
+
+        $security = new Security($container, ['main' => null]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to login without a request context.');
+
+        $security->login($user);
+    }
+
     public function testLogout()
     {
         $request = new Request();
@@ -405,6 +427,27 @@ class SecurityTest extends TestCase
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals('a custom response', $response->getContent());
+    }
+
+    public function testLogoutWithoutRequestContext()
+    {
+        $requestStack = new RequestStack();
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->willReturnMap([
+                ['request_stack', $requestStack],
+            ])
+        ;
+
+        $security = new Security($container, ['main' => null]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to logout without a request context.');
+
+        $security->logout();
     }
 
     private function createContainer(string $serviceId, object $serviceObject): ContainerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53170
| License       | MIT

Using `Security::login()` in a context without request throws a type error
See all details in the issue https://github.com/symfony/symfony/issues/53170

In this PR, we prevent to use `Security::login()` and `Security::logout()` without a request context, to avoid a fatal error.