### PR TITLE
[HttpClient] Properties cannot be `null`

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -46,7 +46,7 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
     private static string $nextId = 'a';
 
     private AmpClientState $multi;
-    private ?array $options;
+    private array $options;
     private \Closure $onProgress;
 
     private static ?string $delay = null;

--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -34,7 +34,7 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
     private const FIRST_CHUNK_YIELDED = 1;
     private const LAST_CHUNK_YIELDED = 2;
 
-    private ?HttpClientInterface $client;
+    private HttpClientInterface $client;
     private ResponseInterface $response;
     private array $info = ['canceled' => false];
     private $passthru;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

From what I found out (check the constructor) it is always an array (`AmpResponse`) or an `HttpClientInterface` (`AsyncResponse`)