### PR TITLE
[Validator] Fix charset encoding detection in `CharsetValidator`

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CharsetValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CharsetValidator.php
@@ -35,9 +35,9 @@ final class CharsetValidator extends ConstraintValidator
             throw new UnexpectedValueException($value, 'string');
         }
 
-        if (!\in_array($detected = mb_detect_encoding($value, $constraint->encodings, true), (array) $constraint->encodings, true)) {
+        if (!\in_array(mb_detect_encoding($value, $constraint->encodings, true), (array) $constraint->encodings, true)) {
             $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ detected }}', $detected)
+                ->setParameter('{{ detected }}', mb_detect_encoding($value, strict: true))
                 ->setParameter('{{ encodings }}', implode(', ', $constraint->encodings))
                 ->setCode(Charset::BAD_ENCODING_ERROR)
                 ->addViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
@@ -42,7 +42,7 @@ class CharsetValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($value, new Charset(encodings: $encodings));
 
         $this->buildViolation('The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.')
-            ->setParameter('{{ detected }}', mb_detect_encoding($value, $encodings, true))
+            ->setParameter('{{ detected }}', 'UTF-8')
             ->setParameter('{{ encodings }}', implode(', ', $encodings))
             ->setCode(Charset::BAD_ENCODING_ERROR)
             ->assertRaised();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/53154#issuecomment-1891000637
| License       | MIT

After @smnandre suggestion, I updated the constraint to display a better message on the detected encoding. Indeed, if we fail to check the encoding is in the provided ones, then we fall back on any encoding detected by mbstring.