### PR TITLE
[FrameworkBundle] deprecate not passing a build dir when warming up the router cache

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -9,6 +9,7 @@ Cache
 FrameworkBundle
 ---------------
 
+ * Deprecate not passing a build dir to `RouterCacheWarmer::warmUp()` and `Router::warmUp()`
  * Mark classes `ConfigBuilderCacheWarmer`, `Router`, `SerializerCacheWarmer`, `TranslationsCacheWarmer`, `Translator` and `ValidatorCacheWarmer` as `final`
 
 Messenger

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.1
 ---
 
+ * Deprecate not passing a build dir to `RouterCacheWarmer::warmUp()` and `Router::warmUp()`
  * Add `private_ranges` as a shortcut for private IP address ranges to the `trusted_proxies` option
  * Mark classes `ConfigBuilderCacheWarmer`, `Router`, `SerializerCacheWarmer`, `TranslationsCacheWarmer`, `Translator` and `ValidatorCacheWarmer` as `final`
  * Move the Router `cache_dir` to `kernel.build_dir`

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
@@ -36,14 +36,15 @@ class RouterCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInterf
 
     public function warmUp(string $cacheDir, string $buildDir = null): array
     {
-        if (!$buildDir) {
-            return [];
+        if (null === $buildDir) {
+            trigger_deprecation('symfony/framework-bundle', '7.1', sprintf('Not passing a build dir as the second argument to "%s()" is deprecated.', __METHOD__));
+            // return [];
         }
 
         $router = $this->container->get('router');
 
         if ($router instanceof WarmableInterface) {
-            return (array) $router->warmUp($cacheDir, $buildDir);
+            return (array) $router->warmUp($cacheDir, $buildDir, false);
         }
 
         throw new \LogicException(sprintf('The router "%s" cannot be warmed up because it does not implement "%s".', get_debug_type($router), WarmableInterface::class));

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -84,14 +84,17 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
 
     public function warmUp(string $cacheDir, string $buildDir = null): array
     {
-        if (!$buildDir) {
-            return [];
+        if (null === $buildDir) {
+            if (\func_num_args() < 3) {
+                trigger_deprecation('symfony/framework-bundle', '7.1', sprintf('Not passing a build dir as the second argument to "%s()" is deprecated.', __METHOD__));
+            }
+            // return [];
         }
 
         $currentDir = $this->getOption('cache_dir');
 
-        // force cache generation in build_dir
-        $this->setOption('cache_dir', $buildDir);
+        // force cache generation (in build_dir if present)
+        $this->setOption('cache_dir', $buildDir ?? $cacheDir);
         $this->getMatcher();
         $this->getGenerator();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | 
| License       | MIT

If I don't miss anything, #52962 went a bit too far introducing a BC break of the current behaviour if no build dir is passed to the `warmUp()` method.