### PR TITLE
[Validator] support `Stringable` instances in `CharsetValidator`

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CharsetValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CharsetValidator.php
@@ -31,7 +31,7 @@ final class CharsetValidator extends ConstraintValidator
             return;
         }
 
-        if (!\is_string($value)) {
+        if (!\is_string($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
@@ -26,7 +26,7 @@ class CharsetValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider provideValidValues
      */
-    public function testEncodingIsValid(string $value, array $encodings)
+    public function testEncodingIsValid(string|\Stringable $value, array $encodings)
     {
         $this->validator->validate($value, new Charset(encodings: $encodings));
 
@@ -66,6 +66,12 @@ class CharsetValidatorTest extends ConstraintValidatorTestCase
         yield ['my ûtf 8', ['ASCII', 'UTF-8']];
         yield ['my ûtf 8', ['UTF-8']];
         yield ['string', ['ISO-8859-1']];
+        yield [new class() implements \Stringable {
+            public function __toString(): string
+            {
+                return 'my ûtf 8';
+            }
+        }, ['UTF-8']];
     }
 
     public static function provideInvalidValues()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT
