### PR TITLE
[AssetMapper] fix test

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
@@ -46,7 +46,7 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
         /* voilà.css */
         body {}
 
-        EOF, $response->getContent());
+        EOF, $client->getInternalResponse()->getContent());
     }
 
     public function test404OnUnknownAsset()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The response's content of a `BinaryFileResponse` is consumed by the `filterResponse()` method of the `HttpKernelBrowser`.