### PR TITLE
[Validator] fix the exception being thrown

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/JsonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/JsonValidator.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 /**
  * @author Imad ZAIRIG <imadzairig@gmail.com>
@@ -34,7 +35,7 @@ class JsonValidator extends ConstraintValidator
         }
 
         if (!\is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
-            throw new UnexpectedTypeException($value, 'string');
+            throw new UnexpectedValueException($value, 'string');
         }
 
         $value = (string) $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

An `UnexpectedValueException` is caught and transformed into a violation (`UnexpectedTypeException` indicates a misconfiguration of a constraint and is not caught).

see also #27917