### PR TITLE
[Config] replace CPP with non-nullable property

### DIFF
--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -23,6 +23,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class ResourceCheckerConfigCache implements ConfigCacheInterface
 {
+    private string $metaFile;
+
     /**
      * @param string                                    $file             The absolute cache path
      * @param iterable<mixed, ResourceCheckerInterface> $resourceCheckers The ResourceCheckers to use for the freshness check
@@ -31,7 +33,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
     public function __construct(
         private string $file,
         private iterable $resourceCheckers = [],
-        private ?string $metaFile = null,
+        ?string $metaFile = null,
     ) {
         $this->metaFile = $metaFile ?? $file.'.meta';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Using constructor property promotion for the `$metaFile` property does not make much sense for two reasons:

* We need to declare it nullable just for the sake of the constructor accepting `null` while the property itself will always receive a string.
* The initially set value is immediately overwritten in the constructor.