### PR TITLE
[HttpKernel] Deprecate `AddAnnotatedClassesToCachePass` and related code infrastructure

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -37,6 +37,11 @@ PropertyInfo
 
  * Deprecate `PropertyTypeExtractorInterface::getTypes()`, use `PropertyTypeExtractorInterface::getType()` instead
 
+HttpKernel
+----------
+
+ * Deprecate `Extension::addAnnotatedClassesToCompile()` and related code infrastructure
+
 SecurityBundle
 --------------
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `$validationFailedStatusCode` argument to `#[MapQueryParameter]` that allows setting a custom HTTP status code when validation fails
  * Add `NearMissValueResolverException` to let value resolvers report when an argument could be under their watch but failed to be resolved
  * Add `$type` argument to `#[MapRequestPayload]` that allows mapping a list of items
+ * Deprecate `Extension::addAnnotatedClassesToCompile()` and related code infrastructure
 
 7.0
 ---

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/AddAnnotatedClassesToCachePass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/AddAnnotatedClassesToCachePass.php
@@ -17,10 +17,14 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\ErrorHandler\DebugClassLoader;
 use Symfony\Component\HttpKernel\Kernel;
 
+trigger_deprecation('symfony/http-kernel', '7.1', 'The "%s" class is deprecated since Symfony 7.1 and will be removed in 8.0.', AddAnnotatedClassesToCachePass::class);
+
 /**
  * Sets the classes to compile in the cache for the container.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 7.1, to be removed in 8.0
  */
 class AddAnnotatedClassesToCachePass implements CompilerPassInterface
 {

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\Extension\Extension as BaseExtension;
  * Allow adding classes to the class cache.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead
  */
 abstract class Extension extends BaseExtension
 {
@@ -26,9 +28,13 @@ abstract class Extension extends BaseExtension
      * Gets the annotated classes to cache.
      *
      * @return string[]
+     *
+     * @deprecated since Symfony 7.1, to be removed in 8.0
      */
     public function getAnnotatedClassesToCompile(): array
     {
+        trigger_deprecation('symfony/http-kernel', '7.1', 'The "%s()" method is deprecated since Symfony 7.1 and will be removed in 8.0.', __METHOD__);
+
         return $this->annotatedClasses;
     }
 
@@ -36,9 +42,13 @@ abstract class Extension extends BaseExtension
      * Adds annotated classes to the class cache.
      *
      * @param string[] $annotatedClasses An array of class patterns
+     *
+     * @deprecated since Symfony 7.1, to be removed in 8.0
      */
     public function addAnnotatedClassesToCompile(array $annotatedClasses): void
     {
+        trigger_deprecation('symfony/http-kernel', '7.1', 'The "%s()" method is deprecated since Symfony 7.1 and will be removed in 8.0.', __METHOD__);
+
         $this->annotatedClasses = array_merge($this->annotatedClasses, $annotatedClasses);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -37,7 +37,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\HttpKernel\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\AddAnnotatedClassesToCachePass;
 use Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass;
 
 // Help opcache.preload discover always-needed symbols
@@ -278,9 +277,13 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     /**
      * @internal
+     *
+     * @deprecated since Symfony 7.1, to be removed in 8.0
      */
     public function setAnnotatedClassCache(array $annotatedClasses): void
     {
+        trigger_deprecation('symfony/http-kernel', '7.1', 'The "%s()" method is deprecated since Symfony 7.1 and will be removed in 8.0.', __METHOD__);
+
         file_put_contents(($this->warmupDir ?: $this->getBuildDir()).'/annotations.map', sprintf('<?php return %s;', var_export($annotatedClasses, true)));
     }
 
@@ -314,9 +317,13 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      * Gets the patterns defining the classes to parse and cache for annotations.
      *
      * @return string[]
+     *
+     * @deprecated since Symfony 7.1, to be removed in 8.0
      */
     public function getAnnotatedClassesToCompile(): array
     {
+        trigger_deprecation('symfony/http-kernel', '7.1', 'The "%s()" method is deprecated since Symfony 7.1 and will be removed in 8.0.', __METHOD__);
+
         return [];
     }
 
@@ -590,8 +597,6 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $container->addObjectResource($this);
         $this->prepareContainer($container);
         $this->registerContainerConfiguration($this->getContainerLoader($container));
-
-        $container->addCompilerPass(new AddAnnotatedClassesToCachePass($this));
 
         return $container;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/AddAnnotatedClassesToCachePassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/AddAnnotatedClassesToCachePassTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\DependencyInjection\AddAnnotatedClassesToCachePass;
 
+/**
+ * @group legacy
+ */
 class AddAnnotatedClassesToCachePassTest extends TestCase
 {
     public function testExpandClasses()

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/MergeExtensionConfigurationPassTest.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass;
 use Symfony\Component\HttpKernel\Tests\Fixtures\AcmeFooBundle\AcmeFooBundle;
 

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^6.4|^7.0",
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #52141
| License       | MIT

These code paths are already no-ops in 7.1 since we don't support annotations anymore.