### PR TITLE
[Cache] harden cache expiration test

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterAndRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterAndRedisAdapterTest.php
@@ -66,6 +66,7 @@ class ProxyAdapterAndRedisAdapterTest extends AbstractRedisAdapterTestCase
         $this->assertSame($value, $this->cache->getItem('baz')->get());
 
         sleep(1);
+        usleep(100000);
         $this->assertSame($value, $this->cache->getItem('foo')->get());
         $this->assertSame($value, $this->cache->getItem('bar')->get());
         $this->assertFalse($this->cache->getItem('baz')->isHit());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In the worst case when the process sleeps for exactly one second the current timestamp would be exactly the same as the expiration time. Increasing the sleep time ensures that the tested item is always expired when executing the test.