### PR TITLE
[ErrorHandler] Fix `RecursiveDirectoryIterator` exception with wrong composer autoload

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorEnhancer/ClassNotFoundErrorEnhancer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorEnhancer/ClassNotFoundErrorEnhancer.php
@@ -21,9 +21,6 @@ use Symfony\Component\ErrorHandler\Error\FatalError;
  */
 class ClassNotFoundErrorEnhancer implements ErrorEnhancerInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function enhance(\Throwable $error): ?\Throwable
     {
         // Some specific versions of PHP produce a fatal error when extending a not found class.
@@ -110,7 +107,8 @@ class ClassNotFoundErrorEnhancer implements ErrorEnhancerInterface
 
     private function findClassInPath(string $path, string $class, string $prefix): array
     {
-        if (!$path = realpath($path.'/'.strtr($prefix, '\\_', '//')) ?: realpath($path.'/'.\dirname(strtr($prefix, '\\_', '//'))) ?: realpath($path)) {
+        $path = realpath($path.'/'.strtr($prefix, '\\_', '//')) ?: realpath($path.'/'.\dirname(strtr($prefix, '\\_', '//'))) ?: realpath($path);
+        if (!$path || !is_dir($path)) {
             return [];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| Issues        | Fix #53541
| License       | MIT

### Issue
When defining an autoload directory in `composer.json` that actually points to a file _(rather than a directory)_, we have the following error :
```
Uncaught UnexpectedValueException: RecursiveDirectoryIterator::__construct(/path/to/file):
Failed to open directory: Not a directory
```
See all details and how to reproduce it in the issue https://github.com/symfony/symfony/issues/53541

### Solution
In this PR :
 - Make sure that the [ClassNotFoundErrorEnhancer::findClassInPath()](https://github.com/symfony/error-handler/blob/7.0/ErrorEnhancer/ClassNotFoundErrorEnhancer.php#L108) method checks if the `$path` is a directory.
- Fixed coding standards proposed by fabbot.io