### PR TITLE
[Cache] Add support for using DSN with `PDOAdapter`

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -124,8 +124,11 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
 
             return CouchbaseCollectionAdapter::createConnection($dsn, $options);
         }
+        if (preg_match('/^(mysql|oci|pgsql|sqlsrv|sqlite):/', $dsn)) {
+            return PdoAdapter::createConnection($dsn, $options);
+        }
 
-        throw new InvalidArgumentException('Unsupported DSN: it does not start with "redis[s]:", "memcached:" nor "couchbase:".');
+        throw new InvalidArgumentException('Unsupported DSN: it does not start with "redis[s]:", "memcached:", "couchbase:", "mysql:", "oci:", "pgsql:", "sqlsrv:" nor "sqlite:".');
     }
 
     public function commit(): bool

--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -89,6 +89,18 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
         parent::__construct($namespace, $defaultLifetime);
     }
 
+    public static function createConnection(#[\SensitiveParameter] string $dsn, array $options = []): \PDO|string
+    {
+        if ($options['lazy'] ?? true) {
+            return $dsn;
+        }
+
+        $pdo = new \PDO($dsn);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        return $pdo;
+    }
+
     /**
      * Creates the table to store cache items which can be called once for setup.
      *

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add option `sentinel_master` as an alias for `redis_sentinel`
  * Deprecate `CouchbaseBucketAdapter`, use `CouchbaseCollectionAdapter`
  * Add support for URL encoded characters in Couchbase DSN
+ * Add support for using DSN with PDOAdapter
 
 7.0
 ---

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 
 /**
@@ -39,6 +40,16 @@ class PdoAdapterTest extends AdapterTestCase
     public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new PdoAdapter('sqlite:'.self::$dbFile, 'ns', $defaultLifetime);
+    }
+
+    public function testCreateConnectionReturnsStringWithLazyTrue()
+    {
+        self::assertSame('sqlite:'.self::$dbFile, AbstractAdapter::createConnection('sqlite:'.self::$dbFile));
+    }
+
+    public function testCreateConnectionReturnsPDOWithLazyFalse()
+    {
+        self::assertInstanceOf(\PDO::class, AbstractAdapter::createConnection('sqlite:'.self::$dbFile, ['lazy' => false]));
     }
 
     public function testCleanupExpiredItems()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52460
| License       | MIT

Adds support for using DSN with the `PDOAdapter`:

```yaml
framework:
  cache:
    pools:
      my.cache:
        adapter: cache.adapter.pdo
        provider: "pgsql:host=localhost;port=5432;dbname=postgres;user=postgres;password=pass"
```