### PR TITLE
[Mailer] Fix usage of stream_set_timeout in case of microseconds

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php
@@ -160,7 +160,7 @@ final class SocketStream extends AbstractStream
         }
 
         stream_set_blocking($this->stream, true);
-        stream_set_timeout($this->stream, $timeout);
+        stream_set_timeout($this->stream, (int) $timeout, (int) (($timeout - (int) $timeout) * 1000000));
         $this->in = &$this->stream;
         $this->out = &$this->stream;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53705
| License       | MIT

Fix usage of stream_set_timeout() in case if stream timeout consist of second decimals.