### PR TITLE
[HttpClient] add DecoratorTrait for response

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `HttpOptions::setHeader()` to add or replace a single header
  * Allow mocking `start_time` info in `MockResponse`
  * Add `MockResponse::fromFile()` and `JsonMockResponse::fromFile()` methods to help using fixtures files
+ * Add `DecoratorTrait` for responses
 
 7.0
 ---

--- a/src/Symfony/Component/HttpClient/Response/DecoratorTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/DecoratorTrait.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Cyril Vermande <https://github.com/cyve>
+ */
+trait DecoratorTrait
+{
+    private ResponseInterface $response;
+
+    public function __construct(
+        ResponseInterface $response,
+    ) {
+        $this->response = $response;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    public function getHeaders(bool $throw = true): array
+    {
+        return $this->response->getHeaders($throw);
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        return $this->response->getContent($throw);
+    }
+
+    public function toArray(bool $throw = true): array
+    {
+        return $this->response->toArray($throw);
+    }
+
+    public function cancel(): void
+    {
+        $this->response->cancel();
+    }
+
+    public function getInfo(string $type = null): mixed
+    {
+        return $this->response->getInfo($type);
+    }
+
+    /**
+     * @return resource
+     */
+    public function toStream(bool $throw = true)
+    {
+        if ($throw) {
+            // Ensure headers arrived
+            $this->response->getHeaders();
+        }
+
+        if ($this->response instanceof StreamableInterface) {
+            return $this->response->toStream($throw);
+        }
+
+        return StreamWrapper::createResource($this->response);
+    }
+
+    /**
+     * @internal
+     */
+    public static function stream(HttpClientInterface $client, ResponseInterface|iterable $responses, float $timeout = null): \Generator
+    {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
+
+        $wrappedResponses = [];
+        $responseMap = new \SplObjectStorage();
+
+        foreach ($responses as $response) {
+            $responseMap[$response->response] = $response;
+            $wrappedResponses[] = $response->response;
+        }
+
+        foreach ($client->stream($wrappedResponses, $timeout) as $wrappedResponse => $chunk) {
+            yield $responseMap[$wrappedResponse] => $chunk;
+        }
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/Response/DecoratorTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/DecoratorTraitTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Response;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Response\DecoratorTrait;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Cyril Vermande <https://github.com/cyve>
+ */
+class DecoratorTraitTest extends TestCase
+{
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $decorated = MockResponse::fromRequest(
+            'GET',
+            'https://symfony.com',
+            [],
+            new MockResponse(
+                '{"foo":"bar"}',
+                [
+                    'http_code' => 200,
+                    'response_headers' => ['Content-Type' => 'application/json'],
+                ],
+            )
+        );
+        $this->subject = $this->getObjectForTrait(DecoratorTrait::class, [$decorated]);
+    }
+
+    public function testShouldReturnDecoratedStatusCode()
+    {
+        $this->assertEquals(200, $this->subject->getStatusCode());
+    }
+
+    public function testShouldReturnDecoratedHeaders()
+    {
+        $this->assertEquals(['content-type' => ['application/json']], $this->subject->getHeaders());
+    }
+
+    public function testShouldReturnDecoratedContent()
+    {
+        $this->assertEquals('{"foo":"bar"}', $this->subject->getContent());
+    }
+
+    public function testShouldReturnDecoratedContentInArray()
+    {
+        $this->assertEquals(['foo' => 'bar'], $this->subject->toArray());
+    }
+
+    public function testShouldReturnDecoratedInfo()
+    {
+        $info = $this->subject->getInfo();
+        $this->assertArrayHasKey('http_code', $info);
+        $this->assertArrayHasKey('response_headers', $info);
+        $this->assertArrayHasKey('http_method', $info);
+        $this->assertArrayHasKey('url', $info);
+    }
+
+    public function testShouldReturnDecoratedInfoByType()
+    {
+        $this->assertEquals('https://symfony.com', $this->subject->getInfo('url'));
+    }
+
+    public function testShouldReturnDecoratedResponseAsStream()
+    {
+        $stream = $this->subject->toStream();
+        $this->assertTrue(\is_resource($stream));
+        $this->assertEquals('{"foo":"bar"}', stream_get_contents($stream));
+    }
+
+    public function testShouldStreamTheDecoratedResponses()
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('stream')->willReturnCallback(fn ($responses, $timeout) => new ResponseStream(MockResponse::stream($responses, $timeout)));
+
+        foreach ($this->subject::stream($httpClient, [$this->subject]) as $response => $chunk) {
+            // Assert that the "stream()" method yield chunks from the decorated response, but with the wrapped response as key.
+            $this->assertSame($response, $this->subject);
+            break;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

When we decorate the HttpClient, we often need to create a dedicated class to wrap the response (ex `TraceableHttpClient` => `TraceableResponse`)

Following the idea introduced in https://github.com/symfony/symfony/pull/41161, I propose to add a trait to simplify the response decoration.

Example:
```php
class MyCustomHttpClient implements HttpClientInterface
{
    use DecoratorTrait;

    public function request(string $method, string $url, array $options = []): ResponseInterface
    {
        return new MyCustomResponse($this->client->request($method, $url, $options));
    }
}

class MyCustomResponse implements ResponseInterface
{
    use Response\DecoratorTrait;
    // overwrite only necessary methods
}
```