### PR TITLE
[HttpClient] Fix error chunk creation in passthru

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -65,7 +65,7 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
             while (true) {
                 foreach (self::stream([$response], $timeout) as $chunk) {
                     if ($chunk->isTimeout() && $response->passthru) {
-                        foreach (self::passthru($response->client, $response, new ErrorChunk($response->offset, new TransportException($chunk->getError()))) as $chunk) {
+                        foreach (self::passthru($response->client, $response, new ErrorChunk($response->offset, $chunk->getError())) as $chunk) {
                             if ($chunk->isFirst()) {
                                 return false;
                             }
@@ -123,9 +123,6 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
         return $this->info + $this->response->getInfo();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toStream(bool $throw = true)
     {
         if ($throw) {
@@ -146,9 +143,6 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
         return $stream;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function cancel(): void
     {
         if ($this->info['canceled']) {

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\Exception\ServerException;
+use Symfony\Component\HttpClient\Exception\TimeoutException;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\NativeHttpClient;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
 use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 class RetryableHttpClientTest extends TestCase
 {
@@ -243,5 +245,34 @@ class RetryableHttpClientTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('Test out content', $response->getContent());
         self::assertSame('Test out content', $response->getContent(), 'Content should be buffered');
+    }
+
+    /**
+     * @testWith ["GET"]
+     *           ["POST"]
+     *           ["PUT"]
+     *           ["PATCH"]
+     *           ["DELETE"]
+     */
+    public function testRetryOnHeaderTimeout(string $method)
+    {
+        $client = HttpClient::create();
+
+        if ($client instanceof NativeHttpClient) {
+            $this->markTestSkipped('NativeHttpClient cannot timeout before receiving headers');
+        }
+
+        TestHttpServer::start();
+
+        $client = new RetryableHttpClient($client);
+        $response = $client->request($method, 'http://localhost:8057/timeout-header', ['timeout' => 0.1]);
+
+        try {
+            $response->getStatusCode();
+            $this->fail(TimeoutException::class.' expected');
+        } catch (TimeoutException $e) {
+        }
+
+        $this->assertSame('Idle timeout reached for "http://localhost:8057/timeout-header".', $response->getInfo('error'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #52587 
| License       | MIT

Timeout chunk should not be recreated as TransportException, because ErrorChunk losts information that it's timeout when passing thru.
Change solves issue mentioned at #52587 