### PR TITLE
[Validator] Added missing Macedonian translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target>Откриеното кодирање на знаци е неважечко ({{ detected }}). Дозволените шифрирања се {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target>Ова не е важечка MAC-адреса.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Added missing translation for Macedonian with help from a professional translator. Related to https://github.com/symfony/symfony/issues/53296.