### PR TITLE
[HttpFoundation] Fix Request::getContent() phpdoc return value

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1531,9 +1531,11 @@ class Request
     /**
      * Returns the request body content.
      *
-     * @param bool $asResource If true, a resource will be returned
+     * @param bool $asResource If true, a resource|false will be returned, otherwise string|false
      *
-     * @return string|resource
+     * @return string|resource|false
+     *
+     * @psalm-return ($asResource is true ? resource|false : string|false)
      */
     public function getContent(bool $asResource = false)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | no issues
| License       | MIT

According to php documentation all of the file-like operations in this method can return false as well.
Not sure if file_get_contents() on php://input can actually never fail, but it would be safe to assume it can.

This should not be any kind of BC but it can lead to projects needing for example a phpstan baseline updates when taken into use or can cause fails on CI pipelines etc.
