### PR TITLE
[Form] Fix assigning data in `PostSetDataEvent` and `PostSubmitEvent`

### DIFF
--- a/src/Symfony/Component/Form/Event/PostSetDataEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSetDataEvent.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Event;
 
-use Symfony\Component\Form\Exception\BadMethodCallException;
 use Symfony\Component\Form\FormEvent;
 
 /**
@@ -29,5 +28,6 @@ final class PostSetDataEvent extends FormEvent
     {
         trigger_deprecation('symfony/form', '6.4', 'Calling "%s()" will throw an exception as of 7.0, listen to "form.pre_set_data" instead.', __METHOD__);
         // throw new BadMethodCallException('Form data cannot be changed during "form.post_set_data", you should use "form.pre_set_data" instead.');
+        parent::setData($data);
     }
 }

--- a/src/Symfony/Component/Form/Event/PostSubmitEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSubmitEvent.php
@@ -28,5 +28,6 @@ final class PostSubmitEvent extends FormEvent
     {
         trigger_deprecation('symfony/form', '6.4', 'Calling "%s()" will throw an exception as of 7.0, listen to "form.pre_submit" or "form.submit" instead.', __METHOD__);
         // throw new BadMethodCallException('Form data cannot be changed during "form.post_submit", you should use "form.pre_submit" or "form.submit" instead.');
+        parent::setData($data);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/53364
| License       | MIT

Ref https://github.com/symfony/symfony/pull/51043 where we changed the behavior on 6.4 since we don't assign the data property anymore.

cc @HeahDude 