### PR TITLE
[HttpFoundation] Request without content-type or content-length header should result in null values, not empty strings

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -31,7 +31,7 @@ class ServerBag extends ParameterBag
         foreach ($this->parameters as $key => $value) {
             if (str_starts_with($key, 'HTTP_')) {
                 $headers[substr($key, 5)] = $value;
-            } elseif (\in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'], true) && \strlen($value) > 0) {
+            } elseif (\in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'], true) && '' !== $value) {
                 $headers[$key] = $value;
             }
         }

--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -31,7 +31,7 @@ class ServerBag extends ParameterBag
         foreach ($this->parameters as $key => $value) {
             if (str_starts_with($key, 'HTTP_')) {
                 $headers[substr($key, 5)] = $value;
-            } elseif (\in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'], true)) {
+            } elseif (\in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'], true) && \strlen($value) > 0) {
                 $headers[$key] = $value;
             }
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
@@ -177,4 +177,20 @@ class ServerBagTest extends TestCase
             'PHP_AUTH_PW' => '',
         ], $bag->getHeaders());
     }
+
+    /**
+     * An HTTP request without content-type and content-length will result in
+     * the variables $_SERVER['CONTENT_TYPE'] and $_SERVER['CONTENT_LENGTH']
+     * containing an empty string in PHP.
+     */
+    public function testRequestWithoutContentTypeAndContentLength()
+    {
+        $bag = new ServerBag([
+            'CONTENT_TYPE' => '',
+            'CONTENT_LENGTH' => '',
+            'HTTP_USER_AGENT' => 'foo'
+        ]);
+
+        $this->assertEquals(['USER_AGENT' => 'foo'], $bag->getHeaders());
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
@@ -188,7 +188,7 @@ class ServerBagTest extends TestCase
         $bag = new ServerBag([
             'CONTENT_TYPE' => '',
             'CONTENT_LENGTH' => '',
-            'HTTP_USER_AGENT' => 'foo'
+            'HTTP_USER_AGENT' => 'foo',
         ]);
 
         $this->assertEquals(['USER_AGENT' => 'foo'], $bag->getHeaders());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

An HTTP request without content-type and content length will result in the variables `$_SERVER['CONTENT_TYPE']` and `$_SERVER['CONTENT_LENGTH']` having an empty string in PHP.

For example, the request:

> POST / HTTP/1.1
> Host: app.dev.localhost:8000
> User-Agent: curl/8.4.0
> Accept: */*

(from curl invocation: `curl -X 'POST' 'http://app.dev.localhost:8000/' -H 'Content-Type:' -H 'Content-length:' -d '' -v> /dev/null`)

It will result in the variables `$_SERVER['CONTENT_TYPE']` and `$_SERVER['CONTENT_LENGTH']` containing an empty string.

In turn, `$request->headers->get('Content-type')` and `$request->headers->get('Content-length')` also result in an empty string.

This PR changes so that `$request->headers->get('Content-type')` and `$request->headers->get('Content-length')` will reflect the original condition of the request header, that they return null (due to the fact the headers did not exist in the request), not an empty string (erroneously implying the client sent an empty content-type and content-length headers).