### PR TITLE
[TwigBundle] Fix configuration when "paths" is null

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -147,7 +147,7 @@ class Configuration implements ConfigurationInterface
                     ->normalizeKeys(false)
                     ->useAttributeAsKey('paths')
                     ->beforeNormalization()
-                        ->always()
+                        ->ifArray()
                         ->then(function ($paths) {
                             $normalized = [];
                             foreach ($paths as $path => $namespace) {

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -52,4 +52,16 @@ class ConfigurationTest extends TestCase
 
         $this->assertSame(['global' => ['value' => ['some-key' => 'some-value']]], $config['globals']);
     }
+
+    public function testNullPathsAreConvertedToIterable()
+    {
+        $input = [
+            'paths' => null,
+        ];
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), [$input]);
+
+        $this->assertSame([], $config['paths']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | ..
| License       | MIT


TwigBundle configuration throws an error when paths config is empty (found it while commenting a line)

```yaml
twig:
    default_path: '%kernel.project_dir%/templates'

    form_themes:
        - 'form/form_theme.html.twig'

    paths:
        # '%kernel.project_dir%/templates/foo': Bar
```


```console

In Configuration.php line 159:
                                                                        
  [ErrorException]                                                      
  Warning: foreach() argument must be of type array|object, null given                                                                         

Exception trace:
```

Triggered by this line

```diff
 ->arrayNode('paths')
    ->normalizeKeys(false)
    ->useAttributeAsKey('paths')
    ->beforeNormalization()
        ->always()
        ->then(function ($paths) {
            $normalized = [];
-            foreach ($paths as $path => $namespace) {
                if (\is_array($namespace)) {
                    // xml
                    $path = $namespace['value'];
                    $namespace = $namespace['namespace'];
                }
```

This PR replace `always` with `isArray` and add a test