### PR TITLE
[RateLimit] Test and fix peeking behavior on rate limit policies

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -69,11 +69,12 @@ final class SlidingWindowLimiter implements LimiterInterface
                 return new RateLimit($availableTokens, $window->getRetryAfter(), false, $this->limit);
             }
 
-            $window->add($tokens);
-
-            if (0 < $tokens) {
-                $this->storage->save($window);
+            if (0 === $tokens) {
+                return new RateLimit($availableTokens, $availableTokens ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true))) : $window->getRetryAfter(), true, $this->limit);
             }
+
+            $window->add($tokens);
+            $this->storage->save($window);
 
             return new RateLimit($this->getAvailableTokens($window->getHitCount()), $window->getRetryAfter(), true, $this->limit);
         } finally {

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -123,7 +123,21 @@ class FixedWindowLimiterTest extends TestCase
             $rateLimit = $limiter->consume(0);
             $this->assertSame(10, $rateLimit->getLimit());
             $this->assertTrue($rateLimit->isAccepted());
+            $this->assertEquals(
+                \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true))),
+                $rateLimit->getRetryAfter()
+            );
         }
+
+        $limiter->consume();
+
+        $rateLimit = $limiter->consume(0);
+        $this->assertEquals(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(
+            \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true) + 60)),
+            $rateLimit->getRetryAfter()
+        );
     }
 
     public static function provideConsumeOutsideInterval(): \Generator

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -31,6 +31,7 @@ class SlidingWindowLimiterTest extends TestCase
 
         ClockMock::register(InMemoryStorage::class);
         ClockMock::register(RateLimit::class);
+        ClockMock::register(SlidingWindowLimiter::class);
     }
 
     public function testConsume()
@@ -82,11 +83,26 @@ class SlidingWindowLimiterTest extends TestCase
 
         $limiter->consume(9);
 
+        // peek by consuming 0 tokens twice (making sure peeking doesn't claim a token)
         for ($i = 0; $i < 2; ++$i) {
             $rateLimit = $limiter->consume(0);
             $this->assertTrue($rateLimit->isAccepted());
             $this->assertSame(10, $rateLimit->getLimit());
+            $this->assertEquals(
+                \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
+                $rateLimit->getRetryAfter()
+            );
         }
+
+        $limiter->consume();
+
+        $rateLimit = $limiter->consume(0);
+        $this->assertEquals(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(
+            \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true) + 12)),
+            $rateLimit->getRetryAfter()
+        );
     }
 
     private function createLimiter(): SlidingWindowLimiter

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -134,11 +134,26 @@ class TokenBucketLimiterTest extends TestCase
 
         $limiter->consume(9);
 
+        // peek by consuming 0 tokens twice (making sure peeking doesn't claim a token)
         for ($i = 0; $i < 2; ++$i) {
             $rateLimit = $limiter->consume(0);
             $this->assertTrue($rateLimit->isAccepted());
             $this->assertSame(10, $rateLimit->getLimit());
+            $this->assertEquals(
+                \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true))),
+                $rateLimit->getRetryAfter()
+            );
         }
+
+        $limiter->consume();
+
+        $rateLimit = $limiter->consume(0);
+        $this->assertEquals(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(
+            \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true) + 1)),
+            $rateLimit->getRetryAfter()
+        );
     }
 
     public function testBucketRefilledWithStrictFrequency()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Ref #52835
| License       | MIT

Although heavily discouraged for user-land code, we've implemented peeking behavior for rate limiting in 6.2 with #46110. However, I found that our rate limit policies show very inconsistent behavior on this.

As we didn't have great test covering peeking return values, we broke BC with #51676 in 6.4. I propose this PR to verify the behavior of the policies and also make it inconsistent. I target 6.3 because we rely on this in the login throttling since 6.2 and this shows buggy error messages ("try again in 0 minute") when not using the default policy for login throttling.

> [!NOTE]  
> When merging this PR, there will be heavy merge conflicts in the SlidingWindowLimiter. You can ignore the changes in this PR for this policy in 6.4. I'll rebase and update #52835 to fix the sliding window limiter in 6.4+