### PR TITLE
Update Albanian translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
@@ -1,18 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="sq" datatype="plaintext" original="file.ext">
+        <header>
+            <note>
+                Për fjalët e huaja, të cilat nuk kanë përkthim të drejtpërdrejtë, ju lutemi të ndiqni rregullat e mëposhtme:
+                 a) në rast se emri është akronim i përdorur gjerësisht si i përveçëm, atëherë, emri lakohet pa thonjëza dhe mbaresa shkruhet me vizë ndarëse. Gjinia gjykohet sipas rastit. Shembull: JSON-i (mashkullore)
+                 b) në rast se emri është akronim i papërdorur gjerësisht si i përveçëm, atëherë, emri lakohet pa thonjëza dhe mbaresa shkruhet me vizë ndarëse. Gjinia është femërore. Shembull: URL-ja (femërore)
+                 c) në rast se emri duhet lakuar për shkak të rasës në fjali, atëherë, emri lakohet pa thonjëza dhe mbaresa shkruhet me vizë ndarëse. Shembull: host-i, prej host-it
+                 d) në rast se emri nuk duhet lakuar për shkak të trajtës në fjali, atëherë, emri rrethohet me thonjëzat “”. Shembull: “locale”
+            </note>
+        </header>
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
-                <target>Kjo formë nuk duhet të përmbajë fusha shtesë.</target>
+                <target>Ky formular nuk duhet të përmbajë fusha shtesë.</target>
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file.</source>
-                <target>Skedari i ngarkuar ishte shumë i madh. Ju lutemi provoni të ngarkoni një skedar më të vogël.</target>
+                <target>Skeda e ngarkuar ishte shumë e madhe. Ju lutemi provoni të ngarkoni një skedë më të vogël.</target>
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>Vlera CSRF është e pavlefshme. Ju lutemi provoni të ridërgoni formën.</target>
+                <target>Vlera CSRF është e pavlefshme. Ju lutemi provoni të ridërgoni formularin.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>
@@ -24,7 +33,7 @@
             </trans-unit>
             <trans-unit id="101">
                 <source>The selected choice is invalid.</source>
-                <target>Opsioni i zgjedhur është i pavlefshëm.</target>
+                <target>Alternativa e zgjedhur është e pavlefshme.</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>The collection is invalid.</source>
@@ -40,11 +49,11 @@
             </trans-unit>
             <trans-unit id="105">
                 <source>Please select a valid currency.</source>
-                <target>Ju lutemi zgjidhni një monedhë të vlefshme.</target>
+                <target>Ju lutemi zgjidhni një valutë të vlefshme.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>Please choose a valid date interval.</source>
-                <target>Ju lutemi zgjidhni një interval të vlefshëm të datës.</target>
+                <target>Ju lutemi zgjidhni një interval të vlefshëm.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Please enter a valid date and time.</source>
@@ -56,7 +65,7 @@
             </trans-unit>
             <trans-unit id="109">
                 <source>Please select a valid file.</source>
-                <target>Ju lutemi zgjidhni një skedar të vlefshëm.</target>
+                <target>Ju lutemi zgjidhni një skedë të vlefshme.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The hidden field is invalid.</source>
@@ -68,11 +77,11 @@
             </trans-unit>
             <trans-unit id="112">
                 <source>Please select a valid language.</source>
-                <target state="needs-review-translation">Ju lutem zgjidhni një gjuhë të vlefshme.</target>
+                <target>Ju lutemi zgjidhni një gjuhë të vlefshme.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>Please select a valid locale.</source>
-                <target>Ju lutemi zgjidhni një lokale të vlefshme.</target>
+                <target>Ju lutemi zgjidhni një “locale” të vlefshme.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>Please enter a valid money amount.</source>
@@ -96,7 +105,7 @@
             </trans-unit>
             <trans-unit id="119">
                 <source>Please enter a valid time.</source>
-                <target>Ju lutemi shkruani një kohë të vlefshme.</target>
+                <target>Ju lutemi shkruani një orë të vlefshme.</target>
             </trans-unit>
             <trans-unit id="120">
                 <source>Please select a valid timezone.</source>
@@ -120,15 +129,15 @@
             </trans-unit>
             <trans-unit id="125">
                 <source>Please enter a valid email address.</source>
-                <target>Ju lutemi shkruani një adresë të vlefshme emaili.</target>
+                <target>Ju lutemi shkruani një adresë të vlefshme email-i.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>Please select a valid option.</source>
-                <target>Ju lutemi zgjidhni një opsion të vlefshëm.</target>
+                <target>Ju lutemi zgjidhni një alternativë të vlefshme.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>Please select a valid range.</source>
-                <target>Ju lutemi zgjidhni një diapazon të vlefshëm.</target>
+                <target>Ju lutemi zgjidhni një seri të vlefshme.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>Please enter a valid week.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="sq" datatype="plaintext" original="file.ext">
+        <header>
+            <note>
+                Për fjalët e huaja, të cilat nuk kanë përkthim të drejtpërdrejtë, ju lutemi të ndiqni rregullat e mëposhtme:
+                 a) në rast se emri është akronim i përdorur gjerësisht si i përveçëm, atëherë, emri lakohet pa thonjëza dhe mbaresa shkruhet me vizë ndarëse. Gjinia gjykohet sipas rastit. Shembull: JSON (mashkullore)
+                 b) në rast se emri është akronim i papërdorur gjerësisht si i përveçëm, atëherë, emri lakohet pa thonjëza dhe mbaresa shkruhet me vizë ndarëse. Gjinia është femërore. Shembull: URL (femërore)
+                 c) në rast se emri duhet lakuar për shkak të rasës në fjali, atëherë, emri lakohet pa thonjëza dhe mbaresa shkruhet me vizë ndarëse. Shembull: host-i, prej host-it
+                 d) në rast se emri nuk duhet lakuar për shkak të trajtës në fjali, atëherë, emri rrethote me thonjëzat “”. Shembull: “locale”
+            </note>
+        </header>
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
@@ -24,11 +33,11 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-                <target>Duhet të zgjedhni së paku {{ limit }} alternativë.|Duhet të zgjedhni së paku {{ limit }} alternativa.</target>
+                <target>Duhet të zgjidhni së paku {{ limit }} alternativë.|Duhet të zgjidhni së paku {{ limit }} alternativa.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-                <target>Duhet të zgjedhni më së shumti {{ limit }} alternativë.|Duhet të zgjedhni më së shumti {{ limit }} alternativa.</target>
+                <target>Duhet të zgjidhni së shumti {{ limit }} alternativë.|Duhet të zgjidhni së shumti {{ limit }} alternativa.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>One or more of the given values is invalid.</source>
@@ -48,7 +57,7 @@
             </trans-unit>
             <trans-unit id="12">
                 <source>This value is not a valid datetime.</source>
-                <target>Kjo vlerë nuk është datë-kohë e vlefshme.</target>
+                <target>Kjo vlerë nuk është datë dhe orë e vlefshme.</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>This value is not a valid email address.</source>
@@ -56,19 +65,19 @@
             </trans-unit>
             <trans-unit id="14">
                 <source>The file could not be found.</source>
-                <target>File nuk mund të gjindej.</target>
+                <target>Skeda nuk u gjet.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>The file is not readable.</source>
-                <target>File nuk është i lexueshëm.</target>
+                <target>Skeda nuk është e lexueshme.</target>
             </trans-unit>
             <trans-unit id="16">
                 <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>File është shumë i madh ({{ size }} {{ suffix }}). Madhësia maksimale e lejuar është {{ limit }} {{ suffix }}.</target>
+                <target>Skeda është shumë e madhe ({{ size }} {{ suffix }}). Madhësia maksimale e lejuar është {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
-                <target>Lloji mime i file-it është i pavlefshëm ({{ type }}). Llojet mime të lejuara janë {{ types }}.</target>
+                <target>Lloji “mime” i skedës është i pavlefshëm ({{ type }}). Llojet “mime” të lejuara janë {{ types }}.</target>
             </trans-unit>
             <trans-unit id="18">
                 <source>This value should be {{ limit }} or less.</source>
@@ -76,7 +85,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>Kjo vlerë është shumë e gjatë. Duhet të përmbaj {{ limit }} karakter ose më pak.|Kjo vlerë është shumë e gjatë. Duhet të përmbaj {{ limit }} karaktere ose më pak.</target>
+                <target>Kjo vlerë është shumë e gjatë. Duhet të përmbajë {{ limit }} karakter ose më pak.|Kjo vlerë është shumë e gjatë. Duhet të përmbajë {{ limit }} karaktere ose më pak.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
@@ -84,7 +93,7 @@
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>Kjo vlerë është shumë e shkurtër. Duhet të përmbaj {{ limit }} karakter ose më shumë.|Kjo vlerë është shumë e shkurtër. Duhet të përmbaj {{ limit }} karaktere ose më shumë.</target>
+                <target>Kjo vlerë është shumë e shkurtër. Duhet të përmbajë {{ limit }} karakter ose më shumë.|Kjo vlerë është shumë e shkurtër. Duhet të përmbajë {{ limit }} karaktere ose më shumë.</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
@@ -92,11 +101,11 @@
             </trans-unit>
             <trans-unit id="23">
                 <source>This value should not be null.</source>
-                <target>Kjo vlerë nuk duhet të jetë null.</target>
+                <target>Kjo vlerë nuk duhet të jetë “null”.</target>
             </trans-unit>
             <trans-unit id="24">
                 <source>This value should be null.</source>
-                <target>Kjo vlerë duhet të jetë null.</target>
+                <target>Kjo vlerë duhet të jetë “null”.</target>
             </trans-unit>
             <trans-unit id="25">
                 <source>This value is not valid.</source>
@@ -104,7 +113,7 @@
             </trans-unit>
             <trans-unit id="26">
                 <source>This value is not a valid time.</source>
-                <target>Kjo vlerë nuk është kohë e vlefshme.</target>
+                <target>Kjo vlerë nuk është një orë e vlefshme.</target>
             </trans-unit>
             <trans-unit id="27">
                 <source>This value is not a valid URL.</source>
@@ -116,39 +125,39 @@
             </trans-unit>
             <trans-unit id="32">
                 <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>Ky file është shumë i madh. Madhësia maksimale e lejuar është {{ limit }} {{ suffix }}.</target>
+                <target>Kjo skedë është shumë e madhe. Madhësia maksimale e lejuar është {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>
-                <target>Ky file është shumë i madh.</target>
+                <target>Kjo skedë është shumë e madhe.</target>
             </trans-unit>
             <trans-unit id="34">
                 <source>The file could not be uploaded.</source>
-                <target>Ky file nuk mund të ngarkohet.</target>
+                <target>Kjo skedë nuk mund të ngarkohet.</target>
             </trans-unit>
             <trans-unit id="35">
                 <source>This value should be a valid number.</source>
-                <target>Kjo vlerë duhet të jetë numër i vlefshëm.</target>
+                <target>Kjo vlerë duhet të jetë një numër i vlefshëm.</target>
             </trans-unit>
             <trans-unit id="36">
                 <source>This file is not a valid image.</source>
-                <target>Ky file nuk është imazh i vlefshëm.</target>
+                <target>Kjo skedë nuk është një imazh i vlefshëm.</target>
             </trans-unit>
             <trans-unit id="37" resname="This is not a valid IP address.">
                 <source>This value is not a valid IP address.</source>
-                <target state="needs-review-translation">Kjo vlerë nuk është një adresë IP e vlefshme.</target>
+                <target>Kjo vlerë nuk është një adresë IP e vlefshme.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
-                <target>Kjo vlerë nuk është gjuhë e vlefshme.</target>
+                <target>Kjo vlerë nuk është një gjuhë e vlefshme.</target>
             </trans-unit>
             <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
-                <target>Kjo vlerë nuk është nje locale i vlefshëm.</target>
+                <target>Kjo vlerë nuk është nje “locale” e vlefshme.</target>
             </trans-unit>
             <trans-unit id="40">
                 <source>This value is not a valid country.</source>
-                <target>Kjo vlerë nuk është shtet i vlefshëm.</target>
+                <target>Kjo vlerë nuk është një shtet i vlefshëm.</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>
@@ -176,7 +185,7 @@
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user's current password.</source>
-                <target>Kjo vlerë duhet të jetë fjalëkalimi aktual i përdoruesit.</target>
+                <target>Kjo vlerë duhet të jetë fjalëkalimi i tanishëm i përdoruesit.</target>
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
@@ -184,23 +193,23 @@
             </trans-unit>
             <trans-unit id="49">
                 <source>The file was only partially uploaded.</source>
-                <target>Ky file është ngarkuar pjesërisht.</target>
+                <target>Kjo skedë është ngarkuar pjesërisht.</target>
             </trans-unit>
             <trans-unit id="50">
                 <source>No file was uploaded.</source>
-                <target>Nuk është ngarkuar ndonjë file.</target>
+                <target>Nuk është ngarkuar ndonjë skedë.</target>
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target state="needs-review-translation">Asnjë dosje e përkohshme nuk është konfiguruar në php.ini, ose dosja e konfiguruar nuk ekziston.</target>
+                <target>Nuk është konfiguruar asnjë skedar i përkohshëm në php.ini, ose skedari i konfiguruar nuk ekziston.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
-                <target>Nuk mund të shkruhet file i përkohshëm në disk.</target>
+                <target>Nuk mund të shkruhet skeda e përkohshme në disk.</target>
             </trans-unit>
             <trans-unit id="53">
                 <source>A PHP extension caused the upload to fail.</source>
-                <target>Një ekstension i PHP-së shkaktoi dështimin e ngarkimit.</target>
+                <target>Një shtojcë PHP shkaktoi dështimin e ngarkimit.</target>
             </trans-unit>
             <trans-unit id="54">
                 <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
@@ -224,7 +233,7 @@
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
-                <target state="needs-review-translation">Kjo vlerë nuk është një Numër i Llogarisë Bankare Ndërkombëtare (IBAN) i vlefshëm.</target>
+                <target>Kjo vlerë nuk është një Numër Llogarie Bankare Ndërkombëtare (IBAN) i vlefshëm.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -244,7 +253,7 @@
             </trans-unit>
             <trans-unit id="64">
                 <source>This value is not a valid currency.</source>
-                <target>Kjo vlerë nuk është një monedhë e vlefshme.</target>
+                <target>Kjo vlerë nuk është një valutë e vlefshme.</target>
             </trans-unit>
             <trans-unit id="65">
                 <source>This value should be equal to {{ compared_value }}.</source>
@@ -300,7 +309,7 @@
             </trans-unit>
             <trans-unit id="78">
                 <source>An empty file is not allowed.</source>
-                <target>Një file i zbrazët nuk lejohet.</target>
+                <target>Një skedë e zbrazët nuk lejohet.</target>
             </trans-unit>
             <trans-unit id="79">
                 <source>The host could not be resolved.</source>
@@ -312,7 +321,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target state="needs-review-translation">Kjo vlerë nuk është një Kod Identifikues i Biznesit (BIC) i vlefshëm.</target>
+                <target>Kjo vlerë nuk është një Kod Identifikues Biznesi (BIC) i vlefshëm.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +329,7 @@
             </trans-unit>
             <trans-unit id="83" resname="This is not a valid UUID.">
                 <source>This value is not a valid UUID.</source>
-                <target state="needs-review-translation">Kjo vlerë nuk është një UUID i vlefshëm.</target>
+                <target state="needs-review-translation">Kjo vlerë nuk është një UUID e vlefshme.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -328,7 +337,7 @@
             </trans-unit>
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
-                <target>Ky Kod Identifikues i Biznesit (BIC) nuk është i lidhur me IBAN {{ iban }}.</target>
+                <target>Ky Kod Identifikues Biznesi (BIC) nuk është i lidhur me IBAN {{ iban }}.</target>
             </trans-unit>
             <trans-unit id="86">
                 <source>This value should be valid JSON.</source>
@@ -368,7 +377,7 @@
             </trans-unit>
             <trans-unit id="95">
                 <source>This value is not a valid hostname.</source>
-                <target>Kjo vlerë nuk është një emër i vlefshëm hosti.</target>
+                <target>Kjo vlerë nuk është një emër i vlefshëm host-i.</target>
             </trans-unit>
             <trans-unit id="96">
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
@@ -404,7 +413,7 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target>Emri i skedarit është shumë i gjatë. Duhet të ketë maksimumi {{ filename_max_length }} karakter ose më pak.|Emri i skedarit është shumë i gjatë. Duhet të ketë maksimumi {{ filename_max_length }} karaktere ose më pak.</target>
+                <target>Emri i skedës është shumë i gjatë. Duhet të ketë maksimumi {{ filename_max_length }} karakter ose më pak.|Emri i skedës është shumë i gjatë. Duhet të ketë maksimumi {{ filename_max_length }} karaktere ose më pak.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
@@ -420,7 +429,7 @@
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target>Përzierja e numrave nga skriptet e ndryshme nuk lejohet.</target>
+                <target>Përzierja e numrave nga shkrimet e ndryshme nuk lejohet.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
@@ -432,7 +441,7 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target>Kodimi i karakterit të identifikuar  është i pavlefshëm ({{ detected }}). Kodimet e lejuara janë {{ encodings }}.</target>
+                <target>Kodimi i karakterit të identifikuar është i pavlefshëm ({{ detected }}). Kodimet e lejuara janë {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no / improvement
| Deprecations? | no 
| Issues        | Fix #53759 
| License       | MIT

## Context for changes beyond the lines needing review: 

- [opsion](https://fjalorthi.com/opsion) does not exist in Albanian, but I found `alternativë` already in other translations.
- [formë](https://fjalorthi.com/forme) means `shape`, changed it `formular` for a form one submits in Symfony.
- [interval](https://fjalorthi.com/interval) already can only be used as a time reference, dropped transliterating the word `time`.
- [skedar](https://fjalorthi.com/skedar) means directory or folder. File is `skedë`
- changed `lokale` as it is used already as a foreign reference for `“locale”`.
- [diapazon](https://fjalorthi.com/diapazon) is only in music, or used figuratively. [seri](https://fjalorthi.com/seri) §2 §4 means `range`.
- used `orë` to mean time of day everywhere, vs mixed `orë` and `kohë`, meaning `time` as in `time-space`.
- corrected some conjugations of [gjej](https://fjalorthi.com/zgjedho/gjej) `gjindem` vs `gjendem`. Check `Joveprore`-> `mënyra dëftore` -> `e kryera e thjeshtë`
- overall fixed minor grammar issues here and there. 
- if there are specific question, please ask me, this list is getting long 😅 

## Tools used: 

- https://fjalorthi.com/zgjedho for verb conjugation
- http://www.seelrc.org:8080/albdict/ to detect barbarisms
- Albanian - German dictionary ISBN 9783468053955

PS. I am Albanian
