### PR TITLE
[Mailer] [Scaleway] Fix attachment handling

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Transport/ScalewayApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Transport/ScalewayApiTransportTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayApiTransport;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ScalewayApiTransportTest extends TestCase
@@ -64,6 +65,10 @@ class ScalewayApiTransportTest extends TestCase
             $this->assertSame(['email' => 'saif.gmati@symfony.com', 'name' => 'Saif Eddin'], $body['to'][0]);
             $this->assertSame('Hello!', $body['subject']);
             $this->assertSame('Hello There!', $body['text']);
+            $this->assertCount(1, $body['attachments']);
+            $this->assertSame('attachment.txt', $body['attachments'][0]['name']);
+            $this->assertSame('text/plain', $body['attachments'][0]['type']);
+            $this->assertSame(base64_encode('some attachment'), $body['attachments'][0]['content']);
 
             return new JsonMockResponse(['emails' => [['message_id' => 'foobar']]], [
                 'http_code' => 200,
@@ -76,7 +81,8 @@ class ScalewayApiTransportTest extends TestCase
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
-            ->text('Hello There!');
+            ->text('Hello There!')
+            ->addPart(new DataPart('some attachment', 'attachment.txt', 'text/plain'));
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Transport/ScalewayApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Transport/ScalewayApiTransport.php
@@ -99,7 +99,7 @@ final class ScalewayApiTransport extends AbstractApiTransport
             $payload['html'] = $email->getHtmlBody();
         }
         if ($attachements = $this->prepareAttachments($email)) {
-            $payload['attachment'] = $attachements;
+            $payload['attachments'] = $attachements;
         }
 
         return $payload;
@@ -115,7 +115,7 @@ final class ScalewayApiTransport extends AbstractApiTransport
             $attachments[] = [
                 'name' => $filename,
                 'type' => $headers->get('Content-Type')->getBody(),
-                'content' => base64_encode($attachment->bodyToString()),
+                'content' => str_replace("\r\n", '', $attachment->bodyToString()),
             ];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Here a pair of fixes for attachments' handling.

1) the attribute in the JSON payload is "attachments", not "attachment". Here you find the [reference documentation](https://www.scaleway.com/en/developers/api/transactional-email/#going-further)

2) as `bodyToString()` already returns a base64-encoded string, there is no need to re-encode it. I've replicated the behaviour [adopted by BrevoMailer](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php#L129), that I also use with profit