### PR TITLE
[DependencyInjection] Allow registering attributes on classes that cannot be instantiated

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -65,8 +65,6 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
 
     /**
      * Processes a value found in a definition tree.
-     *
-     * @return mixed
      */
     protected function processValue(mixed $value, bool $isRoot = false)
     {
@@ -76,9 +74,9 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
                     continue;
                 }
                 if ($isRoot) {
-                    if ($v->hasTag('container.excluded')) {
-                        continue;
-                    }
+                    // if ($v->hasTag('container.excluded')) {
+                    //    continue;
+                    // }
                     $this->currentId = $k;
                 }
                 if ($v !== $processedValue = $this->processValue($v, $isRoot)) {

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -294,6 +294,10 @@ abstract class FileLoader extends BaseFileLoader
 
             if ($r->isInstantiable() || $r->isInterface()) {
                 $classes[$class] = null;
+            } elseif (!$r->isInstantiable() && !$this->container->has($class)) {
+                $this->container->register($class, $class)
+                    ->setAutoconfigured(true)
+                    ->addTag('container.excluded');
             }
 
             if ($autoconfigureAttributes && !$r->isInstantiable()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #48392
| License       | MIT

This is a proof of concept for https://github.com/symfony/symfony/issues/48392

Needs some tests.
