### PR TITLE
chore: use _ syntax for `PHP_VERSION_ID` comparison

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/CodeExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/CodeExtension.php
@@ -123,7 +123,7 @@ final class CodeExtension extends AbstractExtension
             // highlight_file could throw warnings
             // see https://bugs.php.net/25725
             $code = @highlight_file($file, true);
-            if (\PHP_VERSION_ID >= 80300) {
+            if (\PHP_VERSION_ID >= 8_03_00) {
                 // remove main pre/code tags
                 $code = preg_replace('#^<pre.*?>\s*<code.*?>(.*)</code>\s*</pre>#s', '\\1', $code);
                 // split multiline code tags

--- a/src/Symfony/Component/Clock/Clock.php
+++ b/src/Symfony/Component/Clock/Clock.php
@@ -71,7 +71,7 @@ final class Clock implements ClockInterface
      */
     public function withTimeZone(\DateTimeZone|string $timezone): static
     {
-        if (\PHP_VERSION_ID >= 80300 && \is_string($timezone)) {
+        if (\PHP_VERSION_ID >= 8_03_00 && \is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
         } elseif (\is_string($timezone)) {
             try {

--- a/src/Symfony/Component/Clock/DatePoint.php
+++ b/src/Symfony/Component/Clock/DatePoint.php
@@ -30,7 +30,7 @@ final class DatePoint extends \DateTimeImmutable
                 $now = static::createFromInterface($now);
             }
 
-            if (\PHP_VERSION_ID < 80300) {
+            if (\PHP_VERSION_ID < 8_03_00) {
                 try {
                     $timezone = (new parent($datetime, $timezone ?? $now->getTimezone()))->getTimezone();
                 } catch (\Exception $e) {
@@ -81,7 +81,7 @@ final class DatePoint extends \DateTimeImmutable
      */
     public function modify(string $modifier): static
     {
-        if (\PHP_VERSION_ID < 80300) {
+        if (\PHP_VERSION_ID < 8_03_00) {
             return @parent::modify($modifier) ?: throw new \DateMalformedStringException(error_get_last()['message'] ?? sprintf('Invalid modifier: "%s".', $modifier));
         }
 

--- a/src/Symfony/Component/Clock/MonotonicClock.php
+++ b/src/Symfony/Component/Clock/MonotonicClock.php
@@ -75,7 +75,7 @@ final class MonotonicClock implements ClockInterface
      */
     public function withTimeZone(\DateTimeZone|string $timezone): static
     {
-        if (\PHP_VERSION_ID >= 80300 && \is_string($timezone)) {
+        if (\PHP_VERSION_ID >= 8_03_00 && \is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
         } elseif (\is_string($timezone)) {
             try {

--- a/src/Symfony/Component/Clock/NativeClock.php
+++ b/src/Symfony/Component/Clock/NativeClock.php
@@ -49,7 +49,7 @@ final class NativeClock implements ClockInterface
      */
     public function withTimeZone(\DateTimeZone|string $timezone): static
     {
-        if (\PHP_VERSION_ID >= 80300 && \is_string($timezone)) {
+        if (\PHP_VERSION_ID >= 8_03_00 && \is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
         } elseif (\is_string($timezone)) {
             try {

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -251,7 +251,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
             // highlight_file could throw warnings
             // see https://bugs.php.net/25725
             $code = @highlight_file($file, true);
-            if (\PHP_VERSION_ID >= 80300) {
+            if (\PHP_VERSION_ID >= 8_03_00) {
                 // remove main pre/code tags
                 $code = preg_replace('#^<pre.*?>\s*<code.*?>(.*)</code>\s*</pre>#s', '\\1', $code);
                 // split multiline code tags

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectTrait.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectTrait.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Internal;
 
-if (\PHP_VERSION_ID >= 80300) {
+if (\PHP_VERSION_ID >= 8_03_00) {
     /**
      * @internal
      */

--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -27,7 +27,7 @@ final class ProxyHelper
      */
     public static function generateLazyGhost(\ReflectionClass $class): string
     {
-        if (\PHP_VERSION_ID < 80300 && $class->isReadOnly()) {
+        if (\PHP_VERSION_ID < 8_03_00 && $class->isReadOnly()) {
             throw new LogicException(sprintf('Cannot generate lazy ghost: class "%s" is readonly.', $class->name));
         }
         if ($class->isFinal()) {
@@ -91,7 +91,7 @@ final class ProxyHelper
         if ($class?->isFinal()) {
             throw new LogicException(sprintf('Cannot generate lazy proxy: class "%s" is final.', $class->name));
         }
-        if (\PHP_VERSION_ID < 80300 && $class?->isReadOnly()) {
+        if (\PHP_VERSION_ID < 8_03_00 && $class?->isReadOnly()) {
             throw new LogicException(sprintf('Cannot generate lazy proxy: class "%s" is readonly.', $class->name));
         }
 

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -252,7 +252,7 @@ class LazyProxyTraitTest extends TestCase
 
     public function testReadOnlyClass()
     {
-        if (\PHP_VERSION_ID < 80300) {
+        if (\PHP_VERSION_ID < 8_03_00) {
             $this->expectException(LogicException::class);
             $this->expectExceptionMessage('Cannot generate lazy proxy: class "Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\ReadOnlyClass" is readonly.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix CS <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I believe it's easier to read the version, as you visually consider `_` as `.` and have 8.1.0 easily read than 80100