### PR TITLE
[Serializer] `GetSetMethodNormalizer`: fix BC break with `#[Ignore]` attribute 

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\Serializer\Annotation\Ignore as LegacyIgnore;
 use Symfony\Component\Serializer\Attribute\Ignore;
 
 /**
@@ -97,7 +98,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
     private function isGetMethod(\ReflectionMethod $method): bool
     {
         return !$method->isStatic()
-            && !$method->getAttributes(Ignore::class)
+            && !($method->getAttributes(Ignore::class) || $method->getAttributes(LegacyIgnore::class))
             && !$method->getNumberOfRequiredParameters()
             && ((2 < ($methodLength = \strlen($method->name)) && str_starts_with($method->name, 'is'))
                 || (3 < $methodLength && (str_starts_with($method->name, 'has') || str_starts_with($method->name, 'get')))

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/ClassWithIgnoreAnnotation.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/ClassWithIgnoreAnnotation.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+class ClassWithIgnoreAnnotation
+{
+    public string $foo;
+
+    #[Ignore]
+    public function isSomeIgnoredMethod(): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\ClassWithIgnoreAnnotation;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\ClassWithIgnoreAttribute;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
@@ -427,9 +428,22 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->assertFalse($this->normalizer->supportsNormalization(new ObjectWithJustStaticSetterDummy()));
     }
 
-    public function testNotIgnoredMethodSupport()
+    /**
+     * @param class-string $class
+     *
+     * @dataProvider provideNotIgnoredMethodSupport
+     */
+    public function testNotIgnoredMethodSupport(string $class)
     {
-        $this->assertFalse($this->normalizer->supportsNormalization(new ClassWithIgnoreAttribute()));
+        $this->assertFalse($this->normalizer->supportsNormalization(new $class()));
+    }
+
+    public static function provideNotIgnoredMethodSupport(): iterable
+    {
+        return [
+            [ClassWithIgnoreAttribute::class],
+            [ClassWithIgnoreAnnotation::class],
+        ];
     }
 
     public function testPrivateSetter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This PR fixes a subtle BC break introduced by https://github.com/symfony/symfony/pull/52294/files: `GetSetMethodNormalizer` no more ignores methods marked as `#[Ignore]` with the old class `Symfony\Component\Serializer\Annotation\Ignore`
