### PR TITLE
[Console] Add warning on dynamic aliases on lazy command

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -54,6 +54,8 @@ class Command
     private array $usages = [];
     private ?HelperSet $helperSet = null;
 
+    protected bool $initialized = false;
+
     public static function getDefaultName(): ?string
     {
         if ($attribute = (new \ReflectionClass(static::class))->getAttributes(AsCommand::class)) {
@@ -100,6 +102,7 @@ class Command
             $this->setDescription(static::getDefaultDescription() ?? '');
         }
 
+        $this->initialized = ($this instanceof LazyCommand || [] !== (new \ReflectionClass(static::class))->getAttributes(AsCommand::class));
         $this->configure();
     }
 
@@ -573,6 +576,13 @@ class Command
      */
     public function setAliases(iterable $aliases): static
     {
+        if($this->initialized) {
+            error_log(sprintf(
+                'On %s, setting aliases after initialization may lead to unexpected behavior',
+                $this->getName(),
+            ), E_USER_NOTICE);
+        }
+
         $list = [];
 
         foreach ($aliases as $alias) {

--- a/src/Symfony/Component/Console/Command/LazyCommand.php
+++ b/src/Symfony/Component/Console/Command/LazyCommand.php
@@ -193,6 +193,7 @@ final class LazyCommand extends Command
             $command->setHelperSet($this->getHelperSet());
         }
 
+        $command->initialized = false;
         $command->setName($this->getName())
             ->setAliases($this->getAliases())
             ->setHidden($this->isHidden())
@@ -200,7 +201,7 @@ final class LazyCommand extends Command
 
         // Will throw if the command is not correctly initialized.
         $command->getDefinition();
-
+        $command->initialized = true;
         return $command;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This PR addresses the issue described in #52650
