### PR TITLE
[Validator] Consistently use "This value is not" instead of "This is not" in error messages

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Hierdie is nie 'n geldige IP-adres nie.</target>
+                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige IP-adres nie.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Hierdie is nie 'n geldige Internationale Bank Rekening Nommer (IBAN) nie.</target>
+                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige Internasionale Bankrekeningnommer (IBAN) nie.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Hierdie is nie 'n geldige Besigheids Identifikasie Kode (BIC) nie.</target>
+                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige Besigheid Identifiseerder Kode (BIC) nie.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Hierdie is nie 'n geldige UUID nie.</target>
+                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige UUID nie.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Die opgespoorde karakterkodering is ongeldig ({{ detected }}). Toegelate koderings is {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Dit is nie 'n geldige MAC-adres nie.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige MAC-adres nie.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>هذه القيمة ليست عنوان رقمى صحيح.</target>
+                <target state="needs-review-translation">هذه القيمة ليست عنوان IP صالحًا.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>الرقم IBAN (رقم الحساب المصرفي الدولي) الذي تم إدخاله غير صالح.</target>
+                <target state="needs-review-translation">هذه القيمة ليست رقم حساب بنكي دولي (IBAN) صالحًا.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>هذه القيمة ليست رمز معرّف نشاط تجاري صالح (BIC).</target>
+                <target state="needs-review-translation">هذه القيمة ليست رمز معرف الأعمال (BIC) صالحًا.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>هذا ليس UUID صالح.</target>
+                <target state="needs-review-translation">هذه القيمة ليست UUID صالحًا.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">تم اكتشاف ترميز الأحرف غير صالح ({{ detected }}). الترميزات المسموح بها هي {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">هذا ليس عنوان MAC صالحًا.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">هذه القيمة ليست عنوان MAC صالحًا.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Bu düzgün bir IP adresi deyil.</target>
+                <target state="needs-review-translation">Bu dəyər etibarlı bir IP ünvanı deyil.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Bu dəyər doğru bir Beynəlxalq Bank Hesap Nömrəsi (IBAN) deyil.</target>
+                <target state="needs-review-translation">Bu dəyər etibarlı bir Beynəlxalq Bank Hesab Nömrəsi (IBAN) deyil.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Bu dəyər doğru bir Biznes Təyinedici Kodu (BIC) deyil.</target>
+                <target state="needs-review-translation">Bu dəyər etibarlı bir Biznes Təyinat Kodu (BIC) deyil.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Bu dəyər doğru bir UUID deyil.</target>
+                <target state="needs-review-translation">Bu dəyər etibarlı bir UUID deyil.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Təsbit edilən simvol şifrləməsi yanlışdır. ({{ detected }}). İcazə verilən şifrləmələr bunlardır: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Bu MAC ünvanı yanlışdır.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Bu dəyər etibarlı bir MAC ünvanı deyil.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Значэнне не з'яўляецца сапраўдным IP-адрасам.</target>
+                <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным IP-адрасам.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Несапраўдны міжнародны нумар банкаўскага рахунку (IBAN).</target>
+                <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным міжнародным нумарам банкаўскага рахунку (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Несапраўдны банкаўскі ідэнтыфікацыйны код (BIC).</target>
+                <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным кодам ідэнтыфікацыі бізнесу (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Гэта несапраўдны UUID.</target>
+                <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Выяўленая кадыроўка знакаў няслушная ({{ detected }}). Дазволеныя кадыроўкі: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Гэта не сапраўдны MAC-адрас.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным MAC-адрасам.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Това не е валиден IP адрес.</target>
+                <target state="needs-review-translation">Тази стойност не е валиден IP адрес.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Това не е валиден Международен номер на банкова сметка (IBAN).</target>
+                <target state="needs-review-translation">Тази стойност не е валиден международен банков сметка номер (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Това не е валиден Бизнес идентификационен код (BIC).</target>
+                <target state="needs-review-translation">Тази стойност не е валиден код за идентификация на бизнеса (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Това не е валиден UUID.</target>
+                <target state="needs-review-translation">Тази стойност не е валиден UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Откритото кодиране на знаците е невалидно ({{ detected }}). Разрешените кодирания са {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Невалиден MAC адрес.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Тази стойност не е валиден MAC адрес.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ovo nije ispravna IP adresa.</target>
+                <target state="needs-review-translation">Ova vrijednost nije valjana IP adresa.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Ova vrijednost nije ispravan međunarodni broj bankovnog računa (IBAN).</target>
+                <target state="needs-review-translation">Ova vrijednost nije valjan Međunarodni broj bankovnog računa (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ovo nije validan poslovni identifikacioni kod (BIC).</target>
+                <target state="needs-review-translation">Ova vrijednost nije valjan Poslovni identifikacijski kod (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ovo nije validan UUID.</target>
+                <target state="needs-review-translation">Ova vrijednost nije valjan UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Otkriveno kodiranje karaktera je nevažeće ({{ detected }}). Dozvoljena kodiranja su {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Ovo nije važeća MAC adresa.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Ova vrijednost nije valjana MAC adresa.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Això no és una adreça IP vàlida.</target>
+                <target state="needs-review-translation">Aquest valor no és una adreça IP vàlida.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Això no és un nombre de compte bancari internacional (IBAN) vàlid.</target>
+                <target state="needs-review-translation">Aquest valor no és un Número de Compte Bancari Internacional (IBAN) vàlid.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Aquest no és un codi d'identificació bancari (BIC) vàlid.</target>
+                <target state="needs-review-translation">Aquest valor no és un Codi d'Identificador de Negocis (BIC) vàlid.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Aquest valor no és un UUID vàlid.</target>
+                <target state="needs-review-translation">Aquest valor no és un UUID vàlid.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">S'ha detectat que la codificació de caràcters no és vàlida ({{ detected }}). Les codificacions permeses són {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Això no és una adreça MAC vàlida.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Aquest valor no és una adreça MAC vàlida.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Toto není platná IP adresa.</target>
+                <target state="needs-review-translation">Tato hodnota není platnou IP adresou.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Toto je neplatný IBAN.</target>
+                <target state="needs-review-translation">Tato hodnota není platným Mezinárodním bankovním číslem účtu (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Tato hodnota není platný identifikační kód podniku (BIC).</target>
+                <target state="needs-review-translation">Tato hodnota není platným Kódem obchodního identifikátoru (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Tato hodnota není platné UUID.</target>
+                <target state="needs-review-translation">Tato hodnota není platným UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Zjištěné kódování znaků je neplatné ({{ detected }}). Povolená kódování jsou {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Tohle není platná MAC adresa.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Tato hodnota není platnou MAC adresou.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Nid yw hwn yn gyfeiriad IP dilys.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn gyfeiriad IP dilys.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Nid yw hwn yn Rhif Cyfrif Banc Rhyngwladol (IBAN) dilys.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn Rhif Cyfrif Banc Rhyngwladol (IBAN) dilys.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Nid yw hwn yn God Adnabod Busnes (BIC) dilys.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn God Adnabod Busnes (BIC) dilys.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Nid yw hyn yn UUID dilys.</target>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn UUID dilys.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Mae'r codio cymeriadau a ganfuwyd yn annilys ({{ detected }}). Mae'r codiadau a ganiateir yn {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Nid yw hwn yn gyfeiriad MAC dilys.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn gyfeiriad MAC dilys.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Dette er ikke en gyldig IP-adresse.</target>
+                <target state="needs-review-translation">Denne værdi er ikke en gyldig IP-adresse.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Det er ikke et gyldigt International Bank Account Number (IBAN).</target>
+                <target state="needs-review-translation">Denne værdi er ikke et gyldigt internationalt bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Dette er ikke en gyldig Business Identifier Code (BIC).a</target>
+                <target state="needs-review-translation">Denne værdi er ikke en gyldig forretningsidentifikationskode (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Dette er ikke en gyldig UUID.</target>
+                <target state="needs-review-translation">Denne værdi er ikke en gyldig UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Det registrerede tegnsæt er ugyldigt ({{ detected }}). De tilladte tegnsæt er {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Dette er ikke en gyldig MAC-adresse.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Denne værdi er ikke en gyldig MAC-adresse.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Dies ist keine gültige IP-Adresse.</target>
+                <target>Dieser Wert ist keine gültige IP-Adresse.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Dieser Wert ist keine gültige internationale Bankkontonummer (IBAN).</target>
+                <target>Dieser Wert ist keine gültige Internationale Bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Dies ist keine gültige UUID.</target>
+                <target>Dieser Wert ist keine gültige UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Der erkannte Zeichensatz ist nicht gültig ({{ detected }}). Gültige Zeichensätze sind {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Dies ist keine gültige MAC-Adresse.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Dieser Wert ist keine gültige MAC-Adresse.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Αυτό δεν είναι μια έγκυρη διεύθυνση IP.</target>
+                <target state="needs-review-translation">Αυτή η τιμή δεν είναι έγκυρη διεύθυνση IP.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Αυτό δεν αντιστοιχεί σε έγκυρο διεθνή αριθμό τραπεζικού λογαριασμού (IBAN).</target>
+                <target state="needs-review-translation">Αυτή η τιμή δεν είναι έγκυρος Διεθνής Αριθμός Τραπεζικού Λογαριασμού (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Αυτός δεν είναι ένας έγκυρος κωδικός BIC.</target>
+                <target state="needs-review-translation">Αυτή η τιμή δεν είναι έγκυρος Κωδικός Ταυτοποίησης Επιχείρησης (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Αυτό δεν είναι ένα έγκυρο UUID.</target>
+                <target state="needs-review-translation">Αυτή η τιμή δεν είναι έγκυρη UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Η κωδικοποίηση χαρακτήρων που ανιχνεύτηκε δεν είναι έγκυρη ({{ detected }}). Οι επιτρεπόμενες κωδικοποιήσεις είναι {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Αυτή δεν είναι έγκυρη διεύθυνση MAC.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Αυτή η τιμή δεν είναι έγκυρη διεύθυνση MAC.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>This is not a valid IP address.</target>
+                <target>This value is not a valid IP address.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>This is not a valid International Bank Account Number (IBAN).</target>
+                <target>This value is not a valid International Bank Account Number (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>This is not a valid Business Identifier Code (BIC).</target>
+                <target>This value is not a valid Business Identifier Code (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>This is not a valid UUID.</target>
+                <target>This value is not a valid UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>This is not a valid MAC address.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>This value is not a valid MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Esto no es una dirección IP válida.</target>
+                <target state="needs-review-translation">Este valor no es una dirección IP válida.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Esto no es un International Bank Account Number (IBAN) válido.</target>
+                <target state="needs-review-translation">Este valor no es un Número de Cuenta Bancaria Internacional (IBAN) válido.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>No es un Código de Identificación Bancaria (BIC) válido.</target>
+                <target state="needs-review-translation">Este valor no es un Código de Identificación de Negocios (BIC) válido.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Este valor no es un UUID válido.</target>
+                <target state="needs-review-translation">Este valor no es un UUID válido.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>La codificación de los caracteres detectada es inválida ({{ detected }}). Las codificaciones permitidas son {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Esta no es una dirección MAC válida.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Este valor no es una dirección MAC válida.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>IP aadress pole korrektne.</target>
+                <target state="needs-review-translation">See väärtus ei ole kehtiv IP-aadress.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Väärtus pole korrektne IBAN-number.</target>
+                <target state="needs-review-translation">See väärtus ei ole kehtiv Rahvusvaheline Pangakonto Number (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>See ei ole kehtiv ettevõtte identifitseerimiskood (BIC).</target>
+                <target state="needs-review-translation">See väärtus ei ole kehtiv Äriühingu Tuvastuskood (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>See pole kehtiv UUID.</target>
+                <target state="needs-review-translation">See väärtus ei ole kehtiv UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Tuvastatud teksti kodeering on vigane ({{ detected }}). Lubatud kodeeringud on {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>See ei ole kehtiv MAC-aadress.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>See väärtus ei ole kehtiv MAC-aadress.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Honako hau ez da IP helbide egoki bat.</target>
+                <target state="needs-review-translation">Balio hau ez da IP helbide baliozko bat.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Hau ez da baliozko banku internazionaleko kontu zenbaki (IBAN) bat.</target>
+                <target state="needs-review-translation">Balio hau ez da Nazioarteko Banku Kontu Zenbaki (IBAN) baliozko bat.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ez da balizko Banku Identifikazioko Kodea (BIC).</target>
+                <target state="needs-review-translation">Balio hau ez da Negozioaren Identifikazio Kode (BIC) baliozko bat.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Balio hau ez da onartutako UUID bat.</target>
+                <target state="needs-review-translation">Balio hau ez da UUID baliozko bat.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Detektatutako karaktere-kodetzea ez da zuzena ({{ detected }}). Baimendutako kodetzeak hauek dira: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Hau ez da MAC helbide balioduna.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Balio hau ez da MAC helbide baliozko bat.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>این آدرس IP معتبر نیست.</target>
+                <target state="needs-review-translation">این مقدار آدرس IP معتبری نیست.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>این یک شماره حساب بانک بین المللی معتبر نمی‌باشد(IBAN).</target>
+                <target state="needs-review-translation">این مقدار یک شماره حساب بانکی بین‌المللی (IBAN) معتبر نیست.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>این مقدار یک کد شناسایی کسب‌و‌کار معتبر (BIC) نیست.</target>
+                <target state="needs-review-translation">این مقدار یک کد شناسه کسب‌وکار (BIC) معتبر نیست.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>این مقدار یک UUID معتبر نمی‌باشد.</target>
+                <target state="needs-review-translation">این مقدار یک UUID معتبر نیست.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">رمزگذاری کاراکتر تشخیص داده شده نامعتبر است ({{ detected }}). رمزگذاری‌های مجاز {{ encodings }} هستند.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">این یک آدرس MAC معتبر نیست.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">این مقدار یک آدرس MAC معتبر نیست.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Tämä ei ole kelvollinen IP-osoite.</target>
+                <target state="needs-review-translation">Tämä arvo ei ole kelvollinen IP-osoite.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Arvo ei ole kelvollinen kansainvälinen pankkitilinumero (IBAN).</target>
+                <target state="needs-review-translation">Tämä arvo ei ole kelvollinen kansainvälinen pankkitilinumero (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Arvo ei ole kelvollinen yritystunnus (BIC).</target>
+                <target state="needs-review-translation">Tämä arvo ei ole kelvollinen liiketoiminnan tunnistekoodi (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Arvo ei ole kelvollinen UUID.</target>
+                <target state="needs-review-translation">Tämä arvo ei ole kelvollinen UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Havaittu merkistö on virheellinen ({{ detected }}). Sallitut merkistöt ovat {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Tämä ei ole kelvollinen MAC-osoite.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Tämä arvo ei ole kelvollinen MAC-osoite.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Cette adresse IP n'est pas valide.</target>
+                <target>Cette valeur n'est pas une adresse IP valide.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Le numéro IBAN (International Bank Account Number) saisi n'est pas valide.</target>
+                <target>Cette valeur n'est pas un Numéro de Compte Bancaire International (IBAN) valide.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ce n'est pas un code universel d'identification des banques (BIC) valide.</target>
+                <target>Cette valeur n'est pas un Code Identifiant de Business (BIC) valide.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ceci n'est pas un UUID valide.</target>
+                <target>Cette valeur n'est pas un UUID valide.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,7 +435,7 @@
                 <target>L'encodage de caractères détecté est invalide ({{ detected }}). Les encodages autorisés sont {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
+                <source>This value is not a valid MAC address.</source>
                 <target>Cette valeur n'est pas une adresse MAC valide.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Isto non é unha dirección IP válida.</target>
+                <target state="needs-review-translation">Este valor non é un enderezo IP válido.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Este valor non é un International Bank Account Number (IBAN) válido.</target>
+                <target state="needs-review-translation">Este valor non é un Número de Conta Bancaria Internacional (IBAN) válido.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Non é un Código de Identificación Bancaria (BIC) válido.</target>
+                <target state="needs-review-translation">Este valor non é un Código de Identificación de Negocios (BIC) válido.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Isto non é un UUID válido.</target>
+                <target state="needs-review-translation">Este valor non é un UUID válido.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">A codificación de caracteres detectada non é válida ({{ detected }}). As codificacións permitidas son {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Esta non é unha dirección MAC válida.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Este valor non é un enderezo MAC válido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>זו אינה כתובת IP חוקית.</target>
+                <target state="needs-review-translation">ערך זה אינו כתובת IP תקפה.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>מספר חשבון בנק בינלאומי אינו חוקי (IBAN).</target>
+                <target state="needs-review-translation">ערך זה אינו מספר חשבון בנק בינלאומי (IBAN) תקף.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>קוד זיהוי עסקי אינו חוקי (BIC).</target>
+                <target state="needs-review-translation">ערך זה אינו קוד מזהה עסקי (BIC) תקף.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>הערך אינו ערך UUID חוקי.</target>
+                <target state="needs-review-translation">ערך זה אינו UUID תקף.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">קידוד התווים שזוהה אינו חוקי ({{ detected }}). הקידודים המותרים הם {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">זהו אינו כתובת MAC חוקית.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">ערך זה אינו כתובת MAC תקפה.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ovo nije ispravna IP adresa.</target>
+                <target>Ova vrijednost nije valjana IP adresa.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Ova vrijednost nije ispravan međunarodni broj bankovnog računa (IBAN).</target>
+                <target>Ova vrijednost nije valjani međunarodni bankovni broj računa (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ovo nije validan poslovni identifikacijski broj (BIC).</target>
+                <target>Ova vrijednost nije valjani poslovni identifikacijski kod (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ovo nije validan UUID.</target>
+                <target>Ova vrijednost nije valjani UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Otkriveno kodiranje znakova je nevažeće ({{ detected }}). Dopuštena kodiranja su {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Ovo nije valjana MAC adresa.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Ova vrijednost nije valjana MAC adresa.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ez az érték nem egy érvényes IP cím.</target>
+                <target state="needs-review-translation">Ez az érték nem érvényes IP-cím.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Érvénytelen nemzetközi bankszámlaszám (IBAN).</target>
+                <target state="needs-review-translation">Ez az érték nem érvényes Nemzetközi Bankszámlaszám (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Érvénytelen nemzetközi bankazonosító kód (BIC/SWIFT).</target>
+                <target state="needs-review-translation">Ez az érték nem érvényes Üzleti Azonosító Kód (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Érvénytelen egyedi azonosító (UUID).</target>
+                <target state="needs-review-translation">Ez az érték nem érvényes UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Az érzékelt karakterkódolás érvénytelen ({{ detected }}). Engedélyezett karakterkódolások: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Ez egy érvénytelen MAC cím.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Ez az érték nem érvényes MAC-cím.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Արժեքը վավեր IP հասցե չէ։</target>
+                <target state="needs-review-translation">Այս արժեքը վավեր IP հասցե չէ։</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Արժեքը վավեր միջազային բանկային հաշվի համար չէ (IBAN)։</target>
+                <target state="needs-review-translation">Այս արժեքը վավեր միջազգային բանկային հաշվի համար (IBAN) չէ։</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Սա վավեր Business Identifier Code (BIC) չէ։</target>
+                <target state="needs-review-translation">Այս արժեքը վավեր բիզնեսի նորմատիվ կոդ (BIC) չէ։</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Սա վավեր UUID չէ։</target>
+                <target state="needs-review-translation">Այս արժեքը վավեր UUID չէ։</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Հայտնաբերված նիշագրության կոդը անվավեր է ({{ detected }})։ Թույլատրվող կոդերն են՝ {{ encodings }}։</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Սա վավեր MAC հասցե չէ։</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Այս արժեքը վավեր MAC հասցե չէ։</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ini bukan alamat IP yang sah.</target>
+                <target>Nilai ini bukan alamat IP yang valid.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Ini bukan Nomor Rekening Bank Internasional (IBAN) yang sah.</target>
+                <target>Nilai ini bukan Nomor Rekening Bank Internasional (IBAN) yang valid.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ini bukan Business Identifier Code (BIC) yang sah.</target>
+                <target>Nilai ini bukan Kode Identifikasi Bisnis (BIC) yang valid.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ini bukan UUID yang sah.</target>
+                <target>Nilai ini bukan UUID yang valid.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Pengkodean karakter yang terdeteksi tidak valid ({{ detected }}). Pengkodean yang diperbolehkan adalah {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Ini bukan alamat MAC yang valid.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Nilai ini bukan alamat MAC yang valid.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Questo valore non è un indirizzo IP valido.</target>
+                <target state="needs-review-translation">Questo valore non è un indirizzo IP valido.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Questo valore non è un IBAN (International Bank Account Number) valido.</target>
+                <target state="needs-review-translation">Questo valore non è un Numero di Conto Bancario Internazionale (IBAN) valido.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Questo valore non è un codice BIC valido.</target>
+                <target state="needs-review-translation">Questo valore non è un Codice Identificativo di Business (BIC) valido.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Questo non è un UUID valido.</target>
+                <target state="needs-review-translation">Questo valore non è un UUID valido.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>La codifica dei caratteri rilevata non è valida ({{ detected }}). Le codifiche ammesse sono {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Questo non è un indirizzo MAC valido.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Questo valore non è un indirizzo MAC valido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>有効なIPアドレスではありません。</target>
+                <target state="needs-review-translation">この値は有効なIPアドレスではありません。</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>有効なIBANコードではありません。</target>
+                <target state="needs-review-translation">この値は有効な国際銀行口座番号（IBAN）ではありません。</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>有効なSWIFTコードではありません。</target>
+                <target state="needs-review-translation">この値は有効なビジネス識別コード（BIC）ではありません。</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>有効なUUIDではありません。</target>
+                <target state="needs-review-translation">この値は有効なUUIDではありません。</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>検出された文字コードは無効です({{ detected }})。有効な文字コードは{{ encodings }}です。</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">これは有効なMACアドレスではありません。</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">この値は有効なMACアドレスではありません。</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Dëst ass keng gëlteg IP-Adress.</target>
+                <target state="needs-review-translation">Dëse Wäert ass keng gülteg IP-Adress.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Dëst ass keng gëlteg IBAN-Kontonummer.</target>
+                <target state="needs-review-translation">Dëse Wäert ass keng gülteg International Bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Dëst ass kee gëltege "Business Identifier Code" (BIC).</target>
+                <target state="needs-review-translation">Dëse Wäert ass kee gültege Business Identifier Code (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Dëst ass keng gëlteg UUID.</target>
+                <target state="needs-review-translation">Dëse Wäert ass keng gülteg UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Den Encodage vun de Schrëftzeechen ass net valabel ({{ detected }}). Valabel Encodage sinn {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Dat ass keng valabel MAC-Adress.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Dëse Wäert ass keng gülteg MAC-Adress.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ši reikšmė nėra tinkamas IP adresas.</target>
+                <target state="needs-review-translation">Ši vertė nėra galiojantis IP adresas.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Ši reišmė neatitinka tarptautinio banko sąskaitos numerio formato (IBAN).</target>
+                <target state="needs-review-translation">Ši vertė nėra galiojantis Tarptautinis Banko Sąskaitos Numeris (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Bendrovės Identifikavimo Kodas (BIC) nėra tinkamas.</target>
+                <target state="needs-review-translation">Ši vertė nėra galiojantis Verslo Identifikavimo Kodas (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ši reikšmė nėra tinkamas UUID.</target>
+                <target state="needs-review-translation">Ši vertė nėra galiojantis UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Nustatyta simbolių koduotė yra netinkama ({{ detected }}). Leidžiamos koduotės yra {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Tai nėra galiojantis MAC adresas.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Ši vertė nėra galiojantis MAC adresas.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Šī nav derīga IP adrese.</target>
+                <target state="needs-review-translation">Šī vērtība nav derīga IP adrese.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Šis nav derīgs starptautisks banku konta numurs (IBAN).</target>
+                <target state="needs-review-translation">Šī vērtība nav derīgs Starptautiskais Bankas Konta Numurs (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Šī vērtība nav derīgs Biznesa Identifikācijas Kods (BIC).</target>
+                <target state="needs-review-translation">Šī vērtība nav derīgs Uzņēmuma Identifikācijas Kods (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Šis nav derīgs UUID.</target>
+                <target state="needs-review-translation">Šī vērtība nav derīgs UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Noteiktais rakstzīmju kodējums nav derīgs ({{ detected }}). Atļautie kodējumi ir {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Šī nav derīga MAC adrese.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Šī vērtība nav derīga MAC adrese.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ова не е валидна IP адреса.</target>
+                <target state="needs-review-translation">Оваа вредност не е валидна IP адреса.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Ова не е валиден број на меѓународна банкарска сметка (IBAN).</target>
+                <target state="needs-review-translation">Оваа вредност не е валиден Меѓународен Банкарски Сметка Број (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ова не е валиден бизнис идентификациски код (BIC).</target>
+                <target state="needs-review-translation">Оваа вредност не е валиден Бизнис Идентификациски Код (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ова не е валиден универзален уникатен идентификатор (UUID).</target>
+                <target state="needs-review-translation">Оваа вредност не е валиден UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Откриеното кодирање на знаци е неважечко ({{ detected }}). Дозволените шифрирања се {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Ова не е важечка MAC-адреса.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Оваа вредност не е валидна MAC адреса.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>IP хаяг зөв биш байна.</target>
+                <target state="needs-review-translation">Энэ утга хүчинтэй IP хаяг биш юм.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Энэ утга үнэн зөв Олон Улсын Банкны Дансны Дугаар (IBAN) биш байна.</target>
+                <target state="needs-review-translation">Энэ утга хүчинтэй Олон улсын Банкны Дансны Дугаар (IBAN) биш юм.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Энэ утга үнэн зөв Business Identifier Code (BIC) биш байна.</target>
+                <target state="needs-review-translation">Энэ утга хүчинтэй Бизнес Таних Код (BIC) биш юм.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Энэ утга үнэн зөв UUID биш байна.</target>
+                <target state="needs-review-translation">Энэ утга хүчинтэй UUID биш юм.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Илрүүлсэн тэмдэгтийн кодчилол буруу байна ({{ detected }}). Зөвшөөрөгдсөн кодчилолууд нь {{ encodings }} юм.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Энэ нь хүчинтэй MAC хаяг биш юм.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Энэ утга хүчинтэй MAC хаяг биш юм.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>၎င်းသည်တရားဝင် IP လိပ်စာမဟုတ်ပါ။</target>
+                <target state="needs-review-translation">ဤတန်ဖိုးသည် မှန်ကန်သော IP လိပ်စာ မဟုတ်ပါ။</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>ဤတန်ဖိုးသည် တရား၀င်နိုင်ငံတကာဘဏ်အကောင့်နံပါတ် (International Bank Account Number, IBAN) မဟုတ်ပါ။</target>
+                <target state="needs-review-translation">ဤတန်ဖိုးသည် မှန်ကန်သော နိုင်ငံတကာ ဘဏ်စာရင်းနံပါတ် (IBAN) မဟုတ်ပါ။</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>၎င်းသည်မှန်ကန်သော Business Identifier Code (BIC) မဟုတ်ပါ။</target>
+                <target state="needs-review-translation">ဤတန်ဖိုးသည် မှန်ကန်သော စီးပွားရေး မှတ်ပုံတင်ကုဒ် (BIC) မဟုတ်ပါ။</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>ဤတန်ဖိုးသည် သင့်လျှော်သော် UUID မဟုတ်ပါ။</target>
+                <target state="needs-review-translation">ဤတန်ဖိုးသည် မှန်ကန်သော UUID မဟုတ်ပါ။</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">တွေ့ရှိထားသော စာလုံးကုဒ်စံနစ်သည် မမှန်ကန်ပါ ({{ detected }})။ ခွင့်ပြုထားသော ကုဒ်စံနစ်များမှာ {{ encodings }} ဖြစ်သည်။</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">ဤသည်မှန်ကန်သော MAC လိပ်စာမဟုတ်ပါ။</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">ဤတန်ဖိုးသည် မှန်ကန်သော MAC လိပ်စာ မဟုတ်ပါ။</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Dette er ikke en gyldig IP adresse.</target>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig IP-adresse.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Dette er ikke et gyldig IBAN-nummer.</target>
+                <target state="needs-review-translation">Denne verdien er ikke et gyldig internasjonalt bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Dette er ikke en gyldig BIC.</target>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig forretningsidentifikasjonskode (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Dette er ikke en gyldig UUID.</target>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Den oppdagede tegnkodingen er ugyldig ({{ detected }}). Tillatte kodinger er {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Dette er ikke en gyldig MAC-adresse.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig MAC-adresse.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Dit is geen geldig IP-adres.</target>
+                <target>Deze waarde is geen geldig IP-adres.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Dit is geen geldig internationaal bankrekeningnummer (IBAN).</target>
+                <target>Deze waarde is geen geldig internationaal bankrekeningnummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Dit is geen geldige bedrijfsidentificatiecode (BIC/SWIFT).</target>
+                <target>Deze waarde is geen geldige zakelijke identificatiecode (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Dit is geen geldige UUID.</target>
+                <target>Deze waarde is geen geldige UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">De gedetecteerde karaktercodering is ongeldig ({{ detected }}). Toegestane coderingen zijn {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Dit is geen geldig MAC-adres.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Deze waarde is geen geldig MAC-adres.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Dette er ikkje ei gyldig IP-adresse.</target>
+                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig IP-adresse.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Dette er ikkje eit gyldig internasjonalt bankkontonummer (IBAN).</target>
+                <target state="needs-review-translation">Denne verdien er ikkje eit gyldig internasjonalt bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Dette er ikkje ein gyldig Business Identifier Code (BIC).</target>
+                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig forretningsidentifikasjonskode (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Dette er ikkje ein gyldig UUID.</target>
+                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Den oppdaga teiknkodinga er ugyldig ({{ detected }}). Tillatne kodingar er {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Dette er ikkje ein gyldig MAC-adresse.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig MAC-adresse.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Dette er ikke en gyldig IP adresse.</target>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig IP-adresse.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Dette er ikke et gyldig IBAN-nummer.</target>
+                <target state="needs-review-translation">Denne verdien er ikke et gyldig internasjonalt bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Dette er ikke en gyldig BIC.</target>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig forretningsidentifikasjonskode (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Dette er ikke en gyldig UUID.</target>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Den oppdagede tegnkodingen er ugyldig ({{ detected }}). Tillatte kodinger er {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Dette er ikke en gyldig MAC-adresse.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig MAC-adresse.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>To nie jest prawidłowy adres IP.</target>
+                <target>Ta wartość nie jest prawidłowym adresem IP.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Nieprawidłowy międzynarodowy numer rachunku bankowego (IBAN).</target>
+                <target>Ta wartość nie jest prawidłowym Międzynarodowym Numerem Rachunku Bankowego (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ta wartość nie jest poprawnym kodem BIC (Business Identifier Code).</target>
+                <target>Ta wartość nie jest prawidłowym Kodem Identyfikującym Bank (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>To nie jest poprawne UUID.</target>
+                <target>Ta wartość nie jest prawidłowym UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Wykryte kodowanie znaków ({{ detected }}) jest nieprawidłowe. Dozwolone kodowania to {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Podana wartość nie jest poprawnym adresem MAC.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Ta wartość nie jest prawidłowym adresem MAC.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Este endereço de IP não é válido.</target>
+                <target state="needs-review-translation">Este valor não é um endereço IP válido.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Este não é um Número Internacional de Conta Bancária (IBAN) válido.</target>
+                <target state="needs-review-translation">Este valor não é um Número de Conta Bancária Internacional (IBAN) válido.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>O Código de Identificação de Empresa (BIC) não é válido.</target>
+                <target state="needs-review-translation">Este valor não é um Código de Identificação de Negócio (BIC) válido.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Este valor não é um UUID válido.</target>
+                <target state="needs-review-translation">Este valor não é um UUID válido.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>A codificação de carateres detetada é inválida ({{ detected }}). As codificações permitidas são {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Este não é um endereço MAC válido.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Este valor não é um endereço MAC válido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Este não é um endereço de IP válido.</target>
+                <target state="needs-review-translation">Este valor não é um endereço IP válido.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Este não é um Número Internacional de Conta Bancária (IBAN) válido.</target>
+                <target state="needs-review-translation">Este valor não é um Número de Conta Bancária Internacional (IBAN) válido.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Este não é um Código Identificador Bancário (BIC) válido.</target>
+                <target state="needs-review-translation">Este valor não é um Código de Identificação de Negócios (BIC) válido.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Este não é um UUID válido.</target>
+                <target state="needs-review-translation">Este valor não é um UUID válido.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">A codificação de caracteres detectada é inválida ({{ detected }}). As codificações permitidas são {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Este não é um endereço MAC válido.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Este valor não é um endereço MAC válido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Această valoare nu este o adresă IP validă.</target>
+                <target state="needs-review-translation">Această valoare nu este o adresă IP validă.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Acesta nu este un cod IBAN (International Bank Account Number) valid.</target>
+                <target state="needs-review-translation">Această valoare nu este un Număr de Cont Bancar Internațional (IBAN) valid.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Codul BIC (Business Identifier Code) nu este valid.</target>
+                <target state="needs-review-translation">Această valoare nu este un Cod de Identificare a Afacerilor (BIC) valid.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Identificatorul universal unic (UUID) nu este valid.</target>
+                <target state="needs-review-translation">Această valoare nu este un UUID valid.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Codificarea caracterelor detectate nu este valabilă ({{ detected }}). Codificările permise sunt {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Aceasta nu este o adresă MAC validă.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Această valoare nu este o adresă MAC validă.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Значение не является допустимым IP адресом.</target>
+                <target state="needs-review-translation">Это значение не является действительным IP-адресом.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Значение не является допустимым международным номером банковского счета (IBAN).</target>
+                <target state="needs-review-translation">Это значение не является действительным Международным банковским счетом (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Значение не соответствует формату BIC.</target>
+                <target state="needs-review-translation">Это значение не является действительным Бизнес-идентификатором (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Значение не соответствует формату UUID.</target>
+                <target state="needs-review-translation">Это значение не является действительным UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Обнаруженная кодировка символов недопустима ({{ detected }}). Разрешенные кодировки: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Этот MAC-адрес недействительный.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Это значение не является действительным MAC-адресом.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Toto nie je platná IP adresa.</target>
+                <target state="needs-review-translation">Táto hodnota nie je platná IP adresa.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Toto je neplatný IBAN.</target>
+                <target state="needs-review-translation">Táto hodnota nie je platným Medzinárodným bankovým číslom účtu (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Táto hodnota nie je platný identifikačný kód podniku (BIC).</target>
+                <target state="needs-review-translation">Táto hodnota nie je platným Obchodným identifikačným kódom (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Táto hodnota nie je platný UUID.</target>
+                <target state="needs-review-translation">Táto hodnota nie je platným UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Zistené kódovanie znakov je neplatné ({{ detected }}). Povolené kódovania sú {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Toto nie je platná MAC adresa.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Táto hodnota nie je platnou MAC adresou.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>To ni veljaven IP naslov.</target>
+                <target state="needs-review-translation">Ta vrednost ni veljaven IP naslov.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>To ni veljavna mednarodna številka bančnega računa (IBAN).</target>
+                <target state="needs-review-translation">Ta vrednost ni veljavna Mednarodna številka bančnega računa (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>To ni veljavna identifikacijska koda podjetja (BIC).</target>
+                <target state="needs-review-translation">Ta vrednost ni veljavna Poslovna identifikacijska koda (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>To ni veljaven UUID.</target>
+                <target state="needs-review-translation">Ta vrednost ni veljaven UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Zaznano kodiranje znakov ni veljavno ({{ detected }}). Dovoljene so naslednje vrste kodiranja {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>To ni veljaven naslov MAC.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Ta vrednost ni veljaven MAC naslov.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Kjo adresë IP nuk është e vlefshme.</target>
+                <target state="needs-review-translation">Kjo vlerë nuk është një adresë IP e vlefshme.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Ky nuk është një numër i vlefshëm ndërkombëtar i llogarisë bankare (IBAN).</target>
+                <target state="needs-review-translation">Kjo vlerë nuk është një Numër i Llogarisë Bankare Ndërkombëtare (IBAN) i vlefshëm.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ky nuk është një Kod Identifikues i Biznesit (BIC) i vleflshem.</target>
+                <target state="needs-review-translation">Kjo vlerë nuk është një Kod Identifikues i Biznesit (BIC) i vlefshëm.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ky nuk është një UUID i vlefshëm.</target>
+                <target state="needs-review-translation">Kjo vlerë nuk është një UUID i vlefshëm.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Kodimi i karaktereve të zbuluar është i pavlefshëm ({{ detected }}). Kodimet e lejuara janë {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Ky nuk është një adresë MAC e vlefshme.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Kjo vlerë nuk është një adresë MAC e vlefshme.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ово није валидна ИП адреса.</target>
+                <target state="needs-review-translation">Ова вредност није валидна IP адреса.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Ово није валидан међународни број банковног рачуна (IBAN).</target>
+                <target state="needs-review-translation">Ова вредност није валидан Међународни број банкарског рачуна (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ово није валидан међународни идентификацијски код банке (BIC).</target>
+                <target state="needs-review-translation">Ова вредност није валидан Код за идентификацију бизниса (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ово није валидан универзални уникатни идентификатор (UUID).</target>
+                <target state="needs-review-translation">Ова вредност није валидан UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Откривено кодирање знакова је неважеће ({{ detected }}). Дозвољена кодирања су {{  encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Ово није важећа MAC-адреса.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target>Ова вредност није валидна MAC адреса.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ovo nije validna IP adresa.</target>
+                <target state="needs-review-translation">Ova vrednost nije validna IP adresa.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Nevalidan međunarodni broj bankovnog računa (IBAN).</target>
+                <target state="needs-review-translation">Ova vrednost nije validan Međunarodni broj bankovnog računa (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ovo nije validan BIC.</target>
+                <target state="needs-review-translation">Ova vrednost nije validan Kod za identifikaciju biznisa (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ovo nije validan univerzalni unikatni identifikator (UUID).</target>
+                <target state="needs-review-translation">Ova vrednost nije validan UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Detektovani enkoding karaktera nije validan ({{ detected }}). Dozvoljne vrednosti za enkoding su: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Ovo nije važeća MAC-adresa.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Ova vrednost nije validna MAC adresa.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Det här är inte en giltig IP-adress.</target>
+                <target state="needs-review-translation">Detta värde är inte en giltig IP-adress.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Det här är inte en giltig International Bank Account Number (IBANK).</target>
+                <target state="needs-review-translation">Detta värde är inte ett giltigt Internationellt Bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Detta är inte en giltig BIC-kod.</target>
+                <target state="needs-review-translation">Detta värde är inte en giltig Företagsidentifieringskod (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Detta är inte ett giltigt UUID.</target>
+                <target state="needs-review-translation">Detta värde är inte en giltig UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Den upptäckta teckenkodningen är ogiltig ({{ detected }}). Tillåtna kodningar är {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Detta är inte en giltig MAC-adress.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Detta värde är inte en giltig MAC-adress.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>ค่าของ IP ไม่ถูกต้อง</target>
+                <target state="needs-review-translation">ค่านี้ไม่ใช่ที่อยู่ IP ที่ถูกต้อง</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>ค่านี้ไม่ใช่ International Bank Account Number (IBAN) ที่ถูกต้อง</target>
+                <target state="needs-review-translation">ค่านี้ไม่ใช่หมายเลขบัญชีธนาคารระหว่างประเทศ (IBAN) ที่ถูกต้อง</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>นี่ไม่ถูกต้องตามรหัสสำหรับระบุธุรกิจนี้ (BIC)</target>
+                <target state="needs-review-translation">ค่านี้ไม่ใช่รหัสประจำตัวธุรกิจ (BIC) ที่ถูกต้อง</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>นี่ไม่ใช่ UUID ที่ถูกต้อง</target>
+                <target state="needs-review-translation">ค่านี้ไม่ใช่ UUID ที่ถูกต้อง</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">การเข้ารหัสอักขระที่ตรวจพบไม่ถูกต้อง ({{ detected }}). การเข้ารหัสที่อนุญาตคือ {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">นี่ไม่ใช่ที่อยู่ MAC ที่ถูกต้อง</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">ค่านี้ไม่ใช่ที่อยู่ MAC ที่ถูกต้อง</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ito ay hindi wastong IP address.</target>
+                <target state="needs-review-translation">Ang halagang ito ay hindi isang wastong IP address.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Ito ay hindi isang balidong International Bank Account Number (IBAN).</target>
+                <target state="needs-review-translation">Ang halagang ito ay hindi isang wastong International Bank Account Number (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Ito ay hindi isang balidong Business Identifier Code (BIC).</target>
+                <target state="needs-review-translation">Ang halagang ito ay hindi isang wastong Business Identifier Code (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Ito ay hindi wastong UUID.</target>
+                <target state="needs-review-translation">Ang halagang ito ay hindi isang wastong UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Ang nakitang encoding ng karakter ay hindi wasto ({{ detected }}). Ang mga pinapayagang encoding ay {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Ito ay hindi isang wastong MAC address.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Ang halagang ito ay hindi isang wastong MAC address.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Bu geçerli bir IP adresi değildir.</target>
+                <target state="needs-review-translation">Bu değer geçerli bir IP adresi değil.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Bu geçerli bir Uluslararası Banka Hesap Numarası (IBAN) değildir.</target>
+                <target state="needs-review-translation">Bu değer geçerli bir Uluslararası Banka Hesap Numarası (IBAN) değil.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Bu geçerli bir İşletme Tanımlayıcı Kodu (BIC) değildir.</target>
+                <target state="needs-review-translation">Bu değer geçerli bir İşletme Tanımlama Kodu (BIC) değil.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Bu geçerli bir UUID değildir.</target>
+                <target state="needs-review-translation">Bu değer geçerli bir UUID değil.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Tespit edilen karakter kodlaması geçersiz ({{ detected }}). İzin verilen kodlamalar: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Bu geçerli bir MAC adresi değil.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Bu değer geçerli bir MAC adresi değil.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Це некоректна IP адреса.</target>
+                <target state="needs-review-translation">Це значення не є дійсною IP-адресою.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Це не дійсний міжнародний номер банківського рахунку (IBAN).</target>
+                <target state="needs-review-translation">Це значення не є дійсним Міжнародним банківським рахунком (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Це не дійсний банківський код (BIC).</target>
+                <target state="needs-review-translation">Це значення не є дійсним Кодом ідентифікації бізнесу (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Це не валідне значення UUID.</target>
+                <target state="needs-review-translation">Це значення не є дійсним UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target>Недопустиме кодування символів ({{ detected }}). Допустимі кодування: {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target>Некоректна MAC-адреса.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Це значення не є дійсною MAC-адресою.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>ایڈریس نہیں ہے IP یہ ایک درست</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست IP پتہ نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>(IBAN)یہ ایک درست بین الاقوامی بینک اکاؤنٹ نمبر نہیں ہے</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست بین الاقوامی بینک اکاؤنٹ نمبر (IBAN) نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>(BIC)یہ ایک درست کاروباری شناخت کنندہ کوڈ نہیں ہے</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست بزنس شناختی کوڈ (BIC) نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>نہیں ہے UUID یہ درست</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست UUID نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">پتہ چلنے والی کریکٹر انکوڈنگ نامناسب ہے ({{ detected }})۔ اجازت شدہ انکوڈنگز {{ encodings }} ہیں۔</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">یہ درست MAC پتہ نہیں ہے۔</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">یہ قیمت کوئی درست MAC پتہ نہیں ہے۔</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Ip manzil noto'g'ri.</target>
+                <target state="needs-review-translation">Bu qiymat haqiqiy IP manzil emas.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Qiymat haqiqiy xalqaro hisob raqamining raqami (IBAN) emas.</target>
+                <target state="needs-review-translation">Bu qiymat haqiqiy Xalqaro Bank Hisob Raqami (IBAN) emas.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Qiymat BIC formatida emas.</target>
+                <target state="needs-review-translation">Bu qiymat haqiqiy Biznes Identifikatsiya Kodi (BIC) emas.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Qiymat UUID formatida emas.</target>
+                <target state="needs-review-translation">Bu qiymat haqiqiy UUID emas.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Aniqlangan belgi kodlamasi yaroqsiz ({{ detected }}). Ruxsat etilgan kodlamalar {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Bu yaroqli MAC manzili emas.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Bu qiymat haqiqiy MAC manzil emas.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>Địa chỉ IP không hợp lệ.</target>
+                <target state="needs-review-translation">Giá trị này không phải là địa chỉ IP hợp lệ.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Giá trị không phải là International Bank Account Number (IBAN) hợp lệ.</target>
+                <target state="needs-review-translation">Giá trị này không phải là Số Tài Khoản Ngân Hàng Quốc Tế (IBAN) hợp lệ.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>Giá trị này không đúng định dạng mã định danh doanh nghiệp (BIC).</target>
+                <target state="needs-review-translation">Giá trị này không phải là Mã Định Danh Doanh Nghiệp (BIC) hợp lệ.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Giá trị này không đúng định dạng UUID.</target>
+                <target state="needs-review-translation">Giá trị này không phải là UUID hợp lệ.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">Mã hóa ký tự được phát hiện là không hợp lệ ({{ detected }}). Các mã hóa được phép là {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">Đây không phải là địa chỉ MAC hợp lệ.</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">Giá trị này không phải là địa chỉ MAC hợp lệ.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>该值不是有效的IP地址。</target>
+                <target state="needs-review-translation">该值不是有效的IP地址。</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>该值不是有效的国际银行帐号（IBAN）。</target>
+                <target state="needs-review-translation">该值不是有效的国际银行账号（IBAN）。</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>这不是有效的业务标识符代码（BIC)。</target>
+                <target state="needs-review-translation">该值不是有效的业务标识符代码（BIC）。</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>这不是有效的UUID。</target>
+                <target state="needs-review-translation">该值不是有效的UUID。</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,8 +435,8 @@
                 <target state="needs-review-translation">检测到的字符编码无效 ({{ detected }})。允许的编码为 {{ encodings }}。</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
-                <target state="needs-review-translation">这不是有效的MAC地址。</target>
+                <source>This value is not a valid MAC address.</source>
+                <target state="needs-review-translation">该值不是有效的MAC地址。</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
-                <target>該值不是有效的IP地址。</target>
+                <target state="needs-review-translation">此值不是有效的IP地址。</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>該值不是有效的國際銀行帳號（IBAN）。</target>
+                <target state="needs-review-translation">此值不是有效的國際銀行帳戶號碼（IBAN）。</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81">
                 <source>This is not a valid Business Identifier Code (BIC).</source>
-                <target>無效企業識別碼 (BIC)。</target>
+                <target state="needs-review-translation">此值不是有效的業務識別碼（BIC）。</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>無效的通用唯壹標識符 (UUID)。</target>
+                <target state="needs-review-translation">此值不是有效的UUID。</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -435,7 +435,7 @@
                 <target state="needs-review-translation">偵測到的字元編碼無效 ({{ detected }})。允許的編碼為 {{ encodings }}。</target>
             </trans-unit>
             <trans-unit id="112">
-                <source>This is not a valid MAC address.</source>
+                <source>This value is not a valid MAC address.</source>
                 <target state="needs-review-translation">這不是一個有效的MAC地址。</target>
             </trans-unit>
         </body>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

That's longer but more understandable. That's also how most messages are constructed already.

Related to #53417