### PR TITLE
[HttpFoundation] Add nullable getters for `InputBag`/`ParameterBag`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -105,7 +105,7 @@ final class InputBag extends ParameterBag
     /**
      * Returns the parameter value converted to string or null.
      */
-    public function getNullableString(string $key, ?string $default = null): ?string
+    public function getStringOrNull(string $key, ?string $default = null): ?string
     {
         // Shortcuts the parent method because the validation on scalar is already done in get().
         $value = $this->get($key, $default);

--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -102,9 +102,26 @@ final class InputBag extends ParameterBag
         return (string) $this->get($key, $default);
     }
 
-    public function filter(string $key, mixed $default = null, int $filter = \FILTER_DEFAULT, mixed $options = []): mixed
+    /**
+     * Returns the parameter value converted to string or null.
+     */
+    public function getNullableString(string $key, ?string $default = null): ?string
+    {
+        // Shortcuts the parent method because the validation on scalar is already done in get().
+        $value = $this->get($key, $default);
+        if (null === $value) {
+            return null;
+        }
+
+        return (string) $value;
+    }
+
+    public function filter(string $key, mixed $default = null, int $filter = \FILTER_DEFAULT, mixed $options = [], bool $nullable = false): mixed
     {
         $value = $this->has($key) ? $this->all()[$key] : $default;
+        if ($nullable && null === $value) {
+            return null;
+        }
 
         // Always turn $options into an array - this allows filter_var option shortcuts.
         if (!\is_array($options) && $options) {

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -138,7 +138,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter as string or null.
      */
-    public function getNullableString(string $key, ?string $default = null): ?string
+    public function getStringOrNull(string $key, ?string $default = null): ?string
     {
         $value = $this->get($key, $default);
         if (null === $value) {
@@ -163,7 +163,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter value converted to integer or null.
      */
-    public function getNullableInt(string $key, ?int $default = null): ?int
+    public function getIntOrNull(string $key, ?int $default = null): ?int
     {
         return $this->filter($key, $default, \FILTER_VALIDATE_INT, ['flags' => \FILTER_REQUIRE_SCALAR], true);
     }
@@ -179,7 +179,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter value converted to boolean or null.
      */
-    public function getNullableBoolean(string $key, ?bool $default = null): ?bool
+    public function getBooleanOrNull(string $key, ?bool $default = null): ?bool
     {
         return $this->filter($key, $default, \FILTER_VALIDATE_BOOL, ['flags' => \FILTER_REQUIRE_SCALAR], true);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -74,6 +74,26 @@ class InputBagTest extends TestCase
         $this->assertSame('strval', $bag->getString('stringable'), '->getString() gets a value of a stringable paramater as string');
     }
 
+    public function testGetNullableString()
+    {
+        $bag = new InputBag(['nullable' => null, 'integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class() implements \Stringable {
+            public function __toString(): string
+            {
+                return 'strval';
+            }
+        }]);
+
+        $this->assertSame('123', $bag->getNullableString('integer'), '->getString() gets a value of parameter as string');
+        $this->assertSame('abc', $bag->getNullableString('string'), '->getString() gets a value of parameter as string');
+        $this->assertNull($bag->getNullableString('unknown'), '->getString() returns null if a parameter is not defined');
+        $this->assertSame('foo', $bag->getNullableString('unknown', 'foo'), '->getString() returns the default if a parameter is not defined');
+        $this->assertSame('1', $bag->getNullableString('bool_true'), '->getString() returns "1" if a parameter is true');
+        $this->assertSame('', $bag->getNullableString('bool_false', 'foo'), '->getString() returns an empty empty string if a parameter is false');
+        $this->assertSame('strval', $bag->getNullableString('stringable'), '->getString() gets a value of a stringable paramater as string');
+        $this->assertNull($bag->getNullableString('nullable'), '->getNullableString() gets null if a parameter is null');
+        $this->assertNull($bag->getNullableString('nullable', ''), '->getNullableString() gets null if a parameter is null');
+    }
+
     public function testGetStringExceptionWithArray()
     {
         $bag = new InputBag(['key' => ['abc']]);

--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -74,7 +74,7 @@ class InputBagTest extends TestCase
         $this->assertSame('strval', $bag->getString('stringable'), '->getString() gets a value of a stringable paramater as string');
     }
 
-    public function testGetNullableString()
+    public function testGetStringOrNull()
     {
         $bag = new InputBag(['nullable' => null, 'integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class() implements \Stringable {
             public function __toString(): string
@@ -83,15 +83,15 @@ class InputBagTest extends TestCase
             }
         }]);
 
-        $this->assertSame('123', $bag->getNullableString('integer'), '->getString() gets a value of parameter as string');
-        $this->assertSame('abc', $bag->getNullableString('string'), '->getString() gets a value of parameter as string');
-        $this->assertNull($bag->getNullableString('unknown'), '->getString() returns null if a parameter is not defined');
-        $this->assertSame('foo', $bag->getNullableString('unknown', 'foo'), '->getString() returns the default if a parameter is not defined');
-        $this->assertSame('1', $bag->getNullableString('bool_true'), '->getString() returns "1" if a parameter is true');
-        $this->assertSame('', $bag->getNullableString('bool_false', 'foo'), '->getString() returns an empty empty string if a parameter is false');
-        $this->assertSame('strval', $bag->getNullableString('stringable'), '->getString() gets a value of a stringable paramater as string');
-        $this->assertNull($bag->getNullableString('nullable'), '->getNullableString() gets null if a parameter is null');
-        $this->assertNull($bag->getNullableString('nullable', ''), '->getNullableString() gets null if a parameter is null');
+        $this->assertSame('123', $bag->getStringOrNull('integer'), '->getString() gets a value of parameter as string');
+        $this->assertSame('abc', $bag->getStringOrNull('string'), '->getString() gets a value of parameter as string');
+        $this->assertNull($bag->getStringOrNull('unknown'), '->getString() returns null if a parameter is not defined');
+        $this->assertSame('foo', $bag->getStringOrNull('unknown', 'foo'), '->getString() returns the default if a parameter is not defined');
+        $this->assertSame('1', $bag->getStringOrNull('bool_true'), '->getString() returns "1" if a parameter is true');
+        $this->assertSame('', $bag->getStringOrNull('bool_false', 'foo'), '->getString() returns an empty empty string if a parameter is false');
+        $this->assertSame('strval', $bag->getStringOrNull('stringable'), '->getString() gets a value of a stringable paramater as string');
+        $this->assertNull($bag->getStringOrNull('nullable'), '->getStringOrNull() gets null if a parameter is null');
+        $this->assertNull($bag->getStringOrNull('nullable', ''), '->getStringOrNull() gets null if a parameter is null');
     }
 
     public function testGetStringExceptionWithArray()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -204,26 +204,26 @@ class ParameterBagTest extends TestCase
         $bag->getInt('word');
     }
 
-    public function testGetNullableInt()
+    public function testGetIntOrNull()
     {
         $bag = new ParameterBag(['digits' => '123', 'nullable' => null]);
 
-        $this->assertSame(123, $bag->getNullableInt('digits'), '->getNullableInt() gets a value of parameter as integer');
-        $this->assertNull($bag->getNullableInt('unknown'), '->getNullableInt() returns default if a parameter is not defined');
-        $this->assertSame(0, $bag->getNullableInt('unknown', 0), '->getNullableInt() returns default if a parameter is not defined');
-        $this->assertSame(10, $bag->getNullableInt('unknown', 10), '->getNullableInt() returns the default if a parameter is not defined');
-        $this->assertNull($bag->getNullableInt('nullable'), '->getNullableInt() returns null if a parameter is null');
-        $this->assertNull($bag->getNullableInt('nullable', 0), '->getNullableInt() returns null if a parameter is null');
+        $this->assertSame(123, $bag->getIntOrNull('digits'), '->getIntOrNull() gets a value of parameter as integer');
+        $this->assertNull($bag->getIntOrNull('unknown'), '->getIntOrNull() returns default if a parameter is not defined');
+        $this->assertSame(0, $bag->getIntOrNull('unknown', 0), '->getIntOrNull() returns default if a parameter is not defined');
+        $this->assertSame(10, $bag->getIntOrNull('unknown', 10), '->getIntOrNull() returns the default if a parameter is not defined');
+        $this->assertNull($bag->getIntOrNull('nullable'), '->getIntOrNull() returns null if a parameter is null');
+        $this->assertNull($bag->getIntOrNull('nullable', 0), '->getIntOrNull() returns null if a parameter is null');
     }
 
-    public function testGetNullableIntExceptionWithInvalid()
+    public function testGetIntOrNullExceptionWithInvalid()
     {
         $bag = new ParameterBag(['word' => 'foo_BAR_012']);
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Parameter value "word" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.');
 
-        $bag->getNullableInt('word');
+        $bag->getIntOrNull('word');
     }
 
     public function testGetString()
@@ -264,7 +264,7 @@ class ParameterBagTest extends TestCase
         $bag->getString('object');
     }
 
-    public function testGetNullableString()
+    public function testGetStringOrNull()
     {
         $bag = new ParameterBag(['nullable' => null, 'integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class() implements \Stringable {
             public function __toString(): string
@@ -273,15 +273,15 @@ class ParameterBagTest extends TestCase
             }
         }]);
 
-        $this->assertSame('123', $bag->getNullableString('integer'), '->getNullableString() gets a value of parameter as string');
-        $this->assertSame('abc', $bag->getNullableString('string'), '->getNullableString() gets a value of parameter as string');
-        $this->assertNull($bag->getNullableString('unknown'), '->getNullableString() returns null if a parameter is not defined');
-        $this->assertSame('foo', $bag->getNullableString('unknown', 'foo'), '->getNullableString() returns the default if a parameter is not defined');
-        $this->assertSame('1', $bag->getNullableString('bool_true'), '->getNullableString() returns "1" if a parameter is true');
-        $this->assertSame('', $bag->getNullableString('bool_false', 'foo'), '->getNullableString() returns an empty empty string if a parameter is false');
-        $this->assertSame('strval', $bag->getNullableString('stringable'), '->getNullableString() gets a value of a stringable paramater as string');
-        $this->assertNull($bag->getNullableString('nullable'), '->getNullableString() gets null if a parameter is null');
-        $this->assertNull($bag->getNullableString('nullable', ''), '->getNullableString() gets null if a parameter is null');
+        $this->assertSame('123', $bag->getStringOrNull('integer'), '->getStringOrNull() gets a value of parameter as string');
+        $this->assertSame('abc', $bag->getStringOrNull('string'), '->getStringOrNull() gets a value of parameter as string');
+        $this->assertNull($bag->getStringOrNull('unknown'), '->getStringOrNull() returns null if a parameter is not defined');
+        $this->assertSame('foo', $bag->getStringOrNull('unknown', 'foo'), '->getStringOrNull() returns the default if a parameter is not defined');
+        $this->assertSame('1', $bag->getStringOrNull('bool_true'), '->getStringOrNull() returns "1" if a parameter is true');
+        $this->assertSame('', $bag->getStringOrNull('bool_false', 'foo'), '->getStringOrNull() returns an empty empty string if a parameter is false');
+        $this->assertSame('strval', $bag->getStringOrNull('stringable'), '->getStringOrNull() gets a value of a stringable paramater as string');
+        $this->assertNull($bag->getStringOrNull('nullable'), '->getStringOrNull() gets null if a parameter is null');
+        $this->assertNull($bag->getStringOrNull('nullable', ''), '->getStringOrNull() gets null if a parameter is null');
     }
 
     public function testFilter()
@@ -379,27 +379,27 @@ class ParameterBagTest extends TestCase
         $bag->getBoolean('invalid');
     }
 
-    public function testGetNullableBoolean()
+    public function testGetBooleanOrNull()
     {
         $parameters = ['string_true' => 'true', 'string_false' => 'false', 'string' => 'abc', 'nullable' => null];
         $bag = new ParameterBag($parameters);
 
-        $this->assertTrue($bag->getNullableBoolean('string_true'), '->getNullableBoolean() gets the string true as boolean true');
-        $this->assertFalse($bag->getNullableBoolean('string_false'), '->getNullableBoolean() gets the string false as boolean false');
-        $this->assertNull($bag->getNullableBoolean('unknown'), '->getNullableBoolean() returns null if a parameter is not defined');
-        $this->assertTrue($bag->getNullableBoolean('unknown', true), '->getNullableBoolean() returns default if a parameter is not defined');
-        $this->assertNull($bag->getNullableBoolean('nullable'), '->getNullableBoolean() returns null if a parameter is null');
-        $this->assertNull($bag->getNullableBoolean('nullable', true), '->getNullableBoolean() returns null if a parameter is null');
+        $this->assertTrue($bag->getBooleanOrNull('string_true'), '->getBooleanOrNull() gets the string true as boolean true');
+        $this->assertFalse($bag->getBooleanOrNull('string_false'), '->getBooleanOrNull() gets the string false as boolean false');
+        $this->assertNull($bag->getBooleanOrNull('unknown'), '->getBooleanOrNull() returns null if a parameter is not defined');
+        $this->assertTrue($bag->getBooleanOrNull('unknown', true), '->getBooleanOrNull() returns default if a parameter is not defined');
+        $this->assertNull($bag->getBooleanOrNull('nullable'), '->getBooleanOrNull() returns null if a parameter is null');
+        $this->assertNull($bag->getBooleanOrNull('nullable', true), '->getBooleanOrNull() returns null if a parameter is null');
     }
 
-    public function testGetNullableBooleanExceptionWithInvalid()
+    public function testGetBooleanOrNullExceptionWithInvalid()
     {
         $bag = new ParameterBag(['invalid' => 'foo']);
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Parameter value "invalid" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.');
 
-        $bag->getNullableBoolean('invalid');
+        $bag->getBooleanOrNull('invalid');
     }
 
     public function testGetEnum()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -204,6 +204,28 @@ class ParameterBagTest extends TestCase
         $bag->getInt('word');
     }
 
+    public function testGetNullableInt()
+    {
+        $bag = new ParameterBag(['digits' => '123', 'nullable' => null]);
+
+        $this->assertSame(123, $bag->getNullableInt('digits'), '->getNullableInt() gets a value of parameter as integer');
+        $this->assertNull($bag->getNullableInt('unknown'), '->getNullableInt() returns default if a parameter is not defined');
+        $this->assertSame(0, $bag->getNullableInt('unknown', 0), '->getNullableInt() returns default if a parameter is not defined');
+        $this->assertSame(10, $bag->getNullableInt('unknown', 10), '->getNullableInt() returns the default if a parameter is not defined');
+        $this->assertNull($bag->getNullableInt('nullable'), '->getNullableInt() returns null if a parameter is null');
+        $this->assertNull($bag->getNullableInt('nullable', 0), '->getNullableInt() returns null if a parameter is null');
+    }
+
+    public function testGetNullableIntExceptionWithInvalid()
+    {
+        $bag = new ParameterBag(['word' => 'foo_BAR_012']);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Parameter value "word" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.');
+
+        $bag->getNullableInt('word');
+    }
+
     public function testGetString()
     {
         $bag = new ParameterBag(['integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class() implements \Stringable {
@@ -240,6 +262,26 @@ class ParameterBagTest extends TestCase
         $this->expectExceptionMessage('Parameter value "object" cannot be converted to "string".');
 
         $bag->getString('object');
+    }
+
+    public function testGetNullableString()
+    {
+        $bag = new ParameterBag(['nullable' => null, 'integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class() implements \Stringable {
+            public function __toString(): string
+            {
+                return 'strval';
+            }
+        }]);
+
+        $this->assertSame('123', $bag->getNullableString('integer'), '->getNullableString() gets a value of parameter as string');
+        $this->assertSame('abc', $bag->getNullableString('string'), '->getNullableString() gets a value of parameter as string');
+        $this->assertNull($bag->getNullableString('unknown'), '->getNullableString() returns null if a parameter is not defined');
+        $this->assertSame('foo', $bag->getNullableString('unknown', 'foo'), '->getNullableString() returns the default if a parameter is not defined');
+        $this->assertSame('1', $bag->getNullableString('bool_true'), '->getNullableString() returns "1" if a parameter is true');
+        $this->assertSame('', $bag->getNullableString('bool_false', 'foo'), '->getNullableString() returns an empty empty string if a parameter is false');
+        $this->assertSame('strval', $bag->getNullableString('stringable'), '->getNullableString() gets a value of a stringable paramater as string');
+        $this->assertNull($bag->getNullableString('nullable'), '->getNullableString() gets null if a parameter is null');
+        $this->assertNull($bag->getNullableString('nullable', ''), '->getNullableString() gets null if a parameter is null');
     }
 
     public function testFilter()
@@ -335,6 +377,29 @@ class ParameterBagTest extends TestCase
         $this->expectExceptionMessage('Parameter value "invalid" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.');
 
         $bag->getBoolean('invalid');
+    }
+
+    public function testGetNullableBoolean()
+    {
+        $parameters = ['string_true' => 'true', 'string_false' => 'false', 'string' => 'abc', 'nullable' => null];
+        $bag = new ParameterBag($parameters);
+
+        $this->assertTrue($bag->getNullableBoolean('string_true'), '->getNullableBoolean() gets the string true as boolean true');
+        $this->assertFalse($bag->getNullableBoolean('string_false'), '->getNullableBoolean() gets the string false as boolean false');
+        $this->assertNull($bag->getNullableBoolean('unknown'), '->getNullableBoolean() returns null if a parameter is not defined');
+        $this->assertTrue($bag->getNullableBoolean('unknown', true), '->getNullableBoolean() returns default if a parameter is not defined');
+        $this->assertNull($bag->getNullableBoolean('nullable'), '->getNullableBoolean() returns null if a parameter is null');
+        $this->assertNull($bag->getNullableBoolean('nullable', true), '->getNullableBoolean() returns null if a parameter is null');
+    }
+
+    public function testGetNullableBooleanExceptionWithInvalid()
+    {
+        $bag = new ParameterBag(['invalid' => 'foo']);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Parameter value "invalid" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.');
+
+        $bag->getNullableBoolean('invalid');
     }
 
     public function testGetEnum()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no
| Issues        | Fix #... 
| License       | MIT

Rework of the https://github.com/symfony/symfony/pull/49972 PR.

The `getNullable*` are different from the
```php
return $this->has($key) ? $this->getString($key) : null;
```
because the `has` check is using `array_key_exists`.
So in case of a custom bag build with `null` values, the getNullable method will return null, when the has/get* will cast the value (or throw an error in some cases).

The `getNullable*` is also different from the `\FILTER_NULL_ON_FAILURE` flag because because `getNullable*` methods are still validating non-null values and throwing exception (when the FILTER_NULL_ON_FAILURE flag fallback to null).

So currently, the `getNullable*` behavior is not an easy one to produce with the given methods from Symfony.
The https://github.com/symfony/symfony/issues/45775 issue was closed without the nullable getters, but this was still a requested feature.