### PR TITLE
[HttpKernel] Fix VarDumper colors are not shown with DebugBundle enabled on CLI

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -242,7 +242,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                 $dumper = new HtmlDumper('php://output', $this->charset);
                 $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
             } else {
-                $dumper = new CliDumper('php://output', $this->charset);
+                $dumper = new CliDumper(null, $this->charset);
                 if (method_exists($dumper, 'setDisplayOptions')) {
                     $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #37768
| License       | MIT

Colors are not shown using VarDumper with DebugBundle enabled on CLI, this fixes it.