### PR TITLE
[Serializer] Improve nested payload validation for `#[MapRequestPayload]` using a new serialization context

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+7.1
+---
+ * Add `AbstractNormalizer::USE_CLASS_AS_DEFAULT_EXPECTED_TYPE` in order to use the FQCN as the default value for NotNormalizableValueException's expectedTypes instead of unknown
+
 7.0
 ---
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -119,6 +119,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     public const REQUIRE_ALL_PROPERTIES = 'require_all_properties';
 
     /**
+     * Use class name as default expected type when throwing NotNormalizableValueException instead of unknown.
+     */
+    public const USE_CLASS_AS_DEFAULT_EXPECTED_TYPE = 'use_class_as_default_expected_type';
+
+    /**
      * @internal
      */
     protected const CIRCULAR_REFERENCE_LIMIT_COUNTERS = 'circular_reference_limit_counters';
@@ -380,7 +385,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(
                         sprintf('Failed to create object because the class misses the "%s" property.', $constructorParameter->name),
                         $data,
-                        ['unknown'],
+                        [isset($context[self::USE_CLASS_AS_DEFAULT_EXPECTED_TYPE]) && $context[self::USE_CLASS_AS_DEFAULT_EXPECTED_TYPE] ? $class : 'unknown'],
                         $context['deserialization_path'] ?? null,
                         true
                     );
@@ -424,12 +429,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         unset($context['has_constructor']);
 
         if (!$reflectionClass->isInstantiable()) {
-            throw NotNormalizableValueException::createForUnexpectedDataType(
-                sprintf('Failed to create object because the class "%s" is not instantiable.', $class),
-                $data,
-                ['unknown'],
-                $context['deserialization_path'] ?? null
-            );
+            throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Failed to create object because the class "%s" is not instantiable.', $class), $data, ['unknown'], $context['deserialization_path'] ?? null);
         }
 
         return new $class();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Hello everyone,

When validating a **nested object** using MapRequestPayload, and given payload schema doesn't respect the DTO provided, Symfony serializer throws `PartialDenormalizationException`.

Unfortunately the `MapRequestPayloadResolver` doesn't have enough information about the Dto structure to be able to provide a more detailed error, Instead symfony throws the errors "**This value should be of type unknown.**"

![image](https://github.com/symfony/symfony/assets/8487016/c47511e0-f034-4c28-a471-4ec476309cbb)

This **unknown** type is originated from the `AbstractNormalizer` in the serializer component, which injects this value to **NotNormalizableValueException** class.
I propose to add new Serialization context `AbstractNormalizer::USE_CLASS_AS_DEFAULT_EXPECTED_TYPE`, 
which allows us to retrieve the class as the expected type for Our DTO if needed.

Example when using the context AbstractNormalizer::USE_CLASS_AS_DEFAULT_EXPECTED_TYPE:
![image](https://github.com/symfony/symfony/assets/8487016/ca368278-b14a-4241-8537-e67771e3dfed)

I honestly do not know the reason behind using unkown instead of the FQCN. I find adding a new context more safe, and certainly **Backward compatible** to support both usages.

Usage example in a controller:

[https://github.com/mmouih/apps-demo/blob/19f9edfa4361567a4b592a32041ead327fb3b898/src/Controller/HomeController.php#L22,L28](url)

I included tests for the new feature:

[https://github.com/mmouih/symfony/blob/05ef92028cb75c556ebbf2857617bdf40b8f1643/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php#L288C21-L288C94](url)

Best regards.