### PR TITLE
[Validator] Fix option filenameMaxLength to the File constraint (Image)

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -43,6 +43,7 @@ class Image extends File
         self::EMPTY_ERROR => 'EMPTY_ERROR',
         self::TOO_LARGE_ERROR => 'TOO_LARGE_ERROR',
         self::INVALID_MIME_TYPE_ERROR => 'INVALID_MIME_TYPE_ERROR',
+        self::FILENAME_TOO_LONG => 'FILENAME_TOO_LONG',
         self::SIZE_NOT_DETECTED_ERROR => 'SIZE_NOT_DETECTED_ERROR',
         self::TOO_WIDE_ERROR => 'TOO_WIDE_ERROR',
         self::TOO_NARROW_ERROR => 'TOO_NARROW_ERROR',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4<!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | ... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Recent addition of [filenameMaxLength] option to File constraint added a new error message key to ERROR_NAMES array but that change was not reflected in child class Image, so it just adds missing self::FILENAME_TOO_LONG => 'FILENAME_TOO_LONG' item to ERROR_NAMES array in Image constraint.

