### PR TITLE
[DoctrineBridge] Add `EntityValidationListener` to allow auto validation on flush

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Attribute/DisableAutoValidation.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/DisableAutoValidation.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class DisableAutoValidation
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Attribute/EnableAutoValidation.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/EnableAutoValidation.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class EnableAutoValidation
+{
+}

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `EntityValidationListener` to allow auto validation of entities on flush
+
 7.0
 ---
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Listener/EntityValidationListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Listener/EntityValidationListenerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Validator\Listener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Attribute\DisableAutoValidation;
+use Symfony\Bridge\Doctrine\Attribute\EnableAutoValidation;
+use Symfony\Bridge\Doctrine\Validator\Listener\EntityValidationListener;
+use Symfony\Bridge\Doctrine\Validator\Listener\Exception\EntityValidationFailedException;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class EntityValidationListenerTest extends TestCase
+{
+    private ValidatorInterface&MockObject $validator;
+    private UnitOfWork&MockObject $uow;
+    private ObjectManager&MockObject $manager;
+
+    protected function setUp(): void
+    {
+        $this->validator = self::createMock(ValidatorInterface::class);
+        $this->uow = self::createMock(UnitOfWork::class);
+        $this->manager = self::createMock(EntityManagerInterface::class);
+        $this->manager->expects(self::once())->method('getUnitOfWork')->willReturn($this->uow);
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->validator,
+            $this->uow,
+            $this->manager,
+        );
+    }
+
+    /**
+     * @testWith [true, 2]
+     *           [false, 0]
+     */
+    public function testEntityWithoutAttribute(bool $autoValidate, int $expectedCalls)
+    {
+        $this->uow->expects(self::once())->method('getScheduledEntityInsertions')->willReturn([
+            new TestEntityWithoutAttribute('some-name', 'some@email.com'),
+        ]);
+        $this->uow->expects(self::once())->method('getScheduledEntityUpdates')->willReturn([
+            new TestEntityWithoutAttribute('some-name', 'some@email.com'),
+        ]);
+
+        $this->validator->expects(self::exactly($expectedCalls))->method('validate')->willReturn(new ConstraintViolationList());
+
+        $listener = new EntityValidationListener($this->validator, $autoValidate);
+        $listener->onFlush(new OnFlushEventArgs($this->manager));
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testEntityWithAttributeEnabled(bool $autoValidate)
+    {
+        $this->uow->expects(self::once())->method('getScheduledEntityInsertions')->willReturn([
+            new TestEntityWithEnableAttribute('some-name', 'some@email.com'),
+        ]);
+        $this->uow->expects(self::once())->method('getScheduledEntityUpdates')->willReturn([
+            new TestEntityWithEnableAttribute('some-name', 'some@email.com'),
+        ]);
+
+        $this->validator->expects(self::exactly(2))->method('validate')->willReturn(new ConstraintViolationList());
+
+        $listener = new EntityValidationListener($this->validator, $autoValidate);
+        $listener->onFlush(new OnFlushEventArgs($this->manager));
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testEntityWithAttributeDisabled(bool $autoValidate)
+    {
+        $this->uow->expects(self::once())->method('getScheduledEntityInsertions')->willReturn([
+            new TestEntityWithDisableAttribute('some-name', 'some@email.com'),
+        ]);
+        $this->uow->expects(self::once())->method('getScheduledEntityUpdates')->willReturn([
+            new TestEntityWithDisableAttribute('some-name', 'some@email.com'),
+        ]);
+
+        $this->validator->expects(self::never())->method('validate');
+
+        $listener = new EntityValidationListener($this->validator, $autoValidate);
+        $listener->onFlush(new OnFlushEventArgs($this->manager));
+    }
+
+    public function testExceptionIsThrownWhenValidationFails()
+    {
+        $this->uow->expects(self::once())->method('getScheduledEntityInsertions')->willReturn([
+            $object1 = new TestEntityWithEnableAttribute('', 'not-email'),
+            $object2 = new TestEntityWithEnableAttribute('some-name', ''),
+        ]);
+        $this->uow->expects(self::once())->method('getScheduledEntityUpdates')->willReturn([
+            $object3 = new TestEntityWithEnableAttribute('foo', 'some@email.com'),
+        ]);
+
+        $validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator()
+        ;
+
+        $listener = new EntityValidationListener($validator);
+
+        try {
+            $listener->onFlush(new OnFlushEventArgs($this->manager));
+            self::fail(sprintf('Failed asserting that exception of type "%s" is thrown.', EntityValidationFailedException::class));
+        } catch (EntityValidationFailedException $e) {
+            $errors = $e->getErrors();
+
+            self::assertCount(3, $errors);
+
+            self::assertInstanceOf(ValidationFailedException::class, $errors[0]);
+            self::assertSame($object1, $errors[0]->getValue());
+            self::assertCount(3, $violations = $errors[0]->getViolations());
+            self::assertInstanceOf(Assert\NotBlank::class, $violations->get(0)->getConstraint());
+            self::assertInstanceOf(Assert\Length::class, $violations->get(1)->getConstraint());
+
+            self::assertInstanceOf(ValidationFailedException::class, $errors[1]);
+            self::assertSame($object2, $errors[1]->getValue());
+            self::assertCount(1, $violations = $errors[1]->getViolations());
+            self::assertInstanceOf(Assert\NotBlank::class, $violations->get(0)->getConstraint());
+
+            self::assertInstanceOf(ValidationFailedException::class, $errors[2]);
+            self::assertSame($object3, $errors[2]->getValue());
+            self::assertCount(1, $violations = $errors[2]->getViolations());
+            self::assertInstanceOf(Assert\Length::class, $violations->get(0)->getConstraint());
+        }
+    }
+}
+
+class TestEntityWithoutAttribute
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Length(min: 5, max: 50)]
+        public string $name,
+        #[Assert\NotBlank]
+        #[Assert\Email]
+        public string $email,
+    ) {
+    }
+}
+
+#[EnableAutoValidation]
+class TestEntityWithEnableAttribute
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Length(min: 5, max: 50)]
+        public string $name,
+        #[Assert\NotBlank]
+        #[Assert\Email]
+        public string $email,
+    ) {
+    }
+}
+
+#[DisableAutoValidation]
+class TestEntityWithDisableAttribute
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Length(min: 5, max: 50)]
+        public string $name,
+        #[Assert\NotBlank]
+        #[Assert\Email]
+        public string $email,
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Validator/Listener/EntityValidationListener.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Listener/EntityValidationListener.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Validator\Listener;
+
+use Doctrine\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Bridge\Doctrine\Attribute\DisableAutoValidation;
+use Symfony\Bridge\Doctrine\Attribute\EnableAutoValidation;
+use Symfony\Bridge\Doctrine\Validator\Listener\Exception\EntityValidationFailedException;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class EntityValidationListener
+{
+    /**
+     * @var array<class-string, EnableAutoValidation|DisableAutoValidation|false>
+     */
+    private array $attributesCache = [];
+
+    public function __construct(
+        private readonly ValidatorInterface $validator,
+        private readonly bool $autoValidate = false,
+    ) {
+    }
+
+    public function onFlush(ManagerEventArgs $event): void
+    {
+        $manager = $event->getObjectManager();
+
+        $errors = [];
+        foreach ($this->getObjectsToValidate($manager) as $object) {
+            if ($this->shouldValidate($object) && $error = $this->validate($object)) {
+                $errors[] = $error;
+            }
+        }
+
+        if ($errors) {
+            throw new EntityValidationFailedException($errors);
+        }
+    }
+
+    protected function getObjectsToValidate(ObjectManager $manager): iterable
+    {
+        $uow = $manager->getUnitOfWork();
+
+        yield from $uow->getScheduledEntityInsertions();
+        yield from $uow->getScheduledEntityUpdates();
+    }
+
+    private function shouldValidate(object $object): bool
+    {
+        if (!isset($this->attributesCache[$class = $object::class])) {
+            $refClass = new \ReflectionClass($class);
+            $refAttribute = $refClass->getAttributes(EnableAutoValidation::class) ?: $refClass->getAttributes(DisableAutoValidation::class);
+            $this->attributesCache[$class] = ($refAttribute[0] ?? null)?->newInstance() ?? false;
+        }
+
+        return $this->attributesCache[$class] ? $this->attributesCache[$class] instanceof EnableAutoValidation : $this->autoValidate;
+    }
+
+    private function validate(object $object): ?ValidationFailedException
+    {
+        $violations = $this->validator->validate($object);
+
+        return \count($violations) ? new ValidationFailedException($object, $violations) : null;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Validator/Listener/Exception/EntityValidationFailedException.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Listener/Exception/EntityValidationFailedException.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Validator\Listener\Exception;
+
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+
+class EntityValidationFailedException extends \RuntimeException
+{
+    /**
+     * @param ValidationFailedException[] $errors
+     */
+    public function __construct(private readonly array $errors)
+    {
+        parent::__construct('Validation failed for one or more entities.');
+    }
+
+    /**
+     * @return ValidationFailedException[]
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The idea is to have entities get validated automatically through a listener, eg:

```php
#[EnableAutoValidation]
class SomeEntity
{}

$this->entityManager->persist($someEntity);
try {
    $this->entityManager->flush();
} catch (EntityValidationFailedException $e) {
    dump($e);
}
```

I think this could be useful sometimes, so I'd like to hear other people's thoughts.