### PR TITLE
[Mime] Fix undefined array key 0 when empty sender

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -121,6 +121,10 @@ class Email extends Message
      */
     public function from(...$addresses)
     {
+        if (!$addresses) {
+            throw new LogicException('"from()" must be called with at least one address.');
+        }
+
         return $this->setListAddressHeaderBody('From', $addresses);
     }
 

--- a/src/Symfony/Component/Mime/Message.php
+++ b/src/Symfony/Component/Mime/Message.php
@@ -140,7 +140,10 @@ class Message extends RawMessage
         if ($this->headers->has('Sender')) {
             $sender = $this->headers->get('Sender')->getAddress();
         } elseif ($this->headers->has('From')) {
-            $sender = $this->headers->get('From')->getAddresses()[0];
+            if (!$froms = $this->headers->get('From')->getAddresses()) {
+                throw new LogicException('A "From" header must have at least one email address.');
+            }
+            $sender = $froms[0];
         } else {
             throw new LogicException('An email must have a "From" or a "Sender" header.');
         }

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Exception\LogicException;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
 use Symfony\Component\Mime\Part\Multipart\MixedPart;
@@ -60,6 +61,13 @@ class EmailTest extends TestCase
 
         $e->sender($fabien = new Address('fabien@symfony.com'));
         $this->assertSame($fabien, $e->getSender());
+    }
+
+    public function testFromWithNoAddress()
+    {
+        $e = new Email();
+        $this->expectException(LogicException::class);
+        $e->from();
     }
 
     public function testFrom()

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mime\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Exception\LogicException;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
@@ -123,6 +124,14 @@ class MessageTest extends TestCase
         $message->getHeaders()->addMailboxListHeader('From', ['fabien@symfony.com', 'lucas@symfony.com']);
         $message->getHeaders()->addMailboxHeader('Sender', 'thomas@symfony.com');
         $this->assertEquals('thomas@symfony.com', $message->getPreparedHeaders()->get('Sender')->getAddress()->getAddress());
+    }
+
+    public function testGenerateMessageIdThrowsWhenHasFromButNoAddresses()
+    {
+        $message = new Message();
+        $message->getHeaders()->addMailboxListHeader('From', []);
+        $this->expectException(LogicException::class);
+        $message->generateMessageId();
     }
 
     public function testToString()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Today I managed to produce the following error :
![image](https://github.com/symfony/symfony/assets/28731165/11b3b76d-d220-4f08-9b12-838ca936f540)

From the following code :
```php
$email = (new TemplatedEmail())
            ->from()
            ->to($member->getEmail())
            ->subject('Adhésion Sauvade')
            ->htmlTemplate('emails/new-membership/index.html.twig')
            ->context([
                'member' => $member,
            ])
            ->addPart(new DataPart(
                $this->pdfService->generatePdfFromTemplate(
                    'emails/new-membership/attachments/recu.html.twig',
                    ['member' => $member]
                ),
            ))
            ->addPart(new DataPart(
                $this->pdfService->generatePdfFromTemplate(
                    'emails/new-membership/attachments/membership-card.html.twig',
                    ['member' => $member]
                ),
            ))
        ;

        $this->mailer->send($email);
```

This happens because the `from` method from the `Symfony\Component\Mime\Email` class adds the header even if the array of addresses is empty. I identified two ways of fixing this :
- Adding a check in the `Symfony\Component\Mime\Message` class before accessing the key 0 and throw a better exception in case the adresses are empty
- Modifying the `from` method so that it doesn't add the header if the adresses are empty; or throw an exception when trying to do so.

I'm unsure what method is the cleaner, I thought that fixing the Message access of an undefined key was the widest fix (as I guess it could happen from somewhere else than the Mailer component). Also not sure how to test that and wanted to make sure this fix was good before testing it.