### PR TITLE
[VarDumper] Add functional test for `ServerDumpCommand`

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Command/ServerDumpCommandTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/ServerDumpCommandTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\VarDumper\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Command\ServerDumpCommand;
 use Symfony\Component\VarDumper\Server\DumpServer;
 
@@ -28,6 +30,24 @@ class ServerDumpCommandTest extends TestCase
         $this->assertSame($expectedSuggestions, $tester->complete($input));
     }
 
+    public function testServerDumpSuccess()
+    {
+        $command = $this->createCommand();
+        $commandTester = new CommandTester($command);
+
+        $data = new Data([['my dump']]);
+        $input = base64_encode(serialize([$data, ['timestamp' => time(), 'source' => ['name' => 'sourceName', 'line' => 222, 'file' => 'myFile']]]))."\n";
+
+        $commandTester->setInputs([$input]);
+
+        $commandTester->execute(['--format' => 'html']);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('my dump', $output);
+    }
+
     public static function provideCompletionSuggestions()
     {
         yield 'option --format' => [
@@ -38,6 +58,6 @@ class ServerDumpCommandTest extends TestCase
 
     private function createCommand(): ServerDumpCommand
     {
-        return new ServerDumpCommand($this->createMock(DumpServer::class));
+        return new ServerDumpCommand(new DumpServer(''));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Update DumpServer to add functional test for the ServerDumpCommand.
This PR will allow to use DumpServer in the ServerLogCommand and test this command that had regressions in the past.

It's a try following a comment in another closed PR (https://github.com/symfony/symfony/pull/53518#issuecomment-1915548172 cc @nicolas-grekas)