### PR TITLE
[Console] Allow false as a $shortcut in InputOption

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -69,7 +69,7 @@ class InputOption
             throw new InvalidArgumentException('An option name cannot be empty.');
         }
 
-        if ('' === $shortcut || [] === $shortcut) {
+        if ('' === $shortcut || [] === $shortcut || false === $shortcut) {
             $shortcut = null;
         }
 

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -69,6 +69,8 @@ class InputOptionTest extends TestCase
         $this->assertEquals('0|z', $option->getShortcut(), '-0 is an acceptable shortcut value when embedded in an array');
         $option = new InputOption('foo', '0|z');
         $this->assertEquals('0|z', $option->getShortcut(), '-0 is an acceptable shortcut value when embedded in a string-list');
+        $option = new InputOption('foo', false);
+        $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null when given a false as value');
     }
 
     public function testModes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53702
| License       | MIT

This change is needed for laravel 8.x installation to allow running kernel and module based architecture. Right now our deployments are suddenly stopped since morning all saying "An option shortcut cannot be empty" and root cause for this is $shortcut is coming as false from laravel modules feature library.
