### PR TITLE
[Notifer][Smsapi] Set messageId of SentMessage

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
@@ -84,6 +84,9 @@ final class SmsapiTransport extends AbstractTransport
             throw new TransportException(sprintf('Unable to send the SMS: "%s".', $content['message'] ?? 'unknown error'), $response);
         }
 
-        return new SentMessage($message, (string) $this);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($content['list'][0]['id'] ?? '');
+
+        return $sentMessage;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This commit fixes a bug causing the messageId to never be set in the object. SmsApi always returns it.