### PR TITLE
[DependencyInjection] Fix loading all env vars from secrets when only a subset is needed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Secrets;
 
 use Symfony\Component\DependencyInjection\EnvVarLoaderInterface;
+use Symfony\Component\String\LazyString;
 use Symfony\Component\VarExporter\VarExporter;
 
 /**
@@ -169,7 +170,14 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
 
     public function loadEnvVars(): array
     {
-        return $this->list(true);
+        $envs = [];
+        $reveal = $this->reveal(...);
+
+        foreach ($this->list() as $name => $value) {
+            $envs[$name] = LazyString::fromCallable($reveal, $name);
+        }
+
+        return $envs;
     }
 
     private function loadKeys(): void

--- a/src/Symfony/Component/DependencyInjection/EnvVarLoaderInterface.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarLoaderInterface.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\DependencyInjection;
 interface EnvVarLoaderInterface
 {
     /**
-     * @return string[] Key/value pairs that can be accessed using the regular "%env()%" syntax
+     * @return array<string|\Stringable> Key/value pairs that can be accessed using the regular "%env()%" syntax
      */
     public function loadEnvVars(): array;
 }

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -164,10 +164,16 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         if (false !== $i || 'string' !== $prefix) {
             $env = $getEnv($name);
         } elseif ('' === ($env = $_ENV[$name] ?? (str_starts_with($name, 'HTTP_') ? null : ($_SERVER[$name] ?? null)))
-            || (false !== $env && false === ($env = $env ?? getenv($name) ?? false)) // null is a possible value because of thread safety issues
+            || (false !== $env && false === $env ??= getenv($name) ?? false) // null is a possible value because of thread safety issues
         ) {
-            foreach ($this->loadedVars as $vars) {
-                if (false !== ($env = ($vars[$name] ?? $env)) && '' !== $env) {
+            foreach ($this->loadedVars as $i => $vars) {
+                if (false === $env = $vars[$name] ?? $env) {
+                    continue;
+                }
+                if ($env instanceof \Stringable) {
+                    $this->loadedVars[$i][$name] = $env = (string) $env;
+                }
+                if ('' !== ($env ?? '')) {
                     break;
                 }
             }
@@ -185,7 +191,13 @@ class EnvVarProcessor implements EnvVarProcessorInterface
                             continue;
                         }
                         $this->loadedVars[] = $vars = $loader->loadEnvVars();
-                        if (false !== ($env = ($vars[$name] ?? $env)) && '' !== $env) {
+                        if (false === $env = $vars[$name] ?? $env) {
+                            continue;
+                        }
+                        if ($env instanceof \Stringable) {
+                            $this->loadedVars[array_key_last($this->loadedVars)][$name] = $env = (string) $env;
+                        }
+                        if ('' !== ($env ?? '')) {
                             $ended = false;
                             break;
                         }

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -808,6 +808,12 @@ CSV;
                     return [
                         'FOO_ENV_LOADER' => '123',
                         'BAZ_ENV_LOADER' => '',
+                        'LAZY_ENV_LOADER' => new class() {
+                            public function __toString()
+                            {
+                                return '';
+                            }
+                        },
                     ];
                 }
             };
@@ -819,6 +825,12 @@ CSV;
                         'FOO_ENV_LOADER' => '234',
                         'BAR_ENV_LOADER' => '456',
                         'BAZ_ENV_LOADER' => '567',
+                        'LAZY_ENV_LOADER' => new class() {
+                            public function __toString()
+                            {
+                                return '678';
+                            }
+                        },
                     ];
                 }
             };
@@ -840,6 +852,9 @@ CSV;
 
         $result = $processor->getEnv('string', 'FOO_ENV_LOADER', function () {});
         $this->assertSame('123', $result); // check twice
+
+        $result = $processor->getEnv('string', 'LAZY_ENV_LOADER', function () {});
+        $this->assertSame('678', $result);
 
         unset($_ENV['BAZ_ENV_LOADER']);
         unset($_ENV['BUZ_ENV_LOADER']);

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -39,7 +39,7 @@ class LazyString implements \Stringable, \JsonSerializable
                     $callback[1] ??= '__invoke';
                 }
                 $value = $callback(...$arguments);
-                $callback = self::getPrettyName($callback);
+                $callback = !\is_scalar($value) && !$value instanceof \Stringable ? self::getPrettyName($callback) : 'callable';
                 $arguments = null;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53429
| License       | MIT
 
As spotted in the linked issue, we have a significant performance issue when loading env vars.
The issue is that when one env var is needed but not defined, we still decrypt all existing env vars.
This also means we have a scalability issue when the number of env vars increases.
Since this happens usually on every single requests, this can burn the CPU.

The solution implemented in this PR is to use lazy strings to load env vars so that we don't decrypt them unless they are actually needed.