### PR TITLE
[AssetMapper] Add integrity hash to the default es-module-shims script

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -27,7 +27,9 @@ use Symfony\Component\WebLink\Link;
  */
 class ImportMapRenderer
 {
-    private const DEFAULT_ES_MODULE_SHIMS_POLYFILL_URL = 'https://ga.jspm.io/npm:es-module-shims@1.8.0/dist/es-module-shims.js';
+    // https://generator.jspm.io/#S2NnYGAIzSvJLMlJTWEAAMYOgCAOAA
+    private const DEFAULT_ES_MODULE_SHIMS_POLYFILL_URL = 'https://ga.jspm.io/npm:es-module-shims@1.8.2/dist/es-module-shims.js';
+    private const DEFAULT_ES_MODULE_SHIMS_POLYFILL_INTEGRITY = 'sha384-+dzlBT6NPToF0UZu7ZUA6ehxHY8h/TxJOZxzNXKhFD+5He5Hbex+0AIOiSsEaokw';
 
     public function __construct(
         private readonly ImportMapGenerator $importMapGenerator,
@@ -47,7 +49,7 @@ class ImportMapRenderer
         $importMap = [];
         $modulePreloads = [];
         $cssLinks = [];
-        $polyFillPath = null;
+        $polyfillPath = null;
         foreach ($importMapData as $importName => $data) {
             $path = $data['path'];
 
@@ -58,7 +60,7 @@ class ImportMapRenderer
 
             // if this represents the polyfill, hide it from the import map
             if ($importName === $this->polyfillImportName) {
-                $polyFillPath = $path;
+                $polyfillPath = $path;
                 continue;
             }
 
@@ -102,22 +104,31 @@ class ImportMapRenderer
             </script>
             HTML;
 
-        if (false !== $this->polyfillImportName && null === $polyFillPath) {
+        if (false !== $this->polyfillImportName && null === $polyfillPath) {
             if ('es-module-shims' !== $this->polyfillImportName) {
                 throw new \InvalidArgumentException(sprintf('The JavaScript module polyfill was not found in your import map. Either disable the polyfill or run "php bin/console importmap:require "%s"" to install it.', $this->polyfillImportName));
             }
 
             // a fallback for the default polyfill in case it's not in the importmap
-            $polyFillPath = self::DEFAULT_ES_MODULE_SHIMS_POLYFILL_URL;
+            $polyfillPath = self::DEFAULT_ES_MODULE_SHIMS_POLYFILL_URL;
         }
 
-        if ($polyFillPath) {
-            $url = $this->escapeAttributeValue($polyFillPath);
+        if ($polyfillPath) {
+            $url = $this->escapeAttributeValue($polyfillPath);
+            $polyfillAttributes = $scriptAttributes;
+
+            // Add security attributes for the default polyfill hosted on jspm.io
+            if (self::DEFAULT_ES_MODULE_SHIMS_POLYFILL_URL === $polyfillPath) {
+                $polyfillAttributes = $this->createAttributesString([
+                    'crossorigin' => 'anonymous',
+                    'integrity' => self::DEFAULT_ES_MODULE_SHIMS_POLYFILL_INTEGRITY,
+                ] + $attributes);
+            }
 
             $output .= <<<HTML
 
                 <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support -->
-                <script async src="$url"$scriptAttributes></script>
+                <script async src="$url"$polyfillAttributes></script>
                 HTML;
         }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -121,6 +121,7 @@ class ImportMapRendererTest extends TestCase
         );
         $html = $renderer->render(['app']);
         $this->assertStringContainsString('<script async src="https://ga.jspm.io/npm:es-module-shims@', $html);
+        $this->assertStringContainsString('es-module-shims.js" crossorigin="anonymous" integrity="sha384-', $html);
     }
 
     public function testCustomScriptAttributes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52939 (partially)
| License       | MIT

We'll need some deeper changes to manage integrity hashes with custom polyfill URL's...

But this PR already handles the "standard" way of using es-module-shims.
