### PR TITLE
[Serializer] Rewrite `AbstractObjectNormalizer::createChildContext()` to use the provided `cache_key` from original context when creating child contexts

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -781,7 +781,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     protected function createChildContext(array $parentContext, string $attribute, ?string $format): array
     {
         $context = parent::createChildContext($parentContext, $attribute, $format);
-        $context['cache_key'] = $this->getCacheKey($format, $context);
+        if ($context['cache_key'] ?? false) {
+            $context['cache_key'] .= '-'.$attribute;
+        } else {
+            $context['cache_key'] = $this->getCacheKey($format, $context);
+        }
 
         return $context;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

If the normalization starts with an initial 'cache_key' it is currently discarded when creating child contexts. This change fixes that.
The main reason behind it is that if the client code sends a unique identifier (ApiPlatform injects the IRI) and we have a use case
that iterates a big resultset we end up with a big private cache that quickly runs out of allowed memory. The solution should be to
send a 'cache_key' which skips the entire cache key calculation that hashes the context.