### PR TITLE
[Mailer] Add timestamp to SMTP debug log

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
@@ -36,8 +36,9 @@ abstract class AbstractStream
     public function write(string $bytes, bool $debug = true): void
     {
         if ($debug) {
+            $timestamp = date('c');
             foreach (explode("\n", trim($bytes)) as $line) {
-                $this->debug .= sprintf("> %s\n", $line);
+                $this->debug .= sprintf("[%s] > %s\n", $timestamp, $line);
             }
         }
 
@@ -91,7 +92,7 @@ abstract class AbstractStream
             }
         }
 
-        $this->debug .= sprintf('< %s', $line);
+        $this->debug .= sprintf('[%s] < %s', date('c'), $line);
 
         return $line;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

When debugging #53647, the lack of a timestamp made it difficult to understand why the `RSET` was happening before a response had been received. The timestamps gave a clue towards the problem. The timestamps also help show slow connections which you're otherwise not aware of.