### PR TITLE
[Mime] Make RawMessage::message nullable in the constructor

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -21,7 +21,7 @@ class RawMessage
     private iterable|string|null $message = null;
     private bool $isGeneratorClosed;
 
-    public function __construct(iterable|string $message)
+    public function __construct(iterable|string|nullable $message)
     {
         $this->message = $message;
     }

--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -21,7 +21,7 @@ class RawMessage
     private iterable|string|null $message = null;
     private bool $isGeneratorClosed;
 
-    public function __construct(iterable|string|nullable $message)
+    public function __construct(iterable|string|null $message)
     {
         $this->message = $message;
     }

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Mime\Part\Multipart\MixedPart;
 use Symfony\Component\Mime\Part\Multipart\RelatedPart;
 use Symfony\Component\Mime\Part\TextPart;
 use Symfony\Component\Mime\Test\Constraint\EmailHeaderSame;
-use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\MimeMessageNormalizer;
@@ -569,7 +569,7 @@ class EmailTest extends TestCase
 }
 EOF;
 
-        $extractor = new PhpDocExtractor();
+        $extractor = new ReflectionExtractor();
         $propertyNormalizer = new PropertyNormalizer(null, null, $extractor);
         $serializer = new Serializer([
             new ArrayDenormalizer(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #53664 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

The `RawMessage::message` is nullable. However the parameter passed to the constructor is not allowed to be `null`.