### PR TITLE
[TwigBridge] separate child and parent context in NotificationEmail on writes

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
@@ -178,6 +178,23 @@ class NotificationEmail extends TemplatedEmail
         return '@email/'.$this->theme.'/notification/body.html.twig';
     }
 
+    public function context(array $context)
+    {
+        $parentContext = [];
+
+        foreach ($context as $key => $value) {
+            if (\array_key_exists($key, $this->context)) {
+                $this->context[$key] = $value;
+            } else {
+                $parentContext[$key] = $value;
+            }
+        }
+
+        parent::context($parentContext);
+
+        return $this;
+    }
+
     public function getContext(): array
     {
         return array_merge($this->context, parent::getContext());

--- a/src/Symfony/Bridge/Twig/Tests/Mime/NotificationEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/NotificationEmailTest.php
@@ -128,4 +128,54 @@ class NotificationEmailTest extends TestCase
         $headers = $email->getPreparedHeaders();
         $this->assertSame('Foo', $headers->get('Subject')->getValue());
     }
+
+    public function testContext()
+    {
+        $email = new NotificationEmail();
+        $email->context(['some' => 'context']);
+
+        $this->assertSame([
+            'importance' => NotificationEmail::IMPORTANCE_LOW,
+            'content' => '',
+            'exception' => false,
+            'action_text' => null,
+            'action_url' => null,
+            'markdown' => false,
+            'raw' => false,
+            'footer_text' => 'Notification e-mail sent by Symfony',
+            'some' => 'context',
+        ], $email->getContext());
+
+        $context = $email->getContext();
+        $context['foo'] = 'bar';
+        $email->context($context);
+
+        $this->assertSame([
+            'importance' => NotificationEmail::IMPORTANCE_LOW,
+            'content' => '',
+            'exception' => false,
+            'action_text' => null,
+            'action_url' => null,
+            'markdown' => false,
+            'raw' => false,
+            'footer_text' => 'Notification e-mail sent by Symfony',
+            'some' => 'context',
+            'foo' => 'bar',
+        ], $email->getContext());
+
+        $email->action('Action Text', 'Action URL');
+
+        $this->assertSame([
+            'importance' => NotificationEmail::IMPORTANCE_LOW,
+            'content' => '',
+            'exception' => false,
+            'action_text' => 'Action Text',
+            'action_url' => 'Action URL',
+            'markdown' => false,
+            'raw' => false,
+            'footer_text' => 'Notification e-mail sent by Symfony',
+            'some' => 'context',
+            'foo' => 'bar',
+        ], $email->getContext());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53655
| License       | MIT
