### PR TITLE
[PhpUnitBridge] Hide deprecations by default when running tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -299,8 +299,7 @@ class DeprecationErrorHandler
         };
 
         $outputIsCli = !$configuration->shouldWriteToLogFile();
-        // TODO: fix this; we need to detect here if the `simple-phpunit` command was run with `-v` option
-        $commandIsVerbose = false;
+        $commandIsVerbose = [] !== array_intersect(['v', 'verbose'], array_keys(getopt('v', ['verbose'])));
         $deprecationsAreHidden = $outputIsCli && !$commandIsVerbose;
         if ($configuration->shouldWriteToLogFile()) {
             if (false === $handle = @fopen($file = $configuration->getLogFile(), 'a')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #45976
| License       | MIT

As explained in #45976, some people don't like that deprecations are always shown when running tests. The list can be very long and it hides the PHPUnit output. So, this PR proposes to hide the deprecations by default but display them if the `simple-phpunit` is run with the `-v` option.

This is an example of how it looks now:

![test-deprecations-before](https://github.com/symfony/symfony/assets/73419/e23ff7af-ffc8-4619-923d-32e15d99fe27)

And this is how it'd look after this PR:

![test-deprecations-after](https://github.com/symfony/symfony/assets/73419/5629805e-3602-4809-9783-3f885cc3cb42)

~As mentioned in the code, there's a missing piece. I don't know how to detect if the command was run with the `-v` option. I need your help. Thanks.~ This if fixed now.

