### PR TITLE
[Process] Suppress warnings from `is_executable`

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -73,7 +73,7 @@ class ExecutableFinder
         }
 
         $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v';
-        if (\function_exists('exec') && ($executablePath = strtok(@exec($command.' '.escapeshellarg($name)), \PHP_EOL)) && is_executable($executablePath)) {
+        if (\function_exists('exec') && ($executablePath = strtok(@exec($command.' '.escapeshellarg($name)), \PHP_EOL)) && @is_executable($executablePath)) {
             return $executablePath;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #52953
| License       | MIT

The code was recently changed in https://github.com/symfony/process/commit/1f07ae60a23f12edec74a58d91c509f73ce0c00e

Every other `is_executable()` call suppresses warnings. I believe it should here too. Otherwise it outputs:
```
is_executable(): open_basedir restriction in effect. File(/usr/bin/tar) is not within the allowed path(s): (/Users/bytestream)
```

