### PR TITLE
CS: enable ordered_types.null_adjustment=always_last

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -38,6 +38,7 @@ return (new PhpCsFixer\Config())
         'modernize_strpos' => true,
         'get_class_to_class_keyword' => true,
         'nullable_type_declaration' => true,
+        'ordered_types' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
         'trailing_comma_in_multiline' => ['elements' => ['arrays', 'match', 'parameters']],
     ])
     ->setRiskyAllowed(true)

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -33,7 +33,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     protected ?string $key = null;
     protected bool $removeKeyItem = false;
     protected bool $addDefaults = false;
-    protected int|string|array|null|false $addDefaultChildren = false;
+    protected int|string|array|false|null $addDefaultChildren = false;
     protected NodeBuilder $nodeBuilder;
     protected bool $normalizeKeys = true;
 

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -30,7 +30,7 @@ class InputArgument
     public const IS_ARRAY = 4;
 
     private int $mode;
-    private string|int|bool|array|null|float $default;
+    private string|int|bool|array|float|null $default;
 
     /**
      * @param string                                                                        $name            The argument name

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -53,7 +53,7 @@ class InputOption
     private string $name;
     private string|array|null $shortcut;
     private int $mode;
-    private string|int|bool|array|null|float $default;
+    private string|int|bool|array|float|null $default;
 
     /**
      * @param string|array|null                                                             $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -36,7 +36,7 @@ class Question
      */
     public function __construct(
         private string $question,
-        private null|string|bool|int|float $default = null,
+        private string|bool|int|float|null $default = null,
     ) {
     }
 

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/FileLinkFormatter.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/FileLinkFormatter.php
@@ -33,7 +33,7 @@ class FileLinkFormatter
         string|array $fileLinkFormat = null,
         private ?RequestStack $requestStack = null,
         private ?string $baseDir = null,
-        private null|string|\Closure $urlFormat = null,
+        private string|\Closure|null $urlFormat = null,
     ) {
         $fileLinkFormat ??= $_ENV['SYMFONY_IDE'] ?? $_SERVER['SYMFONY_IDE'] ?? '';
 

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -33,7 +33,7 @@ class FormRegistry implements FormRegistryInterface
      */
     private array $types = [];
 
-    private FormTypeGuesserInterface|null|false $guesser = false;
+    private FormTypeGuesserInterface|false|null $guesser = false;
     private ResolvedFormTypeFactoryInterface $resolvedTypeFactory;
     private array $checkedTypes = [];
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
@@ -37,7 +37,7 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
     private int $embeddedResponses = 0;
     private bool $isNotCacheableResponseEmbedded = false;
     private int $age = 0;
-    private \DateTimeInterface|null|false $lastModified = null;
+    private \DateTimeInterface|false|null $lastModified = null;
     private array $flagDirectives = [
         'no-cache' => null,
         'no-store' => null,

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -349,7 +349,7 @@ class ProcessTest extends TestCase
     /**
      * @dataProvider provideInputValues
      */
-    public function testValidInput(?string $expected, null|float|string $value)
+    public function testValidInput(?string $expected, float|string|null $value)
     {
         $process = $this->getProcess('foo');
         $process->setInput($value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix CS
| License       | MIT


This PR is to apply rule to put `null` as last type variant for type declaration.
Sf ruleset is already having enabled very same rule for types in phpdoc.

Diff is very minimal, most of codebase already follows it.

If merged, we can adjust official ruleset (PR already prepared by community: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7356 )