### PR TITLE
[Translation][Crowdin] Use project language mapping

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -56,10 +56,13 @@ final class CrowdinProvider implements ProviderInterface
     public function write(TranslatorBagInterface $translatorBag): void
     {
         $fileList = $this->getFileList();
+        $languageMapping = $this->getLanguageMapping();
 
         $responses = [];
 
         foreach ($translatorBag->getCatalogues() as $catalogue) {
+            $locale = $catalogue->getLocale();
+
             foreach ($catalogue->getDomains() as $domain) {
                 if (0 === \count($catalogue->all($domain))) {
                     continue;
@@ -86,7 +89,7 @@ final class CrowdinProvider implements ProviderInterface
                         continue;
                     }
 
-                    $responses[] = $this->uploadTranslations($fileId, $domain, $content, $catalogue->getLocale());
+                    $responses[] = $this->uploadTranslations($fileId, $domain, $content, $languageMapping[$locale] ?? $locale);
                 }
             }
         }
@@ -105,11 +108,10 @@ final class CrowdinProvider implements ProviderInterface
     public function read(array $domains, array $locales): TranslatorBag
     {
         $fileList = $this->getFileList();
+        $languageMapping = $this->getLanguageMapping();
 
         $translatorBag = new TranslatorBag();
         $responses = [];
-
-        $localeLanguageMap = $this->mapLocalesToLanguageId($locales);
 
         foreach ($domains as $domain) {
             $fileId = $this->getFileIdByDomain($fileList, $domain);
@@ -120,7 +122,7 @@ final class CrowdinProvider implements ProviderInterface
 
             foreach ($locales as $locale) {
                 if ($locale !== $this->defaultLocale) {
-                    $response = $this->exportProjectTranslations($localeLanguageMap[$locale], $fileId);
+                    $response = $this->exportProjectTranslations($languageMapping[$locale] ?? $locale, $fileId);
                 } else {
                     $response = $this->downloadSourceFile($fileId);
                 }
@@ -406,37 +408,24 @@ final class CrowdinProvider implements ProviderInterface
         return $result;
     }
 
-    private function mapLocalesToLanguageId(array $locales): array
+    private function getLanguageMapping(): array
     {
         /**
-         * We cannot query by locales, we need to fetch all and filter out the relevant ones.
-         *
-         * @see https://developer.crowdin.com/api/v2/#operation/api.languages.getMany (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.languages.getMany (Crowdin Enterprise API)
+         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.get (Crowdin API)
+         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.get (Crowdin Enterprise API)
          */
-        $response = $this->client->request('GET', '../../languages?limit=500');
+        $response = $this->client->request('GET', '');
 
         if (200 !== $response->getStatusCode()) {
-            throw new ProviderException('Unable to list set languages.', $response);
+            throw new ProviderException('Unable to get project info.', $response);
         }
 
-        $localeLanguageMap = [];
-        foreach ($response->toArray()['data'] as $language) {
-            foreach (['locale', 'osxLocale', 'id'] as $key) {
-                if (\in_array($language['data'][$key], $locales, true)) {
-                    $localeLanguageMap[$language['data'][$key]] = $language['data']['id'];
-                }
-            }
+        $projectInfo = $response->toArray()['data'];
+        $mapping = [];
+        foreach ($projectInfo['languageMapping'] ?? [] as $key => $value) {
+            $mapping[$value['locale']] = $key;
         }
 
-        if (\count($localeLanguageMap) !== \count($locales)) {
-            $message = implode('", "', array_diff($locales, array_keys($localeLanguageMap)));
-            $message = sprintf('Unable to find all requested locales: "%s" not found.', $message);
-            $this->logger->error($message);
-
-            throw new ProviderException($message, $response);
-        }
-
-        return $localeLanguageMap;
+        return $mapping;
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -110,6 +110,12 @@ XLIFF;
 
                 return new MockResponse(json_encode(['data' => []]));
             },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+            },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
@@ -188,6 +194,12 @@ XLIFF;
 
                 return new MockResponse(json_encode(['data' => []]));
             },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+            },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
@@ -259,6 +271,12 @@ XLIFF;
                         ]],
                     ],
                 ]));
+            },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
             },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -348,6 +366,12 @@ XLIFF;
                         ]],
                     ],
                 ]));
+            },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
             },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -442,6 +466,12 @@ XLIFF;
                     ],
                 ]));
             },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+            },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
@@ -512,6 +542,20 @@ XLIFF;
                     ],
                 ]));
             },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new MockResponse(json_encode([
+                    'data' => [
+                        'languageMapping' => [
+                            'pt-PT' => [
+                                'locale' => 'pt',
+                            ],
+                        ],
+                    ],
+                ]));
+            },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
@@ -538,6 +582,22 @@ XLIFF;
                 return new MockResponse(json_encode(['data' => ['id' => 19]]), ['http_code' => 201]);
             },
             'UploadTranslations' => function (string $method, string $url, array $options = []) use ($expectedLocale): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame(sprintf('https://api.crowdin.com/api/v2/projects/1/translations/%s', $expectedLocale), $url);
+                $this->assertSame('{"storageId":19,"fileId":12}', $options['body']);
+
+                return new MockResponse();
+            },
+            'addStorage3' => function (string $method, string $url, array $options = []) use ($expectedMessagesTranslationsContent): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
+                $this->assertSame('Content-Type: application/octet-stream', $options['normalized_headers']['content-type'][0]);
+                $this->assertSame('Crowdin-API-FileName: messages.xlf', $options['normalized_headers']['crowdin-api-filename'][0]);
+                $this->assertStringMatchesFormat($expectedMessagesTranslationsContent, $options['body']);
+
+                return new MockResponse(json_encode(['data' => ['id' => 19]], ['http_code' => 201]));
+            },
+            'uploadTranslations2' => function (string $method, string $url, array $options = []) use ($expectedLocale): ResponseInterface {
                 $this->assertSame('POST', $method);
                 $this->assertSame(sprintf('https://api.crowdin.com/api/v2/projects/1/translations/%s', $expectedLocale), $url);
                 $this->assertSame('{"storageId":19,"fileId":12}', $options['body']);
@@ -577,6 +637,33 @@ XLIFF;
       <trans-unit id="ypeBEso" resname="a">
         <source>a</source>
         <target>trans_fr_a</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+
+XLIFF
+        ];
+
+        $translatorBagPt = new TranslatorBag();
+        $translatorBagPt->addCatalogue($arrayLoader->load([
+            'a' => 'trans_en_a',
+        ], 'en'));
+        $translatorBagPt->addCatalogue($arrayLoader->load([
+            'a' => 'trans_pt_a',
+        ], 'pt'));
+
+        yield [$translatorBagPt, 'pt-PT', <<<'XLIFF'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="pt" datatype="plaintext" original="file.ext">
+    <header>
+      <tool tool-id="symfony" tool-name="Symfony"/>
+    </header>
+    <body>
+      <trans-unit id="ypeBEso" resname="a">
+        <source>a</source>
+        <target>trans_pt_a</target>
       </trans-unit>
     </body>
   </file>
@@ -632,25 +719,15 @@ XLIFF
                     ],
                 ]));
             },
-            'listLanguages' => function (string $method, string $url, array $options = []): ResponseInterface {
+            'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/languages?limit=500', $url);
-                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
                 return new MockResponse(json_encode([
                     'data' => [
-                        [
-                            'data' => [
-                                'id' => 'en-GB',
-                                'osxLocale' => 'en_GB',
-                                'locale' => 'en-GB',
-                            ],
-                        ],
-                        [
-                            'data' => [
-                                'id' => 'fr',
-                                'osxLocale' => 'fr_FR',
-                                'locale' => 'fr-FR',
+                        'languageMapping' => [
+                            'pt-PT' => [
+                                'locale' => 'pt',
                             ],
                         ],
                     ],
@@ -770,25 +847,15 @@ XLIFF
                     ],
                 ]));
             },
-            'listLanguages' => function (string $method, string $url, array $options = []): ResponseInterface {
+            'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/languages?limit=500', $url);
-                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
                 return new MockResponse(json_encode([
                     'data' => [
-                        [
-                            'data' => [
-                                'id' => 'en',
-                                'osxLocale' => 'en_GB',
-                                'locale' => 'en-GB',
-                            ],
-                        ],
-                        [
-                            'data' => [
-                                'id' => 'fr',
-                                'osxLocale' => 'fr_FR',
-                                'locale' => 'fr-FR',
+                        'languageMapping' => [
+                            'pt-PT' => [
+                                'locale' => 'pt',
                             ],
                         ],
                     ],
@@ -874,25 +941,15 @@ XLIFF
                     ],
                 ]));
             },
-            'listLanguages' => function (string $method, string $url, array $options = []): ResponseInterface {
+            'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/languages?limit=500', $url);
-                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
                 return new MockResponse(json_encode([
                     'data' => [
-                        [
-                            'data' => [
-                                'id' => 'en',
-                                'osxLocale' => 'en_GB',
-                                'locale' => 'en-GB',
-                            ],
-                        ],
-                        [
-                            'data' => [
-                                'id' => 'fr',
-                                'osxLocale' => 'fr_FR',
-                                'locale' => 'fr-FR',
+                        'languageMapping' => [
+                            'pt-PT' => [
+                                'locale' => 'pt',
                             ],
                         ],
                     ],
@@ -933,25 +990,15 @@ XLIFF
                     ],
                 ]));
             },
-            'listLanguages' => function (string $method, string $url, array $options = []): ResponseInterface {
+            'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/languages?limit=500', $url);
-                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
                 return new MockResponse(json_encode([
                     'data' => [
-                        [
-                            'data' => [
-                                'id' => 'en',
-                                'osxLocale' => 'en_GB',
-                                'locale' => 'en-GB',
-                            ],
-                        ],
-                        [
-                            'data' => [
-                                'id' => 'fr',
-                                'osxLocale' => 'fr_FR',
-                                'locale' => 'fr-FR',
+                        'languageMapping' => [
+                            'pt-PT' => [
+                                'locale' => 'pt',
                             ],
                         ],
                     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Sometimes the locale codes may be different from the [codes](https://developer.crowdin.com/language-codes/) used in the Crowdin API. This will cause API errors because the wrong code is passed in the upload and download translation requests. There was already a fix (#50040), but it only works partially.

The suggested approach uses the [language mapping](https://support.crowdin.com/project-settings/#languages) configured in the Crowdin project. If the locale code and the crowdin code are different, the user needs to configure the language mapping in the Crowdin project.

Documentation - https://github.com/symfony/symfony-docs/pull/19325
