### PR TITLE
[Validator] support `\Stringable` instances in all constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.1
 ---
 
+ * Add support for `Stringable` values when using the `Cidr`, `CssColor`, `ExpressionSyntax` and `PasswordStrength` constraints
  * Add `MacAddress` constraint
  * Add `list` and `associative_array` types to `Type` constraint
  * Add the `Charset` constraint

--- a/src/Symfony/Component/Validator/Constraints/CidrValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CidrValidator.php
@@ -28,7 +28,7 @@ class CidrValidator extends ConstraintValidator
             return;
         }
 
-        if (!\is_string($value)) {
+        if (!\is_string($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/CssColorValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColorValidator.php
@@ -62,7 +62,7 @@ class CssColorValidator extends ConstraintValidator
             return;
         }
 
-        if (!\is_string($value)) {
+        if (!\is_string($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
         }
 
@@ -76,7 +76,7 @@ class CssColorValidator extends ConstraintValidator
         }
 
         $this->context->buildViolation($constraint->message)
-            ->setParameter('{{ value }}', $this->formatValue($value))
+            ->setParameter('{{ value }}', $this->formatValue((string) $value))
             ->setCode(CssColor::INVALID_FORMAT_ERROR)
             ->addViolation();
     }

--- a/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
@@ -40,7 +40,7 @@ class ExpressionSyntaxValidator extends ConstraintValidator
             return;
         }
 
-        if (!\is_string($expression)) {
+        if (!\is_string($expression) && !$expression instanceof \Stringable) {
             throw new UnexpectedValueException($expression, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
@@ -36,11 +36,11 @@ final class PasswordStrengthValidator extends ConstraintValidator
             return;
         }
 
-        if (!\is_string($value)) {
+        if (!\is_string($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
         }
         $passwordStrengthEstimator = $this->passwordStrengthEstimator ?? self::estimateStrength(...);
-        $strength = $passwordStrengthEstimator($value);
+        $strength = $passwordStrengthEstimator((string) $value);
 
         if ($strength < $constraint->minScore) {
             $this->context->buildViolation($constraint->message)

--- a/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Validator\Constraints\Charset;
 use Symfony\Component\Validator\Constraints\CharsetValidator;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\StringableValue;
 
 class CharsetValidatorTest extends ConstraintValidatorTestCase
 {
@@ -66,12 +67,7 @@ class CharsetValidatorTest extends ConstraintValidatorTestCase
         yield ['my ûtf 8', ['ASCII', 'UTF-8']];
         yield ['my ûtf 8', ['UTF-8']];
         yield ['string', ['ISO-8859-1']];
-        yield [new class() implements \Stringable {
-            public function __toString(): string
-            {
-                return 'my ûtf 8';
-            }
-        }, ['UTF-8']];
+        yield [new StringableValue('my ûtf 8'), ['UTF-8']];
     }
 
     public static function provideInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\StringableValue;
 
 class CidrValidatorTest extends ConstraintValidatorTestCase
 {
@@ -83,7 +84,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getValid
      */
-    public function testValidCidr(string $cidr, string $version)
+    public function testValidCidr(string|\Stringable $cidr, string $version)
     {
         $this->validator->validate($cidr, new Cidr(['version' => $version]));
 
@@ -93,7 +94,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getWithInvalidMasksAndIps
      */
-    public function testInvalidIpAddressAndNetmask(string $cidr)
+    public function testInvalidIpAddressAndNetmask(string|\Stringable $cidr)
     {
         $this->validator->validate($cidr, new Cidr());
         $this
@@ -195,6 +196,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
             ['::255.255.255.255/32', Ip::V6],
             ['::123.45.67.178/120', Ip::V6],
             ['::123.45.67.178/120', Ip::ALL],
+            [new StringableValue('::123.45.67.178/120'), Ip::ALL],
         ];
     }
 
@@ -233,6 +235,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
             ['::0.0.0/a/'],
             ['::256.0.0.0/-1aa'],
             ['::0.256.0.0/1b'],
+            [new StringableValue('::0.256.0.0/1b')],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Validator\Constraints\CssColor;
 use Symfony\Component\Validator\Constraints\CssColorValidator;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\StringableValue;
 
 final class CssColorValidatorTest extends ConstraintValidatorTestCase
 {
@@ -67,6 +68,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
             ['rgba(255, 255, 255, 0.3)'],
             ['hsl(0, 0%, 20%)'],
             ['hsla(0, 0%, 20%, 0.4)'],
+            [new StringableValue('hsla(0, 0%, 20%, 0.4)')],
         ];
     }
 
@@ -323,7 +325,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public static function getInvalidNamedColors(): array
     {
-        return [['fabpot'], ['ngrekas'], ['symfony'], ['FABPOT'], ['NGREKAS'], ['SYMFONY']];
+        return [['fabpot'], ['ngrekas'], ['symfony'], ['FABPOT'], ['NGREKAS'], ['SYMFONY'], [new StringableValue('SYMFONY')]];
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxValidatorTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Constraints\ExpressionSyntax;
 use Symfony\Component\Validator\Constraints\ExpressionSyntaxValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\StringableValue;
 
 class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
 {
@@ -47,6 +48,16 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testStringableExpressionValid()
+    {
+        $this->validator->validate(new StringableValue('1 + 1'), new ExpressionSyntax([
+            'message' => 'myMessage',
+            'allowedVariables' => [],
+        ]));
+
+        $this->assertNoViolation();
+    }
+
     public function testExpressionWithoutNames()
     {
         $this->validator->validate('1 + 1', new ExpressionSyntax([
@@ -69,6 +80,20 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
     public function testExpressionIsNotValid()
     {
         $this->validator->validate('a + 1', new ExpressionSyntax([
+            'message' => 'myMessage',
+            'allowedVariables' => [],
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ syntax_error }}', '"Variable "a" is not valid around position 1 for expression `a + 1`."')
+            ->setInvalidValue('a + 1')
+            ->setCode(ExpressionSyntax::EXPRESSION_SYNTAX_ERROR)
+            ->assertRaised();
+    }
+
+    public function testStringableExpressionIsNotValid()
+    {
+        $this->validator->validate(new StringableValue('a + 1'), new ExpressionSyntax([
             'message' => 'myMessage',
             'allowedVariables' => [],
         ]));

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/StringableValue.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/StringableValue.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints\Fixtures;
+
+class StringableValue implements \Stringable
+{
+    public function __construct(private string $value)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraints\PasswordStrength;
 use Symfony\Component\Validator\Constraints\PasswordStrengthValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\StringableValue;
 
 class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
 {
@@ -25,7 +26,7 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getValidValues
      */
-    public function testValidValues(string $value, int $expectedStrength)
+    public function testValidValues(string|\Stringable $value, int $expectedStrength)
     {
         $this->validator->validate($value, new PasswordStrength(minScore: $expectedStrength));
 
@@ -48,6 +49,7 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
         yield ['Reasonable-pwd', PasswordStrength::STRENGTH_MEDIUM];
         yield ['This 1s a very g00d Pa55word! ;-)', PasswordStrength::STRENGTH_VERY_STRONG];
         yield ['pudding-smack-👌🏼-fox-😎', PasswordStrength::STRENGTH_VERY_STRONG];
+        yield [new StringableValue('How-is-this'), PasswordStrength::STRENGTH_WEAK];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT