### PR TITLE
[DoctrineBridge]  Fix detection of Xml/Yaml driver in DoctrineExtension

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -215,7 +215,9 @@ abstract class AbstractDoctrineExtension extends Extension
                     array_values($driverPaths),
                 ]);
             }
-            if (str_contains($mappingDriverDef->getClass(), 'yml') || str_contains($mappingDriverDef->getClass(), 'xml')) {
+            if (str_contains($mappingDriverDef->getClass(), 'yml') || str_contains($mappingDriverDef->getClass(), 'xml')
+                || str_contains($mappingDriverDef->getClass(), 'Yaml') || str_contains($mappingDriverDef->getClass(), 'Xml')
+            ) {
                 $mappingDriverDef->setArguments([array_flip($driverPaths)]);
                 $mappingDriverDef->addMethodCall('setGlobalBasename', ['mapping']);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/doctrine/DoctrineMongoDBBundle/issues/841
| License       | MIT

In DoctrineMongoDBBundle v5, we removed `.class` attributes to plain class names in service definitions (see https://github.com/doctrine/DoctrineMongoDBBundle/pull/821). The class for `doctrine_mongodb.odm.default_xml_metadata_driver` changed from `doctrine_mongodb.odm.metadata.xml.class` to `Doctrine\Bundle\MongoDBBundle\Mapping\Driver\XmlDriver`.

I fixed the detection of the driver by checking the uppercase `Xml` and `Yaml` because it might be necessary if the same change is made to DoctrineBundle.

[`doctrine/mongodb-odm-bundle` requires `symfony/doctrine-bridge: "^6.4 || ^7.0"`](https://github.com/doctrine/DoctrineMongoDBBundle/blob/4d8d32b726e7af21a562a2b6a227f0496c7d39d5/composer.json#L36) so this patch if not required for older versions of Symfony even if it could be applied.

