### PR TITLE
[Mailer] [Mailgun] Fix payload converter getReason

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php
@@ -75,7 +75,7 @@ final class MailgunPayloadConverter implements PayloadConverterInterface
 
     private function getReason(array $payload): string
     {
-        if ('' !== $payload['delivery-status']['description']) {
+        if ('' !== ($payload['delivery-status']['description'] ?? '')) {
             return $payload['delivery-status']['description'];
         }
         if ('' !== $payload['delivery-status']['message']) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/permanent_failure_no_description.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/permanent_failure_no_description.json
@@ -1,0 +1,58 @@
+{
+    "signature": {
+        "token": "fff0ebc59c0516f4ce0823212a2f45e5c67814420b99fe558b",
+        "timestamp": "1661590666",
+        "signature": "a0cd251821d8fd56a2130b541becc8e441023574e602fe9829a9ab9fbfdea33f"
+    },
+    "event-data": {
+        "id": "G9Bn5sl1TC6nu79C8C0bwg",
+        "timestamp": 1521233195.375624,
+        "log-level": "error",
+        "event": "failed",
+        "severity": "permanent",
+        "reason": "bounce",
+        "delivery-status": {
+            "attempt-no": 1,
+            "message": "No Such User Here",
+            "code": 550,
+            "enhanced-code": "",
+            "session-seconds": 0
+        },
+        "flags": {
+            "is-routed": false,
+            "is-authenticated": true,
+            "is-system-test": false,
+            "is-test-mode": false
+        },
+        "envelope": {
+            "sender": "bob@app.symfony.com",
+            "transport": "smtp",
+            "targets": "alice@example.com"
+        },
+        "message": {
+            "headers": {
+                "to": "Alice <alice@example.com>",
+                "message-id": "20130503192659.13651.20287@app.symfony.com",
+                "from": "Bob <bob@app.symfony.com>",
+                "subject": "Test permanent_fail webhook"
+            },
+            "attachments": [],
+            "size": 111
+        },
+        "recipient": "alice@example.com",
+        "recipient-domain": "example.com",
+        "storage": {
+            "url": "https://se.api.mailgun.net/v3/domains/app.symfony.com/messages/message_key",
+            "key": "message_key"
+        },
+        "campaigns": [],
+        "tags": [
+            "my_tag_1",
+            "my_tag_2"
+        ],
+        "user-variables": {
+            "my_var_1": "Mailgun Variable #1",
+            "my-var-2": "awesome"
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/permanent_failure_no_description.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/Fixtures/permanent_failure_no_description.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, 'G9Bn5sl1TC6nu79C8C0bwg', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: JSON_THROW_ON_ERROR)['event-data']);
+$wh->setRecipientEmail('alice@example.com');
+$wh->setTags(['my_tag_1', 'my_tag_2']);
+$wh->setMetadata(['my_var_1' => 'Mailgun Variable #1', 'my-var-2' => 'awesome']);
+$wh->setDate(\DateTimeImmutable::createFromFormat('U.u', '1521233195.375624'));
+$wh->setReason('No Such User Here');
+
+return $wh;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Sentry logged in our prod env `ErrorException: Warning: Undefined array key "description"`.
```json
{
    "event-data": {
        "delivery-status": {
            "bounce-code": "5.7.133", 
            "code": 550, 
            "enhanced-code": "5.7.133",
            "message": "[Filtered]"
        }
    }
} 
```

So this means that `description` is not always set