### PR TITLE
[VarDumper] fix DoctrineCaster tests

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/DoctrineCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DoctrineCasterTest.php
@@ -36,9 +36,9 @@ class DoctrineCasterTest extends TestCase
             $expected = <<<EODUMP
                 Doctrine\ORM\PersistentCollection {
                 %A
-                  -em: Mock_EntityManagerInterface_%s { …3}
                   -backRefFieldName: null
                   -isDirty: false
+                  -em: Mock_EntityManagerInterface_%s { …3}
                   -typeClass: Doctrine\ORM\Mapping\ClassMetadata { …}
                 %A
                 EODUMP;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The order in which the properties are handled has changed with the usage of CPP for the entity manager in doctrine/orm#11205.
