### PR TITLE
Trigger WebhookSentEvent after acquiring a Webhook response

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/webhook.php
@@ -27,6 +27,7 @@ return static function (ContainerConfigurator $container) {
                 service('webhook.headers_configurator'),
                 service('webhook.body_configurator.json'),
                 service('webhook.signer'),
+                service('event_dispatcher')->nullOnInvalid(),
             ])
 
         ->set('webhook.headers_configurator', HeadersConfigurator::class)

--- a/src/Symfony/Component/Webhook/CHANGELOG.md
+++ b/src/Symfony/Component/Webhook/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Added `Symfony\Component\Webhook\Event\WebhookSentEvent`
+ * Added an optional dependency to `Psr\EventDispatcher\EventDispatcherInterface` in `Symfony\Component\Webhook\Server\Transport`
+ * Dispatch `WebhookSentEvent` after a webhook is called
+
 6.4
 ---
 

--- a/src/Symfony/Component/Webhook/Event/WebhookSentEvent.php
+++ b/src/Symfony/Component/Webhook/Event/WebhookSentEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Webhook\Event;
+
+use Symfony\Component\RemoteEvent\RemoteEvent;
+use Symfony\Component\Webhook\Subscriber;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This event is dispatched after a webhook event is sent.
+ *
+ * Any listener can access the subscriber, the event and the response.
+ */
+final class WebhookSentEvent extends Event
+{
+    private Subscriber $subscriber;
+    private RemoteEvent $event;
+    private ResponseInterface $response;
+
+    public function __construct(Subscriber $subscriber, RemoteEvent $event, ResponseInterface $response)
+    {
+        $this->subscriber = $subscriber;
+        $this->event = $event;
+        $this->response = $response;
+    }
+
+    public function getSubscriber(): Subscriber
+    {
+        return $this->subscriber;
+    }
+
+    public function getEvent(): RemoteEvent
+    {
+        return $this->event;
+    }
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Symfony/Component/Webhook/Tests/Server/TransportTest.php
+++ b/src/Symfony/Component/Webhook/Tests/Server/TransportTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Webhook\Tests\Server;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpClient\HttpOptions;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+use Symfony\Component\Webhook\Event\WebhookSentEvent;
+use Symfony\Component\Webhook\Server\RequestConfiguratorInterface;
+use Symfony\Component\Webhook\Server\Transport;
+use Symfony\Component\Webhook\Subscriber;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class TransportTest extends TestCase
+{
+    public function testSendWithDispatcher(): void
+    {
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(WebhookSentEvent::class, $listener = new DebugEventListener());
+
+        $transport = new Transport(
+            new MockHttpClient(function (string $method, string $url) {
+                self::assertSame('POST', $method);
+                self::assertSame('https://www.acme.org/webhook', $url);
+
+                return new MockResponse('OK');
+            }),
+            new NullRequestConfigurator(),
+            new NullRequestConfigurator(),
+            new NullRequestConfigurator(),
+            $eventDispatcher,
+        );
+
+        $transport->send(
+            $subscriber = new Subscriber('https://www.acme.org/webhook', '$ecret'),
+            $event = new RemoteEvent('user.created', 'f4afdfd6-32cb-4b72-8a56-4498bada91e0', ['name' => 'John']),
+        );
+
+        $eventReceivedInListener = $listener->event;
+        self::assertInstanceOf(WebhookSentEvent::class, $eventReceivedInListener);
+        self::assertSame($subscriber, $eventReceivedInListener->getSubscriber());
+        self::assertSame($event, $eventReceivedInListener->getEvent());
+        self::assertSame('OK', $eventReceivedInListener->getResponse()->getContent());
+    }
+
+    public function testSendWithoutDispatcher(): void
+    {
+        $transport = new Transport(
+            new MockHttpClient(function (string $method, string $url) {
+                self::assertSame('POST', $method);
+                self::assertSame('https://www.acme.org/webhook', $url);
+
+                return new MockResponse('OK');
+            }),
+            new NullRequestConfigurator(),
+            new NullRequestConfigurator(),
+            new NullRequestConfigurator(),
+        );
+
+        $transport->send(
+            new Subscriber('https://www.acme.org/webhook', '$ecret'),
+            new RemoteEvent('user.created', 'f4afdfd6-32cb-4b72-8a56-4498bada91e0', ['name' => 'John']),
+        );
+    }
+}
+
+class NullRequestConfigurator implements RequestConfiguratorInterface
+{
+    public function configure(RemoteEvent $event, #[\SensitiveParameter] string $secret, HttpOptions $options): void
+    {
+    }
+}
+
+class DebugEventListener
+{
+    public ?Event $event = null;
+
+    public function __invoke(Event $event): void
+    {
+        $this->event = $event;
+    }
+}

--- a/src/Symfony/Component/Webhook/Tests/Server/TransportTest.php
+++ b/src/Symfony/Component/Webhook/Tests/Server/TransportTest.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class TransportTest extends TestCase
 {
-    public function testSendWithDispatcher(): void
+    public function testSendWithDispatcher()
     {
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->addListener(WebhookSentEvent::class, $listener = new DebugEventListener());
@@ -55,7 +55,7 @@ class TransportTest extends TestCase
         self::assertSame('OK', $eventReceivedInListener->getResponse()->getContent());
     }
 
-    public function testSendWithoutDispatcher(): void
+    public function testSendWithoutDispatcher()
     {
         $transport = new Transport(
             new MockHttpClient(function (string $method, string $url) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #50932
| License       | MIT

As a webhook producer I need to track the responses of each webhook.

Either you want to
- provide a UI for a user to debug calls
- disable the webhook if it fails too often
- ...

You will need the acquire the response received when the webhook is called.
But for the moment that `ResponseInterface` object was lost in the `Transport`.
This PR adds a soft dependency to `EventDispatcherInterface`, and trigger a `WebhookSentEvent`, wrapping all available information at that time.