### PR TITLE
[Translation] Add missing translations using ChatGPT

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.cy.xlf
@@ -4,135 +4,135 @@
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
-                <target state="needs-translation">This form should not contain extra fields.</target>
+                <target state="needs-review-translation">Ni ddylai'r ffurflen gynnwys meysydd ychwanegol.</target>
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file.</source>
-                <target state="needs-translation">The uploaded file was too large. Please try to upload a smaller file.</target>
+                <target state="needs-review-translation">Roedd y ffeil a uwchlwythwyd yn rhy fawr. Ceisiwch uwchlwytho ffeil llai.</target>
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target state="needs-translation">The CSRF token is invalid. Please try to resubmit the form.</target>
+                <target state="needs-review-translation">Mae'r tocyn CSRF yn annilys. Ceisiwch ailgyflwyno'r ffurflen.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>
-                <target state="needs-translation">This value is not a valid HTML5 color.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn lliw HTML5 dilys.</target>
             </trans-unit>
             <trans-unit id="100">
                 <source>Please enter a valid birthdate.</source>
-                <target state="needs-translation">Please enter a valid birthdate.</target>
+                <target state="needs-review-translation">Nodwch ddyddiad geni dilys.</target>
             </trans-unit>
             <trans-unit id="101">
                 <source>The selected choice is invalid.</source>
-                <target state="needs-translation">The selected choice is invalid.</target>
+                <target state="needs-review-translation">Mae'r dewis a ddewiswyd yn annilys.</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>The collection is invalid.</source>
-                <target state="needs-translation">The collection is invalid.</target>
+                <target state="needs-review-translation">Mae'r casgliad yn annilys.</target>
             </trans-unit>
             <trans-unit id="103">
                 <source>Please select a valid color.</source>
-                <target state="needs-translation">Please select a valid color.</target>
+                <target state="needs-review-translation">Dewiswch liw dilys.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>Please select a valid country.</source>
-                <target state="needs-translation">Please select a valid country.</target>
+                <target state="needs-review-translation">Dewiswch wlad ddilys.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>Please select a valid currency.</source>
-                <target state="needs-translation">Please select a valid currency.</target>
+                <target state="needs-review-translation">Dewiswch arian cyfred dilys.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>Please choose a valid date interval.</source>
-                <target state="needs-translation">Please choose a valid date interval.</target>
+                <target state="needs-review-translation">Dewiswch ystod dyddiadau dilys.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Please enter a valid date and time.</source>
-                <target state="needs-translation">Please enter a valid date and time.</target>
+                <target state="needs-review-translation">Nodwch ddyddiad ac amser dilys.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Please enter a valid date.</source>
-                <target state="needs-translation">Please enter a valid date.</target>
+                <target state="needs-review-translation">Nodwch ddyddiad dilys.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Please select a valid file.</source>
-                <target state="needs-translation">Please select a valid file.</target>
+                <target state="needs-review-translation">Dewiswch ffeil ddilys.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The hidden field is invalid.</source>
-                <target state="needs-translation">The hidden field is invalid.</target>
+                <target state="needs-review-translation">Mae'r maes cudd yn annilys.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>Please enter an integer.</source>
-                <target state="needs-translation">Please enter an integer.</target>
+                <target state="needs-review-translation">Nodwch rif cyfan.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>Please select a valid language.</source>
-                <target state="needs-translation">Please select a valid language.</target>
+                <target state="needs-review-translation">Dewiswch iaith ddilys.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>Please select a valid locale.</source>
-                <target state="needs-translation">Please select a valid locale.</target>
+                <target state="needs-review-translation">Dewiswch leoliad dilys.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>Please enter a valid money amount.</source>
-                <target state="needs-translation">Please enter a valid money amount.</target>
+                <target state="needs-review-translation">Nodwch swm arian dilys.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>Please enter a number.</source>
-                <target state="needs-translation">Please enter a number.</target>
+                <target state="needs-review-translation">Nodwch rif.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>The password is invalid.</source>
-                <target state="needs-translation">The password is invalid.</target>
+                <target state="needs-review-translation">Mae'r cyfrinair yn annilys.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>Please enter a percentage value.</source>
-                <target state="needs-translation">Please enter a percentage value.</target>
+                <target state="needs-review-translation">Nodwch werth canran.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>The values do not match.</source>
-                <target state="needs-translation">The values do not match.</target>
+                <target state="needs-review-translation">Nid yw'r gwerthoedd yn cyfateb.</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>Please enter a valid time.</source>
-                <target state="needs-translation">Please enter a valid time.</target>
+                <target state="needs-review-translation">Nodwch amser dilys.</target>
             </trans-unit>
             <trans-unit id="120">
                 <source>Please select a valid timezone.</source>
-                <target state="needs-translation">Please select a valid timezone.</target>
+                <target state="needs-review-translation">Dewiswch barth amser dilys.</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>Please enter a valid URL.</source>
-                <target state="needs-translation">Please enter a valid URL.</target>
+                <target state="needs-review-translation">Nodwch URL dilys.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>Please enter a valid search term.</source>
-                <target state="needs-translation">Please enter a valid search term.</target>
+                <target state="needs-review-translation">Nodwch derm chwilio dilys.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>Please provide a valid phone number.</source>
-                <target state="needs-translation">Please provide a valid phone number.</target>
+                <target state="needs-review-translation">Darparwch rif ffôn dilys.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The checkbox has an invalid value.</source>
-                <target state="needs-translation">The checkbox has an invalid value.</target>
+                <target state="needs-review-translation">Mae gan y blwch ticio werth annilys.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>Please enter a valid email address.</source>
-                <target state="needs-translation">Please enter a valid email address.</target>
+                <target state="needs-review-translation">Nodwch gyfeiriad e-bost dilys.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>Please select a valid option.</source>
-                <target state="needs-translation">Please select a valid option.</target>
+                <target state="needs-review-translation">Dewiswch opsiwn dilys.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>Please select a valid range.</source>
-                <target state="needs-translation">Please select a valid range.</target>
+                <target state="needs-review-translation">Dewiswch ystod ddilys.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>Please enter a valid week.</source>
-                <target state="needs-translation">Please enter a valid week.</target>
+                <target state="needs-review-translation">Nodwch wythnos ddilys.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>CSRF tokena ez da egokia.</target>
+                <target state="needs-review-translation">CSRF tokena baliogabea da. Mesedez, saiatu berriro formularioa bidaltzen.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>CSRF nøkkelen er ugyldig.</target>
+                <target state="needs-review-translation">CSRF-tokenen er ugyldig. Vennligst prøv å sende inn skjemaet på nytt.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nn.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>CSRF-nøkkelen er ikkje gyldig.</target>
+                <target state="needs-review-translation">CSRF-teiknet er ugyldig. Ver venleg og prøv å sende inn skjemaet på nytt.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.no.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>CSRF nøkkelen er ugyldig.</target>
+                <target state="needs-review-translation">CSRF-tokenen er ugyldig. Vennligst prøv å sende inn skjemaet på nytt.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="112">
                 <source>Please select a valid language.</source>
-                <target state="needs-translation">Please select a valid language.</target>
+                <target state="needs-review-translation">Ju lutem zgjidhni një gjuhë të vlefshme.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>Please select a valid locale.</source>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.af.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.af.xlf
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target state="needs-translation">Too many failed login attempts, please try again in %minutes% minute.</target>
+                <target state="needs-review-translation">Te veel mislukte aanmeldpogings, probeer asseblief weer oor %minutes% minuut.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.cy.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.cy.xlf
@@ -4,75 +4,75 @@
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
-                <target state="needs-translation">An authentication exception occurred.</target>
+                <target state="needs-review-translation">Digwyddodd eithriad dilysu.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>Authentication credentials could not be found.</source>
-                <target state="needs-translation">Authentication credentials could not be found.</target>
+                <target state="needs-review-translation">Ni ellid dod o hyd i ddogfennau dilysu.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>Authentication request could not be processed due to a system problem.</source>
-                <target state="needs-translation">Authentication request could not be processed due to a system problem.</target>
+                <target state="needs-review-translation">Ni ellid prosesu cais dilysu oherwydd problem gyda'r system.</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>Invalid credentials.</source>
-                <target state="needs-translation">Invalid credentials.</target>
+                <target state="needs-review-translation">Dogfennau annilys.</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
-                <target state="needs-translation">Cookie has already been used by someone else.</target>
+                <target state="needs-review-translation">Mae rhywun arall eisoes wedi defnyddio'r cwcis.</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>Not privileged to request the resource.</source>
-                <target state="needs-translation">Not privileged to request the resource.</target>
+                <target state="needs-review-translation">Heb y fraint i ofyn am yr adnodd.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>Invalid CSRF token.</source>
-                <target state="needs-translation">Invalid CSRF token.</target>
+                <target state="needs-review-translation">Tocyn CSRF annilys.</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
-                <target state="needs-translation">No authentication provider found to support the authentication token.</target>
+                <target state="needs-review-translation">Heb ddod o hyd i ddarparwr dilysu i gefnogi'r tocyn dilysu.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>No session available, it either timed out or cookies are not enabled.</source>
-                <target state="needs-translation">No session available, it either timed out or cookies are not enabled.</target>
+                <target state="needs-review-translation">Dim sesiwn ar gael, naill ai mae wedi dod i ben neu nid yw cwcis wedi'u galluogi.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>No token could be found.</source>
-                <target state="needs-translation">No token could be found.</target>
+                <target state="needs-review-translation">Heb ddod o hyd i docyn.</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>Username could not be found.</source>
-                <target state="needs-translation">Username could not be found.</target>
+                <target state="needs-review-translation">Heb ddod o hyd i enw defnyddiwr.</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>Account has expired.</source>
-                <target state="needs-translation">Account has expired.</target>
+                <target state="needs-review-translation">Mae'r cyfrif wedi dod i ben.</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>Credentials have expired.</source>
-                <target state="needs-translation">Credentials have expired.</target>
+                <target state="needs-review-translation">Mae'r dogfennau wedi dod i ben.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>Account is disabled.</source>
-                <target state="needs-translation">Account is disabled.</target>
+                <target state="needs-review-translation">Mae'r cyfrif wedi'i analluogi.</target>
             </trans-unit>
             <trans-unit id="16">
                 <source>Account is locked.</source>
-                <target state="needs-translation">Account is locked.</target>
+                <target state="needs-review-translation">Mae'r cyfrif wedi'i gloi.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>Too many failed login attempts, please try again later.</source>
-                <target state="needs-translation">Too many failed login attempts, please try again later.</target>
+                <target state="needs-review-translation">Gormod o ymdrechion mewngofnodi wedi methu, ceisiwch eto'n hwyrach.</target>
             </trans-unit>
             <trans-unit id="18">
                 <source>Invalid or expired login link.</source>
-                <target state="needs-translation">Invalid or expired login link.</target>
+                <target state="needs-review-translation">Dolen mewngofnodi annilys neu wedi dod i ben.</target>
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target state="needs-translation">Too many failed login attempts, please try again in %minutes% minute.</target>
+                <target state="needs-review-translation">Gormod o ymdrechion mewngofnodi wedi methu, ceisiwch eto ymhen %minutes% munud.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.mn.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.mn.xlf
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target state="needs-translation">Too many failed login attempts, please try again in %minutes% minute.</target>
+                <target state="needs-review-translation">Нэвтрэх оролдлого ихээр амжилтгүй болсон, %minutes% минутын дараа дахин оролдоно уу.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
@@ -360,7 +360,7 @@
             </trans-unit>
             <trans-unit id="93">
                 <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-                <target state="needs-translation">This password has been leaked in a data breach, it must not be used. Please use another password.</target>
+                <target state="needs-review-translation">Hierdie wagwoord is in 'n data-oortreding uitgelek, dit mag nie gebruik word nie. Gebruik asseblief 'n ander wagwoord.</target>
             </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
@@ -404,39 +404,39 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">Die lêernaam is te lank. Dit moet {{ filename_max_length }} karakter of minder hê.|Die lêernaam is te lank. Dit moet {{ filename_max_length }} karakters of minder hê.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">Die wagwoordsterkte is te laag. Gebruik asseblief 'n sterker wagwoord.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Hierdie waarde bevat karakters wat nie toegelaat word deur die huidige beperkingsvlak nie.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Die gebruik van onsigbare karakters word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Die meng van nommers van verskillende skrifte word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Die gebruik van verborge oorvleuelende karakters word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Die uitbreiding van die lêer is ongeldig ({{ extension }}). Toegelate uitbreidings is {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Die opgespoorde karakterkodering is ongeldig ({{ detected }}). Toegelate koderings is {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Dit is nie 'n geldige MAC-adres nie.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">تم اكتشاف ترميز الأحرف غير صالح ({{ detected }}). الترميزات المسموح بها هي {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">هذا ليس عنوان MAC صالحًا.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
@@ -428,15 +428,15 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Пашырэнне файла няслушнае ({{ extension }}). Дазволеныя пашырэнні: {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Выяўленая кадыроўка знакаў няслушная ({{ detected }}). Дазволеныя кадыроўкі: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Гэта не сапраўдны MAC-адрас.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
@@ -428,15 +428,15 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Ekstenzija datoteke je nevažeća ({{ extension }}). Dozvoljene ekstenzije su {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Otkriveno kodiranje karaktera je nevažeće ({{ detected }}). Dozvoljena kodiranja su {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Ovo nije važeća MAC adresa.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
@@ -428,15 +428,15 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">L'extensió del fitxer no és vàlida ({{ extension }}). Les extensions permeses són {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">S'ha detectat que la codificació de caràcters no és vàlida ({{ detected }}). Les codificacions permeses són {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Això no és una adreça MAC vàlida.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
@@ -332,111 +332,111 @@
             </trans-unit>
             <trans-unit id="86">
                 <source>This value should be valid JSON.</source>
-                <target state="needs-translation">This value should be valid JSON.</target>
+                <target state="needs-review-translation">Dylai'r gwerth hwn fod yn JSON dilys.</target>
             </trans-unit>
             <trans-unit id="87">
                 <source>This collection should contain only unique elements.</source>
-                <target state="needs-translation">This collection should contain only unique elements.</target>
+                <target state="needs-review-translation">Dylai'r casgliad hwn gynnwys elfennau unigryw yn unig.</target>
             </trans-unit>
             <trans-unit id="88">
                 <source>This value should be positive.</source>
-                <target state="needs-translation">This value should be positive.</target>
+                <target state="needs-review-translation">Dylai'r gwerth hwn fod yn gadarnhaol.</target>
             </trans-unit>
             <trans-unit id="89">
                 <source>This value should be either positive or zero.</source>
-                <target state="needs-translation">This value should be either positive or zero.</target>
+                <target state="needs-review-translation">Dylai'r gwerth hwn fod yn gadarnhaol neu sero.</target>
             </trans-unit>
             <trans-unit id="90">
                 <source>This value should be negative.</source>
-                <target state="needs-translation">This value should be negative.</target>
+                <target state="needs-review-translation">Dylai'r gwerth hwn fod yn negyddol.</target>
             </trans-unit>
             <trans-unit id="91">
                 <source>This value should be either negative or zero.</source>
-                <target state="needs-translation">This value should be either negative or zero.</target>
+                <target state="needs-review-translation">Dylai'r gwerth hwn fod yn negyddol neu sero.</target>
             </trans-unit>
             <trans-unit id="92">
                 <source>This value is not a valid timezone.</source>
-                <target state="needs-translation">This value is not a valid timezone.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn gyfnod parth amser dilys.</target>
             </trans-unit>
             <trans-unit id="93">
                 <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-                <target state="needs-translation">This password has been leaked in a data breach, it must not be used. Please use another password.</target>
+                <target state="needs-review-translation">Mae'r cyfrinair hwn wedi'i ddatgelu mewn toriad data, ni ddylid ei ddefnyddio. Defnyddiwch gyfrinair arall.</target>
             </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
-                <target state="needs-translation">This value should be between {{ min }} and {{ max }}.</target>
+                <target state="needs-review-translation">Dylai'r gwerth hwn fod rhwng {{ min }} a {{ max }}.</target>
             </trans-unit>
             <trans-unit id="95">
                 <source>This value is not a valid hostname.</source>
-                <target state="needs-translation">This value is not a valid hostname.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn enw gwesteiwr dilys.</target>
             </trans-unit>
             <trans-unit id="96">
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-                <target state="needs-translation">The number of elements in this collection should be a multiple of {{ compared_value }}.</target>
+                <target state="needs-review-translation">Dylai nifer yr elfennau yn y casgliad hwn fod yn luosrif o {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>
-                <target state="needs-translation">This value should satisfy at least one of the following constraints:</target>
+                <target state="needs-review-translation">Dylai'r gwerth hwn fodloni o leiaf un o'r cyfyngiadau canlynol:</target>
             </trans-unit>
             <trans-unit id="98">
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
-                <target state="needs-translation">Each element of this collection should satisfy its own set of constraints.</target>
+                <target state="needs-review-translation">Dylai pob elfen o'r casgliad hwn fodloni ei gyfres ei hun o gyfyngiadau.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
-                <target state="needs-translation">This value is not a valid International Securities Identification Number (ISIN).</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn Rhif Adnabod Diogelwch Rhyngwladol (ISIN) dilys.</target>
             </trans-unit>
             <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
-                <target state="needs-translation">This value should be a valid expression.</target>
+                <target state="needs-review-translation">Dylai'r gwerth hwn fod yn fynegiant dilys.</target>
             </trans-unit>
             <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
-                <target state="needs-translation">This value is not a valid CSS color.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn lliw CSS dilys.</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>This value is not a valid CIDR notation.</source>
-                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn nodiant CIDR dilys.</target>
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+                <target state="needs-review-translation">Dylai gwerth y mwgwd rhwydwaith fod rhwng {{ min }} a {{ max }}.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">Mae'r enw ffeil yn rhy hir. Dylai fod â {{ filename_max_length }} cymeriad neu lai.|Mae'r enw ffeil yn rhy hir. Dylai fod â {{ filename_max_length }} nodau neu lai.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">Mae cryfder y cyfrinair yn rhy isel. Defnyddiwch gyfrinair cryfach os gwelwch yn dda.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Mae'r gwerth hwn yn cynnwys cymeriadau nad ydynt yn cael eu caniatáu gan y lefel cyfyngu presennol.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Ni chaniateir defnyddio cymeriadau anweledig.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Ni chaniateir cymysgu rhifau o sgriptiau gwahanol.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Ni chaniateir defnyddio cymeriadau goruwchlwytho cudd.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Mae estyniad y ffeil yn annilys ({{ extension }}). Mae'r estyniadau a ganiateir yn {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Mae'r codio cymeriadau a ganfuwyd yn annilys ({{ detected }}). Mae'r codiadau a ganiateir yn {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Nid yw hwn yn gyfeiriad MAC dilys.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">La codificación de caracteres detectada no es válida ({{ detected }}). Las codificaciones permitidas son {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Esta no es una dirección MAC válida.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
@@ -436,7 +436,7 @@
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">See ei ole kehtiv MAC-aadress.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
@@ -428,15 +428,15 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Fitxategiaren luzapena ez da zuzena ({{ extension }}). Baimendutako luzapenak hauek dira: {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Detektatutako karaktere-kodetzea ez da zuzena ({{ detected }}). Baimendutako kodetzeak hauek dira: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Hau ez da MAC helbide balioduna.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
@@ -36,11 +36,11 @@
             </trans-unit>
             <trans-unit id="9">
                 <source>This field was not expected.</source>
-                <target state="needs-translation">This field was not expected.</target>
+                <target state="needs-review-translation">این فیلد انتظار نمی‌رفت.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>This field is missing.</source>
-                <target state="needs-translation">This field is missing.</target>
+                <target state="needs-review-translation">این فیلد گمشده است.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>This value is not a valid date.</source>
@@ -428,15 +428,15 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">پسوند فایل نامعتبر است ({{ extension }}). پسوندهای مجاز {{ extensions }} هستند.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">رمزگذاری کاراکتر تشخیص داده شده نامعتبر است ({{ detected }}). رمزگذاری‌های مجاز {{ encodings }} هستند.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">این یک آدرس MAC معتبر نیست.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
@@ -404,39 +404,39 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">O nome do ficheiro é demasiado longo. Debe ter {{ filename_max_length }} caracteres ou menos.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">A forza do contrasinal é demasiado baixa. Utilice un contrasinal máis forte.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Este valor contén caracteres que non están permitidos polo nivel de restrición actual.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Non se permite usar caracteres invisibles.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Non se permite mesturar números de diferentes scripts.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Non se permite usar caracteres de superposición ocultos.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">A extensión do ficheiro non é válida ({{ extension }}). As extensións permitidas son {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">A codificación de caracteres detectada non é válida ({{ detected }}). As codificacións permitidas son {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Esta non é unha dirección MAC válida.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
@@ -404,39 +404,39 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">שם הקובץ ארוך מדי. עליו להכיל {{ filename_max_length }} תווים או פחות.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">חוזק הסיסמה נמוך מדי. אנא השתמש בסיסמה חזקה יותר.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">הערך כולל תווים שאינם מותרים על פי רמת ההגבלה הנוכחית.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">אסור להשתמש בתווים בלתי נראים.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">אסור לערבב מספרים מתסריטים שונים.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">אסור להשתמש בתווים מוסתרים של חפיפה.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">סיומת הקובץ אינה תקינה ({{ extension }}). הסיומות המותרות הן {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">קידוד התווים שזוהה אינו חוקי ({{ detected }}). הקידודים המותרים הם {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">זהו אינו כתובת MAC חוקית.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -392,51 +392,51 @@
             </trans-unit>
             <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
-                <target state="needs-translation">This value is not a valid CSS color.</target>
+                <target state="needs-review-translation">Այս արժեքը վավեր CSS գույն չէ։</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>This value is not a valid CIDR notation.</source>
-                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+                <target state="needs-review-translation">Այս արժեքը վավեր CIDR նշում չէ։</target>
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+                <target state="needs-review-translation">Ցանցային դիմակի արժեքը պետք է լինի {{ min }}-ի և {{ max }}-ի միջև։</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">Ֆայլի անունը շատ երկար է։ Այն պետք է ունենա {{ filename_max_length }} նիշ կամ պակաս։</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">Գաղտնաբառի անվտանգությունը շատ ցածր է։ Խնդրում ենք գործածել ավելի ամրագույն գաղտնաբառ։</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Այս արժեքը պարունակում է այն նիշերը, որոնք չեն թույլատրվում ըստ ընթացիկ սահմանումների։</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Անտեսանելի նիշերի օգտագործումը չի թույլատրվում։</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Թվերի խառնուրդը տարբեր սցենարներից չի թույլատրվում։</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Թաքնված ծածկանիշերի օգտագործումը չի թույլատրվում։</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Ֆայլի ընդլայնումը անվավեր է ({{ extension }})։ Թույլատրվող ընդլայնումներն են՝ {{ extensions }}։</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Հայտնաբերված նիշագրության կոդը անվավեր է ({{ detected }})։ Թույլատրվող կոդերն են՝ {{ encodings }}։</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Սա վավեր MAC հասցե չէ։</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -436,7 +436,7 @@
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">これは有効なMACアドレスではありません。</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
@@ -428,7 +428,7 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target>D’Extensioun vum Fichier ass net valabel ({{ extension }}). Valabel Extensioune sinn {{ extensions }}.</target>
+                <target>D'Extensioun vum Fichier ass net valabel ({{ extension }}). Valabel Extensioune sinn {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Nustatyta simbolių koduotė yra netinkama ({{ detected }}). Leidžiamos koduotės yra {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Tai nėra galiojantis MAC adresas.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
@@ -388,55 +388,55 @@
             </trans-unit>
             <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
-                <target state="needs-translation">This value should be a valid expression.</target>
+                <target state="needs-review-translation">Энэ утга нь зөв илэрхийлэл байх ёстой.</target>
             </trans-unit>
             <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
-                <target state="needs-translation">This value is not a valid CSS color.</target>
+                <target state="needs-review-translation">Энэ утга нь хүчинтэй CSS өнгө биш байна.</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>This value is not a valid CIDR notation.</source>
-                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+                <target state="needs-review-translation">Энэ утга нь хүчинтэй CIDR тэмдэглэгээ биш байна.</target>
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+                <target state="needs-review-translation">Сүлжээний маскны утга нь {{ min }} ба {{ max }}-ийн хооронд байх ёстой.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">Файлын нэр хэт урт байна. Энэ нь {{ filename_max_length }} тэмдэгт эсвэл түүнээс бага байх ёстой.|Файлын нэр хэт урт байна. Энэ нь {{ filename_max_length }} тэмдэгт эсвэл түүнээс бага байх ёстой.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">Нууц үгийн хүч нь хэт бага байна. Хүчтэй нууц үгийг ашиглана уу.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Энэ утга нь одоогийн хязгаарлалтын түвшинд зөвшөөрөгдөөгүй тэмдэгтүүд агуулж байна.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Харагдахгүй тэмдэгтүүдийг ашиглахыг зөвшөөрөхгүй.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Янз бүрийн скриптүүдээс тоог хольж хэрэглэхийг зөвшөөрөхгүй.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Нууцлагдсан давхаргын тэмдэгтүүдийг ашиглахыг зөвшөөрөхгүй.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Файлын өргөтгөл буруу байна ({{ extension }}). Зөвшөөрөгдсөн өргөтгөлүүд нь {{ extensions }} юм.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Илрүүлсэн тэмдэгтийн кодчилол буруу байна ({{ detected }}). Зөвшөөрөгдсөн кодчилолууд нь {{ encodings }} юм.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Энэ нь хүчинтэй MAC хаяг биш юм.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
@@ -392,51 +392,51 @@
             </trans-unit>
             <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
-                <target state="needs-translation">This value is not a valid CSS color.</target>
+                <target state="needs-review-translation">ဤတန်ဖိုးသည် CSS အရောင်မှန်ကန်မှုမရှိပါ။</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>This value is not a valid CIDR notation.</source>
-                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+                <target state="needs-review-translation">ဤတန်ဖိုးသည် CIDR မှတ်စုံမှန်ကန်မှုမရှိပါ။</target>
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+                <target state="needs-review-translation">ကွန်ယက်မျက်နှာဖုံး၏ တန်ဖိုးသည် {{ min }} နှင့် {{ max }} ကြားရှိရမည်။</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">ဖိုင်နာမည်သည် အရှည်လွန်းသည်။ သင်္ကေတ {{ filename_max_length }} သို့မဟုတ် နည်းသည့်အရေအတွက်ရှိရမည်။|ဖိုင်နာမည်သည် အရှည်လွန်းသည်။ သင်္ကေတ {{ filename_max_length }} သို့မဟုတ် နည်းသည့်အရေအတွက်ရှိရမည်။</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">စကားဝှက်ခိုင်မာမှုနည်းပါးသည်။ ပိုခိုင်မာသော စကားဝှက်ကို သုံးပါ။</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">ဤတန်ဖိုးတွင် လက်ရှိကန့်သတ်မှုအဆင့်မှ ခွင့်မပြုထားသော ဇာတ်ကောင်များပါဝင်သည်။</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">မမြင်ရသော ဇာတ်ကောင်များကို သုံးခြင်းကို ခွင့်မပြုပါ။</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">မတူညီသော ဇာတ်ကောင်များမှ နံပါတ်များကို ရောနှောစပ်ခြင်းကို ခွင့်မပြုပါ။</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">ပုန်းထားသော အထပ်ကောင်းဇာတ်ကောင်များကို သုံးခြင်းကို ခွင့်မပြုပါ။</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">ဖိုင်တွင်းတိုးခြင်းသည် မမှန်ကန်ပါ ({{ extension }})။ ခွင့်ပြုထားသော တိုးခြင်းများမှာ {{ extensions }} ဖြစ်သည်။</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">တွေ့ရှိထားသော စာလုံးကုဒ်စံနစ်သည် မမှန်ကန်ပါ ({{ detected }})။ ခွင့်ပြုထားသော ကုဒ်စံနစ်များမှာ {{ encodings }} ဖြစ်သည်။</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">ဤသည်မှန်ကန်သော MAC လိပ်စာမဟုတ်ပါ။</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
@@ -404,39 +404,39 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">Filnavnet er for langt. Det bør ha {{ filename_max_length }} tegn eller mindre.|Filnavnet er for langt. Det bør ha {{ filename_max_length }} tegn eller mindre.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">Passordstyrken er for lav. Vennligst bruk et sterkere passord.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Denne verdien inneholder tegn som ikke er tillatt av gjeldende restriksjonsnivå.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Det er ikke tillatt å bruke usynlige tegn.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Det er ikke tillatt å blande tall fra forskjellige skript.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Det er ikke tillatt å bruke skjulte overleggskarakterer.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Filutvidelsen er ugyldig ({{ extension }}). Tillatte utvidelser er {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Den oppdagede tegnkodingen er ugyldig ({{ detected }}). Tillatte kodinger er {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Dette er ikke en gyldig MAC-adresse.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">De gedetecteerde karaktercodering is ongeldig ({{ detected }}). Toegestane coderingen zijn {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Dit is geen geldig MAC-adres.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
@@ -404,39 +404,39 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">Filnamnet er for langt. Det bør ha {{ filename_max_length }} teikn eller færre.|Filnamnet er for langt. Det bør ha {{ filename_max_length }} teikn eller færre.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">Passordstyrken er for låg. Vennligst bruk eit sterkare passord.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Denne verdien inneheld teikn som ikkje er tillatne av det gjeldande restriksjonsnivået.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Det er ikkje tillate å bruke usynlege teikn.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Det er ikkje tillate å blande tal frå forskjellige skript.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Det er ikkje tillate å bruke skjulte overleggsteikn.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Filutvidinga er ugyldig ({{ extension }}). Tillatne utvidingar er {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Den oppdaga teiknkodinga er ugyldig ({{ detected }}). Tillatne kodingar er {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Dette er ikkje ein gyldig MAC-adresse.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
@@ -404,39 +404,39 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">Filnavnet er for langt. Det bør ha {{ filename_max_length }} tegn eller mindre.|Filnavnet er for langt. Det bør ha {{ filename_max_length }} tegn eller mindre.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">Passordstyrken er for lav. Vennligst bruk et sterkere passord.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Denne verdien inneholder tegn som ikke er tillatt av gjeldende restriksjonsnivå.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Det er ikke tillatt å bruke usynlige tegn.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Det er ikke tillatt å blande tall fra forskjellige skript.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Det er ikke tillatt å bruke skjulte overleggskarakterer.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Filutvidelsen er ugyldig ({{ extension }}). Tillatte utvidelser er {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Den oppdagede tegnkodingen er ugyldig ({{ detected }}). Tillatte kodinger er {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Dette er ikke en gyldig MAC-adresse.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
@@ -436,7 +436,7 @@
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Este não é um endereço MAC válido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
@@ -428,15 +428,15 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">A extensão do arquivo é inválida ({{ extension }}). As extensões permitidas são {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">A codificação de caracteres detectada é inválida ({{ detected }}). As codificações permitidas são {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Este não é um endereço MAC válido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Codificarea caracterelor detectată este invalidă ({{ detected }}). Codificările permise sunt {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Acesta nu este un adresă MAC validă.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Kodimi i karaktereve të zbuluar është i pavlefshëm ({{ detected }}). Kodimet e lejuara janë {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Ky nuk është një adresë MAC e vlefshme.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -436,7 +436,7 @@
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Detta är inte en giltig MAC-adress.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
@@ -428,15 +428,15 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">นามสกุลไฟล์ไม่ถูกต้อง ({{ extension }}). นามสกุลที่อนุญาตคือ {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">การเข้ารหัสอักขระที่ตรวจพบไม่ถูกต้อง ({{ detected }}). การเข้ารหัสที่อนุญาตคือ {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">นี่ไม่ใช่ที่อยู่ MAC ที่ถูกต้อง</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
@@ -396,47 +396,47 @@
             </trans-unit>
             <trans-unit id="102">
                 <source>This value is not a valid CIDR notation.</source>
-                <target state="needs-translation">This value is not a valid CIDR notation.</target>
+                <target state="needs-review-translation">Ang halagang ito ay hindi wastong notasyong CIDR.</target>
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target state="needs-translation">The value of the netmask should be between {{ min }} and {{ max }}.</target>
+                <target state="needs-review-translation">Ang halaga ng netmask ay dapat nasa pagitan ng {{ min }} at {{ max }}.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">Ang pangalan ng file ay masyadong mahaba. Dapat itong magkaroon ng {{ filename_max_length }} karakter o mas kaunti.|Ang pangalan ng file ay masyadong mahaba. Dapat itong magkaroon ng {{ filename_max_length }} mga karakter o mas kaunti.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">Ang lakas ng password ay masyadong mababa. Mangyaring gumamit ng mas malakas na password.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">Ang halagang ito ay naglalaman ng mga karakter na hindi pinapayagan ng kasalukuyang antas ng paghihigpit.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">Hindi pinapayagan ang paggamit ng mga hindi nakikitang karakter.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">Hindi pinapayagan ang paghahalo ng mga numero mula sa iba't ibang script.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">Hindi pinapayagan ang paggamit ng mga nakatagong overlay na karakter.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">Ang extension ng file ay hindi wasto ({{ extension }}). Ang mga pinapayagang extension ay {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Ang nakitang encoding ng karakter ay hindi wasto ({{ detected }}). Ang mga pinapayagang encoding ay {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Ito ay hindi isang wastong MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
@@ -404,39 +404,39 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-translation">The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</target>
+                <target state="needs-review-translation">فائل کا نام بہت لمبا ہے۔ اس میں {{ filename_max_length }} حرف یا اس سے کم ہونے چاہئیں۔|فائل کا نام بہت لمبا ہے۔ اس میں {{ filename_max_length }} حروف یا اس سے کم ہونے چاہئیں۔</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-translation">The password strength is too low. Please use a stronger password.</target>
+                <target state="needs-review-translation">پاس ورڈ کی طاقت بہت کم ہے۔ براہ کرم مضبوط پاس ورڈ استعمال کریں۔</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-translation">This value contains characters that are not allowed by the current restriction-level.</target>
+                <target state="needs-review-translation">اس قدر میں ایسے حروف موجود ہیں جو موجودہ پابندی کی سطح کی طرف سے اجازت نہیں ہیں۔</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-translation">Using invisible characters is not allowed.</target>
+                <target state="needs-review-translation">نادیدہ حروف استعمال کرنے کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-translation">Mixing numbers from different scripts is not allowed.</target>
+                <target state="needs-review-translation">مختلف اسکرپٹس سے نمبروں کو ملا کر استعمال کرنے کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-translation">Using hidden overlay characters is not allowed.</target>
+                <target state="needs-review-translation">چھپے ہوئے اوورلے کریکٹرز کا استعمال کرنے کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">فائل کی توسیع نامناسب ہے ({{ extension }})۔ اجازت شدہ توسیعات {{ extensions }} ہیں۔</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">پتہ چلنے والی کریکٹر انکوڈنگ نامناسب ہے ({{ detected }})۔ اجازت شدہ انکوڈنگز {{ encodings }} ہیں۔</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">یہ درست MAC پتہ نہیں ہے۔</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Aniqlangan belgi kodlamasi yaroqsiz ({{ detected }}). Ruxsat etilgan kodlamalar {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Bu yaroqli MAC manzili emas.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
@@ -432,11 +432,11 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">Mã hóa ký tự được phát hiện là không hợp lệ ({{ detected }}). Các mã hóa được phép là {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">Đây không phải là địa chỉ MAC hợp lệ.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -428,15 +428,15 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-translation">The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</target>
+                <target state="needs-review-translation">文件的扩展名无效 ({{ extension }})。允许的扩展名为 {{ extensions }}。</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-translation">The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
+                <target state="needs-review-translation">检测到的字符编码无效 ({{ detected }})。允许的编码为 {{ encodings }}。</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This is not a valid MAC address.</source>
-                <target state="needs-translation">This is not a valid MAC address.</target>
+                <target state="needs-review-translation">这不是有效的MAC地址。</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -430,6 +430,14 @@
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
                 <target>無效的副檔名 ({{ extension }}). 允許的副檔名有 {{ extensions }}.</target>
             </trans-unit>
+            <trans-unit id="111">
+                <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
+                <target state="needs-review-translation">偵測到的字元編碼無效 ({{ detected }})。允許的編碼為 {{ encodings }}。</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>This is not a valid MAC address.</source>
+                <target state="needs-review-translation">這不是一個有效的MAC地址。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This is a follow up of #53404

The process around the maintenance of our translation files is too heavy currently. I feel like spending hours on the topic, and I guess it's the same for contributors.

Instead, I propose to account for the GPT tools that are really good at translating our short messages.

In order to still allow and call for human review,  I propose to use the `state="needs-review-translation"` on `<target>` tags as defined by XLIFF.

With some help from carsonbot, we'll be able to call for reviews per language. My proposal would be to make it able to send PRs that remove the `state` attribute but call for reviews by a native speaker before we could merge. We could even make the reviewer the author of the git commit if we want to keep some sort of history on the topic.

~@thunderer I'd prefer being explicit about using GPT. I'm going to replace your PRs by this one sorry.~