### PR TITLE
[DependencyInjection] support lazy evaluated exception messages with Xdebug 3

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
@@ -23,9 +23,7 @@ class AutowiringFailedException extends RuntimeException
     {
         $this->serviceId = $serviceId;
 
-        if ($message instanceof \Closure
-            && (\function_exists('xdebug_is_enabled') ? xdebug_is_enabled() : \function_exists('xdebug_info'))
-        ) {
+        if ($message instanceof \Closure && \function_exists('xdebug_is_enabled') && xdebug_is_enabled()) {
             $message = $message();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The `AutowiringFailedExceptionTest::testLazyness()` passes with Xdebug 3 enabled on my machine. But I would like to get some additional feedback from other Xdebug users. 
