### PR TITLE
[HttpKernel] Document Kernel's array return types

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
@@ -24,6 +24,8 @@ abstract class Extension extends BaseExtension
 
     /**
      * Gets the annotated classes to cache.
+     *
+     * @return string[]
      */
     public function getAnnotatedClassesToCompile(): array
     {
@@ -33,7 +35,7 @@ abstract class Extension extends BaseExtension
     /**
      * Adds annotated classes to the class cache.
      *
-     * @param array $annotatedClasses An array of class patterns
+     * @param string[] $annotatedClasses An array of class patterns
      */
     public function addAnnotatedClassesToCompile(array $annotatedClasses): void
     {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -314,6 +314,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     /**
      * Gets the patterns defining the classes to parse and cache for annotations.
+     *
+     * @return string[]
      */
     public function getAnnotatedClassesToCompile(): array
     {
@@ -534,6 +536,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     /**
      * Returns the kernel parameters.
+     *
+     * @return array<string, array|bool|string|int|float|\UnitEnum|null>
      */
     protected function getKernelParameters(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The `Kernel` methods `getAnnotatedClassesToCompile()` and `getKernelParameters()` are meant to be overridden downstream. These additional annotations help static analyzers determine whether an overridden implementation is correct.