### PR TITLE
[Validator] Add missing Japanese (ja) translation (id=111)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -430,6 +430,10 @@
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>ファイルの拡張子が無効です({{ extension }})。有効な拡張子は{{ extensions }}です。</target>
             </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target>検出された文字コードは無効です({{ detected }})。有効な文字コードは{{ encodings }}です。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53293 
| License       | MIT

This pull request adds missing Japanese translation units.