### PR TITLE
[Serializer]  do not overwrite the cache key when it is false

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -783,7 +783,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $context = parent::createChildContext($parentContext, $attribute, $format);
         if ($context['cache_key'] ?? false) {
             $context['cache_key'] .= '-'.$attribute;
-        } else {
+        } elseif (false !== ($context['cache_key'] ?? null)) {
             $context['cache_key'] = $this->getCacheKey($format, $context);
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -555,11 +555,6 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar->foo = new EmptyDummy();
         $foobar->bar = 'bar';
         $foobar->baz = 'baz';
-        $data = [
-            'foo' => [],
-            'bar' => 'bar',
-            'baz' => 'baz',
-        ];
 
         $normalizer = new class() extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;
@@ -600,11 +595,6 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar->foo = new EmptyDummy();
         $foobar->bar = 'bar';
         $foobar->baz = 'baz';
-        $data = [
-            'foo' => [],
-            'bar' => 'bar',
-            'baz' => 'baz',
-        ];
 
         $normalizer = new class() extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;
@@ -640,11 +630,6 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar->foo = new EmptyDummy();
         $foobar->bar = 'bar';
         $foobar->baz = 'baz';
-        $data = [
-            'foo' => [],
-            'bar' => 'bar',
-            'baz' => 'baz',
-        ];
 
         $normalizer = new class() extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/53530#discussion_r1462990085
| License       | MIT
