### PR TITLE
chore: CS - apply `phpdoc_types_order.sort_algorithm=alpha`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,6 +28,10 @@ return (new PhpCsFixer\Config())
         '@PHPUnit75Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_last',
+            'sort_algorithm' => 'alpha',
+        ],
         'protected_to_private' => false,
         'native_constant_invocation' => ['strict' => false],
         'no_superfluous_phpdoc_tags' => [

--- a/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
@@ -30,7 +30,7 @@ class MapEntity extends ValueResolver
      * @param string[]|null              $exclude       Configures the properties that should be used in the findOneBy() method by excluding
      *                                                  one or more properties so that not all are used
      * @param bool|null                  $stripNull     Whether to prevent null values from being used as parameters in the query (defaults to false)
-     * @param string[]|string|null       $id            If an id option is configured and matches a route parameter, then the resolver will find by the primary key
+     * @param string|string[]|null       $id            If an id option is configured and matches a route parameter, then the resolver will find by the primary key
      * @param bool|null                  $evictCache    If true, forces Doctrine to always fetch the entity from the database instead of cache (defaults to false)
      */
     public function __construct(

--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -36,7 +36,7 @@ class ContainerAwareEventManager extends EventManager
     private ContainerInterface $container;
 
     /**
-     * @param list<array{string[], string|object}> $listeners List of [events, listener] tuples
+     * @param list<array{string[], object|string}> $listeners List of [events, listener] tuples
      */
     public function __construct(ContainerInterface $container, array $listeners = [])
     {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
@@ -80,7 +80,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      * @param string[]             $managerParameters       list of container parameters that could
      *                                                      hold the manager name
      * @param string               $driverPattern           Pattern for the metadata driver service name
-     * @param string|false         $enabledParameter        Service container parameter that must be
+     * @param false|string         $enabledParameter        Service container parameter that must be
      *                                                      present to enable the mapping. Set to false
      *                                                      to not do any check, optional.
      * @param string               $configurationPattern    Pattern for the Configuration service name,

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
@@ -22,7 +22,7 @@ class Query
 {
     private array $params = [];
 
-    /** @var array<ParameterType|int> */
+    /** @var array<int|ParameterType> */
     private array $types = [];
 
     private ?float $start = null;
@@ -64,7 +64,7 @@ class Query
     }
 
     /**
-     * @param array<string|int, string|int|float> $values
+     * @param array<int|string, float|int|string> $values
      */
     public function setValues(array $values): void
     {

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -270,7 +270,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
     }
 
     /**
-     * @return (LegacyQueryMock&MockObject)|(Query&MockObject)
+     * @return (LegacyQueryMock&MockObject)|(MockObject&Query)
      */
     private function getQueryMock(): AbstractQuery
     {

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -38,7 +38,7 @@ class UniqueEntity extends Constraint
 
     /**
      * @param array|string         $fields           The combination of fields that must contain unique values or a set of options
-     * @param bool|string[]|string $ignoreNull       The combination of fields that ignore null values
+     * @param bool|string|string[] $ignoreNull       The combination of fields that ignore null values
      * @param string|null          $em               The entity manager used to query for uniqueness instead of the manager of this class
      * @param string|null          $entityClass      The entity class to enforce uniqueness on instead of the current class
      * @param string|null          $repositoryMethod The repository method to check uniqueness instead of findBy. The method will receive as its argument

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -62,7 +62,7 @@ class DeprecationErrorHandler
      * The mode can alternatively be "/some-regexp/" to stop the test suite whenever
      * a deprecation message matches the given regular expression.
      *
-     * @param int|string|false $mode The reporting mode, defaults to not allowing any deprecations
+     * @param false|int|string $mode The reporting mode, defaults to not allowing any deprecations
      */
     public static function register($mode = 0)
     {

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -79,7 +79,7 @@ final class WorkflowExtension extends AbstractExtension
     /**
      * Returns marked places.
      *
-     * @return string[]|int[]
+     * @return int[]|string[]
      */
     public function getMarkedPlaces(object $subject, bool $placesNameOnly = true, string $name = null): array
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -94,7 +94,7 @@ abstract class Descriptor implements DescriptorInterface
      * Common options are:
      * * name: name of described service
      *
-     * @param Definition|Alias|object $service
+     * @param Alias|Definition|object $service
      */
     abstract protected function describeContainerService(object $service, array $options = [], ContainerBuilder $container = null): void;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -49,7 +49,7 @@ class RedirectController
      *
      * @param string     $route             The route name to redirect to
      * @param bool       $permanent         Whether the redirection is permanent
-     * @param bool|array $ignoreAttributes  Whether to ignore attributes or an array of attributes to ignore
+     * @param array|bool $ignoreAttributes  Whether to ignore attributes or an array of attributes to ignore
      * @param bool       $keepRequestMethod Whether redirect action should keep HTTP request method
      *
      * @throws HttpException In case the route name is empty

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -303,7 +303,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Returns the FQCN of the security voters enabled in the application.
      *
-     * @return string[]|Data
+     * @return Data|string[]
      */
     public function getVoters(): array|Data
     {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -697,7 +697,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
     /**
      * @param array<string, mixed> $config
      *
-     * @return Reference|array<string, mixed>
+     * @return array<string, mixed>|Reference
      */
     private function createHasher(array $config): Reference|array
     {

--- a/src/Symfony/Component/BrowserKit/Response.php
+++ b/src/Symfony/Component/BrowserKit/Response.php
@@ -70,7 +70,7 @@ final class Response
     }
 
     /**
-     * @return string|array|null The first header value if $first is true, an array of values otherwise
+     * @return array|string|null The first header value if $first is true, an array of values otherwise
      */
     public function getHeader(string $header, bool $first = true): string|array|null
     {

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -147,7 +147,7 @@ final class LockRegistry
     }
 
     /**
-     * @return resource|false
+     * @return false|resource
      */
     private static function open(int $key)
     {

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -231,7 +231,7 @@ abstract class AdapterTestCase extends CachePoolTest
             $this->fail('Test classes for pruneable caches must implement `isPruned($cache, $name)` method.');
         }
 
-        /** @var PruneableInterface|CacheItemPoolInterface $cache */
+        /** @var CacheItemPoolInterface|PruneableInterface $cache */
         $cache = $this->createCachePool();
 
         $doSet = function ($name, $value, \DateInterval $expiresAfter = null) use ($cache) {

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -113,7 +113,7 @@ class Psr16CacheTest extends SimpleCacheTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        /** @var PruneableInterface|CacheInterface $cache */
+        /** @var CacheInterface|PruneableInterface $cache */
         $cache = $this->createSimpleCache();
         $cache->clear();
 

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -119,7 +119,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      *
      * This method is applicable to prototype nodes only.
      *
-     * @param int|string|array|null $children The number of children|The child name|The children names to be added
+     * @param array|int|string|null $children The number of children|The child name|The children names to be added
      *
      * @return $this
      */

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -91,7 +91,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Returns the parent node.
      *
-     * @return NodeParentInterface|NodeBuilder|self|ArrayNodeDefinition|VariableNodeDefinition
+     * @return ArrayNodeDefinition|NodeBuilder|NodeParentInterface|self|VariableNodeDefinition
      */
     public function end(): NodeParentInterface
     {

--- a/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
@@ -45,7 +45,7 @@ class NormalizationBuilder
     /**
      * Registers a closure to run before the normalization or an expression builder to build it if null is provided.
      *
-     * @return ExprBuilder|$this
+     * @return $this|ExprBuilder
      */
     public function before(\Closure $closure = null): ExprBuilder|static
     {

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -30,7 +30,7 @@ class TreeBuilder implements NodeParentInterface
     }
 
     /**
-     * @return NodeDefinition|ArrayNodeDefinition The root node (as an ArrayNodeDefinition when the type is 'array')
+     * @return ArrayNodeDefinition|NodeDefinition The root node (as an ArrayNodeDefinition when the type is 'array')
      */
     public function getRootNode(): NodeDefinition|ArrayNodeDefinition
     {

--- a/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
@@ -28,7 +28,7 @@ class ValidationBuilder
     /**
      * Registers a closure to run as normalization or an expression builder to build it if null is provided.
      *
-     * @return ExprBuilder|$this
+     * @return $this|ExprBuilder
      */
     public function rule(\Closure $closure = null): ExprBuilder|static
     {

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -97,7 +97,7 @@ class PrototypedArrayNode extends ArrayNode
     /**
      * Adds default children when none are set.
      *
-     * @param int|string|array|null $children The number of children|The child name|The children names to be added
+     * @param array|int|string|null $children The number of children|The child name|The children names to be added
      */
     public function setAddChildrenIfNoneSet(int|string|array|null $children = ['defaults']): void
     {

--- a/src/Symfony/Component/Config/FileLocatorInterface.php
+++ b/src/Symfony/Component/Config/FileLocatorInterface.php
@@ -25,7 +25,7 @@ interface FileLocatorInterface
      * @param string|null $currentPath The current path
      * @param bool        $first       Whether to return the first occurrence or an array of filenames
      *
-     * @return string|array The full path to the file or an array of file paths
+     * @return array|string The full path to the file or an array of file paths
      *
      * @throws \InvalidArgumentException        If $name is empty
      * @throws FileLocatorFileNotFoundException If a file is not found

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -36,7 +36,7 @@ class XmlUtils
      * Parses an XML string.
      *
      * @param string               $content          An XML string
-     * @param string|callable|null $schemaOrCallable An XSD schema file path, a callable, or null to disable validation
+     * @param callable|string|null $schemaOrCallable An XSD schema file path, a callable, or null to disable validation
      *
      * @throws XmlParsingException When parsing of XML file returns error
      * @throws InvalidXmlException When parsing of XML with schema or callable produces any errors unrelated to the XML parsing itself
@@ -106,7 +106,7 @@ class XmlUtils
      * Loads an XML file.
      *
      * @param string               $file             An XML file path
-     * @param string|callable|null $schemaOrCallable An XSD schema file path, a callable, or null to disable validation
+     * @param callable|string|null $schemaOrCallable An XSD schema file path, a callable, or null to disable validation
      *
      * @throws \InvalidArgumentException When loading of XML file returns error
      * @throws XmlParsingException       When XML parsing returns any errors

--- a/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
+++ b/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
@@ -26,7 +26,7 @@ interface SignalableCommandInterface
     /**
      * The method will be called when the application is signaled.
      *
-     * @return int|false The exit code to return or false to continue the normal execution
+     * @return false|int The exit code to return or false to continue the normal execution
      */
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false;
 }

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -105,7 +105,7 @@ class Table
     /**
      * Sets table column style.
      *
-     * @param TableStyle|string $name The style name or a TableStyle instance
+     * @param string|TableStyle $name The style name or a TableStyle instance
      *
      * @return $this
      */

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -36,7 +36,7 @@ class InputArgument
      * @param string                                                                        $name            The argument name
      * @param int|null                                                                      $mode            The argument mode: a bit mask of self::REQUIRED, self::OPTIONAL and self::IS_ARRAY
      * @param string                                                                        $description     A description text
-     * @param string|bool|int|float|array|null                                              $default         The default value (for self::OPTIONAL mode only)
+     * @param array|bool|float|int|string|null                                              $default         The default value (for self::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @throws InvalidArgumentException When argument mode is not valid

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -174,7 +174,7 @@ class InputDefinition
     }
 
     /**
-     * @return array<string|bool|int|float|array|null>
+     * @return array<array|bool|float|int|string|null>
      */
     public function getArgumentDefaults(): array
     {
@@ -307,7 +307,7 @@ class InputDefinition
     }
 
     /**
-     * @return array<string|bool|int|float|array|null>
+     * @return array<array|bool|float|int|string|null>
      */
     public function getOptionDefaults(): array
     {

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -34,7 +34,7 @@ interface InputInterface
      * Does not necessarily return the correct result for short options
      * when multiple flags are combined in the same option.
      *
-     * @param string|array $values     The values to look for in the raw parameters (can be an array)
+     * @param array|string $values     The values to look for in the raw parameters (can be an array)
      * @param bool         $onlyParams Only check real parameters, skip those following an end of options (--) signal
      */
     public function hasParameterOption(string|array $values, bool $onlyParams = false): bool;
@@ -47,8 +47,8 @@ interface InputInterface
      * Does not necessarily return the correct result for short options
      * when multiple flags are combined in the same option.
      *
-     * @param string|array                     $values     The value(s) to look for in the raw parameters (can be an array)
-     * @param string|bool|int|float|array|null $default    The default value to return if no result is found
+     * @param array|string                     $values     The value(s) to look for in the raw parameters (can be an array)
+     * @param array|bool|float|int|string|null $default    The default value to return if no result is found
      * @param bool                             $onlyParams Only check real parameters, skip those following an end of options (--) signal
      */
     public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false): mixed;
@@ -70,7 +70,7 @@ interface InputInterface
     /**
      * Returns all the given arguments merged with the default values.
      *
-     * @return array<string|bool|int|float|array|null>
+     * @return array<array|bool|float|int|string|null>
      */
     public function getArguments(): array;
 
@@ -96,7 +96,7 @@ interface InputInterface
     /**
      * Returns all the given options merged with the default values.
      *
-     * @return array<string|bool|int|float|array|null>
+     * @return array<array|bool|float|int|string|null>
      */
     public function getOptions(): array;
 

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -56,9 +56,9 @@ class InputOption
     private string|int|bool|array|null|float $default;
 
     /**
-     * @param string|array|null                                                             $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param array|string|null                                                             $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
      * @param int|null                                                                      $mode            The option mode: One of the VALUE_* constants
-     * @param string|bool|int|float|array|null                                              $default         The default value (must be null for self::VALUE_NONE)
+     * @param array|bool|float|int|string|null                                              $default         The default value (must be null for self::VALUE_NONE)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -32,7 +32,7 @@ class Question
 
     /**
      * @param string                     $question The question to ask to the user
-     * @param string|bool|int|float|null $default  The default answer to return if the user enters nothing
+     * @param bool|float|int|string|null $default  The default answer to return if the user enters nothing
      */
     public function __construct(
         private string $question,

--- a/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
@@ -30,7 +30,7 @@ class Autowire
     /**
      * Use only ONE of the following.
      *
-     * @param string|array|ArgumentInterface|null $value      Value to inject (ie "%kernel.project_dir%/some/path")
+     * @param ArgumentInterface|array|string|null $value      Value to inject (ie "%kernel.project_dir%/some/path")
      * @param string|null                         $service    Service ID (ie "some.service")
      * @param string|null                         $expression Expression (ie 'service("some.service").someMethod()')
      * @param string|null                         $env        Environment variable name (ie 'SOME_ENV_VARIABLE')

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireCallable.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class AutowireCallable extends Autowire
 {
     /**
-     * @param string|array|null $callable The callable to autowire
+     * @param array|string|null $callable The callable to autowire
      * @param string|null       $service  The service containing the callable to autowire
      * @param string|null       $method   The method name that will be autowired
      * @param bool|class-string $lazy     Whether to use lazy-loading for this argument

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireIterator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireIterator.php
@@ -26,7 +26,7 @@ class AutowireIterator extends Autowire
      * @param string|null          $indexAttribute        The name of the attribute that defines the key referencing each service in the tagged collection
      * @param string|null          $defaultIndexMethod    The static method that should be called to get each service's key when their tag doesn't define the previous attribute
      * @param string|null          $defaultPriorityMethod The static method that should be called to get each service's priority when their tag doesn't define the "priority" attribute
-     * @param string|array<string> $exclude               A service id or a list of service ids to exclude
+     * @param array<string>|string $exclude               A service id or a list of service ids to exclude
      * @param bool                 $excludeSelf           Whether to automatically exclude the referencing service from the iterator
      */
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireLocator.php
@@ -28,11 +28,11 @@ class AutowireLocator extends Autowire
     /**
      * @see ServiceSubscriberInterface::getSubscribedServices()
      *
-     * @param string|array<string|SubscribedService> $services              A tag name or an explicit list of service ids
+     * @param array<string|SubscribedService>|string $services              A tag name or an explicit list of service ids
      * @param string|null                            $indexAttribute        The name of the attribute that defines the key referencing each service in the locator
      * @param string|null                            $defaultIndexMethod    The static method that should be called to get each service's key when their tag doesn't define the previous attribute
      * @param string|null                            $defaultPriorityMethod The static method that should be called to get each service's priority when their tag doesn't define the "priority" attribute
-     * @param string|array                           $exclude               A service id or a list of service ids to exclude
+     * @param array|string                           $exclude               A service id or a list of service ids to exclude
      * @param bool                                   $excludeSelf           Whether to automatically exclude the referencing service from the locator
      */
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -792,7 +792,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Adds the service aliases.
      *
-     * @param array<string, string|Alias> $aliases
+     * @param array<string, Alias|string> $aliases
      */
     public function addAliases(array $aliases): void
     {
@@ -804,7 +804,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Sets the service aliases.
      *
-     * @param array<string, string|Alias> $aliases
+     * @param array<string, Alias|string> $aliases
      */
     public function setAliases(array $aliases): void
     {

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -94,7 +94,7 @@ class Definition
     /**
      * Sets a factory.
      *
-     * @param string|array|Reference|null $factory A PHP function, reference or an array containing a class/Reference and a method to call
+     * @param array|Reference|string|null $factory A PHP function, reference or an array containing a class/Reference and a method to call
      *
      * @return $this
      */
@@ -116,7 +116,7 @@ class Definition
     /**
      * Gets the factory.
      *
-     * @return string|array|null The PHP function or an array containing a class/Reference and a method to call
+     * @return array|string|null The PHP function or an array containing a class/Reference and a method to call
      */
     public function getFactory(): string|array|null
     {
@@ -691,7 +691,7 @@ class Definition
     /**
      * Sets a configurator to call after the service is fully initialized.
      *
-     * @param string|array|Reference|null $configurator A PHP function, reference or an array containing a class/Reference and a method to call
+     * @param array|Reference|string|null $configurator A PHP function, reference or an array containing a class/Reference and a method to call
      *
      * @return $this
      */

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -124,7 +124,7 @@ class PhpDumper extends Dumper
      *  * namespace:  The class namespace
      *  * as_files:   To split the container in several files
      *
-     * @return string|array A PHP class representing the service container or an array of PHP files if the "as_files" option is set
+     * @return array|string A PHP class representing the service container or an array of PHP files if the "as_files" option is set
      *
      * @throws EnvParameterException When an env var exists but has not been dumped
      */

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -29,7 +29,7 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
     private array $processedConfigs = [];
 
     /**
-     * @return string|false
+     * @return false|string
      */
     public function getXsdValidationBasePath()
     {

--- a/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
@@ -41,7 +41,7 @@ interface ExtensionInterface
     /**
      * Returns the base path for the XSD files.
      *
-     * @return string|false
+     * @return false|string
      */
     public function getXsdValidationBasePath();
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -125,7 +125,7 @@ function inline_service(string $class = null): InlineServiceConfigurator
 /**
  * Creates a service locator.
  *
- * @param array<ReferenceConfigurator|InlineServiceConfigurator> $values
+ * @param array<InlineServiceConfigurator|ReferenceConfigurator> $values
  */
 function service_locator(array $values): ServiceLocatorArgument
 {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
@@ -77,7 +77,7 @@ class PrototypeConfigurator extends AbstractServiceConfigurator
     /**
      * Excludes files from registration using glob patterns.
      *
-     * @param string[]|string $excludes
+     * @param string|string[] $excludes
      *
      * @return $this
      */

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -58,7 +58,7 @@ class Crawler implements \Countable, \IteratorAggregate
     private ?HTML5 $html5Parser = null;
 
     /**
-     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $node A Node to use as the base for the crawling
+     * @param \DOMNode|\DOMNode[]|\DOMNodeList|string|null $node A Node to use as the base for the crawling
      */
     public function __construct(\DOMNodeList|\DOMNode|array|string $node = null, string $uri = null, string $baseHref = null, bool $useHtml5Parser = true)
     {
@@ -102,7 +102,7 @@ class Crawler implements \Countable, \IteratorAggregate
      * This method uses the appropriate specialized add*() method based
      * on the type of the argument.
      *
-     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $node A node
+     * @param \DOMNode|\DOMNode[]|\DOMNodeList|string|null $node A node
      *
      * @throws \InvalidArgumentException when node is not the expected type
      */
@@ -1152,7 +1152,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Creates a crawler for some subnodes.
      *
-     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $nodes
+     * @param \DOMNode|\DOMNode[]|\DOMNodeList|string|null $nodes
      */
     private function createSubCrawler(\DOMNodeList|\DOMNode|array|string|null $nodes): static
     {

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -309,7 +309,7 @@ class Form extends Link implements \ArrayAccess
      * Sets the value of a field.
      *
      * @param string       $name  The field name
-     * @param string|array $value The value of the field
+     * @param array|string $value The value of the field
      *
      * @throws \InvalidArgumentException if the field does not exist
      */

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/FileLinkFormatter.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/FileLinkFormatter.php
@@ -27,7 +27,7 @@ class FileLinkFormatter
     private array|false $fileLinkFormat;
 
     /**
-     * @param string|\Closure $urlFormat the URL format, or a closure that returns it on-demand
+     * @param \Closure|string $urlFormat the URL format, or a closure that returns it on-demand
      */
     public function __construct(
         string|array $fileLinkFormat = null,

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -43,7 +43,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
 
     /**
      * @param bool|callable   $debug        The debugging mode as a boolean or a callable that should return it
-     * @param string|callable $outputBuffer The output buffer as a string or a callable that should return it
+     * @param callable|string $outputBuffer The output buffer as a string or a callable that should return it
      */
     public function __construct(
         bool|callable $debug = false,

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
@@ -29,7 +29,7 @@ class SerializerErrorRenderer implements ErrorRendererInterface
     private bool|\Closure $debug;
 
     /**
-     * @param string|callable(FlattenException) $format The format as a string or a callable that should return it
+     * @param callable(FlattenException)|string $format The format as a string or a callable that should return it
      *                                                  formats not supported by Request::getMimeTypes() should be given as mime types
      * @param bool|callable                     $debug  The debugging mode as a boolean or a callable that should return it
      */

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -48,7 +48,7 @@ interface EventDispatcherInterface extends ContractsEventDispatcherInterface
     /**
      * Gets the listeners of a specific event or all listeners sorted by descending priority.
      *
-     * @return array<callable[]|callable>
+     * @return array<callable|callable[]>
      */
     public function getListeners(string $eventName = null): array;
 

--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -43,7 +43,7 @@ interface EventSubscriberInterface
      * The code must not depend on runtime state as it will only be called at compile time.
      * All logic depending on runtime state must be put into the individual methods handling the events.
      *
-     * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
+     * @return array<string, array{0: string, 1: int}|list<array{0: string, 1?: int}>|string>
      */
     public static function getSubscribedEvents();
 }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -220,7 +220,7 @@ class Filesystem
     /**
      * Change the owner of an array of files or directories.
      *
-     * @param string|int $user      A user name or number
+     * @param int|string $user      A user name or number
      * @param bool       $recursive Whether change the owner recursively or not
      *
      * @throws IOException When the change fails
@@ -246,7 +246,7 @@ class Filesystem
     /**
      * Change the group of an array of files or directories.
      *
-     * @param string|int $group     A group name or number
+     * @param int|string $group     A group name or number
      * @param bool       $recursive Whether change the group recursively or not
      *
      * @throws IOException When the change fails
@@ -628,7 +628,7 @@ class Filesystem
     /**
      * Atomically dumps content into a file.
      *
-     * @param string|resource $content The data to write into the file
+     * @param resource|string $content The data to write into the file
      *
      * @throws IOException if the file cannot be written to
      */
@@ -672,7 +672,7 @@ class Filesystem
     /**
      * Appends content to an existing file.
      *
-     * @param string|resource $content The content to append
+     * @param resource|string $content The content to append
      * @param bool            $lock    Whether the file should be locked when writing to it
      *
      * @throws IOException If the file is not writable

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -114,7 +114,7 @@ class Finder implements \IteratorAggregate, \Countable
      *     $finder->depth('< 3') // the Finder will descend at most 3 levels of directories below the starting point.
      *     $finder->depth(['>= 1', '< 3'])
      *
-     * @param string|int|string[]|int[] $levels The depth level expression or an array of depth levels
+     * @param int|int[]|string|string[] $levels The depth level expression or an array of depth levels
      *
      * @return $this
      *
@@ -297,7 +297,7 @@ class Finder implements \IteratorAggregate, \Countable
      *     $finder->size(4);
      *     $finder->size(['> 10K', '< 20K'])
      *
-     * @param string|int|string[]|int[] $sizes A size range string or an integer or an array of size ranges
+     * @param int|int[]|string|string[] $sizes A size range string or an integer or an array of size ranges
      *
      * @return $this
      *
@@ -320,7 +320,7 @@ class Finder implements \IteratorAggregate, \Countable
      *
      *     $finder->in(__DIR__)->exclude('ruby');
      *
-     * @param string|array $dirs A directory path or an array of directories
+     * @param array|string $dirs A directory path or an array of directories
      *
      * @return $this
      *

--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -35,7 +35,7 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator implements \Recursi
 
     /**
      * @param \Iterator<string, SplFileInfo>          $iterator    The Iterator to filter
-     * @param list<string|callable(SplFileInfo):bool> $directories An array of directories to exclude
+     * @param list<callable(SplFileInfo):bool|string> $directories An array of directories to exclude
      */
     public function __construct(\Iterator $iterator, array $directories)
     {

--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -38,7 +38,7 @@ class SortableIterator implements \IteratorAggregate
 
     /**
      * @param \Traversable<string, \SplFileInfo> $iterator
-     * @param int|callable                       $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a PHP callback)
+     * @param callable|int                       $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a PHP callback)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Finder/Tests/Iterator/VfsIteratorTestTrait.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/VfsIteratorTestTrait.php
@@ -15,7 +15,7 @@ trait VfsIteratorTestTrait
 {
     private static int $vfsNextSchemeIndex = 0;
 
-    /** @var array<string, \Closure(string, 'list_dir_open'|'list_dir_rewind'|'is_dir'): (list<string>|bool)> */
+    /** @var array<string, \Closure(string, 'is_dir'|'list_dir_open'|'list_dir_rewind'): (bool|list<string>)> */
     public static array $vfsProviders;
 
     protected string $vfsScheme;
@@ -30,7 +30,7 @@ trait VfsIteratorTestTrait
         $this->vfsScheme = 'symfony-finder-vfs-test-'.++self::$vfsNextSchemeIndex;
 
         $vfsWrapperClass = \get_class(new class() {
-            /** @var array<string, \Closure(string, 'list_dir_open'|'list_dir_rewind'|'is_dir'): (list<string>|bool)> */
+            /** @var array<string, \Closure(string, 'is_dir'|'list_dir_open'|'list_dir_rewind'): (bool|list<string>)> */
             public static array $vfsProviders = [];
 
             /** @var resource */

--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -43,7 +43,7 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface, Re
     protected array $resources = [];
 
     /**
-     * @var array<array<int|false>>
+     * @var array<array<false|int>>
      */
     private array $resourceHierarchyLevels = [];
 

--- a/src/Symfony/Component/Form/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ChoiceList.php
@@ -57,7 +57,7 @@ final class ChoiceList
     /**
      * Decorates a "choice_value" callback to make it cacheable.
      *
-     * @param callable|array $value Any pseudo callable to create a unique string value from a choice
+     * @param array|callable $value Any pseudo callable to create a unique string value from a choice
      * @param mixed          $vary  Dynamic data used to compute a unique hash when caching the callback
      */
     public static function value(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $value, mixed $vary = null): ChoiceValue
@@ -66,7 +66,7 @@ final class ChoiceList
     }
 
     /**
-     * @param callable|array $filter Any pseudo callable to filter a choice list
+     * @param array|callable $filter Any pseudo callable to filter a choice list
      * @param mixed          $vary   Dynamic data used to compute a unique hash when caching the callback
      */
     public static function filter(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $filter, mixed $vary = null): ChoiceFilter
@@ -88,7 +88,7 @@ final class ChoiceList
     /**
      * Decorates a "choice_name" callback to make it cacheable.
      *
-     * @param callable|array $fieldName Any pseudo callable to create a field name from a choice
+     * @param array|callable $fieldName Any pseudo callable to create a field name from a choice
      * @param mixed          $vary      Dynamic data used to compute a unique hash when caching the callback
      */
     public static function fieldName(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $fieldName, mixed $vary = null): ChoiceFieldName
@@ -99,7 +99,7 @@ final class ChoiceList
     /**
      * Decorates a "choice_attr" option to make it cacheable.
      *
-     * @param callable|array $attr Any pseudo callable or array to create html attributes from a choice
+     * @param array|callable $attr Any pseudo callable or array to create html attributes from a choice
      * @param mixed          $vary Dynamic data used to compute a unique hash when caching the option
      */
     public static function attr(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $attr, mixed $vary = null): ChoiceAttr
@@ -110,7 +110,7 @@ final class ChoiceList
     /**
      * Decorates a "choice_translation_parameters" option to make it cacheable.
      *
-     * @param callable|array $translationParameters Any pseudo callable or array to create translation parameters from a choice
+     * @param array|callable $translationParameters Any pseudo callable or array to create translation parameters from a choice
      * @param mixed          $vary                  Dynamic data used to compute a unique hash when caching the option
      */
     public static function translationParameters(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $translationParameters, mixed $vary = null): ChoiceTranslationParameters
@@ -121,7 +121,7 @@ final class ChoiceList
     /**
      * Decorates a "group_by" callback to make it cacheable.
      *
-     * @param callable|array $groupBy Any pseudo callable to return a group name from a choice
+     * @param array|callable $groupBy Any pseudo callable to return a group name from a choice
      * @param mixed          $vary    Dynamic data used to compute a unique hash when caching the callback
      */
     public static function groupBy(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $groupBy, mixed $vary = null): GroupBy
@@ -132,7 +132,7 @@ final class ChoiceList
     /**
      * Decorates a "preferred_choices" option to make it cacheable.
      *
-     * @param callable|array $preferred Any pseudo callable or array to return a group name from a choice
+     * @param array|callable $preferred Any pseudo callable or array to return a group name from a choice
      * @param mixed          $vary      Dynamic data used to compute a unique hash when caching the option
      */
     public static function preferred(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $preferred, mixed $vary = null): PreferredChoice

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -39,7 +39,7 @@ class ChoiceView
      *
      * @param mixed                              $data                       The original choice
      * @param string                             $value                      The view representation of the choice
-     * @param string|TranslatableInterface|false $label                      The label displayed to humans; pass false to discard the label
+     * @param false|string|TranslatableInterface $label                      The label displayed to humans; pass false to discard the label
      * @param array                              $attr                       Additional attributes for the HTML tag
      * @param array                              $labelTranslationParameters Additional parameters used to translate the label
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -35,7 +35,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
     /**
      * Transforms a normalized format into a localized money string.
      *
-     * @param int|float|null $value Normalized number
+     * @param float|int|null $value Normalized number
      *
      * @throws TransformationFailedException if the given value is not numeric or
      *                                       if the value cannot be transformed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -42,7 +42,7 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
     /**
      * Transforms a number type into localized number.
      *
-     * @param int|float|null $value Number value
+     * @param float|int|null $value Number value
      *
      * @throws TransformationFailedException if the given value is not numeric
      *                                       or if the value cannot be transformed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -63,7 +63,7 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
     /**
      * Transforms between a normalized format (integer or float) into a percentage value.
      *
-     * @param int|float $value Normalized value
+     * @param float|int $value Normalized value
      *
      * @throws TransformationFailedException if the given value is not numeric or
      *                                       if the value could not be transformed

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -25,7 +25,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class FormValidator extends ConstraintValidator
 {
     /**
-     * @var \SplObjectStorage<FormInterface, array<int, string|string[]|GroupSequence>>
+     * @var \SplObjectStorage<FormInterface, array<int, GroupSequence|string|string[]>>
      */
     private \SplObjectStorage $resolvedGroups;
 
@@ -203,7 +203,7 @@ class FormValidator extends ConstraintValidator
     /**
      * Returns the validation groups of the given form.
      *
-     * @return string|GroupSequence|array<string|GroupSequence>
+     * @return array<GroupSequence|string>|GroupSequence|string
      */
     private function getValidationGroups(FormInterface $form): string|GroupSequence|array
     {
@@ -242,9 +242,9 @@ class FormValidator extends ConstraintValidator
     /**
      * Post-processes the validation groups option for a given form.
      *
-     * @param string|GroupSequence|array<string|GroupSequence>|callable $groups The validation groups
+     * @param array<GroupSequence|string>|callable|GroupSequence|string $groups The validation groups
      *
-     * @return GroupSequence|array<string|GroupSequence>
+     * @return array<GroupSequence|string>|GroupSequence
      */
     private static function resolveValidationGroups(string|GroupSequence|array|callable $groups, FormInterface $form): GroupSequence|array
     {

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -135,7 +135,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets the property path that the form should be mapped to.
      *
-     * @param string|PropertyPathInterface|null $propertyPath The property path or null if the path should be set
+     * @param PropertyPathInterface|string|null $propertyPath The property path or null if the path should be set
      *                                                        automatically based on the form's name
      *
      * @return $this

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -263,7 +263,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Submits data to the form.
      *
-     * @param string|array|null $submittedData The submitted data
+     * @param array|string|null $submittedData The submitted data
      * @param bool              $clearMissing  Whether to set fields to NULL
      *                                         when they are missing in the
      *                                         submitted data. This argument

--- a/src/Symfony/Component/Form/Util/OptionsResolverWrapper.php
+++ b/src/Symfony/Component/Form/Util/OptionsResolverWrapper.php
@@ -67,7 +67,7 @@ class OptionsResolverWrapper extends OptionsResolver
     }
 
     /**
-     * @param string|array $allowedTypes
+     * @param array|string $allowedTypes
      *
      * @return $this
      */
@@ -83,7 +83,7 @@ class OptionsResolverWrapper extends OptionsResolver
     }
 
     /**
-     * @param string|array $allowedTypes
+     * @param array|string $allowedTypes
      *
      * @return $this
      */

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
@@ -42,7 +42,7 @@ final class DomVisitor
      * * If an element is present as a key and contains "false", the element should be blocked.
      * * If an element is not present as a key, the element should be dropped.
      *
-     * @var array<string, false|array<string, bool>>
+     * @var array<string, array<string, bool>|false>
      */
     private array $elementsConfig;
 
@@ -62,7 +62,7 @@ final class DomVisitor
     private array $attributeSanitizers = [];
 
     /**
-     * @param array<string, false|array<string, bool>> $elementsConfig
+     * @param array<string, array<string, bool>|false> $elementsConfig
      */
     public function __construct(HtmlSanitizerConfig $config, array $elementsConfig)
     {

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -316,9 +316,9 @@ trait HttpClientTrait
     }
 
     /**
-     * @param array|string|resource|\Traversable|\Closure $body
+     * @param array|\Closure|resource|string|\Traversable $body
      *
-     * @return string|resource|\Closure
+     * @return \Closure|resource|string
      *
      * @throws InvalidArgumentException When an invalid body is passed
      */

--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -84,7 +84,7 @@ class HttpOptions
     }
 
     /**
-     * @param array|string|resource|\Traversable|\Closure $body
+     * @param array|\Closure|resource|string|\Traversable $body
      *
      * @return $this
      */

--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -149,7 +149,7 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
     }
 
     /**
-     * @param UriInterface|string $uri
+     * @param string|UriInterface $uri
      */
     public function createRequest(string $method, $uri = ''): RequestInterface
     {

--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -33,7 +33,7 @@ class MockHttpClient implements HttpClientInterface, ResetInterface
     private array $defaultOptions = [];
 
     /**
-     * @param callable|callable[]|ResponseInterface|ResponseInterface[]|iterable|null $responseFactory
+     * @param callable|callable[]|iterable|ResponseInterface|ResponseInterface[]|null $responseFactory
      */
     public function __construct(callable|iterable|ResponseInterface $responseFactory = null, ?string $baseUri = 'https://example.com')
     {
@@ -42,7 +42,7 @@ class MockHttpClient implements HttpClientInterface, ResetInterface
     }
 
     /**
-     * @param callable|callable[]|ResponseInterface|ResponseInterface[]|iterable|null $responseFactory
+     * @param callable|callable[]|iterable|ResponseInterface|ResponseInterface[]|null $responseFactory
      */
     public function setResponseFactory($responseFactory): void
     {

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -34,7 +34,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
     private string|array|null $subnets;
 
     /**
-     * @param string|array|null $subnets String or array of subnets using CIDR notation that will be used by IpUtils.
+     * @param array|string|null $subnets String or array of subnets using CIDR notation that will be used by IpUtils.
      *                                   If null is passed, the standard private subnets will be used.
      */
     public function __construct(HttpClientInterface $client, string|array $subnets = null)

--- a/src/Symfony/Component/HttpClient/Response/HttplugPromise.php
+++ b/src/Symfony/Component/HttpClient/Response/HttplugPromise.php
@@ -49,7 +49,7 @@ final class HttplugPromise implements HttplugPromiseInterface
     }
 
     /**
-     * @return Psr7ResponseInterface|mixed
+     * @return mixed|Psr7ResponseInterface
      */
     public function wait($unwrap = true): mixed
     {

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -37,7 +37,7 @@ class MockResponse implements ResponseInterface, StreamableInterface
     private static int $idSequence = 0;
 
     /**
-     * @param string|iterable<string|\Throwable> $body The response body as a string or an iterable of strings,
+     * @param iterable<string|\Throwable>|string $body The response body as a string or an iterable of strings,
      *                                                 yielding an empty string simulates an idle timeout,
      *                                                 throwing or yielding an exception yields an ErrorChunk
      *

--- a/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
+++ b/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
@@ -32,7 +32,7 @@ class StreamWrapper
     /** @var resource|string|null */
     private $content;
 
-    /** @var resource|callable|null */
+    /** @var callable|resource|null */
     private $handle;
 
     private bool $blocking = true;
@@ -79,7 +79,7 @@ class StreamWrapper
     }
 
     /**
-     * @param resource|callable|null $handle  The resource handle that should be monitored when
+     * @param callable|resource|null $handle  The resource handle that should be monitored when
      *                                        stream_select() is used on the created stream
      * @param resource|null          $content The seekable resource where the response body is buffered
      */
@@ -267,7 +267,7 @@ class StreamWrapper
     }
 
     /**
-     * @return resource|false
+     * @return false|resource
      */
     public function stream_cast(int $castAs)
     {

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -74,7 +74,7 @@ class Cookie
     /**
      * @see self::__construct
      *
-     * @param self::SAMESITE_*|''|null $sameSite
+     * @param ''|self::SAMESITE_*|null $sameSite
      */
     public static function create(string $name, string $value = null, int|string|\DateTimeInterface $expire = 0, ?string $path = '/', string $domain = null, bool $secure = null, bool $httpOnly = true, bool $raw = false, ?string $sameSite = self::SAMESITE_LAX, bool $partitioned = false): self
     {
@@ -84,13 +84,13 @@ class Cookie
     /**
      * @param string                        $name     The name of the cookie
      * @param string|null                   $value    The value of the cookie
-     * @param int|string|\DateTimeInterface $expire   The time the cookie expires
+     * @param \DateTimeInterface|int|string $expire   The time the cookie expires
      * @param string|null                   $path     The path on the server in which the cookie will be available on
      * @param string|null                   $domain   The domain that the cookie is available to
      * @param bool|null                     $secure   Whether the client should send back the cookie only over HTTPS or null to auto-enable this when the request is already using HTTPS
      * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
-     * @param self::SAMESITE_*|''|null      $sameSite Whether the cookie will be available for cross-site requests
+     * @param ''|self::SAMESITE_*|null      $sameSite Whether the cookie will be available for cross-site requests
      *
      * @throws \InvalidArgumentException
      */
@@ -220,7 +220,7 @@ class Cookie
     /**
      * Creates a cookie copy with SameSite attribute.
      *
-     * @param self::SAMESITE_*|''|null $sameSite
+     * @param ''|self::SAMESITE_*|null $sameSite
      */
     public function withSameSite(?string $sameSite): static
     {

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -222,7 +222,7 @@ class UploadedFile extends File
     /**
      * Returns the maximum size of an uploaded file as configured in php.ini.
      *
-     * @return int|float The maximum size of an uploaded file in bytes (returns float if size > PHP_INT_MAX)
+     * @return float|int The maximum size of an uploaded file in bytes (returns float if size > PHP_INT_MAX)
      */
     public static function getMaxFilesize(): int|float
     {

--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -56,7 +56,7 @@ class FileBag extends ParameterBag
     /**
      * Converts uploaded files to UploadedFile instances.
      *
-     * @return UploadedFile[]|UploadedFile|null
+     * @return UploadedFile|UploadedFile[]|null
      */
     protected function convertFileInformation(array|UploadedFile $file): array|UploadedFile|null
     {

--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -24,7 +24,7 @@ final class InputBag extends ParameterBag
     /**
      * Returns a scalar input value by name.
      *
-     * @param string|int|float|bool|null $default The default value if the input key does not exist
+     * @param bool|float|int|string|null $default The default value if the input key does not exist
      */
     public function get(string $key, mixed $default = null): string|int|float|bool|null
     {
@@ -63,7 +63,7 @@ final class InputBag extends ParameterBag
     /**
      * Sets an input by name.
      *
-     * @param string|int|float|bool|array|null $value
+     * @param array|bool|float|int|string|null $value
      */
     public function set(string $key, mixed $value): void
     {

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -45,7 +45,7 @@ class IpUtils
     /**
      * Checks if an IPv4 or IPv6 address is contained in the list of given IPs or subnets.
      *
-     * @param string|array $ips List of IPs or subnets (can be a string if only a single one)
+     * @param array|string $ips List of IPs or subnets (can be a string if only a single one)
      */
     public static function checkIp(string $requestIp, string|array $ips): bool
     {

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -180,7 +180,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * Filter key.
      *
      * @param int                                     $filter  FILTER_* constant
-     * @param int|array{flags?: int, options?: array} $options Flags from FILTER_* constants
+     * @param array{flags?: int, options?: array}|int $options Flags from FILTER_* constants
      *
      * @see https://php.net/filter-var
      */

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -117,7 +117,7 @@ class Request
     public HeaderBag $headers;
 
     /**
-     * @var string|resource|false|null
+     * @var false|resource|string|null
      */
     protected $content;
 
@@ -203,7 +203,7 @@ class Request
      * @param array                $cookies    The COOKIE parameters
      * @param array                $files      The FILES parameters
      * @param array                $server     The SERVER parameters
-     * @param string|resource|null $content    The raw body data
+     * @param resource|string|null $content    The raw body data
      */
     public function __construct(array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null)
     {
@@ -221,7 +221,7 @@ class Request
      * @param array                $cookies    The COOKIE parameters
      * @param array                $files      The FILES parameters
      * @param array                $server     The SERVER parameters
-     * @param string|resource|null $content    The raw body data
+     * @param resource|string|null $content    The raw body data
      */
     public function initialize(array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null): void
     {
@@ -275,7 +275,7 @@ class Request
      * @param array                $cookies    The request cookies ($_COOKIE)
      * @param array                $files      The request files ($_FILES)
      * @param array                $server     The server parameters ($_SERVER)
-     * @param string|resource|null $content    The raw body data
+     * @param resource|string|null $content    The raw body data
      */
     public static function create(string $uri, string $method = 'GET', array $parameters = [], array $cookies = [], array $files = [], array $server = [], $content = null): static
     {
@@ -1383,7 +1383,7 @@ class Request
      *
      * @param bool $asResource If true, a resource will be returned
      *
-     * @return string|resource
+     * @return resource|string
      *
      * @psalm-return ($asResource is true ? resource : string)
      */

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/IpsRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/IpsRequestMatcher.php
@@ -25,7 +25,7 @@ class IpsRequestMatcher implements RequestMatcherInterface
     private array $ips;
 
     /**
-     * @param string[]|string $ips A specific IP address or a range specified using IP/netmask like 192.168.1.0/24
+     * @param string|string[] $ips A specific IP address or a range specified using IP/netmask like 192.168.1.0/24
      *                             Strings can contain a comma-delimited list of IPs/ranges
      */
     public function __construct(array|string $ips)

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/MethodRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/MethodRequestMatcher.php
@@ -27,7 +27,7 @@ class MethodRequestMatcher implements RequestMatcherInterface
     private array $methods = [];
 
     /**
-     * @param string[]|string $methods An HTTP method or an array of HTTP methods
+     * @param string|string[] $methods An HTTP method or an array of HTTP methods
      *                                 Strings can contain a comma-delimited list of methods
      */
     public function __construct(array|string $methods)

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/SchemeRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/SchemeRequestMatcher.php
@@ -27,7 +27,7 @@ class SchemeRequestMatcher implements RequestMatcherInterface
     private array $schemes;
 
     /**
-     * @param string[]|string $schemes A scheme or a list of schemes
+     * @param string|string[] $schemes A scheme or a list of schemes
      *                                 Strings can contain a comma-delimited list of schemes
      */
     public function __construct(array|string $schemes)

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class ResponseFunctionalTest extends TestCase
 {
-    /** @var resource|false */
+    /** @var false|resource */
     private static $server;
 
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractSessionHandlerTest extends TestCase
 {
-    /** @var resource|false */
+    /** @var false|resource */
     private static $server;
 
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
@@ -28,7 +28,7 @@ class MapQueryString extends ValueResolver
 
     /**
      * @param array<string, mixed>                    $serializationContext       The serialization context to use when deserializing the query string
-     * @param string|GroupSequence|array<string>|null $validationGroups           The validation groups to use when validating the query string mapping
+     * @param array<string>|GroupSequence|string|null $validationGroups           The validation groups to use when validating the query string mapping
      * @param class-string                            $resolver                   The class name of the resolver to use
      * @param int                                     $validationFailedStatusCode The HTTP code to return if the validation fails
      */

--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
@@ -29,7 +29,7 @@ class MapRequestPayload extends ValueResolver
     /**
      * @param array<string>|string|null               $acceptFormat               The payload formats to accept (i.e. "json", "xml")
      * @param array<string, mixed>                    $serializationContext       The serialization context to use when deserializing the payload
-     * @param string|GroupSequence|array<string>|null $validationGroups           The validation groups to use when validating the query string mapping
+     * @param array<string>|GroupSequence|string|null $validationGroups           The validation groups to use when validating the query string mapping
      * @param class-string                            $resolver                   The class name of the resolver to use
      * @param int                                     $validationFailedStatusCode The HTTP code to return if the validation fails
      */

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -102,7 +102,7 @@ class ArgumentMetadata
 
     /**
      * @param class-string          $name
-     * @param self::IS_INSTANCEOF|0 $flags
+     * @param 0|self::IS_INSTANCEOF $flags
      *
      * @return array<object>
      */
@@ -119,7 +119,7 @@ class ArgumentMetadata
      * @template T of object
      *
      * @param class-string<T>       $name
-     * @param self::IS_INSTANCEOF|0 $flags
+     * @param 0|self::IS_INSTANCEOF $flags
      *
      * @return array<T>
      */

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -33,7 +33,7 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     private ?Request $currentRequest = null;
 
     /**
-     * @param iterable<EventDispatcherInterface>|EventDispatcherInterface|null $dispatchers
+     * @param EventDispatcherInterface|iterable<EventDispatcherInterface>|null $dispatchers
      */
     public function __construct(
         iterable|EventDispatcherInterface $dispatchers = null,

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -266,7 +266,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
     }
 
     /**
-     * @return string|resource
+     * @return resource|string
      */
     public function getContent()
     {
@@ -343,7 +343,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
     /**
      * Gets the parsed controller.
      *
-     * @return array|string|Data The controller as a string or array of data
+     * @return array|Data|string The controller as a string or array of data
      *                           with keys 'class', 'method', 'file' and 'line'
      */
     public function getController(): array|string|Data

--- a/src/Symfony/Component/HttpKernel/Log/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Log/Logger.php
@@ -55,7 +55,7 @@ class Logger extends AbstractLogger implements DebugLoggerInterface
     private $handle;
 
     /**
-     * @param string|resource|null $output
+     * @param resource|string|null $output
      */
     public function __construct(string $minLevel = null, $output = null, callable $formatter = null, private readonly ?RequestStack $requestStack = null, bool $debug = false)
     {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -61,7 +61,7 @@ class MongoDbStore implements PersistingStoreInterface
     private float $initialTtl;
 
     /**
-     * @param Collection|Client|Manager|string $mongo      An instance of a Collection or Client or URI @see https://docs.mongodb.com/manual/reference/connection-string/
+     * @param Client|Collection|Manager|string $mongo      An instance of a Collection or Client or URI @see https://docs.mongodb.com/manual/reference/connection-string/
      * @param array                            $options    See below
      * @param float                            $initialTtl The expiration delay of locks in seconds
      *

--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -27,7 +27,7 @@ final class Envelope
     private object $message;
 
     /**
-     * @param object|Envelope  $message
+     * @param Envelope|object  $message
      * @param StampInterface[] $stamps
      */
     public function __construct(object $message, array $stamps = [])

--- a/src/Symfony/Component/Messenger/HandleTrait.php
+++ b/src/Symfony/Component/Messenger/HandleTrait.php
@@ -29,7 +29,7 @@ trait HandleTrait
      * This behavior is useful for both synchronous command & query buses,
      * the last one usually returning the handler result.
      *
-     * @param object|Envelope $message The message or the message pre-wrapped in an envelope
+     * @param Envelope|object $message The message or the message pre-wrapped in an envelope
      */
     private function handle(object $message): mixed
     {

--- a/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
@@ -25,7 +25,7 @@ class HandlersLocator implements HandlersLocatorInterface
     private array $handlers;
 
     /**
-     * @param HandlerDescriptor[][]|callable[][] $handlers
+     * @param callable[][]|HandlerDescriptor[][] $handlers
      */
     public function __construct(array $handlers)
     {

--- a/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
+++ b/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
@@ -16,8 +16,8 @@ use Symfony\Component\Messenger\Envelope;
 final class RedispatchMessage implements \Stringable
 {
     /**
-     * @param object|Envelope $envelope       The message or the message pre-wrapped in an envelope
-     * @param string[]|string $transportNames Transport names to be used for the message
+     * @param Envelope|object $envelope       The message or the message pre-wrapped in an envelope
+     * @param string|string[] $transportNames Transport names to be used for the message
      */
     public function __construct(
         public readonly object $envelope,

--- a/src/Symfony/Component/Messenger/MessageBusInterface.php
+++ b/src/Symfony/Component/Messenger/MessageBusInterface.php
@@ -22,7 +22,7 @@ interface MessageBusInterface
     /**
      * Dispatches the given message.
      *
-     * @param object|Envelope  $message The message or the message pre-wrapped in an envelope
+     * @param Envelope|object  $message The message or the message pre-wrapped in an envelope
      * @param StampInterface[] $stamps
      *
      * @throws ExceptionInterface

--- a/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
@@ -19,7 +19,7 @@ final class TransportNamesStamp implements StampInterface
     private array $transportNames;
 
     /**
-     * @param string[]|string $transportNames Transport names to be used for the message
+     * @param string|string[] $transportNames Transport names to be used for the message
      */
     public function __construct(array|string $transportNames)
     {

--- a/src/Symfony/Component/Messenger/Stamp/ValidationStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ValidationStamp.php
@@ -21,7 +21,7 @@ final class ValidationStamp implements StampInterface
     private array|GroupSequence $groups;
 
     /**
-     * @param string[]|GroupSequence $groups
+     * @param GroupSequence|string[] $groups
      */
     public function __construct(array|GroupSequence $groups)
     {

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -27,7 +27,7 @@ class DataPart extends TextPart
     private ?string $cid = null;
 
     /**
-     * @param resource|string|File $body Use a File instance to defer loading the file until rendering
+     * @param File|resource|string $body Use a File instance to defer loading the file until rendering
      */
     public function __construct($body, string $filename = null, string $contentType = null, string $encoding = null)
     {

--- a/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
+++ b/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
@@ -26,7 +26,7 @@ final class FormDataPart extends AbstractMultipartPart
     private array $fields = [];
 
     /**
-     * @param array<string|array|DataPart> $fields
+     * @param array<array|DataPart|string> $fields
      */
     public function __construct(array $fields = [])
     {

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -28,7 +28,7 @@ class TextPart extends AbstractPart
 
     private static array $encoders = [];
 
-    /** @var resource|string|File */
+    /** @var File|resource|string */
     private $body;
     private ?string $charset;
     private string $subtype;
@@ -38,7 +38,7 @@ class TextPart extends AbstractPart
     private ?bool $seekable = null;
 
     /**
-     * @param resource|string|File $body Use a File instance to defer loading the file until rendering
+     * @param File|resource|string $body Use a File instance to defer loading the file until rendering
      */
     public function __construct($body, ?string $charset = 'utf-8', string $subtype = 'plain', string $encoding = null)
     {

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneOptions.php
@@ -53,7 +53,7 @@ final class ContactEveryoneOptions implements MessageOptionsInterface
     }
 
     /**
-     * @param 'fr_FR'|'en_GB' $locale
+     * @param 'en_GB'|'fr_FR' $locale
      *
      * @return $this
      */

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/FakeChatEmailTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/FakeChatEmailTransport.php
@@ -53,7 +53,7 @@ final class FakeChatEmailTransport extends AbstractTransport
     }
 
     /**
-     * @param MessageInterface|ChatMessage $message
+     * @param ChatMessage|MessageInterface $message
      *
      * @throws TransportExceptionInterface
      */

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/FakeChatLoggerTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/FakeChatLoggerTransport.php
@@ -46,7 +46,7 @@ final class FakeChatLoggerTransport extends AbstractTransport
     }
 
     /**
-     * @param MessageInterface|ChatMessage $message
+     * @param ChatMessage|MessageInterface $message
      */
     protected function doSend(MessageInterface $message): SentMessage
     {

--- a/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
+++ b/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
@@ -82,7 +82,7 @@ final class OptionConfigurator
      *
      * @param string          $package The name of the composer package that is triggering the deprecation
      * @param string          $version The version of the package that introduced the deprecation
-     * @param string|\Closure $message The deprecation message to use
+     * @param \Closure|string $message The deprecation message to use
      *
      * @return $this
      */

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -427,7 +427,7 @@ class OptionsResolver implements Options
      *
      * @param string          $package The name of the composer package that is triggering the deprecation
      * @param string          $version The version of the package that introduced the deprecation
-     * @param string|\Closure $message The deprecation message to use
+     * @param \Closure|string $message The deprecation message to use
      *
      * @return $this
      */

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -26,7 +26,7 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
     private array $passwordHashers;
 
     /**
-     * @param array<string, PasswordHasherInterface|array> $passwordHashers
+     * @param array<string, array|PasswordHasherInterface> $passwordHashers
      */
     public function __construct(array $passwordHashers)
     {

--- a/src/Symfony/Component/Process/InputStream.php
+++ b/src/Symfony/Component/Process/InputStream.php
@@ -37,7 +37,7 @@ class InputStream implements \IteratorAggregate
     /**
      * Appends an input to the write buffer.
      *
-     * @param resource|string|int|float|bool|\Traversable|null $input The input to append as scalar,
+     * @param bool|float|int|resource|string|\Traversable|null $input The input to append as scalar,
      *                                                                stream resource or \Traversable
      */
     public function write(mixed $input): void

--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -23,13 +23,13 @@ abstract class AbstractPipes implements PipesInterface
     public array $pipes = [];
 
     private string $inputBuffer = '';
-    /** @var resource|string|\Iterator */
+    /** @var \Iterator|resource|string */
     private $input;
     private bool $blocked = true;
     private ?string $lastError = null;
 
     /**
-     * @param resource|string|\Iterator $input
+     * @param \Iterator|resource|string $input
      */
     public function __construct($input)
     {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -55,7 +55,7 @@ class Process implements \IteratorAggregate
     private array|string $commandline;
     private ?string $cwd;
     private array $env = [];
-    /** @var resource|string|\Iterator|null */
+    /** @var \Iterator|resource|string|null */
     private $input;
     private ?float $starttime = null;
     private ?float $lastOutputTime = null;
@@ -137,7 +137,7 @@ class Process implements \IteratorAggregate
      * @param string|null    $cwd     The working directory or null to use the working dir of the current PHP process
      * @param array|null     $env     The environment variables or null to use the same environment as the current PHP process
      * @param mixed          $input   The input as stream resource, scalar or \Traversable, or null for no input
-     * @param int|float|null $timeout The timeout in seconds or null to disable
+     * @param float|int|null $timeout The timeout in seconds or null to disable
      *
      * @throws LogicException When proc_open is not installed
      */
@@ -183,7 +183,7 @@ class Process implements \IteratorAggregate
      * @param string|null    $cwd     The working directory or null to use the working dir of the current PHP process
      * @param array|null     $env     The environment variables or null to use the same environment as the current PHP process
      * @param mixed          $input   The input as stream resource, scalar or \Traversable, or null for no input
-     * @param int|float|null $timeout The timeout in seconds or null to disable
+     * @param float|int|null $timeout The timeout in seconds or null to disable
      *
      * @throws LogicException When proc_open is not installed
      */
@@ -879,7 +879,7 @@ class Process implements \IteratorAggregate
     /**
      * Stops the process.
      *
-     * @param int|float $timeout The timeout in seconds
+     * @param float|int $timeout The timeout in seconds
      * @param int|null  $signal  A POSIX signal to send in case the process has not stop at timeout, default is SIGKILL (9)
      *
      * @return int|null The exit-code of the process or null if it's not running
@@ -1111,7 +1111,7 @@ class Process implements \IteratorAggregate
     /**
      * Gets the Process input.
      *
-     * @return resource|string|\Iterator|null
+     * @return \Iterator|resource|string|null
      */
     public function getInput()
     {
@@ -1123,7 +1123,7 @@ class Process implements \IteratorAggregate
      *
      * This content will be passed to the underlying process standard input.
      *
-     * @param string|resource|\Traversable|self|null $input The content
+     * @param resource|self|string|\Traversable|null $input The content
      *
      * @return $this
      *

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -128,7 +128,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
         $parentClass = null;
         $types = [];
-        /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
+        /** @var DocBlock\Tags\Param|DocBlock\Tags\Return_|DocBlock\Tags\Var_ $tag */
         foreach ($docBlock->getTagsByName($tag) as $tag) {
             if ($tag && !$tag instanceof InvalidTag && null !== $tag->getType()) {
                 foreach ($this->phpDocTypeHelper->getTypes($tag->getType()) as $type) {
@@ -174,7 +174,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         }
 
         $types = [];
-        /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
+        /** @var DocBlock\Tags\Param|DocBlock\Tags\Return_|DocBlock\Tags\Var_ $tag */
         foreach ($docBlock->getTagsByName('param') as $tag) {
             if ($tag && null !== $tag->getType()) {
                 $types[] = $this->phpDocTypeHelper->getTypes($tag->getType());

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -71,8 +71,8 @@ class Type
     private array $collectionValueType;
 
     /**
-     * @param Type[]|Type|null $collectionKeyType
-     * @param Type[]|Type|null $collectionValueType
+     * @param Type|Type[]|null $collectionKeyType
+     * @param Type|Type[]|null $collectionValueType
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Routing/Attribute/Route.php
+++ b/src/Symfony/Component/Routing/Attribute/Route.php
@@ -27,8 +27,8 @@ class Route
 
     /**
      * @param array<string|\Stringable> $requirements
-     * @param string[]|string           $methods
-     * @param string[]|string           $schemes
+     * @param string|string[]           $methods
+     * @param string|string[]           $schemes
      */
     public function __construct(
         string|array $path = null,

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -71,7 +71,7 @@ class CollectionConfigurator
     /**
      * Sets the prefix to add to the path of all child routes.
      *
-     * @param string|array $prefix the prefix, or the localized prefixes
+     * @param array|string $prefix the prefix, or the localized prefixes
      *
      * @return $this
      */
@@ -104,7 +104,7 @@ class CollectionConfigurator
     /**
      * Sets the host to use for all child routes.
      *
-     * @param string|array $host the host, or the localized hosts
+     * @param array|string $host the host, or the localized hosts
      *
      * @return $this
      */

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -48,7 +48,7 @@ class ImportConfigurator
     /**
      * Sets the prefix to add to the path of all child routes.
      *
-     * @param string|array $prefix the prefix, or the localized prefixes
+     * @param array|string $prefix the prefix, or the localized prefixes
      *
      * @return $this
      */
@@ -74,7 +74,7 @@ class ImportConfigurator
     /**
      * Sets the host to use for all child routes.
      *
-     * @param string|array $host the host, or the localized hosts
+     * @param array|string $host the host, or the localized hosts
      *
      * @return $this
      */

--- a/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
@@ -36,7 +36,7 @@ class RouteConfigurator
     /**
      * Sets the host to use for all child routes.
      *
-     * @param string|array $host the host, or the localized hosts
+     * @param array|string $host the host, or the localized hosts
      *
      * @return $this
      */

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/AddTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/AddTrait.php
@@ -30,7 +30,7 @@ trait AddTrait
     /**
      * Adds a route.
      *
-     * @param string|array $path the path, or the localized paths of the route
+     * @param array|string $path the path, or the localized paths of the route
      */
     public function add(string $name, string|array $path): RouteConfigurator
     {
@@ -48,7 +48,7 @@ trait AddTrait
     /**
      * Adds a route.
      *
-     * @param string|array $path the path, or the localized paths of the route
+     * @param array|string $path the path, or the localized paths of the route
      */
     public function __invoke(string $name, string|array $path): RouteConfigurator
     {

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/LocalizedRouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/LocalizedRouteTrait.php
@@ -25,7 +25,7 @@ trait LocalizedRouteTrait
     /**
      * Creates one or many routes.
      *
-     * @param string|array $path the path, or the localized paths of the route
+     * @param array|string $path the path, or the localized paths of the route
      */
     final protected function createLocalizedRoute(RouteCollection $collection, string $name, string|array $path, string $namePrefix = '', array $prefixes = null): RouteCollection
     {

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -123,7 +123,7 @@ trait RouteTrait
     /**
      * Adds the "_controller" entry to defaults.
      *
-     * @param callable|string|array $controller a callable or parseable pseudo-callable
+     * @param array|callable|string $controller a callable or parseable pseudo-callable
      *
      * @return $this
      */

--- a/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
@@ -24,8 +24,8 @@ use Symfony\Component\ExpressionLanguage\Expression;
 final class IsGranted
 {
     /**
-     * @param string|Expression            $attribute     The attribute that will be checked against a given authentication token and optional subject
-     * @param array|string|Expression|null $subject       An optional subject - e.g. the current object being voted on
+     * @param Expression|string            $attribute     The attribute that will be checked against a given authentication token and optional subject
+     * @param array|Expression|string|null $subject       An optional subject - e.g. the current object being voted on
      * @param string|null                  $message       A custom message when access is not granted
      * @param int|null                     $statusCode    If set, will throw HttpKernel's HttpException with the given $statusCode; if null, Security\Core's AccessDeniedException will be used
      * @param int|null                     $exceptionCode If set, will add the exception code to thrown exception

--- a/src/Symfony/Component/Serializer/Context/ContextBuilderInterface.php
+++ b/src/Symfony/Component/Serializer/Context/ContextBuilderInterface.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Serializer\Context;
 interface ContextBuilderInterface
 {
     /**
-     * @param self|array<string, mixed> $context
+     * @param array<string, mixed>|self $context
      */
     public function withContext(self|array $context): static;
 

--- a/src/Symfony/Component/Serializer/Context/ContextBuilderTrait.php
+++ b/src/Symfony/Component/Serializer/Context/ContextBuilderTrait.php
@@ -30,7 +30,7 @@ trait ContextBuilderTrait
     }
 
     /**
-     * @param ContextBuilderInterface|array<string, mixed> $context
+     * @param array<string, mixed>|ContextBuilderInterface $context
      */
     public function withContext(ContextBuilderInterface|array $context): static
     {

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
@@ -77,7 +77,7 @@ abstract class AbstractNormalizerContextBuilder implements ContextBuilderInterfa
      *
      * Eg: ['foo', 'bar', 'object' => ['baz']]
      *
-     * @param array<string|array>|null $attributes
+     * @param array<array|string>|null $attributes
      *
      * @throws InvalidArgumentException
      */

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -198,7 +198,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      *
      * @param bool $attributesAsString If false, return an array of {@link AttributeMetadataInterface}
      *
-     * @return string[]|AttributeMetadataInterface[]|bool
+     * @return AttributeMetadataInterface[]|bool|string[]
      *
      * @throws LogicException if the 'allow_extra_attributes' context variable is false and no class metadata factory is provided
      */

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
@@ -29,7 +29,7 @@ interface DenormalizableInterface
      *
      * @param DenormalizerInterface       $denormalizer The denormalizer is given so that you
      *                                                  can use it to denormalize objects contained within this object
-     * @param array|string|int|float|bool $data         The data from which to re-create the object
+     * @param array|bool|float|int|string $data         The data from which to re-create the object
      * @param string|null                 $format       The format is optionally given to be able to denormalize
      *                                                  differently based on different input formats
      * @param array                       $context      Options for denormalizing

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -66,7 +66,7 @@ interface DenormalizerInterface
      * Use type "object" to match any classes or interfaces,
      * and type "*" to match any types.
      *
-     * @return array<class-string|'*'|'object'|string, bool|null>
+     * @return array<'*'|'object'|class-string|string, bool|null>
      */
     public function getSupportedTypes(?string $format): array;
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -28,7 +28,7 @@ interface NormalizerInterface
      * @param string|null $format  Format the normalization result will be encoded as
      * @param array       $context Context options for the normalizer
      *
-     * @return array|string|int|float|bool|\ArrayObject|null \ArrayObject is used to make sure an empty object is encoded as an object not an array
+     * @return array|\ArrayObject|bool|float|int|string|null \ArrayObject is used to make sure an empty object is encoded as an object not an array
      *
      * @throws InvalidArgumentException   Occurs when the object given is not a supported type for the normalizer
      * @throws CircularReferenceException Occurs when the normalizer detects a circular reference when no circular
@@ -59,7 +59,7 @@ interface NormalizerInterface
      * Use type "object" to match any classes or interfaces,
      * and type "*" to match any types.
      *
-     * @return array<class-string|'*'|'object'|string, bool|null>
+     * @return array<'*'|'object'|class-string|string, bool|null>
      */
     public function getSupportedTypes(?string $format): array;
 }

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -73,8 +73,8 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     private array $normalizerCache = [];
 
     /**
-     * @param array<NormalizerInterface|DenormalizerInterface> $normalizers
-     * @param array<EncoderInterface|DecoderInterface>         $encoders
+     * @param array<DenormalizerInterface|NormalizerInterface> $normalizers
+     * @param array<DecoderInterface|EncoderInterface>         $encoders
      */
     public function __construct(
         private array $normalizers = [],

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
@@ -60,17 +60,17 @@ trait ContextMetadataTestTrait
         $normalizer = new ObjectNormalizer($classMetadataFactory, null, null, new PhpDocExtractor());
         new Serializer([new DateTimeNormalizer(), $normalizer]);
 
-        /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
+        /** @var ContextChildMetadataDummy|ContextMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '2011-07-28T08:44:00+00:00'], $contextMetadataDummyClass);
         self::assertEquals(new \DateTimeImmutable('2011-07-28T08:44:00+00:00'), $dummy->date);
 
-        /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
+        /** @var ContextChildMetadataDummy|ContextMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '2011-07-28T08:44:00+00:00'], ContextMetadataDummy::class, null, [
             ObjectNormalizer::GROUPS => 'extended',
         ]);
         self::assertEquals(new \DateTimeImmutable('2011-07-28T08:44:00+00:00'), $dummy->date, 'base denormalization context is unchanged for this group');
 
-        /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
+        /** @var ContextChildMetadataDummy|ContextMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '28/07/2011'], $contextMetadataDummyClass, null, [
             ObjectNormalizer::GROUPS => 'simple',
         ]);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1729,12 +1729,12 @@ class Bar
 class DummyUnionType
 {
     /**
-     * @var \DateTimeImmutable|bool|null
+     * @var bool|\DateTimeImmutable|null
      */
     public $changed = false;
 
     /**
-     * @param \DateTimeImmutable|bool|null
+     * @param bool|\DateTimeImmutable|null
      *
      * @return $this
      */
@@ -1768,11 +1768,11 @@ class DummyCTypeForUnion
 
 class DummyUnionWithAAndCAndB
 {
-    /** @var DummyATypeForUnion|DummyCTypeForUnion|DummyBTypeForUnion */
+    /** @var DummyATypeForUnion|DummyBTypeForUnion|DummyCTypeForUnion */
     public $v;
 
     /**
-     * @param DummyATypeForUnion|DummyCTypeForUnion|DummyBTypeForUnion $v
+     * @param DummyATypeForUnion|DummyBTypeForUnion|DummyCTypeForUnion $v
      */
     public function __construct($v)
     {

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -23,8 +23,8 @@ class StopwatchPeriod
     private int $memory;
 
     /**
-     * @param int|float $start         The relative time of the start of the period (in milliseconds)
-     * @param int|float $end           The relative time of the end of the period (in milliseconds)
+     * @param float|int $start         The relative time of the start of the period (in milliseconds)
+     * @param float|int $end           The relative time of the end of the period (in milliseconds)
      * @param bool      $morePrecision If true, time is stored as float to keep the original microsecond precision
      */
     public function __construct(int|float $start, int|float $end, bool $morePrecision = false)

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -47,7 +47,7 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
     /**
      * Unwraps instances of AbstractString back to strings.
      *
-     * @return string[]|array
+     * @return array|string[]
      */
     public static function unwrap(array $values): array
     {
@@ -65,7 +65,7 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
     /**
      * Wraps (and normalizes) strings in instances of AbstractString.
      *
-     * @return static[]|array
+     * @return array|static[]
      */
     public static function wrap(array $values): array
     {

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -72,7 +72,7 @@ abstract class AbstractUnicodeString extends AbstractString
      *
      * Install the intl extension for best results.
      *
-     * @param string[]|\Transliterator[]|\Closure[] $rules See "*-Latin" rules from Transliterator::listIDs()
+     * @param \Closure[]|string[]|\Transliterator[] $rules See "*-Latin" rules from Transliterator::listIDs()
      */
     public function ascii(array $rules = []): self
     {

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -21,7 +21,7 @@ class LazyString implements \Stringable, \JsonSerializable
     private \Closure|string $value;
 
     /**
-     * @param callable|array $callback A callable or a [Closure, method] lazy-callable
+     * @param array|callable $callback A callable or a [Closure, method] lazy-callable
      */
     public static function fromCallable(callable|array $callback, mixed ...$arguments): static
     {

--- a/src/Symfony/Component/String/Resources/functions.php
+++ b/src/Symfony/Component/String/Resources/functions.php
@@ -27,7 +27,7 @@ if (!\function_exists(b::class)) {
 
 if (!\function_exists(s::class)) {
     /**
-     * @return UnicodeString|ByteString
+     * @return ByteString|UnicodeString
      */
     function s(?string $string = ''): AbstractString
     {

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -31,7 +31,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     private array $messages = [];
 
     /**
-     * @param TranslatorInterface&TranslatorBagInterface&LocaleAwareInterface $translator
+     * @param LocaleAwareInterface&TranslatorBagInterface&TranslatorInterface $translator
      */
     public function __construct(TranslatorInterface $translator)
     {

--- a/src/Symfony/Component/Translation/Extractor/ExtractorInterface.php
+++ b/src/Symfony/Component/Translation/Extractor/ExtractorInterface.php
@@ -24,7 +24,7 @@ interface ExtractorInterface
     /**
      * Extracts translation messages from files, a file or a directory to the catalogue.
      *
-     * @param string|iterable<string> $resource Files, a file or a directory
+     * @param iterable<string>|string $resource Files, a file or a directory
      *
      * @return void
      */

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -25,7 +25,7 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
     private LoggerInterface $logger;
 
     /**
-     * @param TranslatorInterface&TranslatorBagInterface&LocaleAwareInterface $translator The translator must implement TranslatorBagInterface
+     * @param LocaleAwareInterface&TranslatorBagInterface&TranslatorInterface $translator The translator must implement TranslatorBagInterface
      */
     public function __construct(TranslatorInterface $translator, LoggerInterface $logger)
     {

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -104,7 +104,7 @@ class TranslatorCacheTest extends TestCase
         $catalogue = new MessageCatalogue($locale, []);
         $catalogue->addResource(new StaleResource()); // better use a helper class than a mock, because it gets serialized in the cache and re-loaded
 
-        /** @var MockObject&LoaderInterface $loader */
+        /** @var LoaderInterface&MockObject $loader */
         $loader = $this->createMock(LoaderInterface::class);
         $loader
             ->expects($this->exactly(2))

--- a/src/Symfony/Component/Uid/Factory/TimeBasedUuidFactory.php
+++ b/src/Symfony/Component/Uid/Factory/TimeBasedUuidFactory.php
@@ -17,7 +17,7 @@ use Symfony\Component\Uid\Uuid;
 class TimeBasedUuidFactory
 {
     /**
-     * @param class-string<Uuid&TimeBasedUidInterface> $class
+     * @param class-string<TimeBasedUidInterface&Uuid> $class
      */
     public function __construct(
         private string $class,

--- a/src/Symfony/Component/Validator/Constraints/Callback.php
+++ b/src/Symfony/Component/Validator/Constraints/Callback.php
@@ -22,12 +22,12 @@ use Symfony\Component\Validator\Constraint;
 class Callback extends Constraint
 {
     /**
-     * @var string|callable
+     * @var callable|string
      */
     public $callback;
 
     /**
-     * @param string|string[]|callable|array<string,mixed>|null $callback The callback definition
+     * @param array<string,mixed>|callable|string|string[]|null $callback The callback definition
      * @param string[]|null                                     $groups
      */
     public function __construct(array|string|callable $callback = null, array $groups = null, mixed $payload = null, array $options = [])

--- a/src/Symfony/Component/Validator/Constraints/CardScheme.php
+++ b/src/Symfony/Component/Validator/Constraints/CardScheme.php
@@ -47,7 +47,7 @@ class CardScheme extends Constraint
     public array|string|null $schemes = null;
 
     /**
-     * @param string|string[]|array<string,mixed>|null $schemes Name(s) of the number scheme(s) used to validate the credit card number
+     * @param array<string,mixed>|string|string[]|null $schemes Name(s) of the number scheme(s) used to validate the credit card number
      * @param string[]|null                            $groups
      * @param array<string,mixed>                      $options
      */

--- a/src/Symfony/Component/Validator/Constraints/Cascade.php
+++ b/src/Symfony/Component/Validator/Constraints/Cascade.php
@@ -25,7 +25,7 @@ class Cascade extends Constraint
     public array $exclude = [];
 
     /**
-     * @param string[]|string|array<string,mixed>|null $exclude Properties excluded from validation
+     * @param array<string,mixed>|string|string[]|null $exclude Properties excluded from validation
      * @param array<string,mixed>|null                 $options
      */
     public function __construct(array|string $exclude = null, array $options = null)

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -43,7 +43,7 @@ class Count extends Constraint
     public ?int $divisibleBy = null;
 
     /**
-     * @param int|array<string,mixed>|null $exactly     The exact expected number of elements
+     * @param array<string,mixed>|int|null $exactly     The exact expected number of elements
      * @param int|null                     $min         Minimum expected number of elements
      * @param int|null                     $max         Maximum expected number of elements
      * @param int|null                     $divisibleBy The number the collection count should be divisible by

--- a/src/Symfony/Component/Validator/Constraints/CssColor.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColor.php
@@ -62,7 +62,7 @@ class CssColor extends Constraint
     public array|string $formats;
 
     /**
-     * @param string[]|string|array<string,mixed> $formats The types of CSS colors allowed ({@see https://symfony.com/doc/current/reference/constraints/CssColor.html#formats})
+     * @param array<string,mixed>|string|string[] $formats The types of CSS colors allowed ({@see https://symfony.com/doc/current/reference/constraints/CssColor.html#formats})
      * @param string[]|null                       $groups
      * @param array<string,mixed>|null            $options
      */

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -37,7 +37,7 @@ class DateTime extends Constraint
     public string $message = 'This value is not a valid datetime.';
 
     /**
-     * @param string|array<string,mixed>|null $format  The datetime format to match (defaults to 'Y-m-d H:i:s')
+     * @param array<string,mixed>|string|null $format  The datetime format to match (defaults to 'Y-m-d H:i:s')
      * @param string[]|null                   $groups
      * @param array<string,mixed>             $options
      */

--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -39,7 +39,7 @@ class Expression extends Constraint
     public bool $negate = true;
 
     /**
-     * @param string|ExpressionObject|array<string,mixed>|null $expression The expression to evaluate
+     * @param array<string,mixed>|ExpressionObject|string|null $expression The expression to evaluate
      * @param array<string,mixed>|null                         $values     The values of the custom variables used in the expression (defaults to an empty array)
      * @param string[]|null                                    $groups
      * @param array<string,mixed>                              $options

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -74,7 +74,7 @@ class File extends Constraint
      * @param array<string,mixed>|null           $options
      * @param int|string|null                    $maxSize                     The max size of the underlying file
      * @param bool|null                          $binaryFormat                Pass true to use binary-prefixed units (KiB, MiB, etc.) or false to use SI-prefixed units (kB, MB) in displayed messages. Pass null to guess the format from the maxSize option. (defaults to null)
-     * @param string[]|string|null               $mimeTypes                   Acceptable media type(s). Prefer the extensions option that also enforce the file's extension consistency.
+     * @param string|string[]|null               $mimeTypes                   Acceptable media type(s). Prefer the extensions option that also enforce the file's extension consistency.
      * @param int|null                           $filenameMaxLength           Maximum length of the file name
      * @param string|null                        $disallowEmptyMessage        Enable empty upload validation with this message in case of error
      * @param string|null                        $uploadIniSizeErrorMessage   Message if the file size exceeds the max size configured in php.ini

--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -52,7 +52,7 @@ class GroupSequence
     /**
      * The groups in the sequence.
      *
-     * @var array<int, string|string[]|GroupSequence>
+     * @var array<int, GroupSequence|string|string[]>
      */
     public array $groups;
 
@@ -73,7 +73,7 @@ class GroupSequence
     /**
      * Creates a new group sequence.
      *
-     * @param array<string|string[]|GroupSequence> $groups The groups in the sequence
+     * @param array<GroupSequence|string|string[]> $groups The groups in the sequence
      */
     public function __construct(array $groups)
     {

--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -105,10 +105,10 @@ class Image extends File
      * @param int|null                 $maxWidth                    Maximum image width
      * @param int|null                 $maxHeight                   Maximum image height
      * @param int|null                 $minHeight                   Minimum image weight
-     * @param int|float|null           $maxRatio                    Maximum image ratio
-     * @param int|float|null           $minRatio                    Minimum image ration
-     * @param int|float|null           $minPixels                   Minimum amount of pixels
-     * @param int|float|null           $maxPixels                   Maximum amount of pixels
+     * @param float|int|null           $maxRatio                    Maximum image ratio
+     * @param float|int|null           $minRatio                    Minimum image ration
+     * @param float|int|null           $minPixels                   Minimum amount of pixels
+     * @param float|int|null           $maxPixels                   Maximum amount of pixels
      * @param bool|null                $allowSquare                 Whether to allow a square image (defaults to true)
      * @param bool|null                $allowLandscape              Whether to allow a landscape image (defaults to true)
      * @param bool|null                $allowPortrait               Whether to allow a portrait image (defaults to true)

--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -74,7 +74,7 @@ class Ip extends Constraint
 
     /**
      * @param array<string,mixed>|null            $options
-     * @param self::V4*|self::V6*|self::ALL*|null $version The IP version to validate (defaults to {@see self::V4})
+     * @param self::ALL*|self::V4*|self::V6*|null $version The IP version to validate (defaults to {@see self::V4})
      * @param string[]|null                       $groups
      */
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Isbn.php
+++ b/src/Symfony/Component/Validator/Constraints/Isbn.php
@@ -49,7 +49,7 @@ class Isbn extends Constraint
     public ?string $message = null;
 
     /**
-     * @param self::ISBN_*|array<string,mixed>|null $type    The type of ISBN to validate (i.e. {@see Isbn::ISBN_10}, {@see Isbn::ISBN_13} or null to accept both, defaults to null)
+     * @param array<string,mixed>|self::ISBN_*|null $type    The type of ISBN to validate (i.e. {@see Isbn::ISBN_10}, {@see Isbn::ISBN_13} or null to accept both, defaults to null)
      * @param string|null                           $message If defined, this message has priority over the others
      * @param string[]|null                         $groups
      * @param array<string,mixed>                   $options

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -58,7 +58,7 @@ class Length extends Constraint
     public string $countUnit = self::COUNT_CODEPOINTS;
 
     /**
-     * @param int|array<string,mixed>|null $exactly    The exact expected length
+     * @param array<string,mixed>|int|null $exactly    The exact expected length
      * @param int|null                     $min        The minimum expected length
      * @param int|null                     $max        The maximum expected length
      * @param string|null                  $charset    The charset to be used when computing value's length (defaults to UTF-8)

--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -51,9 +51,9 @@ class Range extends Constraint
      * @param array<string,mixed>|null $options
      * @param string|null              $invalidMessage         The message if min and max values are numeric but the given value is not
      * @param string|null              $invalidDateTimeMessage The message if min and max values are PHP datetimes but the given value is not
-     * @param int|float|string|null    $min                    The minimum value, either numeric or a datetime string representation
+     * @param float|int|string|null    $min                    The minimum value, either numeric or a datetime string representation
      * @param string|null              $minPropertyPath        Property path to the min value
-     * @param int|float|string|null    $max                    The maximum value, either numeric or a datetime string representation
+     * @param float|int|string|null    $max                    The maximum value, either numeric or a datetime string representation
      * @param string|null              $maxPropertyPath        Property path to the max value
      * @param string[]|null            $groups
      */

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -36,7 +36,7 @@ class Regex extends Constraint
     public $normalizer;
 
     /**
-     * @param string|array<string,mixed>|null $pattern     The regular expression to match
+     * @param array<string,mixed>|string|null $pattern     The regular expression to match
      * @param string|null                     $htmlPattern The pattern to use in the HTML5 pattern attribute
      * @param bool|null                       $match       Whether to validate the value matches the configured pattern or not (defaults to false)
      * @param string[]|null                   $groups

--- a/src/Symfony/Component/Validator/Constraints/Sequentially.php
+++ b/src/Symfony/Component/Validator/Constraints/Sequentially.php
@@ -25,7 +25,7 @@ class Sequentially extends Composite
     public array|Constraint $constraints = [];
 
     /**
-     * @param Constraint[]|array<string,mixed>|null $constraints An array of validation constraints
+     * @param array<string,mixed>|Constraint[]|null $constraints An array of validation constraints
      * @param string[]|null                         $groups
      */
     public function __construct(mixed $constraints = null, array $groups = null, mixed $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -41,7 +41,7 @@ class Timezone extends Constraint
     ];
 
     /**
-     * @param int|array<string,mixed>|null $zone           Restrict valid timezones to this geographical zone (defaults to {@see \DateTimeZone::ALL})
+     * @param array<string,mixed>|int|null $zone           Restrict valid timezones to this geographical zone (defaults to {@see \DateTimeZone::ALL})
      * @param string|null                  $countryCode    Restrict the valid timezones to this country if the zone option is {@see \DateTimeZone::PER_COUNTRY}
      * @param bool|null                    $intlCompatible Whether to restrict valid timezones to ones available in PHP's intl (defaults to false)
      * @param string[]|null                $groups

--- a/src/Symfony/Component/Validator/Constraints/Traverse.php
+++ b/src/Symfony/Component/Validator/Constraints/Traverse.php
@@ -25,7 +25,7 @@ class Traverse extends Constraint
     public bool $traverse = true;
 
     /**
-     * @param bool|array<string,mixed>|null $traverse Whether to traverse the given object or not (defaults to true). Pass an associative array to configure the constraint's options (e.g. payload).
+     * @param array<string,mixed>|bool|null $traverse Whether to traverse the given object or not (defaults to true). Pass an associative array to configure the constraint's options (e.g. payload).
      */
     public function __construct(bool|array $traverse = null)
     {

--- a/src/Symfony/Component/Validator/Constraints/Type.php
+++ b/src/Symfony/Component/Validator/Constraints/Type.php
@@ -31,7 +31,7 @@ class Type extends Constraint
     public string|array|null $type = null;
 
     /**
-     * @param string|string[]|array<string,mixed>|null $type    The type(s) to enforce on the value
+     * @param array<string,mixed>|string|string[]|null $type    The type(s) to enforce on the value
      * @param string[]|null                            $groups
      * @param array<string,mixed>                      $options
      */

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -37,7 +37,7 @@ class Unique extends Constraint
     /**
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
-     * @param string[]|string|null     $fields  Defines the key or keys in the collection that should be checked for uniqueness (defaults to null, which ensure uniqueness for all keys)
+     * @param string|string[]|null     $fields  Defines the key or keys in the collection that should be checked for uniqueness (defaults to null, which ensure uniqueness for all keys)
      */
     public function __construct(
         array $options = null,

--- a/src/Symfony/Component/Validator/Constraints/Uuid.php
+++ b/src/Symfony/Component/Validator/Constraints/Uuid.php
@@ -96,7 +96,7 @@ class Uuid extends Constraint
 
     /**
      * @param array<string,mixed>|null $options
-     * @param self::V*[]|self::V*|null $versions Specific UUID versions (defaults to {@see Uuid::ALL_VERSIONS})
+     * @param self::V*|self::V*[]|null $versions Specific UUID versions (defaults to {@see Uuid::ALL_VERSIONS})
      * @param bool|null                $strict   Whether to force the value to follow the RFC's input format rules; pass false to allow alternate formats (defaults to true)
      * @param string[]|null            $groups
      */

--- a/src/Symfony/Component/Validator/Constraints/When.php
+++ b/src/Symfony/Component/Validator/Constraints/When.php
@@ -29,8 +29,8 @@ class When extends Composite
     public array $values = [];
 
     /**
-     * @param string|Expression|array<string,mixed> $expression  The condition to evaluate, written with the ExpressionLanguage syntax
-     * @param Constraint[]|Constraint|null          $constraints One or multiple constraints that are applied if the expression returns true
+     * @param array<string,mixed>|Expression|string $expression  The condition to evaluate, written with the ExpressionLanguage syntax
+     * @param Constraint|Constraint[]|null          $constraints One or multiple constraints that are applied if the expression returns true
      * @param array<string,mixed>|null              $values      The values of the custom variables used in the expression (defaults to [])
      * @param string[]|null                         $groups
      * @param array<string,mixed>                   $options

--- a/src/Symfony/Component/Validator/GroupProviderInterface.php
+++ b/src/Symfony/Component/Validator/GroupProviderInterface.php
@@ -24,7 +24,7 @@ interface GroupProviderInterface
      * Returns which validation groups should be used for a certain state
      * of the object.
      *
-     * @return string[]|string[][]|GroupSequence
+     * @return GroupSequence|string[]|string[][]
      */
     public function getGroups(object $object): array|GroupSequence;
 }

--- a/src/Symfony/Component/Validator/GroupSequenceProviderInterface.php
+++ b/src/Symfony/Component/Validator/GroupSequenceProviderInterface.php
@@ -22,7 +22,7 @@ interface GroupSequenceProviderInterface
      * Returns which validation groups should be used for a certain state
      * of the object.
      *
-     * @return string[]|string[][]|GroupSequence
+     * @return GroupSequence|string[]|string[][]
      */
     public function getGroupSequence(): array|GroupSequence;
 }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -379,7 +379,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     /**
      * Sets the default group sequence for this class.
      *
-     * @param string[]|GroupSequence $groupSequence An array of group names
+     * @param GroupSequence|string[] $groupSequence An array of group names
      *
      * @return $this
      *

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -72,7 +72,7 @@ class YamlFileLoader extends FileLoader
      *
      * @param array $nodes The YAML nodes
      *
-     * @return array<array|scalar|Constraint>
+     * @return array<array|Constraint|scalar>
      */
     protected function parseNodes(array $nodes): array
     {

--- a/src/Symfony/Component/Validator/Resources/bin/sync-iban-formats.php
+++ b/src/Symfony/Component/Validator/Resources/bin/sync-iban-formats.php
@@ -181,7 +181,7 @@ final class WikipediaIbanProvider
     }
 
     /**
-     * @return list<array<string, string|int>>
+     * @return list<array<string, int|string>>
      */
     private function readIbanFormatsTable(): array
     {

--- a/src/Symfony/Component/Validator/Validator/ContextualValidatorInterface.php
+++ b/src/Symfony/Component/Validator/Validator/ContextualValidatorInterface.php
@@ -40,7 +40,7 @@ interface ContextualValidatorInterface
      *
      * @param mixed                                                 $value       The value to validate
      * @param Constraint|Constraint[]|null                          $constraints The constraint(s) to validate against
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If none is given, "Default" is assumed
+     * @param array<GroupSequence|string>|GroupSequence|string|null $groups      The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return $this
      */
@@ -51,7 +51,7 @@ interface ContextualValidatorInterface
      * for this property.
      *
      * @param string                                                $propertyName The name of the validated property
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups       The validation groups to validate. If none is given, "Default" is assumed
+     * @param array<GroupSequence|string>|GroupSequence|string|null $groups       The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return $this
      */
@@ -64,7 +64,7 @@ interface ContextualValidatorInterface
      * @param object|string                                         $objectOrClass The object or its class name
      * @param string                                                $propertyName  The name of the property
      * @param mixed                                                 $value         The value to validate against the property's constraints
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups        The validation groups to validate. If none is given, "Default" is assumed
+     * @param array<GroupSequence|string>|GroupSequence|string|null $groups        The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return $this
      */

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -260,9 +260,9 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
     /**
      * Normalizes the given group or list of groups to an array.
      *
-     * @param string|GroupSequence|array<string|GroupSequence> $groups The groups to normalize
+     * @param array<GroupSequence|string>|GroupSequence|string $groups The groups to normalize
      *
-     * @return array<string|GroupSequence>
+     * @return array<GroupSequence|string>
      */
     protected function normalizeGroups(string|GroupSequence|array $groups): array
     {

--- a/src/Symfony/Component/Validator/Validator/ValidatorInterface.php
+++ b/src/Symfony/Component/Validator/Validator/ValidatorInterface.php
@@ -31,7 +31,7 @@ interface ValidatorInterface extends MetadataFactoryInterface
      * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
      *
      * @param Constraint|Constraint[]                               $constraints The constraint(s) to validate against
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If none is given, "Default" is assumed
+     * @param array<GroupSequence|string>|GroupSequence|string|null $groups      The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return ConstraintViolationListInterface A list of constraint violations
      *                                          If the list is empty, validation
@@ -44,7 +44,7 @@ interface ValidatorInterface extends MetadataFactoryInterface
      * for this property.
      *
      * @param string                                                $propertyName The name of the validated property
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups       The validation groups to validate. If none is given, "Default" is assumed
+     * @param array<GroupSequence|string>|GroupSequence|string|null $groups       The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return ConstraintViolationListInterface A list of constraint violations
      *                                          If the list is empty, validation
@@ -59,7 +59,7 @@ interface ValidatorInterface extends MetadataFactoryInterface
      * @param object|string                                         $objectOrClass The object or its class name
      * @param string                                                $propertyName  The name of the property
      * @param mixed                                                 $value         The value to validate against the property's constraints
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups        The validation groups to validate. If none is given, "Default" is assumed
+     * @param array<GroupSequence|string>|GroupSequence|string|null $groups        The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return ConstraintViolationListInterface A list of constraint violations
      *                                          If the list is empty, validation

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -66,7 +66,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate, \Stringable
      *
      * @param array|bool $recursive Whether values should be resolved recursively or not
      *
-     * @return string|int|float|bool|array|Data[]|null
+     * @return array|bool|Data[]|float|int|string|null
      */
     public function getValue(array|bool $recursive = false): string|int|float|bool|array|null
     {

--- a/src/Symfony/Component/VarDumper/Cloner/DumperInterface.php
+++ b/src/Symfony/Component/VarDumper/Cloner/DumperInterface.php
@@ -36,7 +36,7 @@ interface DumperInterface
      * Dumps while entering an hash.
      *
      * @param int             $type     A Cursor::HASH_* const for the type of hash
-     * @param string|int|null $class    The object class, resource type or array count
+     * @param int|string|null $class    The object class, resource type or array count
      * @param bool            $hasChild When the dump of the hash has child item
      */
     public function enterHash(Cursor $cursor, int $type, string|int|null $class, bool $hasChild): void;
@@ -45,7 +45,7 @@ interface DumperInterface
      * Dumps while leaving an hash.
      *
      * @param int             $type     A Cursor::HASH_* const for the type of hash
-     * @param string|int|null $class    The object class, resource type or array count
+     * @param int|string|null $class    The object class, resource type or array count
      * @param bool            $hasChild When the dump of the hash has child item
      * @param int             $cut      The number of items the hash has been cut by
      */

--- a/src/Symfony/Component/WebLink/Link.php
+++ b/src/Symfony/Component/WebLink/Link.php
@@ -149,7 +149,7 @@ class Link implements EvolvableLinkInterface
     private array $rel = [];
 
     /**
-     * @var array<string, string|bool|string[]>
+     * @var array<string, bool|string|string[]>
      */
     private array $attributes = [];
 

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -87,7 +87,7 @@ interface HttpClientInterface
     /**
      * Yields responses chunk by chunk as they complete.
      *
-     * @param ResponseInterface|iterable<array-key, ResponseInterface> $responses One or more responses created by the current HTTP client
+     * @param iterable<array-key, ResponseInterface>|ResponseInterface $responses One or more responses created by the current HTTP client
      * @param float|null                                               $timeout   The idle timeout before yielding timeout chunks
      */
     public function stream(ResponseInterface|iterable $responses, float $timeout = null): ResponseStreamInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix CS <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I suggest to unify types in phpdoc, for combined types (eg `foo|bar`).

So far:
- put `null` as last
- everything else as is (random order?)

Idea:
- put `null` as last
- everything else sorted alphabetically