### PR TITLE
[String] Fix plural of word ending by pus

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -291,6 +291,12 @@ final class EnglishInflector implements InflectorInterface
         // circuses (circus)
         ['suc', 3, true, true, 'cuses'],
 
+        // hippocampi (hippocampus)
+        ['supmacoppih', 11, false, false, 'hippocampi'],
+
+        // campuses (campus)
+        ['sup', 3, true, true, 'puses'],
+
         // status (status)
         ['sutats', 6, true, true, ['status', 'statuses']],
 

--- a/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
@@ -298,6 +298,8 @@ class EnglishInflectorTest extends TestCase
             ['waltz', 'waltzes'],
             ['wife', 'wives'],
             ['icon', 'icons'],
+            ['hippocampus', 'hippocampi'],
+            ['campus', 'campuses'],
 
             // test casing: if the first letter was uppercase, it should remain so
             ['Man', 'Men'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #53685
| License       | MIT

Fix the pluralization of words ending by 'pus' like campus.
Previously was campi instead of campuses
