### PR TITLE
[Serializer] Take unnamed variadic parameters into account when denormalizing

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -372,7 +372,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                             $variadicParameters[$parameterKey] = $this->denormalizeParameter($reflectionClass, $constructorParameter, $paramName, $parameterData, $context, $format);
                         }
 
-                        $params = array_merge($params, $variadicParameters);
+                        $params = array_merge(array_values($params), $variadicParameters);
                         $unsetKeys[] = $key;
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data))) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithWithVariadicParameterConstructor.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithWithVariadicParameterConstructor.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class DummyWithWithVariadicParameterConstructor
+{
+    private $foo;
+
+    private $bar;
+
+    private $baz;
+
+    public function __construct(string $foo, int $bar = 1, Dummy ...$baz)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+        $this->baz = $baz;
+    }
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function getBar(): int
+    {
+        return $this->bar;
+    }
+
+    /** @return Dummy[] */
+    public function getBaz(): array
+    {
+        return $this->baz;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractNormalizerDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyWithWithVariadicParameterConstructor;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableConstructorArgumentDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableOptionalConstructorArgumentDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorDummy;
@@ -245,6 +246,25 @@ class AbstractNormalizerTest extends TestCase
         yield [new PropertyNormalizer(null, null, $extractor)];
         yield [new ObjectNormalizer()];
         yield [new ObjectNormalizer(null, null, null, $extractor)];
+    }
+
+    public function testVariadicConstructorDenormalization()
+    {
+        $data = [
+            'foo' => 'woo',
+            'baz' => [
+                ['foo' => null, 'bar' => null, 'baz' => null, 'qux' => null],
+                ['foo' => null, 'bar' => null, 'baz' => null, 'qux' => null],
+            ],
+        ];
+
+        $normalizer = new ObjectNormalizer();
+        $normalizer->setSerializer(new Serializer([$normalizer]));
+
+        $expected = new DummyWithWithVariadicParameterConstructor('woo', 1, new Dummy(), new Dummy());
+        $actual = $normalizer->denormalize($data, DummyWithWithVariadicParameterConstructor::class);
+
+        $this->assertEquals($expected, $actual);
     }
 
     public static function getNormalizerWithCustomNameConverter()


### PR DESCRIPTION
We shouldn't break when a constructor has variadic parameters without named keys in the array.

| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53354
| License       | MIT

