### PR TITLE
[Routing] Localized Passthrough Locale for #[Route()]

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -201,8 +201,7 @@ abstract class AttributeClassLoader implements LoaderInterface
             }
         }
 
-        if (isset($paths[0]))
-        {
+        if (isset($paths[0])) {
             $paths['{_locale}'] = isset($paths['{_locale}']) ? $paths['{_locale}'] : $paths[0];
             unset($paths[0]);
         }
@@ -212,7 +211,7 @@ abstract class AttributeClassLoader implements LoaderInterface
             $this->configureRoute($route, $class, $method, $annot);
             if (\is_int($locale)) {
                 throw new \InvalidArgumentException(sprintf('Indexed locale paths in the Route paths array are not supported (%d:%s).', $locale, $path));
-            } else if ('{_locale}' === $locale) {
+            } elseif ('{_locale}' === $locale) {
                 $collection->add($name, $route, $priority);
             } else {
                 $route->setDefault('_locale', $locale);

--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -202,7 +202,7 @@ abstract class AttributeClassLoader implements LoaderInterface
         }
 
         if (isset($paths[0])) {
-            $paths['{_locale}'] = isset($paths['{_locale}']) ? $paths['{_locale}'] : $paths[0];
+            $paths['{_locale}'] = $paths['{_locale}'] ?? $paths[0];
             unset($paths[0]);
         }
 

--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -201,16 +201,24 @@ abstract class AttributeClassLoader implements LoaderInterface
             }
         }
 
+        if (isset($paths[0]))
+        {
+            $paths['{_locale}'] = isset($paths['{_locale}']) ? $paths['{_locale}'] : $paths[0];
+            unset($paths[0]);
+        }
+
         foreach ($paths as $locale => $path) {
             $route = $this->createRoute($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
             $this->configureRoute($route, $class, $method, $annot);
-            if (0 !== $locale) {
+            if (\is_int($locale)) {
+                throw new \InvalidArgumentException(sprintf('Indexed locale paths in the Route paths array are not supported (%d:%s)', $locale, $path));
+            } else if ('{_locale}' === $locale) {
+                $collection->add($name, $route, $priority);
+            } else {
                 $route->setDefault('_locale', $locale);
                 $route->setRequirement('_locale', preg_quote($locale));
                 $route->setDefault('_canonical_route', $name);
                 $collection->add($name.'.'.$locale, $route, $priority);
-            } else {
-                $collection->add($name, $route, $priority);
             }
         }
     }

--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -211,7 +211,7 @@ abstract class AttributeClassLoader implements LoaderInterface
             $route = $this->createRoute($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
             $this->configureRoute($route, $class, $method, $annot);
             if (\is_int($locale)) {
-                throw new \InvalidArgumentException(sprintf('Indexed locale paths in the Route paths array are not supported (%d:%s)', $locale, $path));
+                throw new \InvalidArgumentException(sprintf('Indexed locale paths in the Route paths array are not supported (%d:%s).', $locale, $path));
             } else if ('{_locale}' === $locale) {
                 $collection->add($name, $route, $priority);
             } else {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/LocalizedIndexedLocaleActionController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/LocalizedIndexedLocaleActionController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class LocalizedIndexedLocaleActionController
+{
+    #[Route(path: [1 => '/en', 2 => '/nl'], name: 'error')]
+    public function error()
+    {
+    }
+
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/LocalizedPassthroughLocaleActionController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/LocalizedPassthroughLocaleActionController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class LocalizedPassthroughLocaleActionController
+{
+    #[Route(path: ['{_locale}' => '/{_locale}', 'nl' => '/nl'], name: 'action')]
+    public function action()
+    {
+    }
+
+    #[Route(path: ['/{_locale}', 'nl' => '/nl'], name: 'action2')]
+    public function action2()
+    {
+    }
+
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
@@ -253,7 +253,7 @@ class AttributeClassLoaderTest extends TestCase
     public function testLocalizedIndexedLocaleRoute()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Indexed locale paths in the Route paths array are not supported (1:/en)');
+        $this->expectExceptionMessage('Indexed locale paths in the Route paths array are not supported (1:/en).');
         $this->loader->load(LocalizedIndexedLocaleActionController::class);
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
@@ -24,7 +24,9 @@ use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\InvokableControll
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\InvokableLocalizedController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\InvokableMethodController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\LocalizedActionPathController;
+use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\LocalizedIndexedLocaleActionController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\LocalizedMethodActionControllers;
+use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\LocalizedPassthroughLocaleActionController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\LocalizedPrefixLocalizedActionController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\LocalizedPrefixMissingLocaleActionController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\LocalizedPrefixMissingRouteLocaleActionController;
@@ -236,6 +238,23 @@ class AttributeClassLoaderTest extends TestCase
         $this->assertCount(2, $routes);
         $this->assertEquals('/nl/actie', $routes->get('action.nl')->getPath());
         $this->assertEquals('/en/action', $routes->get('action.en')->getPath());
+    }
+
+    public function testLocalizedPassthroughLocaleRoute()
+    {
+        $routes = $this->loader->load(LocalizedPassthroughLocaleActionController::class);
+        $this->assertCount(4, $routes);
+        $this->assertEquals('/{_locale}', $routes->get('action')->getPath());
+        $this->assertEquals('/nl', $routes->get('action.nl')->getPath());
+        $this->assertEquals('/{_locale}', $routes->get('action2')->getPath());
+        $this->assertEquals('/nl', $routes->get('action2.nl')->getPath());
+    }
+
+    public function testLocalizedIndexedLocaleRoute()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Indexed locale paths in the Route paths array are not supported (1:/en)');
+        $this->loader->load(LocalizedIndexedLocaleActionController::class);
     }
 
     public function testInvokableClassMultipleRouteLoad()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

As per reference of #53539, I was looking for a way to solve:
https://stackoverflow.com/questions/41721408/symfony-default-locale-without-specifying-in-url/77819142

Currently the first path (either specifying a path, or a path array) the first path index is 0 in AttributeClassLoader.php. Taking advantage of this, my answer in the Stack Overflow and in #53539 works, but is not advised as this is not documented. My PR adds support for:

```php
    #[Route(path: ['{_locale}' => '/{_locale}', 'nl' => '/nl'], name: 'action')]
```

Which adds the path as 'action' and 'action.nl', means the `{_locale}` can be used to catch all other locales. As @xabbuh and I talked about. Using this:

```php
    #[Route(path: ['/{_locale}', 'nl' => '/nl'], name: 'action')]
```

Is still allowed as the first array index of 0 was always allowed anyway (as the Route would turn the `$path` into `$paths[]`), and should remain to not break backwards compatibility with anyone using it, but if `1 =>` etc (integer array keys) used, it will raise an exception (also tested in the Tests).

If you guys could look this over that would be great. If someone needs any clarification for anyone wanting to document this feature near https://symfony.com/doc/current/routing.html#localized-routes-i18n that also would be great!