### PR TITLE
[HttpClient] Add JSON flags support

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `HttpOptions::setHeader()` to add or replace a single header
  * Allow mocking `start_time` info in `MockResponse`
  * Add `MockResponse::fromFile()` and `JsonMockResponse::fromFile()` methods to help using fixtures files
+ * Add `json_flags` to request options to control encoding json data
 
 7.0
 ---

--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -195,7 +195,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
         $dataArg = [];
 
         if ($json = $trace['options']['json'] ?? null) {
-            $dataArg[] = '--data-raw '.$this->escapePayload(self::jsonEncode($json));
+            $dataArg[] = '--data-raw '.$this->escapePayload(self::jsonEncode($json, $trace['options']['json_flags'] ?? null));
         } elseif ($body = $trace['options']['body'] ?? null) {
             if (\is_string($body)) {
                 $dataArg[] = '--data-raw '.$this->escapePayload($body);

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -85,8 +85,8 @@ trait HttpClientTrait
             if (isset($options['body']) && '' !== $options['body']) {
                 throw new InvalidArgumentException('Define either the "json" or the "body" option, setting both is not supported.');
             }
-            $options['body'] = self::jsonEncode($options['json']);
-            unset($options['json']);
+            $options['body'] = self::jsonEncode($options['json'], $options['json_flags'] ?? null);
+            unset($options['json'], $options['json_flags']);
 
             if (!isset($options['normalized_headers']['content-type'])) {
                 $options['normalized_headers']['content-type'] = ['Content-Type: application/json'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR adds support for passing flags to json_encode function to control encoding json data when sending http requests via http client