### PR TITLE
[String] Correct inflection of axis

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -166,6 +166,9 @@ final class EnglishInflector implements InflectorInterface
         // Fourth entry: Whether the suffix may succeed a consonant
         // Fifth entry: plural suffix, normal
 
+        // axes (axis)
+        ['sixa', 4, false, false, 'axes'],
+
         // criterion (criteria)
         ['airetirc', 8, false, false, 'criterion'],
 

--- a/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
@@ -185,6 +185,7 @@ class EnglishInflectorTest extends TestCase
             ['arch', 'arches'],
             ['atlas', 'atlases'],
             ['axe', 'axes'],
+            ['axis', 'axes'],
             ['baby', 'babies'],
             ['bacterium', 'bacteria'],
             ['base', 'bases'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

***Problem***
Plural form of the word "axis" currently is "axiss", but should be "axes".