### PR TITLE
[Console] Add silent verbosity suppressing all output, including errors

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -14,6 +14,13 @@ Cache
  * `igbinary_serialize()` is not used by default when the igbinary extension is installed
  * Deprecate making `cache.app` adapter taggable, use the `cache.app.taggable` adapter instead
 
+Console
+-------
+
+ * [BC BREAK] Add ``--silent`` global option to enable the silent verbosity mode (suppressing all output, including errors)
+   If a custom command defines the `silent` option, it must be renamed before upgrading.
+ * Add `isSilent()` method to `OutputInterface`
+
 DependencyInjection
 -------------------
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -913,6 +913,9 @@ class Application implements ResetInterface
         }
 
         switch ($shellVerbosity = (int) getenv('SHELL_VERBOSITY')) {
+            case -2:
+                $output->setVerbosity(OutputInterface::VERBOSITY_SILENT);
+                break;
             case -1:
                 $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
                 break;
@@ -930,7 +933,10 @@ class Application implements ResetInterface
                 break;
         }
 
-        if (true === $input->hasParameterOption(['--quiet', '-q'], true)) {
+        if (true === $input->hasParameterOption(['--silent'], true)) {
+            $output->setVerbosity(OutputInterface::VERBOSITY_SILENT);
+            $shellVerbosity = -2;
+        } elseif (true === $input->hasParameterOption(['--quiet', '-q'], true)) {
             $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
             $shellVerbosity = -1;
         } else {
@@ -946,7 +952,7 @@ class Application implements ResetInterface
             }
         }
 
-        if (-1 === $shellVerbosity) {
+        if (0 > $shellVerbosity) {
             $input->setInteractive(false);
         }
 
@@ -1082,7 +1088,8 @@ class Application implements ResetInterface
         return new InputDefinition([
             new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
             new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display help for the given command. When no command is given display help for the <info>'.$this->defaultCommand.'</info> command'),
-            new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
+            new InputOption('--silent', null, InputOption::VALUE_NONE, 'Do not output any message'),
+            new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Only errors are displayed. All other output is suppressed'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
             new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', null),

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add support for `FORCE_COLOR` environment variable
  * Add `verbosity` argument to `mustRun` process helper method
+ * [BC BREAK] Add silent verbosity (`--silent`/`SHELL_VERBOSITY=-2`) to suppress all output, including errors
+ * Add `OutputInterface::isSilent()`, `Output::isSilent()`, `OutputStyle::isSilent()` methods
 
 7.1
 ---

--- a/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
@@ -217,6 +217,7 @@ class ReStructuredTextDescriptor extends Descriptor
     {
         $globalOptions = [
             'help',
+            'silent',
             'quiet',
             'verbose',
             'version',

--- a/src/Symfony/Component/Console/Output/NullOutput.php
+++ b/src/Symfony/Component/Console/Output/NullOutput.php
@@ -54,12 +54,17 @@ class NullOutput implements OutputInterface
 
     public function getVerbosity(): int
     {
-        return self::VERBOSITY_QUIET;
+        return self::VERBOSITY_SILENT;
+    }
+
+    public function isSilent(): bool
+    {
+        return true;
     }
 
     public function isQuiet(): bool
     {
-        return true;
+        return false;
     }
 
     public function isVerbose(): bool

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -17,13 +17,14 @@ use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 /**
  * Base class for output classes.
  *
- * There are five levels of verbosity:
+ * There are six levels of verbosity:
  *
  *  * normal: no option passed (normal output)
  *  * verbose: -v (more output)
  *  * very verbose: -vv (highly extended output)
  *  * debug: -vvv (all debug output)
- *  * quiet: -q (no output)
+ *  * quiet: -q (only output errors)
+ *  * silent: --silent (no output)
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -72,6 +73,11 @@ abstract class Output implements OutputInterface
     public function getVerbosity(): int
     {
         return $this->verbosity;
+    }
+
+    public function isSilent(): bool
+    {
+        return self::VERBOSITY_SILENT === $this->verbosity;
     }
 
     public function isQuiet(): bool

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -17,9 +17,12 @@ use Symfony\Component\Console\Formatter\OutputFormatterInterface;
  * OutputInterface is the interface implemented by all Output classes.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method bool isSilent()
  */
 interface OutputInterface
 {
+    public const VERBOSITY_SILENT = 8;
     public const VERBOSITY_QUIET = 16;
     public const VERBOSITY_NORMAL = 32;
     public const VERBOSITY_VERBOSE = 64;

--- a/src/Symfony/Component/Console/Style/OutputStyle.php
+++ b/src/Symfony/Component/Console/Style/OutputStyle.php
@@ -78,6 +78,12 @@ abstract class OutputStyle implements OutputInterface, StyleInterface
         return $this->output->getFormatter();
     }
 
+    public function isSilent(): bool
+    {
+        // @deprecated since Symfony 7.2, change to $this->output->isSilent() in 8.0
+        return method_exists($this->output, 'isSilent') ? $this->output->isSilent() : self::VERBOSITY_SILENT === $this->output->getVerbosity();
+    }
+
     public function isQuiet(): bool
     {
         return $this->output->isQuiet();

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -851,11 +851,14 @@ class ApplicationTest extends TestCase
         putenv('COLUMNS=120');
         $tester = new ApplicationTester($application);
 
-        $tester->run(['command' => 'foo'], ['decorated' => false, 'capture_stderr_separately' => true]);
+        $tester->run(['command' => 'foo'], ['decorated' => false, 'verbosity' => Output::VERBOSITY_QUIET, 'capture_stderr_separately' => true]);
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception1.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exception');
 
         $tester->run(['command' => 'foo'], ['decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE, 'capture_stderr_separately' => true]);
         $this->assertStringContainsString('Exception trace', $tester->getErrorOutput(), '->renderException() renders a pretty exception with a stack trace when verbosity is verbose');
+
+        $tester->run(['command' => 'foo'], ['decorated' => false, 'verbosity' => Output::VERBOSITY_SILENT, 'capture_stderr_separately' => true]);
+        $this->assertSame('', $tester->getErrorOutput(true), '->renderException() renders nothing in SILENT verbosity');
 
         $tester->run(['command' => 'list', '--foo' => true], ['decorated' => false, 'capture_stderr_separately' => true]);
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception2.txt', $tester->getErrorOutput(true), '->renderException() renders the command synopsis when an exception occurs in the context of a command');

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -119,9 +119,9 @@ class CompleteCommandTest extends TestCase
 
     public static function provideCompleteCommandInputDefinitionInputs()
     {
-        yield 'definition' => [['bin/console', 'hello', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction']];
+        yield 'definition' => [['bin/console', 'hello', '-'], ['--help', '--silent', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction']];
         yield 'custom' => [['bin/console', 'hello'], ['Fabien', 'Robin', 'Wouter']];
-        yield 'definition-aliased' => [['bin/console', 'ahoy', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction']];
+        yield 'definition-aliased' => [['bin/console', 'ahoy', '-'], ['--help', '--silent', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction']];
         yield 'custom-aliased' => [['bin/console', 'ahoy'], ['Fabien', 'Robin', 'Wouter']];
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -80,7 +80,8 @@ Usage:
 
 Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -29,13 +29,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -150,13 +159,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -262,13 +280,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -365,13 +392,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -48,9 +48,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -159,9 +169,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -286,9 +306,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.txt
@@ -5,7 +5,8 @@ Console Tool
 
 <comment>Options:</comment>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
-  <info>-q, --quiet</info>           Do not output any message
+  <info>    --silent</info>          Do not output any message
+  <info>-q, --quiet</info>           Only errors are displayed. All other output is suppressed
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -32,8 +32,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -71,8 +74,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -126,8 +132,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -188,8 +197,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -33,13 +33,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -154,13 +163,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -266,13 +284,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -369,13 +396,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -457,13 +493,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -553,13 +598,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -630,13 +684,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {
@@ -709,13 +772,22 @@
                         "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
+                    "silent": {
+                        "name": "--silent",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
                     "quiet": {
                         "name": "--quiet",
                         "shortcut": "-q",
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Do not output any message",
+                        "description": "Only errors are displayed. All other output is suppressed",
                         "default": false
                     },
                     "verbose": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -61,9 +61,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -172,9 +182,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -299,9 +319,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -374,9 +404,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -465,9 +505,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -537,9 +587,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
@@ -5,7 +5,8 @@ My Symfony application <info>v1.0</info>
 
 <comment>Options:</comment>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
-  <info>-q, --quiet</info>           Do not output any message
+  <info>    --silent</info>          Do not output any message
+  <info>-q, --quiet</info>           Only errors are displayed. All other output is suppressed
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -32,8 +32,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -71,8 +74,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -126,8 +132,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -188,8 +197,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -221,8 +233,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -262,8 +277,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -293,8 +311,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
@@ -326,8 +347,11 @@
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+        <option name="--silent" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Only errors are displayed. All other output is suppressed</description>
         </option>
         <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
@@ -5,7 +5,8 @@ My Symfony application <info>v1.0</info>
 
 <comment>Options:</comment>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
-  <info>-q, --quiet</info>           Do not output any message
+  <info>    --silent</info>          Do not output any message
+  <info>-q, --quiet</info>           Only errors are displayed. All other output is suppressed
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -52,9 +52,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -163,9 +173,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -290,9 +310,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no
@@ -381,9 +411,19 @@ Display help for the given command. When no command is given display help for th
 * Is negatable: no
 * Default: `false`
 
-#### `--quiet|-q`
+#### `--silent`
 
 Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Only errors are displayed. All other output is suppressed
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.txt
@@ -5,7 +5,8 @@ MbString åpplicätion
 
 <comment>Options:</comment>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
-  <info>-q, --quiet</info>           Do not output any message
+  <info>    --silent</info>          Do not output any message
+  <info>-q, --quiet</info>           Only errors are displayed. All other output is suppressed
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run1.txt
@@ -5,7 +5,8 @@ Usage:
 
 Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -12,7 +12,8 @@ Options:
       --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
       --short           To skip describing commands' arguments
   -h, --help            Display help for the given command. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -12,7 +12,8 @@ Options:
       --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
       --short           To skip describing commands' arguments
   -h, --help            Display help for the given command. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
@@ -11,7 +11,8 @@ Options:
       --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
       --raw             To output raw command help
   -h, --help            Display help for the given command. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/Symfony/Component/Console/Tests/Output/NullOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/NullOutputTest.php
@@ -35,10 +35,10 @@ class NullOutputTest extends TestCase
     public function testVerbosity()
     {
         $output = new NullOutput();
-        $this->assertSame(OutputInterface::VERBOSITY_QUIET, $output->getVerbosity(), '->getVerbosity() returns VERBOSITY_QUIET for NullOutput by default');
+        $this->assertSame(OutputInterface::VERBOSITY_SILENT, $output->getVerbosity(), '->getVerbosity() returns VERBOSITY_SILENT for NullOutput by default');
 
         $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
-        $this->assertSame(OutputInterface::VERBOSITY_QUIET, $output->getVerbosity(), '->getVerbosity() always returns VERBOSITY_QUIET for NullOutput');
+        $this->assertSame(OutputInterface::VERBOSITY_SILENT, $output->getVerbosity(), '->getVerbosity() always returns VERBOSITY_QUIET for NullOutput');
     }
 
     public function testGetFormatter()
@@ -60,7 +60,7 @@ class NullOutputTest extends TestCase
     {
         $output = new NullOutput();
         $output->setVerbosity(Output::VERBOSITY_NORMAL);
-        $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity());
+        $this->assertEquals(Output::VERBOSITY_SILENT, $output->getVerbosity());
     }
 
     public function testSetDecorated()
@@ -70,10 +70,16 @@ class NullOutputTest extends TestCase
         $this->assertFalse($output->isDecorated());
     }
 
+    public function testIsSilent()
+    {
+        $output = new NullOutput();
+        $this->assertTrue($output->isSilent());
+    }
+
     public function testIsQuiet()
     {
         $output = new NullOutput();
-        $this->assertTrue($output->isQuiet());
+        $this->assertFalse($output->isQuiet());
     }
 
     public function testIsVerbose()

--- a/src/Symfony/Component/Console/Tests/Output/OutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/OutputTest.php
@@ -164,6 +164,7 @@ class OutputTest extends TestCase
     public static function verbosityProvider()
     {
         return [
+            [Output::VERBOSITY_SILENT, '', '->write() in SILENT mode never outputs'],
             [Output::VERBOSITY_QUIET, '2', '->write() in QUIET mode only outputs when an explicit QUIET verbosity is passed'],
             [Output::VERBOSITY_NORMAL, '123', '->write() in NORMAL mode outputs anything below an explicit VERBOSE verbosity'],
             [Output::VERBOSITY_VERBOSE, '1234', '->write() in VERBOSE mode outputs anything below an explicit VERY_VERBOSE verbosity'],

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
@@ -29,7 +29,8 @@ Usage:
 
 Options:
   -h, --help            Display help for the given command. When no command is given display help for the %s command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/Symfony/Component/Runtime/Tests/phpt/command_list.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command_list.phpt
@@ -23,8 +23,8 @@ Usage:
   command [options] [arguments]
 
 Options:
-  -h, --help            Display %s
-  -q, --quiet           Do not output any message
+  -h, --help            Display %A
+  -q, --quiet           %s
   -V, --version         Display this application version
       --ansi%A
   -n, --no-interaction  Do not ask any interactive question


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #52777 
| License       | MIT

<details>
<summary>Original PR description</summary>

Alternative to #53126

In Symfony 2.8, we decided to still show exceptions/errors when running a command with `--quiet` or `SHELL_VERBOSITY=-1` (#15680).

Since that time, we've introduced the ConsoleLogger and 12-factor app logic. In todays landscape, it's more common to run commands that only output computer-readable text (e.g. JSON), which is ingested and displayed by services like Datadog and Kibana.
Our decision from 2.8 breaks this, as the JSON is interrupted by human-readable exception output that users can't disable. At the same time, this information is duplicated as errors are always logged (and thus shown as JSON).

I think we should revert the 2.8 decision, rather than adding a new "extremely quiet" verbosity mode. As far as I'm aware, this is also more consistent with normal unix commands which also don't output anything when passing `--quiet`.
I don't think this warrants as a BC break, as the errors are human readable and we don't promise BC on human readable console output (afaik, we don't promise BC on any console output, but I think we should be careful when changing e.g. the JSON logging).

</details>

This updated PR adds a new `--silent` verbosity mode that suppresses all output, including exceptions caught by the Application.

I went back and forth between simply passing `NullOutput` to the command in silent mode or not ignoring everything written to silent mode in `Output`. In the end, I've decided for the last to avoid bug reports from people silently expecting a `ConsoleOutputInterface` in their commands (e.g. for sections) without properly guarding it.

The new `isSilent()` methods can be used by commands to e.g. write important messages to the logger instead of command output when running in silent mode.