### PR TITLE
[Notifier] [OneSignal] Add support for sending to external user ids

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `OneSignalOptions::isExternalUserId()` to indicate that recipient is an external user id
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalOptions.php
@@ -108,6 +108,24 @@ final class OneSignalOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * Indicates that the passed recipient is an external user id.
+     *
+     * For more information on how to set an external user id in OneSignal please see:
+     * https://documentation.onesignal.com/docs/aliases-external-id
+     *
+     * For more information on how targeting based on external user id works please see:
+     * https://documentation.onesignal.com/reference/create-notification
+     *
+     * @return $this
+     */
+    public function isExternalUserId(bool $flag = true): static
+    {
+        $this->options['is_external_user_id'] = $flag;
+
+        return $this;
+    }
+
     public function getRecipientId(): ?string
     {
         return $this->options['recipient_id'] ?? null;

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransport.php
@@ -77,7 +77,15 @@ final class OneSignalTransport extends AbstractTransport
 
         $options = $options?->toArray() ?? [];
         $options['app_id'] = $this->appId;
-        $options['include_player_ids'] = [$recipientId];
+        if ($options['is_external_user_id'] ?? false) {
+            $options['include_aliases'] = [
+                'external_id' => [$recipientId],
+            ];
+            $options['target_channel'] = 'push';
+            unset($options['is_external_user_id']);
+        } else {
+            $options['include_subscription_ids'] = [$recipientId];
+        }
         $options['headings'] ??= ['en' => $message->getSubject()];
         $options['contents'] ??= ['en' => $message->getContent()];
 

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/Tests/OneSignalOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/Tests/OneSignalOptionsTest.php
@@ -24,7 +24,8 @@ final class OneSignalOptionsTest extends TestCase
             ->url('https://example.com')
             ->data(['foo' => 'bar'])
             ->sendAfter(new \DateTimeImmutable('Thu Sep 24 2015 14:00:00 GMT-0700 (PDT)'))
-            ->externalId('d637f30d-f709-4bed-9e2c-63637cb91894');
+            ->externalId('d637f30d-f709-4bed-9e2c-63637cb91894')
+            ->isExternalUserId();
 
         $this->assertSame([
             'headings' => ['en' => 'English Heading', 'fr' => 'French Heading'],
@@ -33,6 +34,7 @@ final class OneSignalOptionsTest extends TestCase
             'data' => ['foo' => 'bar'],
             'send_after' => '2015-09-24 14:00:00-0700',
             'external_id' => 'd637f30d-f709-4bed-9e2c-63637cb91894',
+            'is_external_user_id' => true,
         ], $oneSignalOptions->toArray());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/Tests/OneSignalTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/Tests/OneSignalTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\OneSignal\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Notifier\Bridge\OneSignal\OneSignalOptions;
 use Symfony\Component\Notifier\Bridge\OneSignal\OneSignalTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
@@ -84,15 +85,7 @@ final class OneSignalTransportTest extends TransportTestCase
 
     public function testSendWithErrorResponseThrows()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['errors' => ['Message Notifications must have English language content']]));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new JsonMockResponse(['errors' => ['Message Notifications must have English language content']], ['http_code' => 400]));
 
         $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
@@ -104,15 +97,7 @@ final class OneSignalTransportTest extends TransportTestCase
 
     public function testSendWithErrorResponseThrowsWhenAllUnsubscribed()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['id' => '', 'recipients' => 0, 'errors' => ['All included players are not subscribed']]));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new JsonMockResponse(['id' => '', 'recipients' => 0, 'errors' => ['All included players are not subscribed']]));
 
         $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
@@ -124,25 +109,37 @@ final class OneSignalTransportTest extends TransportTestCase
 
     public function testSend()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['id' => 'b98881cc-1e94-4366-bbd9-db8f3429292b', 'recipients' => 1, 'external_id' => null]));
+        $expectedBody = json_encode(['app_id' => '9fb175f0-0b32-4e99-ae97-bd228b9eb246', 'headings' => ['en' => 'Hello'], 'contents' => ['en' => 'World'], 'include_subscription_ids' => ['ea345989-d273-4f21-a33b-0c006efc5edb']]);
 
-        $expectedBody = json_encode(['app_id' => '9fb175f0-0b32-4e99-ae97-bd228b9eb246', 'headings' => ['en' => 'Hello'], 'contents' => ['en' => 'World'], 'include_player_ids' => ['ea345989-d273-4f21-a33b-0c006efc5edb']]);
-
-        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($expectedBody): ResponseInterface {
             $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
 
-            return $response;
+            return new JsonMockResponse(['id' => 'b98881cc-1e94-4366-bbd9-db8f3429292b', 'recipients' => 1, 'external_id' => null]);
         });
 
         $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
         $sentMessage = $transport->send(new PushMessage('Hello', 'World'));
+
+        $this->assertSame('b98881cc-1e94-4366-bbd9-db8f3429292b', $sentMessage->getMessageId());
+    }
+
+    public function testSendExternalIds()
+    {
+        $expectedBody = json_encode(['app_id' => '9fb175f0-0b32-4e99-ae97-bd228b9eb246', 'headings' => ['en' => 'Hello'], 'contents' => ['en' => 'World'], 'include_aliases' => ['external_id' => ['ea345989-d273-4f21-a33b-0c006efc5edb']], 'target_channel' => 'push']);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($expectedBody): ResponseInterface {
+            $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
+
+            return new JsonMockResponse(['id' => 'b98881cc-1e94-4366-bbd9-db8f3429292b', 'recipients' => 1, 'external_id' => null]);
+        });
+
+        $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
+
+        $options = new OneSignalOptions();
+        $options->isExternalUserId();
+
+        $sentMessage = $transport->send(new PushMessage('Hello', 'World', $options));
 
         $this->assertSame('b98881cc-1e94-4366-bbd9-db8f3429292b', $sentMessage->getMessageId());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #50779 
| License       | MIT

As discussed in https://github.com/symfony/symfony/pull/53248, here's the feature PR against 7.1.

This introduces a new `isExternalUserId()` option to indicate that the receiver is an external user id.

At the same time it also replaces the deprecated `include_player_ids` option.
