### PR TITLE
[Security] Added missing Albanian translations

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Link hyrje i pavlefshëm ose i skaduar.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>Shumë përpjekje të dështuara për identifikim; provo sërish pas %minutes% minutë.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+                <target>Shumë përpjekje të dështuara për identifikim; provo sërish pas %minutes% minuta.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Added missing Albanian translations with help from a professional translator. Solves Security component part of #53207.