### PR TITLE
[Ldap] refactor switch to match and tests ldap bind results

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -70,7 +70,6 @@ class Connection extends AbstractConnection
 
         if (false === @ldap_bind($this->connection, $dn, $password)) {
             $error = ldap_error($this->connection);
-        
             throw match (ldap_errno($this->connection)) {
                 self::LDAP_INVALID_CREDENTIALS => new InvalidCredentialsException($error),
                 self::LDAP_TIMEOUT => new ConnectionTimeoutException($error),

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -70,15 +70,13 @@ class Connection extends AbstractConnection
 
         if (false === @ldap_bind($this->connection, $dn, $password)) {
             $error = ldap_error($this->connection);
-            switch (ldap_errno($this->connection)) {
-                case self::LDAP_INVALID_CREDENTIALS:
-                    throw new InvalidCredentialsException($error);
-                case self::LDAP_TIMEOUT:
-                    throw new ConnectionTimeoutException($error);
-                case self::LDAP_ALREADY_EXISTS:
-                    throw new AlreadyExistsException($error);
-            }
-            throw new ConnectionException($error);
+        
+            throw match (ldap_errno($this->connection)) {
+                self::LDAP_INVALID_CREDENTIALS => new InvalidCredentialsException($error),
+                self::LDAP_TIMEOUT => new ConnectionTimeoutException($error),
+                self::LDAP_ALREADY_EXISTS => new AlreadyExistsException($error),
+                default => new ConnectionException($error),
+            };
         }
 
         $this->bound = true;

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -117,7 +117,8 @@ class AdapterTest extends LdapTestCase
         $ldap->getConnection()->bind('invalid_dn', 'invalid_password');
     }
 
-    public function testBindWithConnectionTimeout() {
+    public function testBindWithConnectionTimeout() 
+    {
         $ldap = new Adapter($this->getLdapConfig([\LDAP_OPT_NETWORK_TIMEOUT => 1]));
 
         $this->expectException(ConnectionTimeoutException::class);

--- a/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
@@ -15,13 +15,17 @@ use PHPUnit\Framework\TestCase;
 
 class LdapTestCase extends TestCase
 {
-    protected function getLdapConfig()
+    protected function getLdapConfig($options = [])
     {
         $h = @ldap_connect(getenv('LDAP_HOST'), getenv('LDAP_PORT'));
         @ldap_set_option($h, \LDAP_OPT_PROTOCOL_VERSION, 3);
 
         if (!$h || !@ldap_bind($h)) {
             $this->markTestSkipped('No server is listening on LDAP_HOST:LDAP_PORT');
+        }
+
+        foreach ($options as $option => $value) {
+            @ldap_set_option($h, $option, $value);
         }
 
         ldap_unbind($h);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Refactor switch to match and added tests for each ldap bind result