### PR TITLE
#48167 add fallbackCallbackAccessor to PropertyPathAccessor to suppor…

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataAccessor/PropertyPathAccessor.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataAccessor/PropertyPathAccessor.php
@@ -109,8 +109,7 @@ class PropertyPathAccessor implements DataAccessorInterface
 
             if (!$e instanceof UninitializedPropertyException
                 // For versions without UninitializedPropertyException check the exception message
-                && (class_exists(UninitializedPropertyException::class) || false === strpos($e->getMessage(),
-                        'You should initialize it'))
+                && (class_exists(UninitializedPropertyException::class) || false === strpos($e->getMessage(), 'You should initialize it'))
             ) {
                 throw $e;
             }


### PR DESCRIPTION
…t custom getter methods when submitting a form

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #48167
| License       | MIT

Added a private `CallbackAccessor` to the `PropertyPathAccessor` to have a 2nd look if there is a custom getter defined in the form config and use this as fallback..