### PR TITLE
[Messenger][Redis] Add option to auto generate consumer

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add option to auto generate unique consumer name.
+
 6.3
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -107,6 +107,14 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnGeneratedConsumer()
+    {
+        $this->assertNotEquals(
+            Connection::fromDsn('redis://localhost/queue/group1/_GENERATED', [], $this->createMock(\Redis::class)),
+            Connection::fromDsn('redis://localhost/queue/group1/_GENERATED', [], $this->createMock(\Redis::class))
+        );
+    }
+
     public function testRedisClusterInstanceIsSupported()
     {
         $redis = $this->createMock(\RedisCluster::class);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -157,7 +157,7 @@ class Connection
 
         $this->stream = $options['stream'];
         $this->group = $options['group'];
-        $this->consumer = $options['consumer'];
+        $this->consumer = '_GENERATED' === $options['consumer'] ? bin2hex(random_bytes(8)) : $options['consumer'];
         $this->queue = $this->stream.'__queue';
         $this->autoSetup = $options['auto_setup'];
         $this->maxEntries = $options['stream_max_entries'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #51604 
| License       | MIT

I opened the above mentioned issue about 4 months ago. 
In #53394 @AdamKatzDev , who seems to know a lot more about Redis than I do, also thinks that this is a good idea. 

It looks like nobody has had a reason why this should not be a feature, so here it is.

Docs PR will be added when this looks good to merge.