### PR TITLE
[HttpKernel] Allow `#[WithHttpStatus]` and `#[WithLogLevel]` to take effect on interfaces

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -139,6 +139,21 @@ class ErrorListenerTest extends TestCase
         $this->assertCount(1, $logger->getLogs('warning'));
     }
 
+    public function testHandleClassImplementingInterfaceWithLogLevelAttribute()
+    {
+        $request = new Request();
+        $event = new ExceptionEvent(new TestKernel(), $request, HttpKernelInterface::MAIN_REQUEST, new ImplementingInterfaceWithLogLevelAttribute());
+        $logger = new TestLogger();
+        $l = new ErrorListener('not used', $logger);
+
+        $l->logKernelException($event);
+        $l->onKernelException($event);
+
+        $this->assertEquals(0, $logger->countErrors());
+        $this->assertCount(0, $logger->getLogs('critical'));
+        $this->assertCount(1, $logger->getLogs('warning'));
+    }
+
     public function testHandleWithLogLevelAttributeAndCustomConfiguration()
     {
         $request = new Request();
@@ -298,6 +313,7 @@ class ErrorListenerTest extends TestCase
         yield [new WithCustomUserProvidedAttribute(), 208, ['name' => 'value']];
         yield [new WithGeneralAttribute(), 412, ['some' => 'thing']];
         yield [new ChildOfWithGeneralAttribute(), 412, ['some' => 'thing']];
+        yield [new ImplementingInterfaceWithGeneralAttribute(), 412, ['some' => 'thing']];
     }
 }
 
@@ -359,6 +375,20 @@ class WithGeneralAttribute extends \Exception
 {
 }
 
+#[WithHttpStatus(
+    statusCode: Response::HTTP_PRECONDITION_FAILED,
+    headers: [
+        'some' => 'thing',
+    ]
+)]
+interface InterfaceWithGeneralAttribute
+{
+}
+
+class ImplementingInterfaceWithGeneralAttribute extends \Exception implements InterfaceWithGeneralAttribute
+{
+}
+
 class ChildOfWithGeneralAttribute extends WithGeneralAttribute
 {
 }
@@ -369,5 +399,14 @@ class WarningWithLogLevelAttribute extends \Exception
 }
 
 class ChildOfWarningWithLogLevelAttribute extends WarningWithLogLevelAttribute
+{
+}
+
+#[WithLogLevel(LogLevel::WARNING)]
+interface InterfaceWithLogLevelAttribute
+{
+}
+
+class ImplementingInterfaceWithLogLevelAttribute extends \Exception implements InterfaceWithLogLevelAttribute
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This change lets adding `#[WithHttpStatus]` and `#[WithLogLevel]` to an interface, and exceptions implementing such interface will behave as if `#[WithHttpStatus]` and `#[WithLogLevel]` is attached to itself.

`#[WithHttpStatus]` and `#[WithLogLevel]` were created to have configuration like `config/packages/exceptions.yaml` but using attributes: https://symfony.com/blog/new-in-symfony-6-3-http-exception-attributes

However, unlike `exceptions.yaml`, `#[WithHttpStatus]` and `#[WithLogLevel]` did not previously work with interfaces. Thus, the two ways of configuring have slightly different semantics. This PR fixes the issue.