### PR TITLE
[DoctrineBridge] Allow `EntityValueResolver` to return a list of entities

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -192,7 +192,7 @@ final class EntityValueResolver implements ValueResolverInterface
         return $criteria;
     }
 
-    private function findViaExpression(ObjectManager $manager, Request $request, MapEntity $options): ?object
+    private function findViaExpression(ObjectManager $manager, Request $request, MapEntity $options): object|iterable|null
     {
         if (!$this->expressionLanguage) {
             throw new \LogicException(sprintf('You cannot use the "%s" if the ExpressionLanguage component is not available. Try running "composer require symfony/expression-language".', __CLASS__));

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate the `DoctrineExtractor::getTypes()` method, use `DoctrineExtractor::getType()` instead
+ * Allow `EntityValueResolver` to return a list of entities
 
 7.0
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53236 (sort of)
| License       | MIT

Makes the following possible:
```php
#[Route('/{author_id}', name: 'app_test')]
public function index(
    #[MapEntity(class: Post::class, expr: 'repository.findBy({"author": author_id}, {}, 10)')]
    iterable $posts
): Response {
// ...
}
```

This is actually something that used to be possible with the SensioFrameworkExtraBundle.