### PR TITLE
[Messenger] [Beanstalkd] fix tube stats when it's empty

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
@@ -182,6 +182,7 @@ class Connection
     public function getMessageCount(): int
     {
         try {
+            $this->client->useTube($this->tube);
             $tubeStats = $this->client->statsTube($this->tube);
         } catch (Exception $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Issues        | Fix #53526
| License       | MIT

When Beanstalkd's tube was empty `messenger:stats` commands throws an `NOT_FOUND` error instead of 0.
Initializing tube before retrieving tube stats force beanstalkd to created it and then it returns proper value.