### PR TITLE
[Security] Reduce log level in case of UserNotFoundException in ContextListener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -234,7 +234,7 @@ class ContextListener extends AbstractListener
             } catch (UnsupportedUserException) {
                 // let's try the next user provider
             } catch (UserNotFoundException $e) {
-                $this->logger?->warning('Username could not be found in the selected user provider.', ['username' => $e->getUserIdentifier(), 'provider' => $provider::class]);
+                $this->logger?->info('Username could not be found in the selected user provider.', ['username' => $e->getUserIdentifier(), 'provider' => $provider::class]);
 
                 $userNotFoundByProvider = true;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #50402
| License       | MIT

I didn't get a clear answer for https://github.com/symfony/symfony/issues/50402 so I'm opening a PR about the suggested change to get opinion on it.

There was a similar discussion, some message which could help:
- @fabpot https://github.com/symfony/symfony/pull/1073#issuecomment-1234384
- @stof https://github.com/symfony/symfony/pull/1073#issuecomment-1270189

Here, the `UserNotFoundException` should be considered as a "normal" behavior to me. You can trigger it this way
- Connect yourself with an account.
- Ask someone else to deleted you account on an admin panel.
- Refresh the page, since your account doesn't exist anymore, the Provider doesn't find your user, throw a NotFoundException
- You're logged out

I consider this as a normal behavior, so no warning shouldn't be logged and an info should be preferred.
It's expected to not found a user after this one being deleted.

That seems to be one of the purpose of the refreshUser method to returns null:
- If the user changed
- If the user doesn't exist

WDYT ?