### PR TITLE
[HttpClient] rename `addHeader()` to `setHeader()`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.1
 ---
 
+ * Add `HttpOptions::setHeader()` to add or replace a single header
  * Allow mocking `start_time` info in `MockResponse`
  * Add `MockResponse::fromFile()` and `JsonMockResponse::fromFile()` methods to help using fixtures files
 

--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -66,9 +66,8 @@ class HttpOptions
     /**
      * @return $this
      */
-    public function addHeader(string $key, string $value): static
+    public function setHeader(string $key, string $value): static
     {
-        $this->options['headers'] ??= [];
         $this->options['headers'][$key] = $value;
 
         return $this;

--- a/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
@@ -40,14 +40,14 @@ class HttpOptionsTest extends TestCase
         $this->assertSame('foobar', (new HttpOptions())->setAuthBearer('foobar')->toArray()['auth_bearer']);
     }
 
-    public function testAddHeader()
+    public function testSetHeader()
     {
         $options = new HttpOptions();
-        $options->addHeader('Accept', 'application/json');
+        $options->setHeader('Accept', 'application/json');
         $this->assertSame(['Accept' => 'application/json'], $options->toArray()['headers']);
-        $options->addHeader('Accept-Language', 'en-US,en;q=0.5');
+        $options->setHeader('Accept-Language', 'en-US,en;q=0.5');
         $this->assertSame(['Accept' => 'application/json', 'Accept-Language' => 'en-US,en;q=0.5'], $options->toArray()['headers']);
-        $options->addHeader('Accept', 'application/html');
+        $options->setHeader('Accept', 'application/html');
         $this->assertSame(['Accept' => 'application/html', 'Accept-Language' => 'en-US,en;q=0.5'], $options->toArray()['headers']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

while reviewing the related documentation PR I figured that `addHeader()` might not be the best name if we do not only add new headers but also replace existing ones