### PR TITLE
[RateLimiter] Fix RateLimit->getRetryAfter() return value when consuming 0 or last tokens

### DIFF
--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -52,6 +52,7 @@ class SlidingWindowLimiterTest extends TestCase
         $rateLimit = $limiter->consume(10);
         $this->assertTrue($rateLimit->isAccepted());
         $this->assertSame(10, $rateLimit->getLimit());
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
     }
 
     public function testWaitIntervalOnConsumeOverLimit()
@@ -76,6 +77,9 @@ class SlidingWindowLimiterTest extends TestCase
 
         // 2 over the limit, causing the WaitDuration to become 2/10th of the 12s interval
         $this->assertEqualsWithDelta(12 / 5, $limiter->reserve(4)->getWaitDuration(), 1);
+
+        $limiter->reset();
+        $this->assertEquals(0, $limiter->reserve(10)->getWaitDuration());
     }
 
     public function testPeekConsume()
@@ -90,7 +94,7 @@ class SlidingWindowLimiterTest extends TestCase
             $this->assertTrue($rateLimit->isAccepted());
             $this->assertSame(10, $rateLimit->getLimit());
             $this->assertEquals(
-                \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
+                \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true))),
                 $rateLimit->getRetryAfter()
             );
         }
@@ -101,7 +105,7 @@ class SlidingWindowLimiterTest extends TestCase
         $this->assertEquals(0, $rateLimit->getRemainingTokens());
         $this->assertTrue($rateLimit->isAccepted());
         $this->assertEquals(
-            \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true) + 12)),
+            \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true) + 12)),
             $rateLimit->getRetryAfter()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Replaces #52835 Original description:

> Have got some BC after updating the project to Symfony 6.4 (after that PR https://github.com/symfony/symfony/pull/51676).
> 
> Sometimes I need to get `RateLimit` object without consuming just before consuming a try, in example:
> ```php
> $rateLimit = $limiter->consume(0);
> if ($rateLimit->getRemainingTokens() === 0) {
>    throw new SomeException($rateLimit->getRetryAfter());
> }
> ...
> $limiter->consume(1)
> ...
> ```
> and found that in that case `$rateLimit->getRetryAfter()` always returns `now`.
> 
> So this PR fixes it.
