### PR TITLE
[Mailer] [Postmark] `PostmarkDeliveryEvent::$message` cannot be null

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Event/PostmarkDeliveryEvent.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Event/PostmarkDeliveryEvent.php
@@ -17,17 +17,13 @@ class PostmarkDeliveryEvent
 {
     public const CODE_INACTIVE_RECIPIENT = 406;
 
-    private int $errorCode;
-
     private Headers $headers;
 
-    private ?string $message;
-
-    public function __construct(string $message, int $errorCode)
+    public function __construct(
+        private string $message,
+        private int $errorCode,
+    )
     {
-        $this->message = $message;
-        $this->errorCode = $errorCode;
-
         $this->headers = new Headers();
     }
 
@@ -41,7 +37,7 @@ class PostmarkDeliveryEvent
         return $this->headers;
     }
 
-    public function getMessage(): ?string
+    public function getMessage(): string
     {
         return $this->message;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT
