### PR TITLE
Use Symfony "dark-mode"-responsive logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center"><a href="https://symfony.com" target="_blank">
-    <img src="https://symfony.com/logos/symfony_black_02.svg">
+    <img src="https://symfony.com/logos/symfony_dynamic_01.svg" alt="Symfony Logo">
 </a></p>
 
 [Symfony][1] is a **PHP framework** for web and console applications and a set


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53105 
| License       | MIT

Following #53105 @javiereguiluz [uploaded](https://github.com/symfony/symfony/issues/53105#issuecomment-1915193582) a Symfony "dynamic" logo, featuring a color scheme that adapts to user preferences. 

This enhancement allows the README's logo to appear sharper and cleaner in dark mode (on Github.com, in PHPStorm, ...)

```diff
<svg>
    <style>
+        @media (prefers-color-scheme: dark) {
+            .symfony-logo-circle, .symfony-logo-letter { fill: #fff; }
+            .symfony-logo-circle-letters { fill: #000; }
        }
    </style>
    <!-- SVG code -->
</svg>
```
| Before | After |
| - | - |
| ![before_dark](https://github.com/symfony/symfony/assets/1359581/a01633d4-c0e5-45fd-b158-8f007bd22144) | ![after_dark](https://github.com/symfony/symfony/assets/1359581/ebacc787-b049-435e-9615-eead19743f39) |

( Thank you again @javiereguiluz )


