### PR TITLE
[Console] Add ability to schedule alarm signals and a `ConsoleAlarmEvent`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * [BC BREAK] Add silent verbosity (`--silent`/`SHELL_VERBOSITY=-2`) to suppress all output, including errors
  * Add `OutputInterface::isSilent()`, `Output::isSilent()`, `OutputStyle::isSilent()` methods
  * Add a configurable finished indicator to the progress indicator to show that the progress is finished
+ * Add ability to schedule alarm signals and a `ConsoleAlarmEvent`
 
 7.1
 ---

--- a/src/Symfony/Component/Console/Event/ConsoleAlarmEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleAlarmEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Event;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ConsoleAlarmEvent extends ConsoleEvent
+{
+    public function __construct(
+        Command $command,
+        InputInterface $input,
+        OutputInterface $output,
+        private int|false $exitCode = 0,
+    ) {
+        parent::__construct($command, $input, $output);
+    }
+
+    public function setExitCode(int $exitCode): void
+    {
+        if ($exitCode < 0 || $exitCode > 255) {
+            throw new \InvalidArgumentException('Exit code must be between 0 and 255.');
+        }
+
+        $this->exitCode = $exitCode;
+    }
+
+    public function abortExit(): void
+    {
+        $this->exitCode = false;
+    }
+
+    public function getExitCode(): int|false
+    {
+        return $this->exitCode;
+    }
+}

--- a/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
+++ b/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
@@ -54,4 +54,12 @@ final class SignalRegistry
             $signalHandler($signal, $hasNext);
         }
     }
+
+    /**
+     * @internal
+     */
+    public function scheduleAlarm(int $seconds): void
+    {
+        pcntl_alarm($seconds);
+    }
 }

--- a/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
@@ -21,26 +21,34 @@ require $vendor.'/vendor/autoload.php';
 
 class MyCommand extends Command implements SignalableCommandInterface
 {
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->getApplication()->setAlarmInterval(1);
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        posix_kill(posix_getpid(), \SIGINT);
+        sleep(5);
 
         $output->writeln('should not be displayed');
 
         return 0;
     }
 
-
     public function getSubscribedSignals(): array
     {
-        return [\SIGINT];
+        return [\SIGALRM];
     }
 
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
-        echo "Received signal!";
+        if (\SIGALRM === $signal) {
+            echo "Received alarm!";
 
-        return 0;
+            return 0;
+        }
+
+        return false;
     }
 }
 
@@ -53,4 +61,4 @@ $app
     ->run()
 ;
 --EXPECT--
-Received signal!
+Received alarm!


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #47920
| License       | MIT

Part of #53508

This PR introduces the ability to schedule alarm signals and a `console.alarm` event. A command using this feature will automatically dispatch an alarm at the specified interval:

```php
#[AsCommand('app:alarm')]
class AlarmCommand extends Command implements SignalableCommandInterface
{
    private bool $run = true;
    private int $count = 0;
    private OutputInterface $output;

    protected function initialize(InputInterface $input, OutputInterface $output): void
    {
        $this->getApplication()->setAlarmInterval(10);
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $this->output = $output;

        while ($this->run) {
            $this->count++;
            $output->writeln('execute '.$this->count);
            sleep(1);
        }

        $output->writeln('Done');

        return Command::SUCCESS;
    }

    public function getSubscribedSignals(): array
    {
        return [\SIGINT, \SIGALRM];
    }

    public function handleSignal(int $signal, false|int $previousExitCode = 0): int|false
    {
        if (\SIGINT === $signal) {
            $this->run = false;
            $this->output->writeln('Bye');
        } elseif (\SIGALRM === $signal) {
            $this->count = 0;
            $this->output->writeln('handleAlarm');
        }

        return false;
    }
}
```

The `console.alarm` event is dispatched on every `SIGALRM` signal:

```php
#[AsEventListener(event: ConsoleAlarmEvent::class)]
final class ConsoleAlarmListener
{
    public function __invoke(ConsoleAlarmEvent $event): void
    {
        $event->getOutput()->writeln('ConsoleAlarmListener');
    }
}
```