### PR TITLE
[Clock] Fix calling `mockTime()` in `setUpBeforeClass()`

### DIFF
--- a/src/Symfony/Component/Clock/Test/ClockSensitiveTrait.php
+++ b/src/Symfony/Component/Clock/Test/ClockSensitiveTrait.php
@@ -42,13 +42,19 @@ trait ClockSensitiveTrait
     }
 
     /**
+     * @beforeClass
+     *
      * @before
      *
      * @internal
      */
-    protected static function saveClockBeforeTest(bool $save = true): ClockInterface
+    public static function saveClockBeforeTest(bool $save = true): ClockInterface
     {
         static $originalClock;
+
+        if ($save && $originalClock) {
+            self::restoreClockAfterTest();
+        }
 
         return $save ? $originalClock = Clock::get() : $originalClock;
     }

--- a/src/Symfony/Component/Clock/Tests/ClockBeforeClassTest.php
+++ b/src/Symfony/Component/Clock/Tests/ClockBeforeClassTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Clock\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Clock\NativeClock;
+use Symfony\Component\Clock\Test\ClockSensitiveTrait;
+
+class ClockBeforeClassTest extends TestCase
+{
+    use ClockSensitiveTrait;
+
+    private static ?ClockInterface $clock = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$clock = self::mockTime();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$clock = null;
+    }
+
+    public function testMockClock()
+    {
+        $this->assertInstanceOf(MockClock::class, self::$clock);
+        $this->assertInstanceOf(NativeClock::class, Clock::get());
+
+        $clock = self::mockTime();
+        $this->assertInstanceOf(MockClock::class, Clock::get());
+        $this->assertSame(Clock::get(), $clock);
+
+        $this->assertNotSame($clock, self::$clock);
+
+        self::restoreClockAfterTest();
+        self::saveClockBeforeTest();
+
+        $this->assertInstanceOf(MockClock::class, self::$clock);
+        $this->assertInstanceOf(NativeClock::class, Clock::get());
+
+        $clock = self::mockTime();
+        $this->assertInstanceOf(MockClock::class, Clock::get());
+        $this->assertSame(Clock::get(), $clock);
+
+        $this->assertNotSame($clock, self::$clock);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, calling `mockTime()` in `setUpBeforeClass()` results in the static `$originalClock` variable always being an instance of `MockClock`.

Since `setUpBeforeClass()` is called **before** `saveClockBeforeTest()`, the native clock is never saved. However, by calling `mockTime()` in `setUpBeforeClass()`, the `Clock::set()` method is called, and the clock is set to an instance of `MockClock`. Then, when `saveClockBeforeTest()` is called, it sets the static `$originalClock` variable to that `MockClock` instance.

The problem becomes more noticeable on Symfony 6.4 where `MockClock` uses `DatePoint`, which itself uses `Clock::get()`:
https://github.com/symfony/symfony/blob/d67685897f2246fd22bf8b2ab684e38c14666079/src/Symfony/Component/Clock/DatePoint.php#L24-L27