### PR TITLE
[Validator] Improve `Charset` constraint message

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Charset.php
+++ b/src/Symfony/Component/Validator/Constraints/Charset.php
@@ -27,7 +27,7 @@ final class Charset extends Constraint
     ];
 
     public array|string $encodings = [];
-    public string $message = 'The detected character encoding "{{ detected }}" is invalid. Allowed encodings are "{{ encodings }}".';
+    public string $message = 'The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.';
 
     public function __construct(array|string $encodings = null, string $message = null, array $groups = null, mixed $payload = null, array $options = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

After a little discussion with @xabbuh, I think we found the final message :+1: This format is more consistent with existing ones like `File`.