### PR TITLE
[Validator] re-allow an empty list of fields

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -42,10 +42,7 @@ class Collection extends Composite
      */
     public function __construct($fields = null, array $groups = null, $payload = null, bool $allowExtraFields = null, bool $allowMissingFields = null, string $extraFieldsMessage = null, string $missingFieldsMessage = null)
     {
-        if (\is_array($fields)
-            && (($firstField = reset($fields)) instanceof Constraint
-                || ($firstField[0] ?? null) instanceof Constraint
-            )) {
+        if (\is_array($fields) && ([] === $fields || ($firstField = reset($fields)) instanceof Constraint || ($firstField[0] ?? null) instanceof Constraint)) {
             $fields = ['fields' => $fields];
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
@@ -153,4 +153,24 @@ class CollectionTest extends TestCase
         $this->assertTrue($constraint->allowExtraFields);
         $this->assertSame('foo bar baz', $constraint->extraFieldsMessage);
     }
+
+    public function testEmptyFields()
+    {
+        $constraint = new Collection([], [], null, true, null, 'foo bar baz');
+
+        $this->assertTrue($constraint->allowExtraFields);
+        $this->assertSame('foo bar baz', $constraint->extraFieldsMessage);
+    }
+
+    public function testEmptyFieldsInOptions()
+    {
+        $constraint = new Collection([
+            'fields' => [],
+            'allowExtraFields' => true,
+            'extraFieldsMessage' => 'foo bar baz',
+        ]);
+
+        $this->assertTrue($constraint->allowExtraFields);
+        $this->assertSame('foo bar baz', $constraint->extraFieldsMessage);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/53133#issuecomment-1873955345
| License       | MIT
