### PR TITLE
[DomCrawler] Allow to add choices to single select

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Allow to add choices to single select
+
 8.0
 ---
 

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -141,20 +141,18 @@ class ChoiceFormField extends FormField
     /**
      * Adds a choice to the current ones.
      *
-     * @throws \LogicException When choice provided is not multiple nor radio
-     *
-     * @internal
+     * @throws \LogicException When choice provided is neither multiple, radio nor select
      */
-    public function addChoice(\DOMElement $node): void
+    final public function addChoice(\DOMElement $node): void
     {
-        if (!$this->multiple && 'radio' !== $this->type) {
-            throw new \LogicException(\sprintf('Unable to add a choice for "%s" as it is not multiple or is not a radio button.', $this->name));
+        if (!$this->multiple && !\in_array($this->type, ['radio', 'select'], true)) {
+            throw new \LogicException(\sprintf('Unable to add a choice for "%s" as it is neither multiple, a radio button nor a select field.', $this->name));
         }
 
         $option = $this->buildOptionValue($node);
         $this->options[] = $option;
 
-        if ($node->hasAttribute('checked')) {
+        if ($node->hasAttribute('select' === $this->type ? 'selected' : 'checked')) {
             $this->value = $option['value'];
         }
     }

--- a/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
@@ -112,6 +112,24 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         }
     }
 
+    public function testAddChoiceToSingleSelect()
+    {
+        $node = $this->createSelectNode(['foo' => false, 'bar' => false]);
+        $field = new ChoiceFormField($node);
+
+        $option = $this->createNode('option', 'Hello World', ['value' => 'hello_world']);
+        $field->addChoice($option);
+
+        $this->assertNotSame('hello_world', $field->getValue());
+        $field->setValue('hello_world');
+        $this->assertSame('hello_world', $field->getValue(), '->setValue() changes the selected option to dynamically added one');
+
+        $option = $this->createNode('option', 'Mr. Robot', ['value' => 'mr_robot', 'selected' => true]);
+        $field->addChoice($option);
+
+        $this->assertSame('mr_robot', $field->getValue(), '->addChoice() changes the value to added choice if selected attribute is set');
+    }
+
     public function testSelectWithEmptyBooleanAttribute()
     {
         $node = $this->createSelectNode(['foo' => false, 'bar' => true], [], '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | https://github.com/symfony/ux/issues/1334#issuecomment-1854470006 https://github.com/symfony/ux/issues/1334#issuecomment-1855811337 https://github.com/symfony/symfony/pull/47642
| License       | MIT

Not sure why this was designed this way, but when using JS autocomplete's we cannot simulate it's behavior with a select element when a new choice was added to the list

cc @yceruto :pray: 