### PR TITLE
[PropertyInfo] Restrict access to `PhpStanExtractor` based on visibility

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Introduce `PropertyDocBlockExtractorInterface` to extract a property's doc block
+ * Restrict access to `PhpStanExtractor` based on visibility
 
 6.4
 ---

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithoutDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyPropertyAndGetterWithDifferentTypes;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80PromotedDummy;
@@ -474,6 +475,26 @@ class PhpStanExtractorTest extends TestCase
             [Php80Dummy::class, 'collection', [new Type(Type::BUILTIN_TYPE_ARRAY, collection: true, collectionValueType: new Type(Type::BUILTIN_TYPE_STRING))]],
             [Php80PromotedDummy::class, 'promoted', null],
         ];
+    }
+
+    public static function allowPrivateAccessProvider(): array
+    {
+        return [
+            [true, [new Type(Type::BUILTIN_TYPE_STRING)]],
+            [false, [new Type(Type::BUILTIN_TYPE_ARRAY, collection: true, collectionKeyType: new Type('int'), collectionValueType: new Type('string'))]],
+        ];
+    }
+
+    /**
+     * @dataProvider allowPrivateAccessProvider
+     */
+    public function testAllowPrivateAccess(bool $allowPrivateAccess, array $expectedTypes)
+    {
+        $extractor = new PhpStanExtractor(allowPrivateAccess: $allowPrivateAccess);
+        $this->assertEquals(
+            $expectedTypes,
+            $extractor->getTypes(DummyPropertyAndGetterWithDifferentTypes::class, 'foo')
+        );
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyPropertyAndGetterWithDifferentTypes.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyPropertyAndGetterWithDifferentTypes.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+final readonly class DummyPropertyAndGetterWithDifferentTypes
+{
+    public function __construct(
+        /**
+         * @var string
+         */
+        private string $foo
+    ) {
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getFoo(): array
+    {
+        return (array)$this->foo;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Hi,

this small PR gives a bit more control on what `PhpStanExtractor` can see or not, based on the visibility of the property or its accessor.

It's pretty unusual, but sometimes, the getter does not return the same type than the property itself, and before this PR, there was actually no way to extract the type returned by the getter. `ReflectionExtractor` has this granularity, but it cannot read complex PhpDoc types.
