### PR TITLE
[Notifier] Updated the NTFY notifier to run without a user parameter

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransport.php
@@ -84,6 +84,8 @@ final class NtfyTransport extends AbstractTransport
 
         if (null !== $this->user && null !== $this->password) {
             $headers['Authorization'] = 'Basic '.rtrim(base64_encode($this->user.':'.$this->password), '=');
+        } elseif (null !== $this->password) {
+            $headers['Authorization'] = 'Bearer '.$this->password;
         }
 
         $response = $this->client->request('POST', ($this->secureHttp ? 'https' : 'http').'://'.$this->getEndpoint(), [
@@ -115,8 +117,8 @@ final class NtfyTransport extends AbstractTransport
 
     public function supports(MessageInterface $message): bool
     {
-        return $message instanceof PushMessage &&
-            (null === $message->getOptions() || $message->getOptions() instanceof NtfyOptions);
+        return $message instanceof PushMessage
+            && (null === $message->getOptions() || $message->getOptions() instanceof NtfyOptions);
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransportFactory.php
@@ -41,8 +41,11 @@ final class NtfyTransportFactory extends AbstractTransportFactory
             $transport->setPort($port);
         }
 
-        if (!empty($user = $dsn->getUser()) && !empty($password = $dsn->getPassword())) {
+        if (!empty($user = $dsn->getUser())) {
             $transport->setUser($user);
+        }
+
+        if (!empty($password = $dsn->getPassword())) {
             $transport->setPassword($password);
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportFactoryTest.php
@@ -32,6 +32,10 @@ final class NtfyTransportFactoryTest extends TransportFactoryTestCase
             'ntfy://user:password@default/test',
         ];
         yield [
+            'ntfy://ntfy.sh/test',
+            'ntfy://:password@default/test',
+        ];
+        yield [
             'ntfy://ntfy.sh:8888/test',
             'ntfy://user:password@default:8888/test?secureHttp=off',
         ];

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
@@ -85,6 +85,32 @@ final class NtfyTransportTest extends TransportTestCase
         $this->assertSame('2BYIwRmvBKcv', $sentMessage->getMessageId());
     }
 
+    public function testSendWithPassword()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(200);
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+            $expectedBody = json_encode(['topic' => 'test', 'title' => 'Hello', 'message' => 'World']);
+            $expectedAuthorization = 'Authorization: Bearer testtokentesttoken';
+            $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
+            $this->assertTrue(\in_array($expectedAuthorization, $options['headers'], true));
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client)->setPassword('testtokentesttoken');
+
+        $sentMessage = $transport->send(new PushMessage('Hello', 'World'));
+
+        $this->assertSame('2BYIwRmvBKcv', $sentMessage->getMessageId());
+    }
+
     public function testSendWithUserAndPassword()
     {
         $response = $this->createMock(ResponseInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The ntfy integration of the notifier component was missing the option to run without set username. 
