### PR TITLE
[Messenger] [AMQP] Throw exception on `nack` callback

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -494,7 +494,7 @@ class Connection
                 $this->amqpChannel->confirmSelect();
                 $this->amqpChannel->setConfirmCallback(
                     static fn (): bool => false,
-                    static fn (): bool => throw new RuntimeException('Confirm calls back with nack.'),
+                    static fn () => throw new RuntimeException('Confirm calls back with nack.'),
                 );
             }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\LogicException;
-use Symfony\Component\Messenger\Exception\RuntimeException;
+use Symfony\Component\Messenger\Exception\TransportException;
 
 /**
  * An AMQP connection.
@@ -494,7 +494,7 @@ class Connection
                 $this->amqpChannel->confirmSelect();
                 $this->amqpChannel->setConfirmCallback(
                     static fn (): bool => false,
-                    static fn () => throw new RuntimeException('Confirm calls back with nack.'),
+                    static fn () => throw new TransportException('Confirm calls back with nack.'),
                 );
             }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -494,7 +494,7 @@ class Connection
                 $this->amqpChannel->confirmSelect();
                 $this->amqpChannel->setConfirmCallback(
                     static fn (): bool => false,
-                    static fn () => throw new TransportException('Confirm calls back with nack.'),
+                    static fn () => throw new TransportException('Message publication failed due to a negative acknowledgment (nack) from the broker.'),
                 );
             }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\RuntimeException;
-use Symfony\Component\Messenger\Exception\SendingMessageFailedException;
 
 /**
  * An AMQP connection.

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Exception\RuntimeException;
+use Symfony\Component\Messenger\Exception\SendingMessageFailedException;
 
 /**
  * An AMQP connection.
@@ -493,7 +495,7 @@ class Connection
                 $this->amqpChannel->confirmSelect();
                 $this->amqpChannel->setConfirmCallback(
                     static fn (): bool => false,
-                    static fn (): bool => false
+                    static fn (): bool => throw new RuntimeException('Confirm calls back with nack'),
                 );
             }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -495,7 +495,7 @@ class Connection
                 $this->amqpChannel->confirmSelect();
                 $this->amqpChannel->setConfirmCallback(
                     static fn (): bool => false,
-                    static fn (): bool => throw new RuntimeException('Confirm calls back with nack'),
+                    static fn (): bool => throw new RuntimeException('Confirm calls back with nack.'),
                 );
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53229 
| License       | MIT

If the channel is in confirm mode, it is currently not possible to determine if a message has been nack'ed. By throwing an exception within the confirm callback, it is at least possible to react to it.

Return false is not needed to end the wait loop, [since the amqp ext checks for exceptions](https://github.com/php-amqp/php-amqp/blob/e58ac221e317c840ee06f7731e0dc76c7d6a431a/amqp_methods_handling.c#L249).
