### PR TITLE
[WebProfilerBundle] Fix the design of the compact toolbar button

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -47,6 +47,8 @@
 }
 
 .sf-minitoolbar {
+    --sf-toolbar-gray-800: #262626;
+
     background-color: var(--sf-toolbar-gray-800);
     border-top-left-radius: 4px;
     bottom: 0;
@@ -66,6 +68,8 @@
 }
 .sf-minitoolbar svg,
 .sf-minitoolbar img {
+    --sf-toolbar-gray-200: #e5e5e5;
+
     color: var(--sf-toolbar-gray-200);
     max-height: 24px;
     max-width: 24px;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This continues #52769. The bug was in 6.3 and newer versions, not in 5.4.

This is how the compact toolbar looks in dark mode:

<img width="892" alt="before" src="https://github.com/symfony/symfony/assets/73419/430f371b-4507-48ad-a8c7-a41c7e6db9ce">

And this is the same after this PR:

<img width="892" alt="after" src="https://github.com/symfony/symfony/assets/73419/0b197a57-02e0-47ea-999b-db4a296549cc">

