### PR TITLE
[DependencyInjection] Add a configuration option to disable autowiring of optional parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add argument `$prepend` to `ContainerConfigurator::extension()` to prepend the configuration instead of appending it
  * Have `ServiceLocator` implement `ServiceCollectionInterface`
+ * Add new configuration `Definition::setAutowireOptionalParameters` to disable autowiring of optional arguments
 
 7.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -41,6 +41,7 @@ class Definition
     private bool $lazy = false;
     private ?array $decoratedService = null;
     private bool $autowired = false;
+    private bool $autowireOptionalParameters = true;
     private array $changes = [];
     private array $bindings = [];
     private array $errors = [];
@@ -736,6 +737,28 @@ class Definition
         $this->changes['autowired'] = true;
 
         $this->autowired = $autowired;
+
+        return $this;
+    }
+
+    /**
+     * Is the definition autowired?
+     */
+    public function isAutowiringOptionalParameters(): bool
+    {
+        return $this->autowireOptionalParameters;
+    }
+
+    /**
+     * Enables/disables autowiring.
+     *
+     * @return $this
+     */
+    public function setAutowireOptionalParameters(bool $autowireOptionalParameters): static
+    {
+        $this->changes['autowireOptionalParameters'] = true;
+
+        $this->autowireOptionalParameters = $autowireOptionalParameters;
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -203,6 +203,10 @@ class XmlDumper extends Dumper
             $service->setAttribute('autowire', 'true');
         }
 
+        if (!$definition->isAutowiringOptionalParameters()) {
+            $service->setAttribute('autowire-optional-parameters', 'false');
+        }
+
         if ($definition->isAutoconfigured()) {
             $service->setAttribute('autoconfigure', 'true');
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -107,6 +107,10 @@ class YamlDumper extends Dumper
             $code .= "        autowire: true\n";
         }
 
+        if (!$definition->isAutowiringOptionalParameters()) {
+            $code .= "        autowire_optional_parameters: false\n";
+        }
+
         if ($definition->isAutoconfigured()) {
             $code .= "        autoconfigure: true\n";
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutowireTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutowireTrait.php
@@ -24,4 +24,16 @@ trait AutowireTrait
 
         return $this;
     }
+
+    /**
+     * Enables/disables autowiring of optional arguments.
+     *
+     * @return $this
+     */
+    final public function autowireOptionalParameters(bool $autowireOptionalParameters = true): static
+    {
+        $this->definition->setAutowireOptionalParameters($autowireOptionalParameters);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -247,6 +247,7 @@ class XmlFileLoader extends FileLoader
             $definition->setPublic($defaults->isPublic());
         }
         $definition->setAutowired($defaults->isAutowired());
+        $definition->setAutowireOptionalParameters($defaults->isAutowiringOptionalParameters());
         $definition->setAutoconfigured($defaults->isAutoconfigured());
         $definition->setChanges([]);
 
@@ -266,6 +267,10 @@ class XmlFileLoader extends FileLoader
 
         if ($value = $service->getAttribute('autowire')) {
             $definition->setAutowired(XmlUtils::phpize($value));
+        }
+
+        if ($value = $service->getAttribute('autowire-optional-parameters')) {
+            $definition->setAutowireOptionalParameters(XmlUtils::phpize($value));
         }
 
         if ($value = $service->getAttribute('autoconfigure')) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -62,6 +62,7 @@ class YamlFileLoader extends FileLoader
         'decoration_priority' => 'decoration_priority',
         'decoration_on_invalid' => 'decoration_on_invalid',
         'autowire' => 'autowire',
+        'autowire_optional_parameters' => 'autowire_optional_parameters',
         'autoconfigure' => 'autoconfigure',
         'bind' => 'bind',
         'constructor' => 'constructor',
@@ -84,6 +85,7 @@ class YamlFileLoader extends FileLoader
         'calls' => 'calls',
         'tags' => 'tags',
         'autowire' => 'autowire',
+        'autowire_optional_parameters' => 'autowire_optional_parameters',
         'autoconfigure' => 'autoconfigure',
         'bind' => 'bind',
         'constructor' => 'constructor',
@@ -98,6 +100,7 @@ class YamlFileLoader extends FileLoader
         'calls' => 'calls',
         'tags' => 'tags',
         'autowire' => 'autowire',
+        'autowire_optional_parameters' => 'autowire_optional_parameters',
         'bind' => 'bind',
         'constructor' => 'constructor',
     ];
@@ -106,6 +109,7 @@ class YamlFileLoader extends FileLoader
         'public' => 'public',
         'tags' => 'tags',
         'autowire' => 'autowire',
+        'autowire_optional_parameters' => 'autowire_optional_parameters',
         'autoconfigure' => 'autoconfigure',
         'bind' => 'bind',
     ];
@@ -469,6 +473,9 @@ class YamlFileLoader extends FileLoader
         if (isset($defaults['autowire'])) {
             $definition->setAutowired($defaults['autowire']);
         }
+        if (isset($defaults['autowire_optional_parameters'])) {
+            $definition->setAutowireOptionalParameters($defaults['autowire_optional_parameters']);
+        }
         if (isset($defaults['autoconfigure'])) {
             $definition->setAutoconfigured($defaults['autoconfigure']);
         }
@@ -655,6 +662,10 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['autowire'])) {
             $definition->setAutowired($service['autowire']);
+        }
+
+        if (isset($service['autowire_optional_parameters'])) {
+            $definition->setAutowireOptionalParameters($service['autowire_optional_parameters']);
         }
 
         if (isset($defaults['bind']) || isset($service['bind'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -138,6 +138,7 @@
     </xsd:choice>
     <xsd:attribute name="public" type="boolean" />
     <xsd:attribute name="autowire" type="boolean" />
+    <xsd:attribute name="autowire-optional-parameters" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
   </xsd:complexType>
 
@@ -168,6 +169,7 @@
     <xsd:attribute name="decoration-inner-name" type="xsd:string" />
     <xsd:attribute name="decoration-priority" type="xsd:integer" />
     <xsd:attribute name="autowire" type="boolean" />
+    <xsd:attribute name="autowire-optional-parameters" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
     <xsd:attribute name="constructor" type="xsd:string" />
   </xsd:complexType>
@@ -185,6 +187,7 @@
     <xsd:attribute name="public" type="boolean" />
     <xsd:attribute name="lazy" type="xsd:string" />
     <xsd:attribute name="autowire" type="boolean" />
+    <xsd:attribute name="autowire-optional-parameters" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
     <xsd:attribute name="constructor" type="xsd:string" />
   </xsd:complexType>
@@ -210,6 +213,7 @@
     <xsd:attribute name="abstract" type="boolean" />
     <xsd:attribute name="parent" type="xsd:string" />
     <xsd:attribute name="autowire" type="boolean" />
+    <xsd:attribute name="autowire-optional-parameters" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
     <xsd:attribute name="constructor" type="xsd:string" />
   </xsd:complexType>

--- a/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
@@ -80,6 +80,16 @@ class ChildDefinitionTest extends TestCase
         $this->assertSame(['autowired' => true], $def->getChanges());
     }
 
+    public function testSetAutowireOptionalParameters()
+    {
+        $def = new ChildDefinition('foo');
+
+        $this->assertTrue($def->isAutowiringOptionalParameters());
+        $this->assertSame($def, $def->setAutowireOptionalParameters(false));
+        $this->assertFalse($def->isAutowiringOptionalParameters());
+        $this->assertSame(['autowireOptionalParameters' => true], $def->getChanges());
+    }
+
     public function testSetArgument()
     {
         $def = new ChildDefinition('foo');

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -417,6 +417,44 @@ class AutowirePassTest extends TestCase
         $this->assertEquals(Foo::class, $definition->getArgument(2));
     }
 
+    public function testAutowiringOptionalParametersDisabled()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(A::class);
+        $container->register(Foo::class);
+        $optDefinition = $container->register('opt', OptionalParameter::class);
+        $optDefinition->setAutowired(true);
+        $optDefinition->setAutowireOptionalParameters(false);
+
+        (new ResolveClassPass())->process($container);
+        (new AutowirePass())->process($container);
+
+        $definition = $container->getDefinition('opt');
+        $this->assertNull($definition->getArgument(0));
+        $this->assertEquals(A::class, $definition->getArgument(1));
+        $this->assertCount(2, $definition->getArguments());
+    }
+
+    public function testAutowiringOptionalParametersEnabled()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(A::class);
+        $container->register(Foo::class);
+        $optDefinition = $container->register('opt', OptionalParameter::class);
+        $optDefinition->setAutowired(true);
+        $optDefinition->setAutowireOptionalParameters(true);
+
+        (new ResolveClassPass())->process($container);
+        (new AutowirePass())->process($container);
+
+        $definition = $container->getDefinition('opt');
+        $this->assertNull($definition->getArgument(0));
+        $this->assertEquals(A::class, $definition->getArgument(1));
+        $this->assertEquals(Foo::class, $definition->getArgument(2));
+    }
+
     public function testParameterWithNullUnionIsSkipped()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -462,7 +462,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowired', [new Autowire(service: 'service.id')])),
             'autowired.nullable' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'autowired.nullable', [new Autowire(service: 'service.id')])),
             'autowired.parameter' => new ServiceClosureArgument('foobar'),
-            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.420ES7z.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
+            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.CZ.vqUn.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'target', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1449,6 +1449,51 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals(A::class, (string) $container->getDefinition('b')->getArgument(0));
     }
 
+    public function testAutowiringOptionalParameters()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(A::class)->setPublic(true);
+        $bDefinition = $container->register('f', F::class);
+        $bDefinition->setAutowired(true);
+        $bDefinition->setAutowireOptionalParameters(true);
+        $bDefinition->setPublic(true);
+
+        $container->compile();
+
+        $this->assertEquals(A::class, (string) $container->getDefinition('f')->getArgument(0));
+    }
+
+    public function testAutowiringOptionalParametersDisabled()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(A::class)->setPublic(true);
+        $bDefinition = $container->register('f', F::class);
+        $bDefinition->setAutowired(true);
+        $bDefinition->setAutowireOptionalParameters(false);
+        $bDefinition->setPublic(true);
+
+        $container->compile();
+
+        $this->assertEquals([], $container->getDefinition('f')->getArguments());
+    }
+
+    public function testAutowiringDisabledAndAutowiringOptionalParametersEnabled()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(A::class)->setPublic(true);
+        $bDefinition = $container->register('f', F::class);
+        $bDefinition->setAutowired(false);
+        $bDefinition->setAutowireOptionalParameters(true);
+        $bDefinition->setPublic(true);
+
+        $container->compile();
+
+        $this->assertEquals([], $container->getDefinition('f')->getArguments());
+    }
+
     public function testClassFromId()
     {
         $container = new ContainerBuilder();
@@ -2065,5 +2110,12 @@ class E
     {
         $this->first = $first;
         $this->second = $second;
+    }
+}
+
+class F
+{
+    public function __construct(?A $a = null)
+    {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -337,6 +337,18 @@ class DefinitionTest extends TestCase
         $this->assertFalse($def->isAutowired());
     }
 
+    public function testAutowiringOptionalParameters()
+    {
+        $def = new Definition('stdClass');
+        $this->assertTrue($def->isAutowiringOptionalParameters());
+
+        $def->setAutowireOptionalParameters(false);
+        $this->assertFalse($def->isAutowiringOptionalParameters());
+
+        $def->setAutowireOptionalParameters(true);
+        $this->assertTrue($def->isAutowiringOptionalParameters());
+    }
+
     public function testChangesNoChanges()
     {
         $def = new Definition();
@@ -350,6 +362,7 @@ class DefinitionTest extends TestCase
 
         $def->setAbstract(true);
         $def->setAutowired(true);
+        $def->setAutowireOptionalParameters(false);
         $def->setConfigurator('configuration_func');
         $def->setDecoratedService(null);
         $def->setDeprecated('vendor/package', '1.1', '%service_id%');
@@ -369,6 +382,7 @@ class DefinitionTest extends TestCase
         $this->assertSame([
             'class' => true,
             'autowired' => true,
+            'autowireOptionalParameters' => true,
             'configurator' => true,
             'decorated_service' => true,
             'deprecated' => true,

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -192,6 +192,14 @@ class XmlDumperTest extends TestCase
         $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services24.xml'), $dumper->dump());
     }
 
+    public function testDumpAutowireWithOptionalParametersDisabledData()
+    {
+        $container = include self::$fixturesPath.'/containers/container25.php';
+        $dumper = new XmlDumper($container);
+
+        $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services25.xml'), $dumper->dump());
+    }
+
     public function testDumpLoad()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -80,6 +80,13 @@ class YamlDumperTest extends TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services24.yml', $dumper->dump());
     }
 
+    public function testDumpAutowireWithOptionalParametersDisabledData()
+    {
+        $container = include self::$fixturesPath.'/containers/container25.php';
+        $dumper = new YamlDumper($container);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services25.yml', $dumper->dump());
+    }
+
     public function testDumpDecoratedServices()
     {
         $container = include self::$fixturesPath.'/containers/container34.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container25.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container25.php
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+$container = new ContainerBuilder();
+
+$container
+    ->register('foo', 'Foo')
+    ->setAutowired(true)
+    ->setAutowireOptionalParameters(false)
+    ->setPublic(true)
+;
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_duplicates.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_duplicates.php
@@ -41,7 +41,7 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.lViPm9k' => true,
+            '.service_locator.XqfMnpl' => true,
             'foo' => true,
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -43,7 +43,7 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.DyWBOhJ' => true,
+            '.service_locator.Qqb2hSg' => true,
         ];
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
@@ -44,7 +44,7 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.X7o4UPP' => true,
+            '.service_locator.y.HMS.V' => true,
             'foo2' => true,
             'foo3' => true,
             'foo4' => true,

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -43,9 +43,9 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.2x56Fsq' => true,
-            '.service_locator.2x56Fsq.foo_service' => true,
-            '.service_locator.K8KBCZO' => true,
+            '.service_locator.7048shw' => true,
+            '.service_locator.T54m7_U' => true,
+            '.service_locator.T54m7_U.foo_service' => true,
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => true,
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services25.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services25.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="foo" class="Foo" public="true" autowire="true" autowire-optional-parameters="false"/>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services25.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services25.yml
@@ -1,0 +1,11 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo:
+        class: Foo
+        public: true
+        autowire: true
+        autowire_optional_parameters: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 7.1
| Bug fix      | no
| New feature  | yes
| Deprecations | no
| Issues        | Fix #53640
| License       | MIT

For the idea behind this feature see the issue that contains examples https://github.com/symfony/symfony/issues/53640

Example usage:
```php
$servicesConfigurator
    ->defaults()
    ->autowire()
    ->autowireOptionalParameters(false);

$servicesConfigurator
    ->set('someServiceName')
    ->class(RateLimiterFactory::class)
    ->args([
        '$config' => ...,
        '$storage' => ...,
    ])
    ->public();
```

This then will ensure that the `$lockFactory` argument will never be implicit autowired even though someone creates a service for `LockFactory`.

https://github.com/symfony/symfony/blob/d621936e8c638247de4c5d1cd75cc5ff55b84c3e/src/Symfony/Component/RateLimiter/RateLimiterFactory.php#L33-L42