### PR TITLE
[Messenger] [AmazonSqs] Allow `async-aws/sqs` version 2

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -95,9 +95,9 @@ jobs:
           - 8094:8094
           - 11210:11210
       sqs:
-        image: asyncaws/testing-sqs
+        image: localstack/localstack:3.0.2
         ports:
-          - 9494:9494
+          - 4566:4566
       zookeeper:
         image: wurstmeister/zookeeper:3.4.6
       kafka:
@@ -184,8 +184,8 @@ jobs:
           REDIS_SENTINEL_SERVICE: redis_sentinel
           MESSENGER_REDIS_DSN: redis://127.0.0.1:7006/messages
           MESSENGER_AMQP_DSN: amqp://localhost/%2f/messages
-          MESSENGER_SQS_DSN: "sqs://localhost:9494/messages?sslmode=disable&poll_timeout=0.01"
-          MESSENGER_SQS_FIFO_QUEUE_DSN: "sqs://localhost:9494/messages.fifo?sslmode=disable&poll_timeout=0.01"
+          MESSENGER_SQS_DSN: "sqs://localhost:4566/messages?sslmode=disable&poll_timeout=0.01"
+          MESSENGER_SQS_FIFO_QUEUE_DSN: "sqs://localhost:4566/messages.fifo?sslmode=disable&poll_timeout=0.01"
           KAFKA_BROKER: 127.0.0.1:9092
           POSTGRES_HOST: localhost
 

--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
         "amphp/http-client": "^4.2.1",
         "amphp/http-tunnel": "^1.0",
         "async-aws/ses": "^1.0",
-        "async-aws/sqs": "^1.0",
+        "async-aws/sqs": "^1.0|^2.0",
         "async-aws/sns": "^1.0",
         "cache/integration-tests": "dev-master",
         "doctrine/annotations": "^1.13.1|^2",

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "async-aws/core": "^1.5",
-        "async-aws/sqs": "^1.0",
+        "async-aws/sqs": "^1.0|^2.0",
         "symfony/messenger": "^4.3|^5.0|^6.0",
         "symfony/service-contracts": "^1.1|^2|^3",
         "psr/log": "^1|^2|^3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        |  -
| License       | MIT

With this PR async-aws/sqs version 2 would be allowed to be installed. [With version 2 they are using the AWS JSON-1.0 protocol instead of the XML one](https://github.com/async-aws/sqs/blob/master/CHANGELOG.md#200). They declared this as a BC-Break as they switced the protocol from query to json, but no public method signatures have been changed.

TODO
- [x] Provide JSON stubs for tests