### PR TITLE
[FrameworkBundle] [CacheWarmer]  Run `ConfigBuilderCacheWarmer` during execution of `bin/console cache:warmup`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -45,7 +45,7 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
         $buildDir = 1 < \func_num_args() ? func_get_arg(1) : null;
 
         if (!$buildDir) {
-            return [];
+            $buildDir = $this->kernel->getBuildDir();
         }
 
         $generator = new ConfigBuilderGenerator($buildDir);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
@@ -90,7 +90,7 @@ class ConfigBuilderCacheWarmerTest extends TestCase
         $warmer = new ConfigBuilderCacheWarmer($kernel);
         $warmer->warmUp($kernel->getCacheDir());
 
-        self::assertDirectoryDoesNotExist($kernel->getBuildDir().'/Symfony');
+        self::assertDirectoryExists($kernel->getBuildDir().'/Symfony');
         self::assertDirectoryDoesNotExist($kernel->getCacheDir().'/Symfony');
 
         $warmer->warmUp($kernel->getCacheDir(), $kernel->getBuildDir());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53496 
| License       | MIT

`ConfigBuilderCacheWarmer` is not called when executing `bin/console cache:warmup`
This is an attempt to fix linked issue. 
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
