### PR TITLE
[Mailer] [Smtp] Add DSN param 'auto_tls' to disable automatic STARTTLS

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Dispatch Postmark's "406 - Inactive recipient" API error code as a `PostmarkDeliveryEvent` instead of throwing an exception
+ * Add DSN param `auto_tls` to disable automatic STARTTLS
 
 7.0
 ---

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -157,5 +157,28 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtps', 'example.com', '', '', 465, ['ping_threshold' => '10']),
             $transport,
         ];
+
+        $transport = new EsmtpTransport('example.com', 25, false, null, $logger);
+        $transport->setAutoTls(false);
+
+        yield [
+            new Dsn('smtp', 'example.com', '', '', 25, ['auto_tls' => false]),
+            $transport,
+        ];
+        yield [
+            new Dsn('smtp', 'example.com', '', '', 0, ['auto_tls' => false]),
+            $transport,
+        ];
+        yield [
+            Dsn::fromString('smtp://:@example.com?auto_tls=false'),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, false, null, $logger);
+        $transport->setAutoTls(false);
+        yield [
+            Dsn::fromString('smtp://:@example.com:465?auto_tls=false'),
+            $transport,
+        ];
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -31,6 +31,7 @@ class EsmtpTransport extends SmtpTransport
     private string $username = '';
     private string $password = '';
     private array $capabilities;
+    private bool $autoTls = true;
 
     public function __construct(string $host = 'localhost', int $port = 0, ?bool $tls = null, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null, ?AbstractStream $stream = null, ?array $authenticators = null)
     {
@@ -99,6 +100,21 @@ class EsmtpTransport extends SmtpTransport
         return $this->password;
     }
 
+    /**
+     * @return $this
+     */
+    public function setAutoTls(bool $autoTls): static
+    {
+        $this->autoTls = $autoTls;
+
+        return $this;
+    }
+
+    public function isAutoTls(): bool
+    {
+        return $this->autoTls;
+    }
+
     public function setAuthenticators(array $authenticators): void
     {
         $this->authenticators = [];
@@ -145,7 +161,7 @@ class EsmtpTransport extends SmtpTransport
         // WARNING: !$stream->isTLS() is right, 100% sure :)
         // if you think that the ! should be removed, read the code again
         // if doing so "fixes" your issue then it probably means your SMTP server behaves incorrectly or is wrongly configured
-        if (!$stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && \array_key_exists('STARTTLS', $this->capabilities)) {
+        if ($this->autoTls && !$stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && \array_key_exists('STARTTLS', $this->capabilities)) {
             $this->executeCommand("STARTTLS\r\n", [220]);
 
             if (!$stream->startTLS()) {

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -23,11 +23,13 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
 {
     public function create(Dsn $dsn): TransportInterface
     {
-        $tls = 'smtps' === $dsn->getScheme() ? true : null;
+        $autoTls = '' === $dsn->getOption('auto_tls') || filter_var($dsn->getOption('auto_tls', true), \FILTER_VALIDATE_BOOL);
+        $tls = 'smtps' === $dsn->getScheme() ? true : ($autoTls ? null : false);
         $port = $dsn->getPort(0);
         $host = $dsn->getHost();
 
         $transport = new EsmtpTransport($host, $port, $tls, $this->dispatcher, $this->logger);
+        $transport->setAutoTls($autoTls);
 
         /** @var SocketStream $stream */
         $stream = $transport->getStream();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49114
| License       | MIT

Many times we don't have any jurisdiction over configuration of SMTP server we are trying to connect to.  If such server claims to be capable of STARTTLS, but drops connection after sending this command, there was no way to prevent mailer from sending it - despite defining protocol as `stmp` and port `25`.

Now adding `auto_tls=false` to DSN we can prevent transport to automatically send STARTTLS when we do not intend to use TLS.