### PR TITLE
[Form][Security][Validator] Normalize translation files

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.af.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="af" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ar.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ar" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.az.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.az.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="az" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.be.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="be" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.bg.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="bg" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.bs.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="bs" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ca.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ca" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.cs.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="cs" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.cy.xlf
@@ -1,138 +1,138 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="sv" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="cy" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
-                <target>Formuläret kan inte innehålla extra fält.</target>
+                <target state="needs-translation">This form should not contain extra fields.</target>
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file.</source>
-                <target>Den uppladdade filen var för stor. Försök ladda upp en mindre fil.</target>
+                <target state="needs-translation">The uploaded file was too large. Please try to upload a smaller file.</target>
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>CSRF-elementet är inte giltigt. Försök att skicka formuläret igen.</target>
+                <target state="needs-translation">The CSRF token is invalid. Please try to resubmit the form.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>
-                <target>Värdet är inte en giltig HTML5-färg.</target>
+                <target state="needs-translation">This value is not a valid HTML5 color.</target>
             </trans-unit>
             <trans-unit id="100">
                 <source>Please enter a valid birthdate.</source>
-                <target>Ange ett giltigt födelsedatum.</target>
+                <target state="needs-translation">Please enter a valid birthdate.</target>
             </trans-unit>
             <trans-unit id="101">
                 <source>The selected choice is invalid.</source>
-                <target>Det valda alternativet är ogiltigt.</target>
+                <target state="needs-translation">The selected choice is invalid.</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>The collection is invalid.</source>
-                <target>Den här samlingen är ogiltig.</target>
+                <target state="needs-translation">The collection is invalid.</target>
             </trans-unit>
             <trans-unit id="103">
                 <source>Please select a valid color.</source>
-                <target>Välj en giltig färg.</target>
+                <target state="needs-translation">Please select a valid color.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>Please select a valid country.</source>
-                <target>Välj ett land.</target>
+                <target state="needs-translation">Please select a valid country.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>Please select a valid currency.</source>
-                <target>Välj en valuta.</target>
+                <target state="needs-translation">Please select a valid currency.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>Please choose a valid date interval.</source>
-                <target>Välj ett giltigt datumintervall.</target>
+                <target state="needs-translation">Please choose a valid date interval.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Please enter a valid date and time.</source>
-                <target>Ange ett giltigt datum och tid.</target>
+                <target state="needs-translation">Please enter a valid date and time.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Please enter a valid date.</source>
-                <target>Ange ett giltigt datum.</target>
+                <target state="needs-translation">Please enter a valid date.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Please select a valid file.</source>
-                <target>Välj en fil.</target>
+                <target state="needs-translation">Please select a valid file.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The hidden field is invalid.</source>
-                <target>Det dolda fältet är ogiltigt.</target>
+                <target state="needs-translation">The hidden field is invalid.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>Please enter an integer.</source>
-                <target>Ange ett heltal.</target>
+                <target state="needs-translation">Please enter an integer.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>Please select a valid language.</source>
-                <target>Välj språk.</target>
+                <target state="needs-translation">Please select a valid language.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>Please select a valid locale.</source>
-                <target>Välj plats.</target>
+                <target state="needs-translation">Please select a valid locale.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>Please enter a valid money amount.</source>
-                <target>Ange en giltig summa pengar.</target>
+                <target state="needs-translation">Please enter a valid money amount.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>Please enter a number.</source>
-                <target>Ange en siffra.</target>
+                <target state="needs-translation">Please enter a number.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>The password is invalid.</source>
-                <target>Lösenordet är ogiltigt.</target>
+                <target state="needs-translation">The password is invalid.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>Please enter a percentage value.</source>
-                <target>Ange ett procentuellt värde.</target>
+                <target state="needs-translation">Please enter a percentage value.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>The values do not match.</source>
-                <target>De angivna värdena stämmer inte överens.</target>
+                <target state="needs-translation">The values do not match.</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>Please enter a valid time.</source>
-                <target>Ange en giltig tid.</target>
+                <target state="needs-translation">Please enter a valid time.</target>
             </trans-unit>
             <trans-unit id="120">
                 <source>Please select a valid timezone.</source>
-                <target>Välj en tidszon.</target>
+                <target state="needs-translation">Please select a valid timezone.</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>Please enter a valid URL.</source>
-                <target>Ange en giltig URL.</target>
+                <target state="needs-translation">Please enter a valid URL.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>Please enter a valid search term.</source>
-                <target>Ange ett giltigt sökbegrepp.</target>
+                <target state="needs-translation">Please enter a valid search term.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>Please provide a valid phone number.</source>
-                <target>Ange ett giltigt telefonnummer.</target>
+                <target state="needs-translation">Please provide a valid phone number.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The checkbox has an invalid value.</source>
-                <target>Kryssrutan har ett ogiltigt värde.</target>
+                <target state="needs-translation">The checkbox has an invalid value.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>Please enter a valid email address.</source>
-                <target>Ange en giltig e-postadress.</target>
+                <target state="needs-translation">Please enter a valid email address.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>Please select a valid option.</source>
-                <target>Välj ett alternativ.</target>
+                <target state="needs-translation">Please select a valid option.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>Please select a valid range.</source>
-                <target>Välj ett intervall.</target>
+                <target state="needs-translation">Please select a valid range.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>Please enter a valid week.</source>
-                <target>Ange en giltig vecka.</target>
+                <target state="needs-translation">Please enter a valid week.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Form/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.da.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="da" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.de.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.el.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.el.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="el" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.en.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.es.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.et.xlf
@@ -1,6 +1,6 @@
-<?xml version='1.0'?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="et" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="eu" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
@@ -11,7 +11,7 @@
                 <target>Igotako fitxategia handiegia da. Mesedez saiatu fitxategi txikiago bat igotzen.</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF tokena ez da egokia.</target>
             </trans-unit>
             <trans-unit id="99">

--- a/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fa" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fi" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.gl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="gl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.he.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="he" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.hr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.hu.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hu" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.hy.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hy" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.id.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="id" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.it.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ja" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
@@ -15,125 +15,125 @@
                 <target>CSRFトークンが無効です、再送信してください。</target>
             </trans-unit>
             <trans-unit id="99">
-                 <source>This value is not a valid HTML5 color.</source>
-                 <target>有効なHTML5の色ではありません。</target>
-             </trans-unit>
-             <trans-unit id="100">
-                 <source>Please enter a valid birthdate.</source>
-                 <target>有効な生年月日を入力してください。</target>
-             </trans-unit>
-             <trans-unit id="101">
-                 <source>The selected choice is invalid.</source>
-                 <target>選択した値は無効です。</target>
-             </trans-unit>
-             <trans-unit id="102">
-                 <source>The collection is invalid.</source>
-                 <target>コレクションは無効です。</target>
-             </trans-unit>
-             <trans-unit id="103">
-                 <source>Please select a valid color.</source>
-                 <target>有効な色を選択してください。</target>
-             </trans-unit>
-             <trans-unit id="104">
-                 <source>Please select a valid country.</source>
-                 <target>有効な国を選択してください。</target>
-             </trans-unit>
-             <trans-unit id="105">
-                 <source>Please select a valid currency.</source>
-                 <target>有効な通貨を選択してください。</target>
-             </trans-unit>
-             <trans-unit id="106">
-                 <source>Please choose a valid date interval.</source>
-                 <target>有効な日付間隔を選択してください。</target>
-             </trans-unit>
-             <trans-unit id="107">
-                 <source>Please enter a valid date and time.</source>
-                 <target>有効な日時を入力してください。</target>
-             </trans-unit>
-             <trans-unit id="108">
-                 <source>Please enter a valid date.</source>
-                 <target>有効な日付を入力してください。</target>
-             </trans-unit>
-             <trans-unit id="109">
-                 <source>Please select a valid file.</source>
-                 <target>有効なファイルを選択してください。</target>
-             </trans-unit>
-             <trans-unit id="110">
-                 <source>The hidden field is invalid.</source>
-                 <target>隠しフィールドが無効です。</target>
-             </trans-unit>
-             <trans-unit id="111">
-                 <source>Please enter an integer.</source>
-                 <target>整数で入力してください。</target>
-             </trans-unit>
-             <trans-unit id="112">
-                 <source>Please select a valid language.</source>
-                 <target>有効な言語を選択してください。</target>
-             </trans-unit>
-             <trans-unit id="113">
-                 <source>Please select a valid locale.</source>
-                 <target>有効なロケールを選択してください。</target>
-             </trans-unit>
-             <trans-unit id="114">
-                 <source>Please enter a valid money amount.</source>
-                 <target>有効な金額を入力してください。</target>
-             </trans-unit>
-             <trans-unit id="115">
-                 <source>Please enter a number.</source>
-                 <target>数値で入力してください。</target>
-             </trans-unit>
-             <trans-unit id="116">
-                 <source>The password is invalid.</source>
-                 <target>パスワードが無効です。</target>
-             </trans-unit>
-             <trans-unit id="117">
-                 <source>Please enter a percentage value.</source>
-                 <target>パーセント値で入力してください。</target>
-             </trans-unit>
-             <trans-unit id="118">
-                 <source>The values do not match.</source>
-                 <target>値が一致しません。</target>
-             </trans-unit>
-             <trans-unit id="119">
-                 <source>Please enter a valid time.</source>
-                 <target>有効な時間を入力してください。</target>
-             </trans-unit>
-             <trans-unit id="120">
-                 <source>Please select a valid timezone.</source>
-                 <target>有効なタイムゾーンを選択してください。</target>
-             </trans-unit>
-             <trans-unit id="121">
-                 <source>Please enter a valid URL.</source>
-                 <target>有効なURLを入力してください。</target>
-             </trans-unit>
-             <trans-unit id="122">
-                 <source>Please enter a valid search term.</source>
-                 <target>有効な検索語を入力してください。</target>
-             </trans-unit>
-             <trans-unit id="123">
-                 <source>Please provide a valid phone number.</source>
-                 <target>有効な電話番号を入力してください。</target>
-             </trans-unit>
-             <trans-unit id="124">
-                 <source>The checkbox has an invalid value.</source>
-                 <target>チェックボックスの値が無効です。</target>
-             </trans-unit>
-             <trans-unit id="125">
-                 <source>Please enter a valid email address.</source>
-                 <target>有効なメールアドレスを入力してください。</target>
-             </trans-unit>
-             <trans-unit id="126">
-                 <source>Please select a valid option.</source>
-                 <target>有効な値を選択してください。</target>
-             </trans-unit>
-             <trans-unit id="127">
-                 <source>Please select a valid range.</source>
-                 <target>有効な範囲を選択してください。</target>
-             </trans-unit>
-             <trans-unit id="128">
-                 <source>Please enter a valid week.</source>
-                 <target>有効な週を入力してください。</target>
-             </trans-unit>
+                <source>This value is not a valid HTML5 color.</source>
+                <target>有効なHTML5の色ではありません。</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>有効な生年月日を入力してください。</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>選択した値は無効です。</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>コレクションは無効です。</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>有効な色を選択してください。</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>有効な国を選択してください。</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>有効な通貨を選択してください。</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>有効な日付間隔を選択してください。</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>有効な日時を入力してください。</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>有効な日付を入力してください。</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>有効なファイルを選択してください。</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>隠しフィールドが無効です。</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>整数で入力してください。</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>有効な言語を選択してください。</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>有効なロケールを選択してください。</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>有効な金額を入力してください。</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>数値で入力してください。</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>パスワードが無効です。</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>パーセント値で入力してください。</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>値が一致しません。</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>有効な時間を入力してください。</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>有効なタイムゾーンを選択してください。</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>有効なURLを入力してください。</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>有効な検索語を入力してください。</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>有効な電話番号を入力してください。</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>チェックボックスの値が無効です。</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>有効なメールアドレスを入力してください。</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>有効な値を選択してください。</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>有効な範囲を選択してください。</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>有効な週を入力してください。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lb.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lt.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lt" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lv.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lv" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.mk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.mk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="mk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.mn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="mn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.my.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.my.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="my" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
@@ -11,7 +11,7 @@
                 <target>Den opplastede filen var for stor. Vennligst last opp en mindre fil.</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF nøkkelen er ugyldig.</target>
             </trans-unit>
             <trans-unit id="99">

--- a/src/Symfony/Component/Form/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
@@ -11,7 +11,7 @@
                 <target>Fila du lasta opp var for stor. Last opp ei mindre fil.</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF-nøkkelen er ikkje gyldig.</target>
             </trans-unit>
             <trans-unit id="99">

--- a/src/Symfony/Component/Form/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.no.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
@@ -11,7 +11,7 @@
                 <target>Den opplastede filen var for stor. Vennligst last opp en mindre fil.</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF nøkkelen er ugyldig.</target>
             </trans-unit>
             <trans-unit id="99">

--- a/src/Symfony/Component/Form/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pt.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pt" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
@@ -14,7 +14,7 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>O token CSRF está inválido. Por favor, tente enviar o formulário novamente.</target>
             </trans-unit>
-             <trans-unit id="99">
+            <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>
                 <target>Este valor não é uma cor HTML5 válida.</target>
             </trans-unit>
@@ -50,7 +50,7 @@
                 <source>Please enter a valid date and time.</source>
                 <target>Por favor, informe uma data e horário válidos.</target>
             </trans-unit>
-             <trans-unit id="108">
+            <trans-unit id="108">
                 <source>Please enter a valid date.</source>
                 <target>Por favor, informe uma data válida.</target>
             </trans-unit>

--- a/src/Symfony/Component/Form/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pt_BR.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pt-BR" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ro.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ro" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ru.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ru" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sq" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="112">
                 <source>Please select a valid language.</source>
-                <target>Please select a valid language.</target>
+                <target state="needs-translation">Please select a valid language.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>Please select a valid locale.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sr_Cyrl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sr-Cyrl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sr_Latn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sr-Latn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.th.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="th" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="th" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.tl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="tl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.tr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="tr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.uk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="uk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ur.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="ur" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ur" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.uz.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="uz" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.vi.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="vi" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.zh_CN.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="zh-CN" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.zh_TW.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="zh-TW" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.af.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.af.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="af" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -69,6 +69,10 @@
             <trans-unit id="18">
                 <source>Invalid or expired login link.</source>
                 <target>Ongeldige of vervalde aanmeldskakel.</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target state="needs-translation">Too many failed login attempts, please try again in %minutes% minute.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ar.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ar.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ar" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>عدد كبير جدا من محاولات الدخول الفاشلة، يرجى اعادة المحاولة بعد %minutes% دقيقة.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>عدد كبير جدا من محاولات الدخول الفاشلة، يرجى اعادة المحاولة بعد %minutes% دقيقة.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.az.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.az.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="az" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Həddindən artıq uğursuz giriş cəhdi, lütfən %minutes% dəqiqə ərzində yenidən yoxlayın.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Həddindən artıq uğursuz giriş cəhdi, lütfən %minutes% dəqiqə ərzində yenidən yoxlayın.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.be.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.be.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="be" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Занадта шмат няўдалых спроб уваходу ў сістэму, паспрабуйце спробу праз %minutes% хвіліну.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Занадта шмат няўдалых спроб уваходу ў сістэму, паспрабуйце спробу праз %minutes% хвілін.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.bg.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.bg.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="bg" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -71,13 +71,9 @@
                 <target>Невалиден или изтекъл линк за вход.</target>
             </trans-unit>
             <trans-unit id="19">
-				<source>Too many failed login attempts, please try again in %minutes% minute.</source>
-				<target>Твърде много неуспешни опити за вход, моля опитайте отново след %minutes% минута.</target>
-			</trans-unit>
-			<trans-unit id="20">
-				<source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-				<target>Твърде много неуспешни опити за вход, моля опитайте отново след %minutes% минути.</target>
-			</trans-unit>
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>Твърде много неуспешни опити за вход, моля опитайте отново след %minutes% минута.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.bs.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.bs.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="bs" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Previše neuspjelih pokušaja prijave, pokušajte ponovo za %minutes% minuta.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Previše neuspjelih pokušaja prijave, pokušajte ponovo za %minutes% minuta.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ca.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ca.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ca" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Massa intents d'inici de sessió fallits, torneu-ho a provar en %minutes% minut.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Massa intents d'inici de sessió fallits, torneu-ho a provar en %minutes% minuts.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.cs.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.cs.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="cs" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Příliš mnoho neúspěšných pokusů o přihlášení, zkuste to prosím znovu za %minutes% minutu.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Příliš mnoho neúspěšných pokusů o přihlášení, zkuste to prosím znovu za %minutes% minut.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.cy.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.cy.xlf
@@ -1,78 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="ru" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="cy" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
-                <target>Ошибка аутентификации.</target>
+                <target state="needs-translation">An authentication exception occurred.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>Authentication credentials could not be found.</source>
-                <target>Аутентификационные данные не найдены.</target>
+                <target state="needs-translation">Authentication credentials could not be found.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>Authentication request could not be processed due to a system problem.</source>
-                <target>Запрос аутентификации не может быть обработан в связи с проблемой в системе.</target>
+                <target state="needs-translation">Authentication request could not be processed due to a system problem.</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>Invalid credentials.</source>
-                <target>Недействительные аутентификационные данные.</target>
+                <target state="needs-translation">Invalid credentials.</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
-                <target>Cookie уже был использован кем-то другим.</target>
+                <target state="needs-translation">Cookie has already been used by someone else.</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>Not privileged to request the resource.</source>
-                <target>Отсутствуют права на запрос этого ресурса.</target>
+                <target state="needs-translation">Not privileged to request the resource.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>Invalid CSRF token.</source>
-                <target>Недействительный токен CSRF.</target>
+                <target state="needs-translation">Invalid CSRF token.</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
-                <target>Не найден провайдер аутентификации, поддерживающий токен аутентификации.</target>
+                <target state="needs-translation">No authentication provider found to support the authentication token.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>No session available, it either timed out or cookies are not enabled.</source>
-                <target>Сессия не найдена, ее время истекло, либо cookies не включены.</target>
+                <target state="needs-translation">No session available, it either timed out or cookies are not enabled.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>No token could be found.</source>
-                <target>Токен не найден.</target>
+                <target state="needs-translation">No token could be found.</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>Username could not be found.</source>
-                <target>Имя пользователя не найдено.</target>
+                <target state="needs-translation">Username could not be found.</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>Account has expired.</source>
-                <target>Время действия учетной записи истекло.</target>
+                <target state="needs-translation">Account has expired.</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>Credentials have expired.</source>
-                <target>Время действия аутентификационных данных истекло.</target>
+                <target state="needs-translation">Credentials have expired.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>Account is disabled.</source>
-                <target>Учетная запись отключена.</target>
+                <target state="needs-translation">Account is disabled.</target>
             </trans-unit>
             <trans-unit id="16">
                 <source>Account is locked.</source>
-                <target>Учетная запись заблокирована.</target>
+                <target state="needs-translation">Account is locked.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>Too many failed login attempts, please try again later.</source>
-                <target>Слишком много неудачных попыток входа, пожалуйста, попробуйте позже.</target>
+                <target state="needs-translation">Too many failed login attempts, please try again later.</target>
             </trans-unit>
             <trans-unit id="18">
                 <source>Invalid or expired login link.</source>
-                <target>Ссылка для входа недействительна или просрочена.</target>
+                <target state="needs-translation">Invalid or expired login link.</target>
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Слишком много неудачных попыток входа в систему, повторите попытку через %minutes% минуту.</target>
+                <target state="needs-translation">Too many failed login attempts, please try again in %minutes% minute.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.da.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.da.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="da" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>For mange fejlede login forsøg, prøv igen om %minutes% minut.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>For mange fejlede login forsøg, prøv igen om %minutes% minutter.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.de.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.de.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es in einer Minute noch einmal.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es in %minutes% Minuten noch einmal.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.el.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.el.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="el" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Πολλαπλές αποτυχημένες απόπειρες σύνδεσης, παρακαλούμε ξαναδοκιμάστε σε %minutes% λεπτό.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Πολλαπλές αποτυχημένες απόπειρες σύνδεσης, παρακαλούμε ξαναδοκιμάστε σε %minutes% λεπτά.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.en.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.en.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Too many failed login attempts, please try again in %minutes% minute.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Too many failed login attempts, please try again in %minutes% minutes.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.es.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.es.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Demasiados intentos fallidos de inicio de sesión, inténtelo de nuevo en %minutes% minuto.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Demasiados intentos fallidos de inicio de sesión, inténtelo de nuevo en %minutes% minutos.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.et.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.et.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="et" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Liiga palju ebaõnnestunud autentimise katseid, palun proovi uuesti %minutes% minuti pärast.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Liiga palju ebaõnnestunud autentimise katseid, palun proovi uuesti %minutes% minuti pärast.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.eu.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.eu.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="eu" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Saioa hasteko huts gehiegi egin dira, saiatu berriro minutu %minutes% geroago.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Saioa hasteko huts gehiegi egin dira, saiatu berriro %minutes% minututan.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.fa.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.fa.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fa" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>تلاش‌های ناموفق زیادی برای ورود صورت گرفته است، لطفاً %minutes% دقیقه دیگر دوباره امتحان کنید.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>تلاش‌های ناموفق زیادی برای ورود صورت گرفته است، لطفاً %minutes% دقیقه دیگر دوباره امتحان کنید.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.fi.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.fi.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fi" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Liian monta epäonnistunutta kirjautumisyritystä, yritä uudelleen %minutes% minuutin kuluttua.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Liian monta epäonnistunutta kirjautumisyritystä, yritä uudelleen %minutes% minuutin kuluttua.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.fr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.fr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Plusieurs tentatives de connexion ont échoué, veuillez réessayer dans %minutes% minute.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Plusieurs tentatives de connexion ont échoué, veuillez réessayer dans %minutes% minutes.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.gl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.gl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="gl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Demasiados intentos de inicio de sesión errados, por favor, ténteo de novo en %minutes% minuto.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Demasiados intentos de inicio de sesión errados, por favor, ténteo de novo en %minutes% minutos.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.he.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.he.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="he" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>יותר מדי ניסיונות כניסה כושלים, אנא נסה שוב בוד %minutes% דקה.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>יותר מדי ניסיונות כניסה כושלים, אנא נסה שוב בוד %minutes% דקות.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.hr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.hr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Previše neuspjelih pokušaja prijave, molim pokušajte ponovo za %minutes% minutu.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Previše neuspjelih pokušaja prijave, molim pokušajte ponovo za %minutes% minutu.|Previše neuspjelih pokušaja prijave, molim pokušajte ponovo za %minutes% minute.|Previše neuspjelih pokušaja prijave, molim pokušajte ponovo za %minutes% minuta.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.hu.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.hu.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hu" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Túl sok sikertelen bejelentkezési kísérlet, kérjük próbálja újra %minutes% perc múlva.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Túl sok sikertelen bejelentkezési kísérlet, kérjük próbálja újra %minutes% perc múlva.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.hy.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.hy.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hy" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Մուտքի չափազանց շատ անհաջող փորձեր: Խնդրում ենք կրկին փորձել %minutes րոպե:</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Մուտքի չափազանց շատ անհաջող փորձեր: Խնդրում ենք կրկին փորձել %minutes րոպե:</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.id.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.id.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="id" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Terlalu banyak percobaan login yang salah, silahkan coba lagi dalam %minutes% menit.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Terlalu banyak percobaan login yang salah, silahkan coba lagi dalam %minutes% menit.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.it.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.it.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Troppi tentativi di login falliti, riprova tra %minutes% minuto.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Troppi tentativi di login falliti, riprova tra %minutes% minuti.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ja.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ja.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ja" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>ログイン試行回数が多すぎます。%minutes%分後に再度お試しください。</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>ログイン試行回数が多すぎます。%minutes%分後に再度お試しください。</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.lb.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.lb.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Zu vill fehlgeschloen Loginversich, w. e. g. probéiert nach am %minutes% Minutt.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Zu vill fehlgeschloen Loginversich, w. e. g. probéiert nach an %minutes% Minutten.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.lt.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.lt.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lt" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Per daug nepavykusių prisijungimo bandymų, pabandykite dar kartą po %minutes% minutės.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Per daug nepavykusių prisijungimo bandymų, pabandykite dar kartą po %minutes% minutės.|Per daug nepavykusių prisijungimo bandymų, pabandykite dar kartą po %minutes% minučių.|Per daug nepavykusių prisijungimo bandymų, pabandykite dar kartą po %minutes% minučių.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.lv.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.lv.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lv" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Pārāk daudz nesekmīgu autentifikācijas mēģinājumu, lūdzu mēģiniet vēlreiz pēc %minutes% minūtes.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Pārāk daudz nesekmīgu autentifikācijas mēģinājumu, lūdzu mēģiniet vēlreiz pēc %minutes% minūtēm.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.mk.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.mk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="mk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Премногу неуспешни обиди за најавување, обидете се повторно за %minutes% минута.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Премногу неуспешни обиди за најавување, обидете се повторно за %minutes% минути.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.mn.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.mn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="mn" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="mn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -35,7 +35,7 @@
                 <target>Нэвтрэх токенг дэмжих нэвтрэх эрхийн хангагч олдсонгүй.</target>
             </trans-unit>
             <trans-unit id="10">
-                <source>No  available, it either timed out or cookies are not enabled.</source>
+                <source>No session available, it either timed out or cookies are not enabled.</source>
                 <target>Хэрэглэгчийн session олдсонгүй, хугацаа нь дууссан эсвэл күүки идэвхижүүлээгүй байна.</target>
             </trans-unit>
             <trans-unit id="11">
@@ -69,6 +69,10 @@
             <trans-unit id="18">
                 <source>Invalid or expired login link.</source>
                 <target>Буруу эсвэл хугацаа нь дууссан нэвтрэх зам.</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target state="needs-translation">Too many failed login attempts, please try again in %minutes% minute.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.my.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.my.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="my" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Too many failed login attempts, please try again in %minutes% minute.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Login ၀င်ရန်ကြိုးစားမှုများလွန်းပါသည်၊ ကျေးဇူးပြု၍ နောက် %minutes% မှထပ်မံကြိုးစားပါ။</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nb.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nb.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutt.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutter.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Te veel onjuiste inlogpogingen, probeer het opnieuw over %minutes% minuut.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Te veel onjuiste inlogpogingen, probeer het opnieuw over %minutes% minuten.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nn.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -70,13 +70,9 @@
                 <source>Invalid or expired login link.</source>
                 <target>Innloggingslenka er ugyldig eller utgjengen.</target>
             </trans-unit>
-    	    <trans-unit id="19">
+            <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutt.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutter.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.no.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.no.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutt.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutter.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.pl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.pl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Zbyt wiele nieudanych prób logowania, spróbuj ponownie po upływie %minutes% minut.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Zbyt wiele nieudanych prób logowania, spróbuj ponownie po upływie %minutes% minut.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.pt.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.pt.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pt" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Demasiadas tentativas de login, tente novamente num minuto.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Demasiadas tentativas de login, tente novamente em %minutes% minutos.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.pt_BR.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.pt_BR.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pt-BR" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Muitas tentativas de login inválidas, por favor, tente novamente em um minuto.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Muitas tentativas de login inválidas, por favor, tente novamente em %minutes% minutos.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ro.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ro.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ro" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -70,13 +70,9 @@
                 <source>Invalid or expired login link.</source>
                 <target>Link de autentificare invalid sau expirat.</target>
             </trans-unit>
-             <trans-unit id="19">
+            <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Prea multe încercări nereușite, încearcă din nou în %minutes% minut.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Prea multe încercări nereușite, încearcă din nou în %minutes% minute.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sk.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Príliš veľa neúspešných pokusov o prihlásenie. Skúste to znova o %minutes% minútu.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Príliš veľa neúspešných pokusov o prihlásenie. Skúste to znova o %minutes% minút.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Preveč neuspelih poskusov prijave, poskusite znova čez %minutes% minuto.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Preveč neuspelih poskusov prijave, poskusite znova čez %minutes% minut.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sq" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Shumë përpjekje të dështuara për identifikim; provo sërish pas %minutes% minutë.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Shumë përpjekje të dështuara për identifikim; provo sërish pas %minutes% minuta.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sr_Cyrl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sr-Cyrl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Превише неуспешних покушаја пријављивања, молим покушајте поново за %minutes% минут.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Превише неуспешних покушаја пријављивања, молим покушајте поново за %minutes% минута.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sr_Latn.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sr_Latn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sr-Latn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Previše neuspešnih pokušaja prijavljivanja, molim pokušajte ponovo za %minutes% minut.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Previše neuspešnih pokušaja prijavljivanja, molim pokušajte ponovo za %minutes% minuta.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sv.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sv.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sv" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>För många misslyckade inloggningsförsök, försök igen om %minutes% minut.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>För många misslyckade inloggningsförsök, försök igen om %minutes% minuter.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.th.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.th.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="th" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>มีความพยายามเข้าสู่ระบบล้มเหลวมากเกินไป โปรดลองอีกครั้งใน %minutes% นาที</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>มีความพยายามเข้าสู่ระบบล้มเหลวมากเกินไป โปรดลองอีกครั้งใน %minutes% นาที</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.tl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.tl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="tl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -71,10 +71,6 @@
                 <target>Inbalido o nagexpire na ang link para makapaglogin.</target>
             </trans-unit>
             <trans-unit id="19">
-                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Napakaraming nabigong mga pagtatangka sa pag-login, pakisubukan ulit sa% minuto% minuto.</target>
-            </trans-unit>
-            <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Napakaraming nabigong mga pagtatangka sa pag-login, pakisubukan ulit sa% minuto% minuto.</target>
             </trans-unit>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="tr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Çok fazla başarısız giriş denemesi, lütfen %minutes% dakika sonra tekrar deneyin.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Çok fazla başarısız giriş denemesi, lütfen %minutes% dakika sonra tekrar deneyin.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.uk.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.uk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="uk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -73,10 +73,6 @@
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
                 <target>Забагато невдалих спроб входу. Будь ласка, спробуйте знову через %minutes% хвилину.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Забагато невдалих спроб входу. Будь ласка, спробуйте знову через %minutes% хв.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ur.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ur.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="ur" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ur" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>منٹ باد %minutes% لاگ ان کی بہت زیادہ ناکام کوششیں ہو چکی ہیں، براۓ کرم دوبارھ کوشيش کريں </target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>منٹ باد %minutes% لاگ ان کی بہت زیادہ ناکام کوششیں ہو چکی ہیں، براۓ کرم دوبارھ کوشيش کريں </target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.uz.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.uz.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="uz" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Kirish uchun muvaffaqiyatsiz urinishlar, %minutes% daqiqadan so'ng qayta urinib ko'ring.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Kirish uchun muvaffaqiyatsiz urinishlar, %minutes% daqiqadan so'ng qayta urinib ko'ring.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="vi" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Quá nhiều lần thử đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>Quá nhiều lần thử đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.zh_CN.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.zh_CN.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="zh-CN" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>登入失败的次数过多，请在%minutes%分钟后再试。</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>登入失败的次数过多，请在%minutes%分钟后再试。</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.zh_TW.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.zh_TW.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="zh-TW" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
@@ -72,10 +72,6 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>登錄失敗的次數過多，請在%minutes%分鐘後再試。</target>
-            </trans-unit>
-            <trans-unit id="20">
-                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
                 <target>登錄失敗的次數過多，請在%minutes%分鐘後再試。</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -111,6 +111,10 @@ class XliffFileLoader implements LoaderInterface
                     continue;
                 }
 
+                if (isset($translation->target) && 'needs-translation' === (string) $translation->target->attributes()['state']) {
+                    continue;
+                }
+
                 $source = isset($attributes['resname']) && $attributes['resname'] ? $attributes['resname'] : $translation->source;
                 // If the xlf file has another encoding specified, try to convert it because
                 // simple_xml will always return utf-8 encoded values

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources.xlf
@@ -18,6 +18,10 @@
         <target>with</target>
         <note>note</note>
       </trans-unit>
+      <trans-unit id="5">
+        <source>skipped</source>
+        <target state="needs-translation">skipped</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="af" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -358,6 +358,10 @@
                 <source>This value is not a valid timezone.</source>
                 <target>Hierdie waarde is nie 'n geldige tydsone nie.</target>
             </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target state="needs-translation">This password has been leaked in a data breach, it must not be used. Please use another password.</target>
+            </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
                 <target>Hierdie waarde moet tussen {{ min }} en {{ max }} wees.</target>
@@ -397,6 +401,42 @@
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>Die waarde van die netmasker moet tussen {{ min }} en {{ max }} wees.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ar" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>امتداد الملف غير صحيح ({{ extension }}). الامتدادات المسموح بها هي {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="az" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Faylın uzantısı yanlışdır ({{ extension }}). İcazə verilən uzantılar {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="be" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>Выкарыстанне схаваных накладзеных сімвалаў не дазваляецца.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="bg" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>Използването на скрити насложени символи не е позволено.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="bs" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>Upotreba skrivenih preklapajućih znakova nije dozvoljena.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ca" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -302,7 +302,7 @@
                 <source>An empty file is not allowed.</source>
                 <target>No està permès un fixter buit.</target>
             </trans-unit>
-              <trans-unit id="79">
+            <trans-unit id="79">
                 <source>The host could not be resolved.</source>
                 <target>No s'ha pogut resoldre l'amfitrió.</target>
             </trans-unit>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>No es permet l'ús de caràcters superposats ocults.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="cs" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -414,18 +414,30 @@
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
                 <target>Tato hodnota obsahuje znaky, které nejsou povoleny aktuální úrovní omezení.</target>
             </trans-unit>
-           <trans-unit id="107">
-               <source>Using invisible characters is not allowed.</source>
-               <target>Používání neviditelných znaků není povoleno.</target>
-           </trans-unit>
-           <trans-unit id="108">
-               <source>Mixing numbers from different scripts is not allowed.</source>
-               <target>Kombinování čísel z různých písem není povoleno.</target>
-           </trans-unit>
-           <trans-unit id="109">
-               <source>Using hidden overlay characters is not allowed.</source>
-               <target>Použití skrytých překrývajících znaků není povoleno.</target>
-           </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target>Používání neviditelných znaků není povoleno.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target>Kombinování čísel z různých písem není povoleno.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target>Použití skrytých překrývajících znaků není povoleno.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="cy" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -329,6 +329,114 @@
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
                 <target>Nid yw'r Cod Adnabod Busnes (BIC) hwn yn gysylltiedig ag IBAN {{ iban }}.</target>
+            </trans-unit>
+            <trans-unit id="86">
+                <source>This value should be valid JSON.</source>
+                <target state="needs-translation">This value should be valid JSON.</target>
+            </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target state="needs-translation">This collection should contain only unique elements.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target state="needs-translation">This value should be positive.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target state="needs-translation">This value should be either positive or zero.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target state="needs-translation">This value should be negative.</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target state="needs-translation">This value should be either negative or zero.</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target state="needs-translation">This value is not a valid timezone.</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target state="needs-translation">This password has been leaked in a data breach, it must not be used. Please use another password.</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target state="needs-translation">This value should be between {{ min }} and {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target state="needs-translation">This value is not a valid hostname.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target state="needs-translation">The number of elements in this collection should be a multiple of {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target state="needs-translation">This value should satisfy at least one of the following constraints:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target state="needs-translation">Each element of this collection should satisfy its own set of constraints.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target state="needs-translation">This value is not a valid International Securities Identification Number (ISIN).</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>This value should be a valid expression.</source>
+                <target state="needs-translation">This value should be a valid expression.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>This value is not a valid CSS color.</source>
+                <target state="needs-translation">This value is not a valid CSS color.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="da" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>At bruge skjulte overlejringstegn er ikke tilladt.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="el" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Η επέκταση του αρχείου δεν είναι έγκυρη ({{ extension }}). Οι επιτρεπτόμενες επεκτάσεις είναι {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>La extensión del archivo no es válida ({{ extension }}). Las extensiones permitidas son {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
@@ -1,6 +1,6 @@
-<?xml version='1.0'?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="et" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -433,6 +433,10 @@
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
                 <target>Tuvastatud teksti kodeering on vigane ({{ detected }}). Lubatud kodeeringud on {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="eu" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -105,7 +105,7 @@
             <trans-unit id="26">
                 <source>This value is not a valid time.</source>
                 <target>Balio hau ez da ordu egoki bat.</target>
-           </trans-unit>
+            </trans-unit>
             <trans-unit id="27">
                 <source>This value is not a valid URL.</source>
                 <target>Balio hau ez da baliabideen kokatzaile uniforme (URL) egoki bat.</target>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>Ez da onartzen karaktere gainjarri ezkutuen erabilera.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fa" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -35,12 +35,12 @@
                 <target>یک یا چند مقدار داده شده نامعتبر است.</target>
             </trans-unit>
             <trans-unit id="9">
-                <source>The fields {{ fields }} were not expected.</source>
-                <target>فیلدهای {{ fields }} مورد انتظار نبود.</target>
+                <source>This field was not expected.</source>
+                <target state="needs-translation">This field was not expected.</target>
             </trans-unit>
             <trans-unit id="10">
-                <source>The fields {{ fields }} are missing.</source>
-                <target>فیلدهای {{ fields }} مفقود شده اند.</target>
+                <source>This field is missing.</source>
+                <target state="needs-translation">This field is missing.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>This value is not a valid date.</source>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>استفاده از کاراکترهای همپوشانی پنهان (hidden overlay characters) مجاز نیست.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fi" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Tiedostopääte ({{ extension }}) on virheellinen. Sallitut tiedostopäätteet ovat: {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -433,6 +433,10 @@
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
                 <target>L'encodage de caractères détecté est invalide ({{ detected }}). Les encodages autorisés sont {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="gl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -401,6 +401,42 @@
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>O valor da máscara de rede debería estar entre {{ min }} e {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="he" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -386,7 +386,7 @@
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
                 <target>ערך זה אינו מספר זיהוי ניירות ערך בינלאומי תקף (ISIN).</target>
             </trans-unit>
-             <trans-unit id="100">
+            <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
                 <target>ערך זה חייב להיות ביטוי חוקי.</target>
             </trans-unit>
@@ -401,6 +401,42 @@
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>הערך של מסכת הרשת חייב להיות בין {{ min }} ו {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hu" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -335,24 +335,24 @@
                 <target>Ez az érték érvényes JSON kell, hogy legyen.</target>
             </trans-unit>
             <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>Ez a gyűjtemény csak egyedi elemeket tartalmazhat.</target>
+            </trans-unit>
+            <trans-unit id="88">
                 <source>This value should be positive.</source>
                 <target>Ennek az értéknek pozitívnak kell lennie.</target>
             </trans-unit>
-            <trans-unit id="88">
+            <trans-unit id="89">
                 <source>This value should be either positive or zero.</source>
                 <target>Ennek az értéknek pozitívnak vagy nullának kell lennie.</target>
             </trans-unit>
-            <trans-unit id="89">
+            <trans-unit id="90">
                 <source>This value should be negative.</source>
                 <target>Ennek az értéknek negatívnak kell lennie.</target>
             </trans-unit>
-            <trans-unit id="90">
+            <trans-unit id="91">
                 <source>This value should be either negative or zero.</source>
                 <target>Ennek az értéknek negatívnak vagy nullának kell lennie.</target>
-            </trans-unit>
-            <trans-unit id="91">
-                <source>This collection should contain only unique elements.</source>
-                <target>Ez a gyűjtemény csak egyedi elemeket tartalmazhat.</target>
             </trans-unit>
             <trans-unit id="92">
                 <source>This value is not a valid timezone.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hy" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -371,7 +371,7 @@
                 <target>Այս հոստի անունը վավեր չէ։</target>
             </trans-unit>
             <trans-unit id="96">
-                <source>The number of elements in this collection should be a multiple of {{ compared_value }}․</source>
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
                 <target>Այս համախմբի տարրերի քանակը պետք է հավասար լինի {{ compared_value }}-ի բազմապատիկներին։</target>
             </trans-unit>
             <trans-unit id="97">
@@ -389,6 +389,54 @@
             <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
                 <target>Այս արժեքը պետք է լինի վավեր արտահայտություն:</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>This value is not a valid CSS color.</source>
+                <target state="needs-translation">This value is not a valid CSS color.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="id" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>L'estensione del file non è valida ({{ extension }}). Le estensioni consentite sono {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ja" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -433,6 +433,10 @@
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
                 <target>検出された文字コードは無効です({{ detected }})。有効な文字コードは{{ encodings }}です。</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>D'Benotzen vu verstoppten Iwwerlagungszeechen ass net erlaabt.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lt" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Failo plėtinys netinkamas ({{ extension }}). Leidžiami plėtiniai yra {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="lv" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="mk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Зголемувања на датотеката е неважечка ({{ extension }}). Дозволени зголемувања се ({{ extensions }}).</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="mn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -385,6 +385,58 @@
             <trans-unit id="99">
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
                 <target>Энэ утга зөв International Securities Identification Number (ISIN) биш байна.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>This value should be a valid expression.</source>
+                <target state="needs-translation">This value should be a valid expression.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>This value is not a valid CSS color.</source>
+                <target state="needs-translation">This value is not a valid CSS color.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="my" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -389,6 +389,54 @@
             <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
                 <target>ဤတန်ဖိုးသည်မှန်ကန်သောစကားရပ်ဖြစ်သင့်သည်။</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>This value is not a valid CSS color.</source>
+                <target state="needs-translation">This value is not a valid CSS color.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -401,6 +401,42 @@
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>Verdien på nettmasken skal være mellom {{ min }} og {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -226,7 +226,7 @@
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
                 <target>Dit is geen geldig internationaal bankrekeningnummer (IBAN).</target>
             </trans-unit>
-             <trans-unit id="60">
+            <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
                 <target>Deze waarde is geen geldige ISBN-10.</target>
             </trans-unit>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>De extensie van het bestand is ongeldig ({{ extension }}). Toegestane extensies zijn {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -386,7 +386,7 @@
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
                 <target>Verdien er ikkje eit gyldig International Securities Identification Number (ISIN).</target>
             </trans-unit>
-             <trans-unit id="100">
+            <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
                 <target>Denne verdien skal være et gyldig uttrykk.</target>
             </trans-unit>
@@ -401,6 +401,42 @@
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>Verdien av nettmasken skal være mellom {{ min }} og {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nb" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -401,6 +401,42 @@
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>Verdien på nettmasken skal være mellom {{ min }} og {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pt" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>A extensão do ficheiro é inválida ({{ extension }}). As extensões permitidas são {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pt-BR" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>O uso de caracteres de sobreposição ocultos não é permitido.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ro" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Extensia fișierului este invalidă ({{ extension }}). Extensiile permise sunt {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ru" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Недопустимое расширение файла ({{ extension }}). Разрешенные расширения: {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -168,7 +168,7 @@
             </trans-unit>
             <trans-unit id="45">
                 <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target>>Obrázok je príliš vysoký ({{ height }}px). Maximálna povolená výška obrázku je {{ max_height }}px.</target>
+                <target><![CDATA[>Obrázok je príliš vysoký ({{ height }}px). Maximálna povolená výška obrázku je {{ max_height }}px.]]></target>
             </trans-unit>
             <trans-unit id="46">
                 <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>Používanie skrytých prekryvných znakov nie je povolené.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Končnica datoteke ni veljavna ({{ extension }}). Dovoljene so naslednje končnice: {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sq" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -223,8 +223,8 @@
                 <target>Lloj karte i papranuar ose numër karte i pavlefshëm.</target>
             </trans-unit>
             <trans-unit id="59">
-                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                 <target>Ky nuk është një numër i vlefshëm ndërkombëtar i llogarisë bankare (IBAN).</target>
+                <source>This is not a valid International Bank Account Number (IBAN).</source>
+                <target>Ky nuk është një numër i vlefshëm ndërkombëtar i llogarisë bankare (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Shtesa e skedarit është e pavlefshme ({{ extension }}). Shtesat e lejuara janë {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sr-Cyrl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Екстензија фајла није валидна ({{ extension }}). Дозвољене екстензије су {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sr-Latn" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -433,6 +433,10 @@
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
                 <target>Detektovani enkoding karaktera nije validan ({{ detected }}). Dozvoljne vrednosti za enkoding su: {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sv" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -390,7 +390,7 @@
                 <source>This value should be a valid expression.</source>
                 <target>Det här värdet bör vara ett giltigt uttryck.</target>
             </trans-unit>
-               <trans-unit id="101">
+            <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
                 <target>Det här värdet är inte en giltig CSS-färg.</target>
             </trans-unit>
@@ -433,6 +433,10 @@
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
                 <target>Den upptäckta teckenkodningen är ogiltig ({{ detected }}). Tillåtna kodningar är {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="th" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -390,7 +390,7 @@
                 <source>This value should be a valid expression.</source>
                 <target>ค่านี้ควรเป็นนิพจน์ที่ถูกต้อง</target>
             </trans-unit>
-           <trans-unit id="101">
+            <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
                 <target>ค่านี้ไม่ใช่สี CSS ที่ถูกต้อง</target>
             </trans-unit>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>ไม่อนุญาตให้ใช้ตัวอักษรซ้อนทับที่ซ่อนอยู่</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="tl" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -394,6 +394,50 @@
                 <source>This value is not a valid CSS color.</source>
                 <target>Ang halagang ito ay hindi wastong kulay ng CSS.</target>
             </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
+            </trans-unit>
         </body>
     </file>
- </xliff>
+</xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="tr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Dosya uzantısı geçersiz ({{ extension }}). İzin verilen uzantılar {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="uk" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="ur" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ur" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -401,6 +401,42 @@
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
                 <target>کے درمیان ہونی چاہیے {{ max }} اور {{ min }} نیٹ ماسک کی ويليو</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
+                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>The password strength is too low. Please use a stronger password.</source>
+                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>This value contains characters that are not allowed by the current restriction-level.</source>
+                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Using invisible characters is not allowed.</source>
+                <target state="needs-translation">Using invisible characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Mixing numbers from different scripts is not allowed.</source>
+                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Using hidden overlay characters is not allowed.</source>
+                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="uz" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Fayl kengaytmasi yaroqsiz ({{ extension }}). Ruxsat berilgan kengaytmalar {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="vi" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -361,19 +361,19 @@
             <trans-unit id="93">
                 <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
                 <target>Mật khẩu này đã bị rò rỉ dữ liệu, không được sử dụng nữa. Xin vui lòng sử dụng mật khẩu khác.</target>
-           </trans-unit>
-           <trans-unit id="94">
-               <source>This value should be between {{ min }} and {{ max }}.</source>
-               <target>Giá trị này nên thuộc giữa {{ min }} và {{ max }}.</target>
-           </trans-unit>
-           <trans-unit id="95">
-               <source>This value is not a valid hostname.</source>
-               <target>Giá trị này không phải là tên máy chủ hợp lệ.</target>
-           </trans-unit>
-           <trans-unit id="96">
-               <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-               <target>Số lượng các phần tử trong bộ sưu tập này nên là bội số của {{ compared_value }}.</target>
-           </trans-unit>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>Giá trị này nên thuộc giữa {{ min }} và {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Giá trị này không phải là tên máy chủ hợp lệ.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Số lượng các phần tử trong bộ sưu tập này nên là bội số của {{ compared_value }}.</target>
+            </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>
                 <target>Giá trị này nên thỏa mãn ít nhất một trong những ràng buộc sau:</target>
@@ -429,6 +429,14 @@
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>Phần mở rộng của tệp không hợp lệ ({{ extension }}). Phần mở rộng cho phép là {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="zh-CN" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -135,13 +135,13 @@
                 <target>该文件不是有效的图片。</target>
             </trans-unit>
             <trans-unit id="37">
-                 <source>This is not a valid IP address.</source>
-                 <target>该值不是有效的IP地址。</target>
-             </trans-unit>
-             <trans-unit id="38">
-                 <source>This value is not a valid language.</source>
-                 <target>该值不是有效的语言名。</target>
-             </trans-unit>
+                <source>This is not a valid IP address.</source>
+                <target>该值不是有效的IP地址。</target>
+            </trans-unit>
+            <trans-unit id="38">
+                <source>This value is not a valid language.</source>
+                <target>该值不是有效的语言名。</target>
+            </trans-unit>
             <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
                 <target>该值不是有效的区域值（locale）。</target>
@@ -425,6 +425,18 @@
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
                 <target>不允许使用隐藏的覆盖字符。</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-translation">This is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="zh-TW" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -315,7 +315,7 @@
                 <target>無效企業識別碼 (BIC)。</target>
             </trans-unit>
             <trans-unit id="82">
-                <source>Error.</source>
+                <source>Error</source>
                 <target>錯誤。</target>
             </trans-unit>
             <trans-unit id="83">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I used the below script to spot mistakes and normalize translation files.

I propose to accept English where translations are missing because this makes it easier to automate and also to spot what's missing (opening only one file is needed.)

Carsonbot would need to be updated to account for this when checking for missing translations /cc @Nyholm 

<details>

```php
<?php

use Symfony\Component\Finder\Finder;
use Symfony\Component\Translation\Loader\XliffFileLoader;
use Symfony\Component\Translation\MessageCatalogue;

require __DIR__.'/vendor/autoload.php';

function dumpXliff1(string $defaultLocale, MessageCatalogue $messages, string $domain)
{
    $dom = new \DOMDocument('1.0', 'utf-8');
    $dom->formatOutput = true;

    $xliff = $dom->appendChild($dom->createElement('xliff'));
    $xliff->setAttribute('version', '1.2');
    $xliff->setAttribute('xmlns', 'urn:oasis:names:tc:xliff:document:1.2');

    $xliffFile = $xliff->appendChild($dom->createElement('file'));
    $xliffFile->setAttribute('source-language', str_replace('_', '-', $defaultLocale));
    $xliffFile->setAttribute('target-language', 'no' === $messages->getLocale() ? 'nb' : str_replace('_', '-', $messages->getLocale()));
    $xliffFile->setAttribute('datatype', 'plaintext');
    $xliffFile->setAttribute('original', 'file.ext');

    $xliffBody = $xliffFile->appendChild($dom->createElement('body'));
    foreach ($messages->all($domain) as $source => $target) {
        $translation = $dom->createElement('trans-unit');
        $metadata = $messages->getMetadata($source, $domain);

        $translation->setAttribute('id', $metadata['id']);

        $s = $translation->appendChild($dom->createElement('source'));
        $s->appendChild($dom->createTextNode($source));

        $text = 1 === preg_match('/[&<>]/', $target) ? $dom->createCDATASection($target) : $dom->createTextNode($target);

        $targetElement = $dom->createElement('target');

        if ('en' !== $messages->getLocale() && $target === $source && 'Error' !== $source) {
            $targetElement->setAttribute('state', 'needs-translation');
        }
        if (isset($metadata['target-attributes'])) {
            foreach ($metadata['target-attributes'] as $key => $value) {
                $targetElement->setAttribute($key, $value);
            }
        }

        $t = $translation->appendChild($targetElement);
        $t->appendChild($text);

        $xliffBody->appendChild($translation);
    }

    return preg_replace('/^ +/m', '$0$0', $dom->saveXML());
}


foreach (['Security/Core' => 'security', 'Form' => 'validators', 'Validator' => 'validators'] as $component => $domain) {
    $dir = __DIR__.'/src/Symfony/Component/'.$component.'/Resources/translations';

    $enCatalogue = (new XliffFileLoader())->load($dir.'/'.$domain.'.en.xlf', 'en', $domain);

    file_put_contents($dir.'/'.$domain.'.en.xlf', dumpXliff1('en', $enCatalogue, $domain));
    $finder = new Finder();

    foreach ($finder->files()->in($dir)->name('*.xlf') as $file) {
        $locale = substr($file->getBasename(), 1 + strlen($domain), -4);

        $catalogue = (new XliffFileLoader())->load($file, $locale, $domain);
        $localeCatalogue = new MessageCatalogue($locale);

        foreach ($enCatalogue->all($domain) as $id => $translation) {
            $metadata = [];
            if ($catalogue->defines($id, $domain)) {
                $translation = $catalogue->get($id, $domain);
                $metadata = $catalogue->getMetadata($id, $domain);
            }
            $metadata['id'] = $enCatalogue->getMetadata($id, $domain)['id'];
            $localeCatalogue->set($id, $translation, $domain);
            $localeCatalogue->setMetadata($id, $metadata, $domain);
        }

        file_put_contents($file, dumpXliff1('en', $localeCatalogue, $domain));
    }
}


```

</details>