### PR TITLE
[Process] Fix executable finder when the command starts with a dash

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -35,7 +35,7 @@ class PhpExecutableFinder
     {
         if ($php = getenv('PHP_BINARY')) {
             if (!is_executable($php)) {
-                $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v';
+                $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v --';
                 if ($php = strtok(exec($command.' '.escapeshellarg($php)), \PHP_EOL)) {
                     if (!is_executable($php)) {
                         return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #53479 
| License       | MIT

