### PR TITLE
[FrameworkBundle] `ConfigBuilderCacheWarmer` should be non-optional

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -85,6 +85,6 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
 
     public function isOptional(): bool
     {
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53496
| License       | MIT

Replaces #53512

This became apparent after #50391, where the warmer is run only when compiling the container. Before, it didn't really matter.