### PR TITLE
[Console] Fix color support for TTY output

### DIFF
--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -106,10 +106,22 @@ class StreamOutput extends Output
             return true;
         }
 
-        return 'Hyper' === getenv('TERM_PROGRAM')
+        if ('Hyper' === getenv('TERM_PROGRAM')
+            || false !== getenv('COLORTERM')
             || false !== getenv('ANSICON')
             || 'ON' === getenv('ConEmuANSI')
-            || str_starts_with((string) getenv('TERM'), 'xterm');
+        ) {
+            return true;
+        }
+
+        $term = (string) getenv('TERM');
+
+        if ('dumb' === $term) {
+            return false;
+        }
+
+        // See https://github.com/chalk/supports-color/blob/d4f413efaf8da045c5ab440ed418ef02dbb28bf1/index.js#L157
+        return 1 === @preg_match('/^((screen|xterm|vt100|vt220|putty|rxvt|ansi|cygwin|linux).*)|(.*-256(color)?(-bce)?)$/', $term);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #53693
| License       | MIT

Prior to https://github.com/symfony/symfony/pull/53576, the output being a TTY was sufficient to consider the output as supporting colors. This is not enough but as a result, we are missing some additional checks.

This PR:

- Adds a check for the `COLORTERM` environment variable. From what I've found it does not look this variable is ever set if there is no color support.
- Adds a check for the `screen-*` `TERM` values. Similar to the check we already for `xterm`, you have `screen-256color`, `screen-256color-bce`, `screen.xterm-256color` or more.