### PR TITLE
[AssetMapper] Fix exception if assets directory is missing in production

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
@@ -161,6 +161,10 @@ class AssetMapperRepository
                 continue;
             }
 
+            if ('dev' !== $_ENV['APP_ENV'] && 'assets/' === $path) {
+                continue;
+            }
+
             throw new \InvalidArgumentException(sprintf('The asset mapper directory "%s" does not exist.', $path));
         }
 

--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Add a `importmap:audit` command to check for security vulnerability advisories in dependencies
  * Add a `importmap:outdated` command to check for outdated packages
  * Change the polyfill used for the importmap renderer from a URL to an entry in the importmap
+ * Fix exception if assets directory is missing in production mode
 
 6.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53669 
| License       | MIT


During deployment some people will compile their assets with Asset Mapper then delete the root `assets/` directory. This causes Asset Mapper to throw an exception, and a common work around people mentioned in the issue is to create an empty `assets/` directory.

This adds a check so that if the application is running in `prod` mode, and the $path being checked by Asset Mapper is `assets/`, it will continue instead of throwing an exception.