### PR TITLE
[FrameworkBundle] Fix a link in the README

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/README.md
+++ b/src/Symfony/Bundle/FrameworkBundle/README.md
@@ -17,4 +17,4 @@ Resources
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
 
-[3]: https://symfony.com/sponsor
+[1]: https://symfony.com/sponsor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This issue was reported by the nice folks at Symfony Slack.