### PR TITLE
[Form][Security][Validator] prevent incompatible Translator implementations to be used

### DIFF
--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -39,7 +39,7 @@
         "symfony/http-kernel": "^4.4|^5.0|^6.0",
         "symfony/intl": "^4.4|^5.0|^6.0",
         "symfony/security-csrf": "^4.4|^5.0|^6.0",
-        "symfony/translation": "^4.4|^5.0|^6.0",
+        "symfony/translation": "^5.4.35|~6.3.12|^6.4.3",
         "symfony/var-dumper": "^4.4|^5.0|^6.0",
         "symfony/uid": "^5.1|^6.0"
     },
@@ -50,7 +50,7 @@
         "symfony/error-handler": "<4.4.5",
         "symfony/framework-bundle": "<4.4",
         "symfony/http-kernel": "<4.4",
-        "symfony/translation": "<4.4",
+        "symfony/translation": "<5.4.35|>=6.0,<6.3.12|>=6.4,<6.4.3",
         "symfony/translation-contracts": "<1.1.7",
         "symfony/twig-bridge": "<5.4.21|>=6,<6.2.7"
     },

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -31,7 +31,7 @@
         "symfony/expression-language": "^4.4|^5.0|^6.0",
         "symfony/http-foundation": "^5.3|^6.0",
         "symfony/ldap": "^4.4|^5.0|^6.0",
-        "symfony/translation": "^4.4|^5.0|^6.0",
+        "symfony/translation": "^5.4.35|~6.3.12|^6.4.3",
         "symfony/validator": "^5.2|^6.0",
         "psr/log": "^1|^2|^3"
     },
@@ -40,6 +40,7 @@
         "symfony/http-foundation": "<5.3",
         "symfony/security-guard": "<4.4",
         "symfony/ldap": "<4.4",
+        "symfony/translation": "<5.4.35|>=6.0,<6.3.12|>=6.4,<6.4.3",
         "symfony/validator": "<5.2"
     },
     "suggest": {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -40,7 +40,7 @@
         "symfony/mime": "^4.4|^5.0|^6.0",
         "symfony/property-access": "^4.4|^5.0|^6.0",
         "symfony/property-info": "^5.3|^6.0",
-        "symfony/translation": "^4.4|^5.0|^6.0",
+        "symfony/translation": "^5.4.35|~6.3.12|^6.4.3",
         "doctrine/annotations": "^1.13|^2",
         "doctrine/cache": "^1.11|^2.0",
         "egulias/email-validator": "^2.1.10|^3|^4"
@@ -54,7 +54,7 @@
         "symfony/http-kernel": "<4.4",
         "symfony/intl": "<4.4",
         "symfony/property-info": "<5.3",
-        "symfony/translation": "<4.4",
+        "symfony/translation": "<5.4.35|>=6.0,<6.3.12|>=6.4,<6.4.3",
         "symfony/yaml": "<4.4"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/53404#issuecomment-1876954850
| License       | MIT