### PR TITLE
[HttpKernel] Fix default locale is ignored when `set_locale_from_accept_language` is used

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -68,8 +68,10 @@ class LocaleListener implements EventSubscriberInterface
     {
         if ($locale = $request->attributes->get('_locale')) {
             $request->setLocale($locale);
-        } elseif ($this->useAcceptLanguageHeader && $this->enabledLocales && ($preferredLanguage = $request->getPreferredLanguage($this->enabledLocales))) {
-            $request->setLocale($preferredLanguage);
+        } elseif ($this->useAcceptLanguageHeader && $this->enabledLocales) {
+            if ($request->getLanguages() && $preferredLanguage = $request->getPreferredLanguage($this->enabledLocales)) {
+                $request->setLocale($preferredLanguage);
+            }
             $request->attributes->set('_vary_by_language', true);
         }
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -130,6 +130,28 @@ class LocaleListenerTest extends TestCase
         $this->assertEquals('fr', $request->getLocale());
     }
 
+    public function testRequestDefaultLocaleIfNoAcceptLanguageHeaderIsPresent()
+    {
+        $request = new Request();
+        $listener = new LocaleListener($this->requestStack, 'de', null, true, ['lt', 'de']);
+        $event = $this->getEvent($request);
+
+        $listener->setDefaultLocale($event);
+        $listener->onKernelRequest($event);
+        $this->assertEquals('de', $request->getLocale());
+    }
+
+    public function testRequestVaryByLanguageAttributeIsSetIfUsingAcceptLanguageHeader()
+    {
+        $request = new Request();
+        $listener = new LocaleListener($this->requestStack, 'de', null, true, ['lt', 'de']);
+        $event = $this->getEvent($request);
+
+        $listener->setDefaultLocale($event);
+        $listener->onKernelRequest($event);
+        $this->assertTrue($request->attributes->get('_vary_by_language'));
+    }
+
     public function testRequestSecondPreferredLocaleFromAcceptLanguageHeader()
     {
         $request = Request::create('/');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53086
| License       | MIT

Fix as discussed in #53086
