### PR TITLE
[Security] SwitchUser: add dynamic redirection path over config redirection

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 
 The CHANGELOG for version 5.4 and newer can be found in the security sub-packages (e.g. `Http/`).
 
+7.2
+---
+
+* Add a request query string `_redirect_path` handled in `SwitchUserListener` to allow controlling the redirection path post switching user. It takes precedence over the `SwitchUserListener $targetRoute` configured value if any.
+
 5.3
 ---
 

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,7 +6,7 @@ The CHANGELOG for version 5.4 and newer can be found in the security sub-package
 7.2
 ---
 
-* Add a request query string `_redirect_path` handled in `SwitchUserListener` to allow controlling the redirection path post switching user. It takes precedence over the `SwitchUserListener $targetRoute` configured value if any.
+ * Add a request query string `_redirect_path` handled in `SwitchUserListener` to allow controlling the redirection path post switching user. It takes precedence over the `SwitchUserListener $targetRoute` configured value if any.
 
 5.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/53645
| License       | MIT

As per related issue, I would love to have such logic on symfony core security part switch user

---

> [!NOTE]
> Will provide doc PR if accepted, but as is: this feature allows to use url like:
> `https://my-app.wip/?_switch_user=user@domain.tld&_redirect_path=/account/order`

