### PR TITLE
[DependencyInjection] Fix replacing arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -257,10 +257,6 @@ class Definition
             throw new OutOfBoundsException(sprintf('Cannot replace arguments for class "%s" if none have been configured yet.', $this->class));
         }
 
-        if (\is_int($index) && ($index < 0 || $index > \count($this->arguments) - 1)) {
-            throw new OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d] of the arguments of class "%s".', $index, \count($this->arguments) - 1, $this->class));
-        }
-
         if (!\array_key_exists($index, $this->arguments)) {
             throw new OutOfBoundsException(sprintf('The argument "%s" doesn\'t exist in class "%s".', $index, $this->class));
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -292,7 +292,7 @@ class DefinitionTest extends TestCase
         $def->addArgument('foo');
 
         $this->expectException(\OutOfBoundsException::class);
-        $this->expectExceptionMessage('The index "1" is not in the range [0, 0] of the arguments of class "stdClass".');
+        $this->expectExceptionMessage('The argument "1" doesn\'t exist in class "stdClass".');
 
         $def->replaceArgument(1, 'bar');
     }
@@ -305,6 +305,17 @@ class DefinitionTest extends TestCase
         $this->expectExceptionMessage('Cannot replace arguments for class "stdClass" if none have been configured yet.');
 
         $def->replaceArgument(0, 'bar');
+    }
+
+    public function testReplaceArgumentWithNonConsecutiveIntIndex()
+    {
+        $def = new Definition('stdClass');
+
+        $def->setArguments([1 => 'foo']);
+        $this->assertSame([1 => 'foo'], $def->getArguments());
+
+        $def->replaceArgument(1, 'bar');
+        $this->assertSame([1 => 'bar'], $def->getArguments());
     }
 
     public function testSetGetProperties()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, `replaceArgument()` can throw an `OutOfBoundsException` for a valid index.