### PR TITLE
[Mailer] [Azure] Fix resource name validation

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
@@ -121,7 +121,7 @@ class AzureApiTransportTest extends TestCase
     public function testItDoesNotAllowToAddResourceNameWithDot()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Resource name cannot contain or end with a dot');
+        $this->expectExceptionMessage('Resource name must not end with a dot "."');
 
         new AzureApiTransport('KEY', 'ACS_RESOURCE_NAME.');
     }

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
@@ -43,8 +43,8 @@ final class AzureApiTransport extends AbstractApiTransport
         EventDispatcherInterface $dispatcher = null,
         LoggerInterface $logger = null,
     ) {
-        if (str_contains($resourceName, '.') || str_ends_with($resourceName, '.')) {
-            throw new \Exception('Resource name cannot contain or end with a dot.');
+        if (str_ends_with($resourceName, '.')) {
+            throw new \Exception('Resource name must not end with a dot ".".');
         }
 
         parent::__construct($client, $dispatcher, $logger);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53385
| License       | MIT

Remove validation where Azure Email Communication Resource with dot in name is not being allowed to use.