### PR TITLE
[Messenger] Fix `DoctrineOpenTransactionLoggerMiddleware`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -51,8 +51,8 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
     public function testMiddlewareWrapsInTransactionAndFlushes()
     {
         $this->connection->expects($this->exactly(1))
-            ->method('isTransactionActive')
-            ->will($this->onConsecutiveCalls(true, true, false))
+            ->method('getTransactionNestingLevel')
+            ->willReturn(1)
         ;
 
         $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -52,7 +52,7 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
     {
         $this->connection->expects($this->exactly(1))
             ->method('getTransactionNestingLevel')
-            ->will($this->onConsecutiveCalls(1, 1, 0))
+            ->will($this->onConsecutiveCalls(0, 1))
         ;
 
         $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -52,7 +52,7 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
     {
         $this->connection->expects($this->exactly(1))
             ->method('getTransactionNestingLevel')
-            ->willReturn(1)
+            ->will($this->onConsecutiveCalls(1, 1, 0))
         ;
 
         $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
follow up #52075

when we run in a uncontrollable outer transaction the middeleware still falsely produces logs