### PR TITLE
[SecurityBundle] Add missing removed config options to upgrade guide

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -429,6 +429,8 @@ SecurityBundle
 --------------
 
  * Enabling SecurityBundle and not configuring it is not allowed, either remove the bundle or configure at least one firewall
+ * Remove the `enable_authenticator_manager` config option
+ * Remove the `security.firewalls.logout.csrf_token_generator` config option, use `security.firewalls.logout.csrf_token_manager` instead
  * Remove the `require_previous_session` config option from authenticators
 
 Serializer

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,7 +5,9 @@ CHANGELOG
 ---
 
  * Enabling SecurityBundle and not configuring it is not allowed
- * Remove configuration options `enable_authenticator_manager`, `csrf_token_generator` and `require_previous_session`
+ * Remove the `enable_authenticator_manager` config option
+ * Remove the `security.firewalls.logout.csrf_token_generator` config option, use `security.firewalls.logout.csrf_token_manager` instead
+ * Remove the `require_previous_session` config option from authenticators
 
 6.4
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Seems like some entries added in https://github.com/symfony/symfony/pull/50866 from got lost from the upgrade guide.
