### PR TITLE
[AssetMapper] Handle assets with non-ascii characters in dev server

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapperDevServerSubscriber.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperDevServerSubscriber.php
@@ -117,7 +117,7 @@ final class AssetMapperDevServerSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $pathInfo = $event->getRequest()->getPathInfo();
+        $pathInfo = rawurldecode($event->getRequest()->getPathInfo());
         if (!str_starts_with($pathInfo, $this->publicPrefix)) {
             return;
         }

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
@@ -32,6 +32,20 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
         $this->assertSame('immutable, max-age=604800, public', $response->headers->get('Cache-Control'));
     }
 
+    public function testGettingAssetWithNonAsciiFilenameWorks()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/assets/voilà-6344422da690fcc471f23f7a8966cd1c.css');
+        $response = $client->getResponse();
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(<<<EOF
+        /* voilà.css */
+        body {}
+
+        EOF, $response->getContent());
+    }
+
     public function test404OnUnknownAsset()
     {
         $client = static::createClient();

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetsMapperCompileCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetsMapperCompileCommandTest.php
@@ -63,7 +63,7 @@ class AssetsMapperCompileCommandTest extends TestCase
 
         $finder = new Finder();
         $finder->in($targetBuildDir)->files();
-        $this->assertCount(10, $finder);
+        $this->assertCount(11, $finder);
         $this->assertFileExists($targetBuildDir.'/manifest.json');
 
         $this->assertSame([
@@ -74,6 +74,7 @@ class AssetsMapperCompileCommandTest extends TestCase
             'file4.js',
             'subdir/file5.js',
             'subdir/file6.js',
+            'voilà.css',
         ], array_keys(json_decode(file_get_contents($targetBuildDir.'/manifest.json'), true)));
 
         $this->assertFileExists($targetBuildDir.'/importmap.json');

--- a/src/Symfony/Component/AssetMapper/Tests/fixtures/AssetMapperTestAppKernel.php
+++ b/src/Symfony/Component/AssetMapper/Tests/fixtures/AssetMapperTestAppKernel.php
@@ -40,7 +40,7 @@ class AssetMapperTestAppKernel extends Kernel
                 'http_client' => true,
                 'assets' => null,
                 'asset_mapper' => [
-                    'paths' => ['dir1', 'dir2'],
+                    'paths' => ['dir1', 'dir2', 'non_ascii'],
                 ],
                 'test' => true,
             ]);

--- a/src/Symfony/Component/AssetMapper/Tests/fixtures/non_ascii/voilà.css
+++ b/src/Symfony/Component/AssetMapper/Tests/fixtures/non_ascii/voilà.css
@@ -1,0 +1,2 @@
+/* voilà.css */
+body {}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

In `AssetMapperDevServerSubscriber`, `$event->getRequest()->getPathInfo()` is used to get the path of the asset to serve. As `Request::getPathInfo()` returns the raw path, if the requested asset contains non-ascii characters in it's path, a 404 is returned instead of the asset because of the encoded path info.

Using `rawurldecode` enabled handling of encoded paths.

I just pushed the use of the `rawurldecode` for now as don't known how to test this properly.

I tried renaming `dir1/file1.css` to `dir1/file 1.css` or creating a new `and voilà.css` but both approches affect many other tests.

How could I test this properly?
