### PR TITLE
[Messenger] consistently use dates in UTC in Doctrine connection tests

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -72,9 +72,9 @@ class DoctrineIntegrationTest extends TestCase
             $stmt = $stmt->execute();
         }
 
-        $availableAt = new \DateTimeImmutable($stmt instanceof Result ? $stmt->fetchOne() : $stmt->fetchColumn());
+        $availableAt = new \DateTimeImmutable($stmt instanceof Result ? $stmt->fetchOne() : $stmt->fetchColumn(), new \DateTimeZone('UTC'));
 
-        $now = new \DateTimeImmutable('now + 60 seconds');
+        $now = new \DateTimeImmutable('now + 60 seconds', new \DateTimeZone('UTC'));
         $this->assertGreaterThan($now, $availableAt);
     }
 
@@ -91,9 +91,9 @@ class DoctrineIntegrationTest extends TestCase
         // DBAL 2 compatibility
         $result = method_exists($qb, 'executeQuery') ? $qb->executeQuery() : $qb->execute();
 
-        $availableAt = new \DateTimeImmutable($result->fetchOne());
+        $availableAt = new \DateTimeImmutable($result->fetchOne(), new \DateTimeZone('UTC'));
 
-        $now = new \DateTimeImmutable('now - 60 seconds');
+        $now = new \DateTimeImmutable('now - 60 seconds', new \DateTimeZone('UTC'));
         $this->assertLessThan($now, $availableAt);
     }
 
@@ -175,7 +175,7 @@ class DoctrineIntegrationTest extends TestCase
     public function testItRetrieveTheMessageThatIsOlderThanRedeliverTimeout()
     {
         $this->connection->setup();
-        $twoHoursAgo = new \DateTimeImmutable('now -2 hours');
+        $twoHoursAgo = new \DateTimeImmutable('now -2 hours', new \DateTimeZone('UTC'));
         $this->driverConnection->insert('messenger_messages', [
             'body' => '{"message": "Hi requeued"}',
             'headers' => json_encode(['type' => DummyMessage::class]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

related to #50287 and #53187