### PR TITLE
[Mime] Fix serializing uninitialized `RawMessage::$message` to null

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -94,8 +94,7 @@ class TemplatedEmailTest extends TestCase
             }
         ]
     },
-    "body": null,
-    "message": null
+    "body": null
 }
 EOF;
 

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -42,7 +42,7 @@
         "symfony/security-core": "^4.4|^5.0|^6.0",
         "symfony/security-csrf": "^4.4|^5.0|^6.0",
         "symfony/security-http": "^4.4|^5.0|^6.0",
-        "symfony/serializer": "^5.2|^6.0",
+        "symfony/serializer": "^5.4.35|~6.3.12|^6.4.3",
         "symfony/stopwatch": "^4.4|^5.0|^6.0",
         "symfony/console": "^5.3|^6.0",
         "symfony/expression-language": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -18,6 +18,9 @@ use Symfony\Component\Mime\Exception\LogicException;
  */
 class RawMessage implements \Serializable
 {
+    /**
+     * @var iterable|string
+     */
     private $message;
 
     /**

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -547,8 +547,7 @@ class EmailTest extends TestCase
             }
         ]
     },
-    "body": null,
-    "message": null
+    "body": null
 }
 EOF;
 

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -254,8 +254,7 @@ EOF;
             ]
         },
         "class": "Symfony\\\\Component\\\\Mime\\\\Part\\\\Multipart\\\\MixedPart"
-    },
-    "message": null
+    }
 }
 EOF;
 

--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -28,14 +28,14 @@
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "symfony/property-access": "^4.4|^5.1|^6.0",
         "symfony/property-info": "^4.4|^5.1|^6.0",
-        "symfony/serializer": "^5.4.26|~6.2.13|^6.3.2"
+        "symfony/serializer": "^5.4.35|~6.3.12|^6.4.3"
     },
     "conflict": {
         "egulias/email-validator": "~3.0.0",
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",
         "symfony/mailer": "<4.4",
-        "symfony/serializer": "<5.4.26|>=6,<6.2.13|>=6.3,<6.3.2"
+        "symfony/serializer": "<5.4.35|>=6,<6.3.12|>=6.4,<6.4.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mime\\": "" },

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\Part\AbstractPart;
+use Symfony\Component\Mime\RawMessage;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -63,15 +64,18 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
             return $ret;
         }
 
+        $ret = $this->normalizer->normalize($object, $format, $context);
+
         if ($object instanceof AbstractPart) {
-            $ret = $this->normalizer->normalize($object, $format, $context);
             $ret['class'] = \get_class($object);
             unset($ret['seekable'], $ret['cid'], $ret['handle']);
-
-            return $ret;
         }
 
-        return $this->normalizer->normalize($object, $format, $context);
+        if ($object instanceof RawMessage && \array_key_exists('message', $ret) && null === $ret['message']) {
+            unset($ret['message']);
+        }
+
+        return $ret;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53664
| License       | MIT

