### PR TITLE
Fix client side connection timeout breaks mail authentication

### DIFF
--- a/src/Symfony/Component/Mailer/Exception/UnexpectedResponseException.php
+++ b/src/Symfony/Component/Mailer/Exception/UnexpectedResponseException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Exception;
+
+class UnexpectedResponseException extends TransportException
+{
+}

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/DummyStream.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/DummyStream.php
@@ -62,6 +62,8 @@ class DummyStream extends AbstractStream
             $this->nextResponse = '334 UGFzc3dvcmQ6';
         } elseif (str_starts_with($bytes, 'cDRzc3cwcmQ=')) {
             $this->nextResponse = '535 5.7.139 Authentication unsuccessful';
+        } elseif (str_starts_with($bytes, 'dGltZWRvdXQ=')) {
+            throw new TransportException('Connection to "localhost" timed out.');
         } elseif (str_starts_with($bytes, 'AUTH CRAM-MD5')) {
             $this->nextResponse = '334 PDAxMjM0NTY3ODkuMDEyMzQ1NjdAc3ltZm9ueT4=';
         } elseif (str_starts_with($bytes, 'dGVzdHVzZXIgNTdlYzg2ODM5OWZhZThjY2M5OWFhZGVjZjhiZTAwNmY=')) {

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -214,6 +214,41 @@ class EsmtpTransportTest extends TestCase
             $this->assertEquals(504, $e->getCode());
         }
     }
+
+    public function testSocketTimeout()
+    {
+        $stream = new DummyStream();
+        $transport = new EsmtpTransport(stream: $stream);
+        $transport->setUsername('testuser');
+        $transport->setPassword('timedout');
+        $transport->setAuthenticators([new LoginAuthenticator()]);
+
+        $message = new Email();
+        $message->from('sender@example.org');
+        $message->addTo('recipient@example.org');
+        $message->text('.');
+
+        try {
+            $transport->send($message);
+            $this->fail('Symfony\Component\Mailer\Exception\TransportException to be thrown');
+        } catch (TransportException $e) {
+            $this->assertStringStartsWith('Connection to "localhost" timed out.', $e->getMessage());
+        }
+
+        $this->assertEquals(
+            [
+                "EHLO [127.0.0.1]\r\n",
+                // S: 250 localhost
+                // S: 250-AUTH PLAIN LOGIN CRAM-MD5 XOAUTH2
+                "AUTH LOGIN\r\n",
+                // S: 334 VXNlcm5hbWU6
+                "dGVzdHVzZXI=\r\n",
+                // S: 334 UGFzc3dvcmQ6
+                "dGltZWRvdXQ=\r\n",
+            ],
+            $stream->getCommands()
+        );
+    }
 }
 
 class CustomEsmtpTransport extends EsmtpTransport

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -15,6 +15,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\Exception\UnexpectedResponseException;
 use Symfony\Component\Mailer\Transport\Smtp\Auth\AuthenticatorInterface;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\AbstractStream;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
@@ -199,7 +200,7 @@ class EsmtpTransport extends SmtpTransport
                 $authenticator->authenticate($this);
 
                 return;
-            } catch (TransportExceptionInterface $e) {
+            } catch (UnexpectedResponseException $e) {
                 $code = $e->getCode();
 
                 try {

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\Exception\UnexpectedResponseException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\AbstractStream;
@@ -335,7 +336,7 @@ class SmtpTransport extends AbstractTransport
             $codeStr = $code ? sprintf('code "%s"', $code) : 'empty code';
             $responseStr = $response ? sprintf(', with message "%s"', trim($response)) : '';
 
-            throw new TransportException(sprintf('Expected response code "%s" but got ', implode('/', $codes)).$codeStr.$responseStr.'.', $code ?: 0);
+            throw new UnexpectedResponseException(sprintf('Expected response code "%s" but got ', implode('/', $codes)).$codeStr.$responseStr.'.', $code ?: 0);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53647
| License       | MIT

The authentication loop should only continue when an unexpected response has been received. Any other exception, for example,  `throw new TransportException('Connection to "localhost" timed out.'));` should be treated as fatal and thrown. 

As demonstrated in #53647, when anything other than a server response is skipped it results in later commands not matching their expected response codes.
