### PR TITLE
[Translation] fix multi-byte code area to convert

### DIFF
--- a/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
+++ b/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
@@ -123,7 +123,7 @@ final class PseudoLocalizationTranslator implements TranslatorInterface
             return [[true, true, $originalTrans]];
         }
 
-        $html = mb_encode_numericentity($originalTrans, [0x80, 0xFFFF, 0, 0xFFFF], mb_detect_encoding($originalTrans, null, true) ?: 'UTF-8');
+        $html = mb_encode_numericentity($originalTrans, [0x80, 0x10FFFF, 0, 0x1FFFFF], mb_detect_encoding($originalTrans, null, true) ?: 'UTF-8');
 
         $useInternalErrors = libxml_use_internal_errors(true);
 

--- a/src/Symfony/Component/Translation/Tests/PseudoLocalizationTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/PseudoLocalizationTranslatorTest.php
@@ -44,6 +44,7 @@ final class PseudoLocalizationTranslatorTest extends TestCase
             ['<p data-foo="ccc&quot;&quot;">ƀåŕ</p>', '<p data-foo="ccc&quot;&quot;">bar</p>', self::getIsolatedOptions(['parse_html' => true, 'accents' => true])],
             ['<p>″≤″</p>', '<p>&quot;&lt;&quot;</p>', self::getIsolatedOptions(['parse_html' => true, 'accents' => true])],
             ['Symfony is an Open Source, community-driven project with thousands of contributors. ~~~~~~~ ~~ ~~~~ ~~~~~~~ ~~~~~~~ ~~ ~~~~ ~~~~~~~~~~~~~ ~~~~~~~~~~~~~ ~~~~~~~ ~~ ~~~', 'Symfony is an Open Source, community-driven project with thousands of contributors.', self::getIsolatedOptions(['expansion_factor' => 2.0])],
+            ['<p>👇👇👇👇👇👇👇</p>', '<p>👇👇👇👇👇👇👇</p>', self::getIsolatedOptions(['parse_html' => true])],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

While debugging #47783 I stumbled upon tijsverkoyen/CssToInlineStyles#237 which made me realise that we suffer from the same issue in `PseudoLocalizationTranslator`. So I decided to apply the patch from tijsverkoyen/CssToInlineStyles#238 here.