### PR TITLE
[Config] Provide more precise phpdoc for `FileLocatorInterface::locate()`

### DIFF
--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -31,7 +31,9 @@ class FileLocator implements FileLocatorInterface
     }
 
     /**
-     * @return string|array
+     * @return string|string[]
+     *
+     * @psalm-return ($first is true ? string : string[])
      */
     public function locate(string $name, ?string $currentPath = null, bool $first = true)
     {

--- a/src/Symfony/Component/Config/FileLocatorInterface.php
+++ b/src/Symfony/Component/Config/FileLocatorInterface.php
@@ -25,10 +25,12 @@ interface FileLocatorInterface
      * @param string|null $currentPath The current path
      * @param bool        $first       Whether to return the first occurrence or an array of filenames
      *
-     * @return string|array The full path to the file or an array of file paths
+     * @return string|string[] The full path to the file or an array of file paths
      *
      * @throws \InvalidArgumentException        If $name is empty
      * @throws FileLocatorFileNotFoundException If a file is not found
+     *
+     * @psalm-return ($first is true ? string : string[])
      */
     public function locate(string $name, ?string $currentPath = null, bool $first = true);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | ?
| New feature?  | ?
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

When working with psalm/phpstan, they believe `$locator->locate('...');` returns possibly an array which is not true.
This can be defined with `@psalm-return` annotation that Symfony started to integrate in the code base.