### PR TITLE
 [AssetMapper] Fix exception if assets directory is missing in production

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -75,6 +75,7 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.project_dir'),
                 abstract_arg('array of excluded path patterns'),
                 abstract_arg('exclude dot files'),
+                param('kernel.debug'),
             ])
 
         ->set('asset_mapper.public_assets_path_resolver', PublicAssetsPathResolver::class)

--- a/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
@@ -34,6 +34,7 @@ class AssetMapperRepository
         private readonly string $projectRootDir,
         private readonly array $excludedPathPatterns = [],
         private readonly bool $excludeDotFiles = true,
+        private readonly bool $debug = false
     ) {
     }
 
@@ -147,7 +148,7 @@ class AssetMapperRepository
         $this->absolutePaths = [];
         foreach ($this->paths as $path => $namespace) {
             if ($filesystem->isAbsolutePath($path)) {
-                if (!file_exists($path)) {
+                if (!file_exists($path) && $this->debug) {
                     throw new \InvalidArgumentException(sprintf('The asset mapper directory "%s" does not exist.', $path));
                 }
                 $this->absolutePaths[realpath($path)] = $namespace;
@@ -161,7 +162,9 @@ class AssetMapperRepository
                 continue;
             }
 
-            throw new \InvalidArgumentException(sprintf('The asset mapper directory "%s" does not exist.', $path));
+            if ($this->debug) {
+                throw new \InvalidArgumentException(sprintf('The asset mapper directory "%s" does not exist.', $path));
+            }
         }
 
         return $this->absolutePaths;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53669 
| License       | MIT


During deployment some people will compile their assets with Asset Mapper then delete the root `assets/` directory. This causes Asset Mapper to throw an exception, and a common work around people mentioned in the issue is to create an empty `assets/` directory.

This PR makes it so the exception is only thrown while `kernel.debug` is equal to true, letting developers know locally that there's an issue, but allowing people to safely do this in their `production` environments.