### PR TITLE
[Routing] Merge Route conditions.

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -256,7 +256,11 @@ class RouteCollection implements \IteratorAggregate, \Countable
     public function setCondition(?string $condition): void
     {
         foreach ($this->routes as $route) {
-            $route->setCondition($condition);
+            if ('' === $route->getCondition()) {
+                $route->setCondition($condition);
+            } else {
+                $route->setCondition('('.$route->getCondition().') and ('.$condition.')');
+            }
         }
     }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.xml
@@ -14,5 +14,7 @@
         <condition>context.getMethod() == "GET"</condition>
     </route>
 
-    <route id="blog_show_inherited" path="/blog/{slug}" />
+    <route id="blog_show_inherited" path="/blog/{slug}">
+        <condition>context.getMethod() == "GET"</condition>
+    </route>
 </routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.yml
@@ -11,3 +11,4 @@ blog_show:
 
 blog_show_inherited:
     path:      /blog/{slug}
+    condition:    'context.getMethod() == "GET"'

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -87,7 +87,7 @@ class XmlFileLoaderTest extends TestCase
             $this->assertSame('\d+', $route->getRequirement('foo'));
             $this->assertSame('bar', $route->getOption('foo'));
             $this->assertSame('', $route->getHost());
-            $this->assertSame('context.getMethod() == "POST"', $route->getCondition());
+            $this->assertSame('(context.getMethod() == "GET") and (context.getMethod() == "POST")', $route->getCondition());
         }
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -117,7 +117,7 @@ class YamlFileLoaderTest extends TestCase
             $this->assertSame('\d+', $route->getRequirement('foo'));
             $this->assertSame('bar', $route->getOption('foo'));
             $this->assertSame('', $route->getHost());
-            $this->assertSame('context.getMethod() == "POST"', $route->getCondition());
+            $this->assertSame('(context.getMethod() == "GET") and (context.getMethod() == "POST")', $route->getCondition());
         }
     }
 

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -262,7 +262,7 @@ class RouteCollectionTest extends TestCase
         $collection->setCondition('context.getMethod() == "POST"');
 
         $this->assertEquals('context.getMethod() == "POST"', $routea->getCondition());
-        $this->assertEquals('context.getMethod() == "POST"', $routeb->getCondition());
+        $this->assertEquals('(context.getMethod() == "GET") and (context.getMethod() == "POST")', $routeb->getCondition());
     }
 
     public function testClone()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53171
| License       | MIT

When defining condition for a Route and for the RouteCollection it belongs, the two conditions are now merged instead of letting the RouteCollection overrides the Route condition.
