### PR TITLE
[MonologBridge] Support symfony/security-core 5.4 again

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -51,7 +51,8 @@ abstract class AbstractTokenProcessor
                 'roles' => $token->getRoleNames(),
             ];
 
-            $record['extra'][$this->getKey()]['user_identifier'] = $token->getUserIdentifier();
+            // @deprecated since Symfony 5.3, change to $token->getUserIdentifier() in 7.0
+            $record['extra'][$this->getKey()]['user_identifier'] = method_exists($token, 'getUserIdentifier') ? $token->getUserIdentifier() : $token->getUsername();
         }
 
         return $record;

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "symfony/console": "^5.4|^6.0|^7.0",
         "symfony/http-client": "^5.4|^6.0|^7.0",
-        "symfony/security-core": "^6.0|^7.0",
+        "symfony/security-core": "^5.4|^6.0|^7.0",
         "symfony/var-dumper": "^5.4|^6.0|^7.0",
         "symfony/mailer": "^5.4|^6.0|^7.0",
         "symfony/mime": "^5.4|^6.0|^7.0",
@@ -34,7 +34,7 @@
     "conflict": {
         "symfony/console": "<5.4",
         "symfony/http-foundation": "<5.4",
-        "symfony/security-core": "<6.0"
+        "symfony/security-core": "<5.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\Monolog\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53699
| License       | MIT

This change should allow the installation of MonologBridge 6.4 in Symfony 5.4 projects that want to use Monolog 3.