### PR TITLE
[Notifier/OneSignal] Fix external player IDs

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransport.php
@@ -81,7 +81,17 @@ final class OneSignalTransport extends AbstractTransport
 
         $options = $opts ? $opts->toArray() : [];
         $options['app_id'] = $this->appId;
-        $options['include_player_ids'] = [$recipientId];
+        if (isset($options['external_id'])) {
+            $options['include_aliases'] = [
+                'external_id' => [
+                    $options['external_id']
+                ]
+            ];
+            $options['target_channel'] = 'push';
+            unset($options['external_id']);
+        } else {
+            $options['include_subscription_ids'] = [$recipientId]; // include_player_ids has been deprecated
+        }
 
         if (!isset($options['headings'])) {
             $options['headings'] = ['en' => $message->getSubject()];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes (kinda, if it never worked is it a deprecation?)
| Issues        | Fix #50779
| License       | MIT

After digging into it I found that the original implementation seems to plan for external players but the implementation seems like it never would have worked, since the parameter was called `include_external_user_ids` and not `external_id`.

Looking at their docs, you can also see they recently changed their API parameters, so I took the chance to just go ahead and update to the new parameters.

Since the new one is a bit more complicated to set external IDs I ended up marking the old method as deprecated and adding a new option.

I think this should be better since external ids and subscription ids should be mutually exclusive.

See: https://documentation.onesignal.com/reference/create-notification

I didn't have time to test it yet so it's a draft for now, so please someone feel free to check it out, otherwise I'll try to real world test it in the coming days.