### PR TITLE
[HttpClient] Add support for `flatten_query_string`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `HttpOptions::setHeader()` to add or replace a single header
  * Allow mocking `start_time` info in `MockResponse`
  * Add `MockResponse::fromFile()` and `JsonMockResponse::fromFile()` methods to help using fixtures files
+ * Add support for `flatten_query_string` in HttpClient options
 
 7.0
 ---

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -175,7 +175,7 @@ trait HttpClientTrait
             }
 
             // Validate and resolve URL
-            $url = self::parseUrl($url, $options['query']);
+            $url = self::parseUrl($url, $options['query'], flattenQueryString: $options['flatten_query_string'] ?? false);
             $url = self::resolveUrl($url, $options['base_uri'], $defaultOptions['query'] ?? []);
         }
 
@@ -618,7 +618,7 @@ trait HttpClientTrait
      *
      * @throws InvalidArgumentException When an invalid URL is passed
      */
-    private static function parseUrl(string $url, array $query = [], array $allowedSchemes = ['http' => 80, 'https' => 443]): array
+    private static function parseUrl(string $url, array $query = [], array $allowedSchemes = ['http' => 80, 'https' => 443], bool $flattenQueryString = false): array
     {
         if (false === $parts = parse_url($url)) {
             throw new InvalidArgumentException(sprintf('Malformed URL "%s".', $url));
@@ -626,6 +626,10 @@ trait HttpClientTrait
 
         if ($query) {
             $parts['query'] = self::mergeQueryString($parts['query'] ?? null, $query, true);
+
+            if ($flattenQueryString) {
+                $parts['query'] = preg_replace('/\[\d++]=/', '=', $parts['query']);
+            }
         }
 
         $port = $parts['port'] ?? 0;

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -257,11 +257,11 @@ class HttpClientTraitTest extends TestCase
     /**
      * @dataProvider provideParseUrl
      */
-    public function testParseUrl(array $expected, string $url, array $query = [])
+    public function testParseUrl(array $expected, string $url, array $query = [], bool $flattenUrl = false)
     {
         $expected = array_combine(['scheme', 'authority', 'path', 'query', 'fragment'], $expected);
 
-        $this->assertSame($expected, self::parseUrl($url, $query));
+        $this->assertSame($expected, self::parseUrl($url, $query, flattenQueryString: $flattenUrl));
     }
 
     public static function provideParseUrl(): iterable
@@ -283,6 +283,10 @@ class HttpClientTraitTest extends TestCase
         yield [[null, null, 'bar', '?a=b&a[b%20c]=d&e%3Df=%E2%9C%93', null], 'bar?a=b', ['a' => ['b c' => 'd'], 'e=f' => '✓']];
         // IDNA 2008 compliance
         yield [['https:', '//xn--fuball-cta.test', null, null, null], 'https://fußball.test'];
+        // Test query string flattening
+        yield [[null, null, 'bar', '?a=b&a=c', null], 'bar', ['a' => ['b', 'c']], true];
+        yield [[null, null, 'bar', '?a=b&a=c&d=e&d=f', null], 'bar', ['a' => ['b', 'c'], 'd' => ['e', 'f']], true];
+        yield [[null, null, 'bar', '?a=b&a[c]=d', null], 'bar', ['a' => ['b', 'c' => 'd']], true];
     }
 
     /**

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -67,6 +67,8 @@ interface HttpClientInterface
         'peer_fingerprint' => null,
         'capture_peer_cert_chain' => false,
         'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT, // STREAM_CRYPTO_METHOD_TLSv*_CLIENT - minimum TLS version
+        'flatten_query_string' => false, // bool - whether the query string parameter keys with an array notation should
+                                         // be flattened (i.e. "foo[0]=bar&foo[1]=baz" becomes "foo=bar&foo=baz")
         'extra' => [],          // array - additional options that can be ignored if unsupported, unlike regular options
     ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/orgs/symfony/projects/1#card-30505735
| License       | MIT

Allows to pass a query string in a standard way, where `foo[0]=bar&foo[1]=baz` becomes `foo=bar&foo=baz`.

If someone is asking, the way the query string is formatted by PHP is not standard. This may lead to confusion and errors for non-PHP target that doesn't understand this syntax.