### PR TITLE
[Validator] deal with fields for which no constraints have been configured

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -42,7 +42,7 @@ class Collection extends Composite
      */
     public function __construct($fields = null, array $groups = null, $payload = null, bool $allowExtraFields = null, bool $allowMissingFields = null, string $extraFieldsMessage = null, string $missingFieldsMessage = null)
     {
-        if (\is_array($fields) && ([] === $fields || ($firstField = reset($fields)) instanceof Constraint || ($firstField[0] ?? null) instanceof Constraint)) {
+        if (self::isFieldsOption($fields)) {
             $fields = ['fields' => $fields];
         }
 
@@ -86,5 +86,32 @@ class Collection extends Composite
     protected function getCompositeOption()
     {
         return 'fields';
+    }
+
+    private static function isFieldsOption($options): bool
+    {
+        if (!\is_array($options)) {
+            return false;
+        }
+
+        if ([] === $options) {
+            return true;
+        }
+
+        foreach ($options as $optionOrField) {
+            if ($optionOrField instanceof Constraint) {
+                return true;
+            }
+
+            if (!\is_array($optionOrField)) {
+                return false;
+            }
+
+            if ([] !== $optionOrField && !($optionOrField[0] ?? null) instanceof Constraint) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
@@ -170,6 +170,41 @@ class CollectionTest extends TestCase
             'extraFieldsMessage' => 'foo bar baz',
         ]);
 
+        $this->assertSame([], $constraint->fields);
+        $this->assertTrue($constraint->allowExtraFields);
+        $this->assertSame('foo bar baz', $constraint->extraFieldsMessage);
+    }
+
+    public function testEmptyConstraintListFor()
+    {
+        $constraint = new Collection([
+                'foo' => [],
+            ],
+            null,
+            null,
+            true,
+            null,
+            'foo bar baz'
+        );
+
+        $this->assertArrayHasKey('foo', $constraint->fields);
+        $this->assertInstanceOf(Required::class, $constraint->fields['foo']);
+        $this->assertTrue($constraint->allowExtraFields);
+        $this->assertSame('foo bar baz', $constraint->extraFieldsMessage);
+    }
+
+    public function testEmptyConstraintListForFieldInOptions()
+    {
+        $constraint = new Collection([
+            'fields' => [
+                'foo' => [],
+            ],
+            'allowExtraFields' => true,
+            'extraFieldsMessage' => 'foo bar baz',
+        ]);
+
+        $this->assertArrayHasKey('foo', $constraint->fields);
+        $this->assertInstanceOf(Required::class, $constraint->fields['foo']);
         $this->assertTrue($constraint->allowExtraFields);
         $this->assertSame('foo bar baz', $constraint->extraFieldsMessage);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/53133#issuecomment-1878479736, Fix #53455
| License       | MIT