### PR TITLE
[Scheduler] Fix use for CallbackMessageProvider

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\Trigger\CallbackMessageProvider;
 
 class ScheduleTest extends TestCase
 {
@@ -26,5 +27,15 @@ class ScheduleTest extends TestCase
         $this->expectException(LogicException::class);
 
         $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
+    }
+
+    public function testAddWithMessageProvider()
+    {
+        $schedule = new Schedule();
+        $schedule->add(new CallbackMessageProvider(function () {
+            // no-op
+        }));
+
+        $this->assertCount(1, $schedule->getRecurringMessages());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When using the Scheduler component, it is not possible to create a `CallbackMessageProvider` as a recurring message.

As per [the documentation](https://symfony.com/doc/current/scheduler.html#a-dynamic-vision-for-the-messages-generated), you should be able to create an instance of `CallbackMessageProvider` and use it as a recurring message:

```php
    public function getSchedule(): Schedule
    {
        return $this->schedule ??= (new Schedule())
            ->with(
                RecurringMessage::trigger(
                    new ExcludeHolidaysTrigger(
                        CronExpressionTrigger::fromSpec('@daily'),
                    ),
                // instead of being static as in the previous example
                new CallbackMessageProvider([$this, 'generateReports'], 'foo')),
                RecurringMessage::cron(‘3 8 * * 1’, new CleanUpOldSalesReport())
            );
    }
```

It is actually not possible to do this because all the methods in the `Schedule` class only accept instances of `RecurringMessage`, when it should be using the interface `MessageProviderInterface` instead of the actual implementation of the recurring message.

With the same code as the documentation, the following error is thrown when trying to run the scheduler (`bin/console messenger:consume scheduler_default`):

```
Symfony\Component\Scheduler\Schedule::with(): Argument #2 must be of type Symfony\Component\Scheduler\RecurringMessage, Symfony\Component\Scheduler\Trigger\CallbackMessageProvider given
```

To make this work, all methods from the `Schedule` class should use the `MessageProviderInterface` instead of forcing to use the `RecurringMessage` class.
