### PR TITLE
[Contracts] Allow psr/container 1.1 again

### DIFF
--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "psr/cache": "^3.0",
-        "psr/container": "^2.0",
+        "psr/container": "^1.1|^2.0",
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This a follow up from  #53150 (initially incorrectly submitted against https://github.com/symfony/contracts/pull/6).