### PR TITLE
[Validator] Fix `Charset` validator test data

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
@@ -65,7 +65,7 @@ class CharsetValidatorTest extends ConstraintValidatorTestCase
         yield ['my ascii string', ['ASCII', 'UTF-8']];
         yield ['my ûtf 8', ['ASCII', 'UTF-8']];
         yield ['my ûtf 8', ['UTF-8']];
-        yield ['ώ', ['UTF-16']];
+        yield ['string', ['ISO-8859-1']];
     }
 
     public static function provideInvalidValues()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ώ` is not always detected as an UTF-16 valid string by mbstring. This cause the test to fail [in some condition](https://ci.appveyor.com/project/fabpot/symfony/builds/48837004).

The purpose of this test is to try different encodings accepted by mbstring, thus I suggest to change the last data set to make it more stable. The UTF-16 thing seems related to some mbstring platform-dependant implementation so let's "move away" from this.