### PR TITLE
[Security] Fix `AuthenticationUtils::getLastUsername()` returning null

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -59,10 +59,10 @@ class AuthenticationUtils
         $request = $this->getRequest();
 
         if ($request->attributes->has(Security::LAST_USERNAME)) {
-            return $request->attributes->get(Security::LAST_USERNAME, '');
+            return $request->attributes->get(Security::LAST_USERNAME) ?? '';
         }
 
-        return $request->hasSession() ? $request->getSession()->get(Security::LAST_USERNAME, '') : '';
+        return $request->hasSession() ? ($request->getSession()->get(Security::LAST_USERNAME) ?? '') : '';
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticationUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticationUtilsTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authentication;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+
+class AuthenticationUtilsTest extends TestCase
+{
+    public function testLastAuthenticationErrorWhenRequestHasAttribute()
+    {
+        $request = Request::create('/');
+        $request->attributes->set(Security::AUTHENTICATION_ERROR, 'my error');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $utils = new AuthenticationUtils($requestStack);
+        $this->assertSame('my error', $utils->getLastAuthenticationError());
+    }
+
+    public function testLastAuthenticationErrorInSession()
+    {
+        $request = Request::create('/');
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set(Security::AUTHENTICATION_ERROR, 'session error');
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $utils = new AuthenticationUtils($requestStack);
+        $this->assertSame('session error', $utils->getLastAuthenticationError());
+        $this->assertFalse($session->has(Security::AUTHENTICATION_ERROR));
+    }
+
+    public function testLastAuthenticationErrorInSessionWithoutClearing()
+    {
+        $request = Request::create('/');
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set(Security::AUTHENTICATION_ERROR, 'session error');
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $utils = new AuthenticationUtils($requestStack);
+        $this->assertSame('session error', $utils->getLastAuthenticationError(false));
+        $this->assertTrue($session->has(Security::AUTHENTICATION_ERROR));
+    }
+
+    public function testLastUserNameIsDefinedButNull()
+    {
+        $request = Request::create('/');
+        $request->attributes->set(Security::LAST_USERNAME, null);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $utils = new AuthenticationUtils($requestStack);
+        $this->assertSame('', $utils->getLastUsername());
+    }
+
+    public function testLastUserNameIsDefined()
+    {
+        $request = Request::create('/');
+        $request->attributes->set(Security::LAST_USERNAME, 'user');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $utils = new AuthenticationUtils($requestStack);
+        $this->assertSame('user', $utils->getLastUsername());
+    }
+
+    public function testLastUserNameIsDefinedInSessionButNull()
+    {
+        $request = Request::create('/');
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set(Security::LAST_USERNAME, null);
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $utils = new AuthenticationUtils($requestStack);
+        $this->assertSame('', $utils->getLastUsername());
+    }
+
+    public function testLastUserNameIsDefinedInSession()
+    {
+        $request = Request::create('/');
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set(Security::LAST_USERNAME, 'user');
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $utils = new AuthenticationUtils($requestStack);
+        $this->assertSame('user', $utils->getLastUsername());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53503
| License       | MIT

This can happen when the attribute is actually set with `null`.

Covered the class while at it.