### PR TITLE
[FrameworkBundle][Notifier] Fix service registration (MessageBird + TurboSms)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -138,7 +138,7 @@ use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mailjet\MailjetTransportFactory as MailjetNotifierTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mercure\MercureTransportFactory;
-use Symfony\Component\Notifier\Bridge\MessageBird\MessageBirdTransport;
+use Symfony\Component\Notifier\Bridge\MessageBird\MessageBirdTransportFactory;
 use Symfony\Component\Notifier\Bridge\MessageMedia\MessageMediaTransportFactory;
 use Symfony\Component\Notifier\Bridge\MicrosoftTeams\MicrosoftTeamsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
@@ -157,7 +157,7 @@ use Symfony\Component\Notifier\Bridge\Smsc\SmscTransportFactory;
 use Symfony\Component\Notifier\Bridge\SpotHit\SpotHitTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telnyx\TelnyxTransportFactory;
-use Symfony\Component\Notifier\Bridge\TurboSms\TurboSmsTransport;
+use Symfony\Component\Notifier\Bridge\TurboSms\TurboSmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
 use Symfony\Component\Notifier\Bridge\Vonage\VonageTransportFactory;
 use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransportFactory;
@@ -2555,7 +2555,7 @@ class FrameworkExtension extends Extension
             MailjetNotifierTransportFactory::class => 'notifier.transport_factory.mailjet',
             MattermostTransportFactory::class => 'notifier.transport_factory.mattermost',
             MercureTransportFactory::class => 'notifier.transport_factory.mercure',
-            MessageBirdTransport::class => 'notifier.transport_factory.message-bird',
+            MessageBirdTransportFactory::class => 'notifier.transport_factory.message-bird',
             MessageMediaTransportFactory::class => 'notifier.transport_factory.message-media',
             MicrosoftTeamsTransportFactory::class => 'notifier.transport_factory.microsoft-teams',
             MobytTransportFactory::class => 'notifier.transport_factory.mobyt',
@@ -2574,7 +2574,7 @@ class FrameworkExtension extends Extension
             SpotHitTransportFactory::class => 'notifier.transport_factory.spot-hit',
             TelegramTransportFactory::class => 'notifier.transport_factory.telegram',
             TelnyxTransportFactory::class => 'notifier.transport_factory.telnyx',
-            TurboSmsTransport::class => 'notifier.transport_factory.turbo-sms',
+            TurboSmsTransportFactory::class => 'notifier.transport_factory.turbo-sms',
             TwilioTransportFactory::class => 'notifier.transport_factory.twilio',
             VonageTransportFactory::class => 'notifier.transport_factory.vonage',
             YunpianTransportFactory::class => 'notifier.transport_factory.yunpian',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #
| License       | MIT

Inside the [registerNotifierConfiguration](https://github.com/symfony/symfony/blob/9069d14de61d6d54ba62a6b611430dd5f9cadc78/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L2486) method, the [$classToServices](https://github.com/symfony/symfony/blob/9069d14de61d6d54ba62a6b611430dd5f9cadc78/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L2537) map (TransportFactoryClass => serviceId) used the Transport class (instead of the TransportFactory) for MessageBird and TurboSms.

The services are registered in [Ressources/config/notifier_transports.php](https://github.com/symfony/symfony/blob/9069d14de61d6d54ba62a6b611430dd5f9cadc78/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php#L261) (with the correct Factory classes).

This map is then used in this loop:

```php
foreach ($classToServices as $class => $service) {
  $package = substr($service, \strlen('notifier.transport_factory.'));

  if (!ContainerBuilder::willBeAvailable(sprintf('symfony/%s-notifier', $package), $class, $parentPackages, true)) {
      $container->removeDefinition($service);
      $container->removeAlias(str_replace('-', '', $service)); // @deprecated to be removed in 6.0
  }
}
``` 

So i'm not sure it's considered a bug as IRL checking the Factory class or the Transport class did not make any difference as i read it....  but it's worth a fix for the future :) 


So i target 5.4 with no certitude :) 
