### PR TITLE
[Notifier] [Smsc] Require login and password

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
@@ -34,9 +34,9 @@ final class SmscTransport extends AbstractTransport
     private $password;
     private $from;
 
-    public function __construct(?string $username, ?string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $login, string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
-        $this->login = $username;
+        $this->login = $login;
         $this->password = $password;
         $this->from = $from;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | ---
| License       | MIT

Checking the tests, and the DSN, there is no need to make it nullable

From a technical POV this is a BC break, which could not really happen in real life 🤷‍♂️ 