### PR TITLE
[VarDumper] Fixes `Typed property Symfony\Component\VarDumper\Dumper\CliDumper::$colors must not be accessed before initialization`

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -550,7 +550,7 @@ class CliDumper extends AbstractDumper
 
     protected function dumpLine(int $depth, bool $endOfValue = false): void
     {
-        if ($this->colors) {
+        if ($this->colors ??= $this->supportsColors()) {
             $this->line = sprintf("\033[%sm%s\033[m", $this->styles['default'], $this->line);
         }
         parent::dumpLine($depth);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | N/A
| License       | MIT

Fixes the following error:

![CleanShot 2024-01-12 at 16 27 25](https://github.com/symfony/symfony/assets/172966/dfb482ff-4754-41cd-bc06-36143afad5cb)

Other methods in the class start with `$this->colors ??= $this->supportsColors();`. I believe this should have the same code. 
