### PR TITLE
[Process] Fixed inconsistent test

### DIFF
--- a/src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
+++ b/src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
@@ -25,7 +25,7 @@ try {
     while (!str_contains($process->getOutput(), 'ready')) {
         usleep(1000);
     }
-    $process->signal(\SIGSTOP);
+    $process->isRunning() && $process->signal(\SIGSTOP);
     $process->wait();
 
     return $process->getExitCode();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Sometimes the process no longer appears to be running when the signal is sent which causes a LogicException to be thrown. This doesn't appear to be consistent and I can reproduce it randomly on my local machine. To avoid having tests fail at random I decided that it's better to send the signal only if the process is still marked as running.


```bash
amne@wnbpowerbox:~/work/projects/symfony$ php7.4 src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
The process "'php' '-r' 'echo '\''ready'\''; trigger_error('\''error'\'', E_USER_ERROR);'" exceeded the timeout of 0.5 seconds.
amne@wnbpowerbox:~/work/projects/symfony$ php7.4 src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
The process "'php' '-r' 'echo '\''ready'\''; trigger_error('\''error'\'', E_USER_ERROR);'" exceeded the timeout of 0.5 seconds.
amne@wnbpowerbox:~/work/projects/symfony$ php7.4 src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
The process "'php' '-r' 'echo '\''ready'\''; trigger_error('\''error'\'', E_USER_ERROR);'" exceeded the timeout of 0.5 seconds.
amne@wnbpowerbox:~/work/projects/symfony$ php7.4 src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
The process "'php' '-r' 'echo '\''ready'\''; trigger_error('\''error'\'', E_USER_ERROR);'" exceeded the timeout of 0.5 seconds.
amne@wnbpowerbox:~/work/projects/symfony$ php7.4 src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
PHP Fatal error:  Uncaught Symfony\Component\Process\Exception\LogicException: Cannot send signal on a non running process. in /home/amne/work/projects/symfony/src/Symfony/Component/Process/Process.php:1502
Stack trace:
#0 /home/amne/work/projects/symfony/src/Symfony/Component/Process/Process.php(516): Symfony\Component\Process\Process->doSignal()
#1 /home/amne/work/projects/symfony/src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php(28): Symfony\Component\Process\Process->signal()
#2 {main}
  thrown in /home/amne/work/projects/symfony/src/Symfony/Component/Process/Process.php on line 1502
```

