### PR TITLE
[Translation] Fix `TranslationNodeVisitor` with constant domain

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
@@ -158,6 +158,22 @@ final class TranslationNodeVisitor extends AbstractNodeVisitor
             return $node->getAttribute('value');
         }
 
+        if (
+            $node instanceof FunctionExpression
+            && 'constant' === $node->getAttribute('name')
+        ) {
+            $nodeArguments = $node->getNode('arguments');
+            if ($nodeArguments->getIterator()->current() instanceof ConstantExpression) {
+                $constantName = $nodeArguments->getIterator()->current()->getAttribute('value');
+                if (\defined($constantName)) {
+                    $value = \constant($constantName);
+                    if (\is_string($value)) {
+                        return $value;
+                    }
+                }
+            }
+        }
+
         return self::UNDEFINED_DOMAIN;
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -22,6 +22,8 @@ use Twig\Loader\LoaderInterface;
 
 class TwigExtractorTest extends TestCase
 {
+    public const CUSTOM_DOMAIN = 'domain';
+
     /**
      * @dataProvider getExtractData
      */
@@ -76,6 +78,11 @@ class TwigExtractorTest extends TestCase
 
             // make sure this works with twig's named arguments
             ['{{ "new key" | trans(domain="domain") }}', ['new key' => 'domain']],
+
+            // make sure this works with const domain
+            ['{{ "new key" | trans({}, constant(\'Symfony\\\\Bridge\\\\Twig\\\\Tests\\\\Translation\\\\TwigExtractorTest::CUSTOM_DOMAIN\')) }}', ['new key' => self::CUSTOM_DOMAIN]],
+            ['{% trans from constant(\'Symfony\\\\Bridge\\\\Twig\\\\Tests\\\\Translation\\\\TwigExtractorTest::CUSTOM_DOMAIN\') %}new key{% endtrans %}', ['new key' => self::CUSTOM_DOMAIN]],
+            ['{{ t("new key", {}, constant(\'Symfony\\\\Bridge\\\\Twig\\\\Tests\\\\Translation\\\\TwigExtractorTest::CUSTOM_DOMAIN\')) | trans() }}', ['new key' => self::CUSTOM_DOMAIN]],
 
             // concat translations
             ['{{ ("new" ~ " key") | trans() }}', ['new key' => 'messages']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Related to https://github.com/symfony/symfony/issues/53356 but fixing only the twig part.
