### PR TITLE
[Console] Allow '0' as a $shortcut in InputOption.php

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -69,7 +69,7 @@ class InputOption
             throw new InvalidArgumentException('An option name cannot be empty.');
         }
 
-        if (empty($shortcut)) {
+        if ('' === $shortcut || [] === $shortcut) {
             $shortcut = null;
         }
 
@@ -78,10 +78,10 @@ class InputOption
                 $shortcut = implode('|', $shortcut);
             }
             $shortcuts = preg_split('{(\|)-?}', ltrim($shortcut, '-'));
-            $shortcuts = array_filter($shortcuts);
+            $shortcuts = array_filter($shortcuts, 'strlen');
             $shortcut = implode('|', $shortcuts);
 
-            if (empty($shortcut)) {
+            if ('' === $shortcut) {
                 throw new InvalidArgumentException('An option shortcut cannot be empty.');
             }
         }

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -55,6 +55,20 @@ class InputOptionTest extends TestCase
         $this->assertEquals('f|ff|fff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
         $option = new InputOption('foo');
         $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null by default');
+        $option = new InputOption('foo', '');
+        $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null when given an empty string');
+        $option = new InputOption('foo', []);
+        $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null when given an empty array');
+        $option = new InputOption('foo', ['f', '', 'fff']);
+        $this->assertEquals('f|fff', $option->getShortcut(), '__construct() removes empty shortcuts');
+        $option = new InputOption('foo', 'f||fff');
+        $this->assertEquals('f|fff', $option->getShortcut(), '__construct() removes empty shortcuts');
+        $option = new InputOption('foo', '0');
+        $this->assertEquals('0', $option->getShortcut(), '-0 is an acceptable shortcut value');
+        $option = new InputOption('foo', ['0', 'z']);
+        $this->assertEquals('0|z', $option->getShortcut(), '-0 is an acceptable shortcut value when embedded in an array');
+        $option = new InputOption('foo', '0|z');
+        $this->assertEquals('0|z', $option->getShortcut(), '-0 is an acceptable shortcut value when embedded in a string-list');
     }
 
     public function testModes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53514
| License       | MIT

Fixes some comparisons to no longer erroneously disallow `'0'`/`'-0'` as a shortcut value.