### PR TITLE
[Messenger] Improve Redis integration tests

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -257,7 +257,7 @@ class RedisExtIntegrationTest extends TestCase
             ], $message['data']);
             $connection->reject($message['id']);
         } finally {
-            $redis->del('messenger-lazy');
+            $redis->unlink('messenger-lazy');
         }
     }
 
@@ -295,14 +295,13 @@ class RedisExtIntegrationTest extends TestCase
         } catch (TransportException $e) {
             $this->assertSame('Malformed UTF-8 characters, possibly incorrectly encoded', $e->getMessage());
         } finally {
-            $redis->del('messenger-json-error');
+            $redis->unlink('messenger-json-error');
         }
     }
 
     public function testGetNonBlocking()
     {
         $redis = new \Redis();
-
         $connection = Connection::fromDsn('redis://localhost/messenger-getnonblocking', ['delete_after_ack' => true], $redis);
 
         try {
@@ -311,7 +310,7 @@ class RedisExtIntegrationTest extends TestCase
             $this->assertNotEmpty($message = $connection->get());
             $connection->reject($message['id']);
         } finally {
-            $redis->del('messenger-getnonblocking');
+            $redis->unlink('messenger-getnonblocking');
         }
     }
 
@@ -330,7 +329,7 @@ class RedisExtIntegrationTest extends TestCase
             $connection = Connection::fromDsn('redis://localhost/messenger-rejectthenget', ['delete_after_ack' => true]);
             $this->assertNotNull($connection->get());
         } finally {
-            $redis->del('messenger-rejectthenget');
+            $redis->unlink('messenger-rejectthenget');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This kind of failure can happen when cleaning Redis in the `finally` clause:

![image](https://github.com/symfony/symfony/assets/2144837/92053c64-3a41-4235-9105-7d96378cf925)

Unlinking will trigger the cleaning in another process, thus it won't make the test fail if a problem is triggered. I think this is desired so we don't have false negatives.