### PR TITLE
[Mailer] [Mailgun] Fix sender header encoding

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -270,4 +270,17 @@ class MailgunApiTransportTest extends TestCase
         $this->assertArrayHasKey('v:Client-ID', $payload);
         $this->assertSame('12345', $payload['v:Client-ID']);
     }
+
+    public function testEnvelopeSenderHeaderIsCorrectlyEncoded()
+    {
+        $email = new Email();
+        $envelope = new Envelope(new Address('alice@system.com', 'Žluťoučký Kůň'), [new Address('bob@system.com')]);
+
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('h:Sender', $payload);
+        $this->assertSame('=?utf-8?Q?=C5=BDlu=C5=A5ou=C4=8Dk=C3=BD_K=C5=AF=C5=88?= <alice@system.com>', $payload['h:Sender']);
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -87,7 +87,7 @@ class MailgunApiTransport extends AbstractApiTransport
     private function getPayload(Email $email, Envelope $envelope): array
     {
         $headers = $email->getHeaders();
-        $headers->addHeader('h:Sender', $envelope->getSender()->toString());
+        $headers->addMailboxHeader('h:Sender', $envelope->getSender());
         $html = $email->getHtmlBody();
         if (null !== $html && \is_resource($html)) {
             if (stream_get_meta_data($html)['seekable'] ?? false) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/51773#issuecomment-1914410394
| License       | MIT

This adjustment fixes a problem with header encoding in MailgunApiTransport.
The issue occurs only in some cases when using Sender Address with name part with diacritics, because of the difference in encoding of UnstructuredHeader and MailboxHeader.

It changes the method used to add header `h:Sender` so that MailboxHeader is used. 