### PR TITLE
[ExpressionLanguage] Add ``min`` and ``max`` php functions

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add support for php `min` and `max` functions
+
 7.0
 ---
 

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -140,7 +140,10 @@ class ExpressionLanguage
      */
     protected function registerFunctions()
     {
-        $this->addFunction(ExpressionFunction::fromPhp('constant'));
+        $basicPhpFunctions = ['constant', 'min', 'max'];
+        foreach ($basicPhpFunctions as $function) {
+            $this->addFunction(ExpressionFunction::fromPhp($function));
+        }
 
         $this->addFunction(new ExpressionFunction('enum',
             static fn ($str): string => sprintf("(\constant(\$v = (%s))) instanceof \UnitEnum ? \constant(\$v) : throw new \TypeError(\sprintf('The string \"%%s\" is not the name of a valid enum case.', \$v))", $str),

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -71,13 +71,23 @@ class ExpressionLanguageTest extends TestCase
         $this->assertSame($savedParsedExpression, $parsedExpression);
     }
 
-    public function testConstantFunction()
+    /**
+     * @dataProvider basicPhpFunctionProvider
+     */
+    public function testBasicPhpFunction($expression, $expected, $compiled)
     {
         $expressionLanguage = new ExpressionLanguage();
-        $this->assertEquals(\PHP_VERSION, $expressionLanguage->evaluate('constant("PHP_VERSION")'));
+        $this->assertEquals($expected, $expressionLanguage->evaluate($expression));
+        $this->assertEquals($compiled, $expressionLanguage->compile($expression));
+    }
 
-        $expressionLanguage = new ExpressionLanguage();
-        $this->assertEquals('\constant("PHP_VERSION")', $expressionLanguage->compile('constant("PHP_VERSION")'));
+    public static function basicPhpFunctionProvider()
+    {
+        return [
+            ['constant("PHP_VERSION")', \PHP_VERSION, '\constant("PHP_VERSION")'],
+            ['min(1,2,3)', 1, '\min(1, 2, 3)'],
+            ['max(1,2,3)', 3, '\max(1, 2, 3)'],
+        ];
     }
 
     public function testEnumFunctionWithConstantThrows()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53627 
| License       | MIT

Add support for php `min` and `max` functions in the ExpressionLanguage.

I'll create also a pr for the docs when it's merged.