### PR TITLE
[Routing] Remove `@final` annotation from `Route` attribute

### DIFF
--- a/src/Symfony/Component/Routing/Attribute/Route.php
+++ b/src/Symfony/Component/Routing/Attribute/Route.php
@@ -20,8 +20,6 @@ namespace Symfony\Component\Routing\Attribute;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Alexander M. Turek <me@derrabus.de>
- *
- * @final since Symfony 6.4
  */
 #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class Route

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/ExtendedRoute.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/ExtendedRoute.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class ExtendedRoute extends Route
+{
+    public function __construct(array|string $path = null, ?string $name = null, array $defaults = []) {
+        parent::__construct("/{section<(foo|bar|baz)>}" . $path, $name, [], [], array_merge(['section' => 'foo'], $defaults));
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/ExtendedRouteOnClassController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/ExtendedRouteOnClassController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+#[ExtendedRoute('/class-level')]
+class ExtendedRouteOnClassController
+{
+    #[Route(path: '/method-level', name: 'action')]
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/ExtendedRouteOnMethodController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/ExtendedRouteOnMethodController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+class ExtendedRouteOnMethodController
+{
+    #[ExtendedRoute(path: '/method-level', name: 'action')]
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTestCase.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTestCase.php
@@ -16,6 +16,8 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Routing\Alias;
 use Symfony\Component\Routing\Loader\AttributeClassLoader;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\AbstractClassController;
+use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\ExtendedRouteOnClassController;
+use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\ExtendedRouteOnMethodController;
 
 abstract class AttributeClassLoaderTestCase extends TestCase
 {
@@ -310,6 +312,22 @@ abstract class AttributeClassLoaderTestCase extends TestCase
         $this->assertSame(['http'], $routes->get('array_one')->getSchemes());
         $this->assertSame(['POST'], $routes->get('string')->getMethods());
         $this->assertSame(['https'], $routes->get('string')->getSchemes());
+    }
+
+    public function testLoadingExtendedRouteOnClass()
+    {
+        $routes = $this->loader->load(ExtendedRouteOnClassController::class);
+        $this->assertCount(1, $routes);
+        $this->assertSame('/{section}/class-level/method-level', $routes->get('action')->getPath());
+        $this->assertSame(['section' => 'foo'], $routes->get('action')->getDefaults());
+    }
+
+    public function testLoadingExtendedRouteOnMethod()
+    {
+        $routes = $this->loader->load(ExtendedRouteOnMethodController::class);
+        $this->assertCount(1, $routes);
+        $this->assertSame('/{section}/method-level', $routes->get('action')->getPath());
+        $this->assertSame(['section' => 'foo'], $routes->get('action')->getDefaults());
     }
 
     abstract protected function getNamespace(): string;


### PR DESCRIPTION
To be able to create a custom attribute containing application or section level defaults, the final annotation is removed from the Route attribute.

Fixes #53467

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53467
| License       | MIT

Removing the `@final` annotations makes it possible to create custom Route annotations containing pre set properties relevant for your application. Examples are a host name, defaults, requirements.

```php
use Symfony\Component\Routing\Attribute\Route;

#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
class DefaultSectionRoute extends Route
{
    // Limited arguments for readability of the example
    public function __construct(
        array|string $path = null,
        ?string      $name = null,
        array        $defaults = [],
    ) {
        parent::__construct(
            "/{section<(foo|bar|baz)>}" . $path,
            $name,
            [],
            [],
            array_merge(['section' => 'foo'], $defaults),
        );
    }
}
```

```php
use Symfony\Component\Routing\Attribute\Route;

#[\Attribute(\Attribute::TARGET_CLASS)]
class AdminRoute extends Route
{
    public function __construct(...$params) {
        if (isset($params[5])) {
            $params[5] = 'admin.example.com';
        } else {
            $params['host'] = "admin.example.com";
        }

        parent::__construct(...$params);
    }
}
```