### PR TITLE
[Cache] Fix Couchbase expiration test

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
@@ -183,7 +183,7 @@ class CouchbaseCollectionAdapter extends AbstractAdapter
         }
 
         $upsertOptions = new UpsertOptions();
-        $upsertOptions->expiry(\DateTimeImmutable::createFromFormat('U', time() + $lifetime));
+        $upsertOptions->expiry($lifetime);
 
         $ko = [];
         foreach ($values as $key => $value) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

We changed for a datetime instance because older versions of Couchbase supported an expiration time in seconds only if it was < 30 days. But this limit was raised to 50 years, so I suggest we go back to basics and only provide an integer.