### PR TITLE
[TwigBundle] Add "use_yield" option to allow opting in for this new rendering mode and skip a deprecation

### DIFF
--- a/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
+++ b/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractRendererEngine;
 use Symfony\Component\Form\FormView;
 use Twig\Environment;
 use Twig\Template;
+use Twig\YieldingTemplate;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -46,12 +47,16 @@ class TwigRendererEngine extends AbstractRendererEngine
 
         $context = $this->environment->mergeGlobals($variables);
 
-        ob_start();
-
         // By contract,This method can only be called after getting the resource
         // (which is passed to the method). Getting a resource for the first time
         // (with an empty cache) is guaranteed to invoke loadResourcesFromTheme(),
         // where the property $template is initialized.
+
+        if ($this->template instanceof YieldingTemplate) {
+            return $this->template->renderBlock($blockName, $context, $this->resources[$cacheKey]);
+        }
+
+        ob_start();
 
         // We do not call renderBlock here to avoid too many nested level calls
         // (XDebug limits the level to 100 by default)

--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -138,7 +138,7 @@ Configured Paths
   (None)      templates%e%A
   %A
   @Twig       templates/bundles/TwigBundle%e%A
-              vendors/twig-bundle/Resources/views%e%A 
+              vendors/twig-bundle/Resources/views%e%A
  ----------- -------------------------------------%A
 
 
@@ -305,7 +305,7 @@ TXT
 
         $projectDir = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Fixtures';
         $loader = new FilesystemLoader([], $projectDir);
-        $environment = new Environment($loader);
+        $environment = new Environment($loader, ['use_yield' => true]);
 
         $application = new Application();
         $application->add(new DebugCommand($environment, $projectDir, [], null, null));
@@ -337,7 +337,7 @@ TXT
             $loader = new ChainLoader([$loader]);
         }
 
-        $environment = new Environment($loader);
+        $environment = new Environment($loader, ['use_yield' => true]);
         foreach ($globals as $name => $value) {
             $environment->addGlobal($name, $value);
         }

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -162,7 +162,7 @@ class LintCommandTest extends TestCase
 
     private function createCommand(): Command
     {
-        $environment = new Environment(new FilesystemLoader(\dirname(__DIR__).'/Fixtures/templates/'));
+        $environment = new Environment(new FilesystemLoader(\dirname(__DIR__).'/Fixtures/templates/'), ['use_yield' => true]);
         $environment->addFilter(new TwigFilter('deprecated_filter', function ($v) {
             return $v;
         }, ['deprecated' => true]));

--- a/src/Symfony/Bridge/Twig/Tests/ErrorRenderer/TwigErrorRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/ErrorRenderer/TwigErrorRendererTest.php
@@ -40,7 +40,7 @@ class TwigErrorRendererTest extends TestCase
     {
         $exception = new NotFoundHttpException();
 
-        $twig = new Environment(new ArrayLoader([]));
+        $twig = new Environment(new ArrayLoader([]), ['use_yield' => true]);
 
         $nativeRenderer = $this->createMock(HtmlErrorRenderer::class);
         $nativeRenderer
@@ -57,7 +57,7 @@ class TwigErrorRendererTest extends TestCase
     {
         $twig = new Environment(new ArrayLoader([
             '@Twig/Exception/error404.html.twig' => '<h1>Page Not Found</h1>',
-        ]));
+        ]), ['use_yield' => true]);
         $exception = (new TwigErrorRenderer($twig))->render(new NotFoundHttpException());
 
         $this->assertSame('<h1>Page Not Found</h1>', $exception->getAsString());

--- a/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
@@ -116,7 +116,6 @@ HTML;
         $this->assertEquals($expected, $this->render($template, $data));
     }
 
-
     public function testFormatFileIntegration()
     {
         $template = <<<'TWIG'
@@ -156,7 +155,7 @@ HTML;
     {
         $twig = new Environment(
             new ArrayLoader(['index' => $template]),
-            ['debug' => true]
+            ['debug' => true, 'use_yield' => true]
         );
         $twig->addExtension($this->getExtension());
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
@@ -32,6 +32,7 @@ class DumpExtensionTest extends TestCase
             'debug' => $debug,
             'cache' => false,
             'optimizations' => 0,
+            'use_yield' => true,
         ]);
         $twig->addExtension($extension);
 
@@ -72,6 +73,7 @@ class DumpExtensionTest extends TestCase
             'debug' => $debug,
             'cache' => false,
             'optimizations' => 0,
+            'use_yield' => true,
         ]);
 
         array_unshift($args, $context);
@@ -129,6 +131,7 @@ class DumpExtensionTest extends TestCase
             'debug' => true,
             'cache' => false,
             'optimizations' => 0,
+            'use_yield' => true,
         ]);
 
         $dump = $extension->dump($twig, [], 'foo');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/ExpressionExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/ExpressionExtensionTest.php
@@ -21,7 +21,7 @@ class ExpressionExtensionTest extends TestCase
     public function testExpressionCreation()
     {
         $template = "{{ expression('1 == 1') }}";
-        $twig = new Environment(new ArrayLoader(['template' => $template]), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0]);
+        $twig = new Environment(new ArrayLoader(['template' => $template]), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0, 'use_yield' => true]);
         $twig->addExtension(new ExpressionExtension());
 
         $output = $twig->render('template');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
@@ -43,7 +43,7 @@ class FormExtensionBootstrap3HorizontalLayoutTest extends AbstractBootstrap3Hori
             __DIR__.'/Fixtures/templates/form',
         ]);
 
-        $environment = new Environment($loader, ['strict_variables' => true]);
+        $environment = new Environment($loader, ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -39,7 +39,7 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTestCase
             __DIR__.'/Fixtures/templates/form',
         ]);
 
-        $environment = new Environment($loader, ['strict_variables' => true]);
+        $environment = new Environment($loader, ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
 
@@ -80,7 +80,7 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTestCase
         $environment = new Environment(new FilesystemLoader([
             __DIR__.'/../../Resources/views/Form',
             __DIR__.'/Fixtures/templates/form',
-        ]), ['strict_variables' => true]);
+        ]), ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
         $environment->setCharset('ISO-8859-1');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
@@ -45,7 +45,7 @@ class FormExtensionBootstrap4HorizontalLayoutTest extends AbstractBootstrap4Hori
             __DIR__.'/Fixtures/templates/form',
         ]);
 
-        $environment = new Environment($loader, ['strict_variables' => true]);
+        $environment = new Environment($loader, ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -43,7 +43,7 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTestCase
             __DIR__.'/Fixtures/templates/form',
         ]);
 
-        $environment = new Environment($loader, ['strict_variables' => true]);
+        $environment = new Environment($loader, ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
 
@@ -84,7 +84,7 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTestCase
         $environment = new Environment(new FilesystemLoader([
             __DIR__.'/../../Resources/views/Form',
             __DIR__.'/Fixtures/templates/form',
-        ]), ['strict_variables' => true]);
+        ]), ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
         $environment->setCharset('ISO-8859-1');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5HorizontalLayoutTest.php
@@ -45,7 +45,7 @@ class FormExtensionBootstrap5HorizontalLayoutTest extends AbstractBootstrap5Hori
             __DIR__.'/Fixtures/templates/form',
         ]);
 
-        $environment = new Environment($loader, ['strict_variables' => true]);
+        $environment = new Environment($loader, ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
@@ -46,7 +46,7 @@ class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTestCase
             __DIR__.'/Fixtures/templates/form',
         ]);
 
-        $environment = new Environment($loader, ['strict_variables' => true]);
+        $environment = new Environment($loader, ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
 
@@ -87,7 +87,7 @@ class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTestCase
         $environment = new Environment(new FilesystemLoader([
             __DIR__.'/../../Resources/views/Form',
             __DIR__.'/Fixtures/templates/form',
-        ]), ['strict_variables' => true]);
+        ]), ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
         $environment->setCharset('ISO-8859-1');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -41,7 +41,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
             __DIR__.'/Fixtures/templates/form',
         ]);
 
-        $environment = new Environment($loader, ['strict_variables' => true]);
+        $environment = new Environment($loader, ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addGlobal('global', '');
         // the value can be any template that exists
@@ -171,7 +171,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
         $environment = new Environment(new FilesystemLoader([
             __DIR__.'/../../Resources/views/Form',
             __DIR__.'/Fixtures/templates/form',
-        ]), ['strict_variables' => true]);
+        ]), ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
         $environment->setCharset('ISO-8859-1');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -40,7 +40,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTestCase
             __DIR__.'/Fixtures/templates/form',
         ]);
 
-        $environment = new Environment($loader, ['strict_variables' => true]);
+        $environment = new Environment($loader, ['strict_variables' => true, 'use_yield' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addGlobal('global', '');
         $environment->addExtension(new FormExtension());

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -75,7 +75,7 @@ class HttpKernelExtensionTest extends TestCase
 {{ fragment_uri(controller("%s::templateAction", {template: "foo.html.twig"})) }}
 TWIG
                 , TemplateController::class), ]);
-        $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
+        $twig = new Environment($loader, ['debug' => true, 'cache' => false, 'use_yield' => true]);
         $twig->addExtension(new HttpKernelExtension());
 
         $loader = $this->createMock(RuntimeLoaderInterface::class);
@@ -103,7 +103,7 @@ TWIG
     protected function renderTemplate(FragmentHandler $renderer, $template = '{{ render("foo") }}')
     {
         $loader = new ArrayLoader(['index' => $template]);
-        $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
+        $twig = new Environment($loader, ['debug' => true, 'cache' => false, 'use_yield' => true]);
         $twig->addExtension(new HttpKernelExtension());
 
         $loader = $this->createMock(RuntimeLoaderInterface::class);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
@@ -26,7 +26,7 @@ class RoutingExtensionTest extends TestCase
      */
     public function testEscaping($template, $mustBeEscaped)
     {
-        $twig = new Environment($this->createMock(LoaderInterface::class), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0]);
+        $twig = new Environment($this->createMock(LoaderInterface::class), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0, 'use_yield' => true]);
         $twig->addExtension(new RoutingExtension($this->createMock(UrlGeneratorInterface::class)));
 
         $nodes = $twig->parse($twig->tokenize(new Source($template, '')));

--- a/src/Symfony/Bridge/Twig/Tests/Extension/SerializerExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SerializerExtensionTest.php
@@ -61,7 +61,7 @@ class SerializerExtensionTest extends TestCase
             ])
         ;
 
-        $twig = new Environment(new ArrayLoader(['template' => $template]));
+        $twig = new Environment(new ArrayLoader(['template' => $template, 'use_yield' => true]));
         $twig->addExtension(new SerializerExtension());
         $twig->addRuntimeLoader($mockRuntimeLoader);
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -32,7 +32,7 @@ class StopwatchExtensionTest extends TestCase
      */
     public function testTiming($template, $events)
     {
-        $twig = new Environment(new ArrayLoader(['template' => $template]), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0]);
+        $twig = new Environment(new ArrayLoader(['template' => $template]), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0, 'use_yield' => true]);
         $twig->addExtension(new StopwatchExtension($this->getStopwatch($events)));
 
         try {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -37,7 +37,7 @@ class TranslationExtensionTest extends TestCase
         if ($expected != $this->getTemplate($template)->render($variables)) {
             echo $template."\n";
             $loader = new TwigArrayLoader(['index' => $template]);
-            $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
+            $twig = new Environment($loader, ['debug' => true, 'cache' => false, 'use_yield' => true]);
             $twig->addExtension(new TranslationExtension(new Translator('en')));
 
             echo $twig->compile($twig->parse($twig->tokenize($twig->getLoader()->getSourceContext('index'))))."\n\n";
@@ -217,7 +217,7 @@ class TranslationExtensionTest extends TestCase
         } else {
             $loader = new TwigArrayLoader(['index' => $template]);
         }
-        $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
+        $twig = new Environment($loader, ['debug' => true, 'cache' => false, 'use_yield' => true]);
         $twig->addExtension(new TranslationExtension($translator));
 
         return $twig->load('index');

--- a/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
@@ -83,7 +83,7 @@ HTML;
     {
         $twig = new Environment(new ArrayLoader([
             'text' => 'Text',
-        ]));
+        ]), ['use_yield' => true]);
         $renderer = new BodyRenderer($twig);
         $email = (new TemplatedEmail())
             ->to('fabien@symfony.com')
@@ -104,7 +104,7 @@ HTML;
     {
         $twig = new Environment(new ArrayLoader([
             'text' => 'Text',
-        ]));
+        ]), ['use_yield' => true]);
         $renderer = new BodyRenderer($twig);
         $email = (new TemplatedEmail())
             ->to('fabien@symfony.com')
@@ -128,7 +128,7 @@ HTML;
             'html' => $html,
             'document.txt' => 'Some text document...',
             'image.jpg' => 'Some image data',
-        ]));
+        ]), ['use_yield' => true]);
         $renderer = new BodyRenderer($twig);
         $email = (new TemplatedEmail())
             ->to('fabien@symfony.com')

--- a/src/Symfony/Bridge/Twig/Tests/Node/DumpNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/DumpNodeTest.php
@@ -25,7 +25,7 @@ class DumpNodeTest extends TestCase
     {
         $node = new DumpNode('bar', null, 7);
 
-        $env = new Environment($this->createMock(LoaderInterface::class));
+        $env = new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]);
         $compiler = new Compiler($env);
 
         $expected = <<<'EOTXT'
@@ -49,7 +49,7 @@ EOTXT;
     {
         $node = new DumpNode('bar', null, 7);
 
-        $env = new Environment($this->createMock(LoaderInterface::class));
+        $env = new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]);
         $compiler = new Compiler($env);
 
         $expected = <<<'EOTXT'
@@ -76,7 +76,7 @@ EOTXT;
         ]);
         $node = new DumpNode('bar', $vars, 7);
 
-        $env = new Environment($this->createMock(LoaderInterface::class));
+        $env = new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]);
         $compiler = new Compiler($env);
 
         $expected = <<<'EOTXT'
@@ -100,7 +100,7 @@ EOTXT;
         ]);
         $node = new DumpNode('bar', $vars, 7);
 
-        $env = new Environment($this->createMock(LoaderInterface::class));
+        $env = new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]);
         $compiler = new Compiler($env);
 
         $expected = <<<'EOTXT'

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -55,7 +55,7 @@ class FormThemeTest extends TestCase
 
         $node = new FormThemeNode($form, $resources, 0);
 
-        $environment = new Environment($this->createMock(LoaderInterface::class));
+        $environment = new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]);
         $formRenderer = new FormRenderer($this->createMock(FormRendererEngineInterface::class));
         $this->registerTwigRuntimeLoader($environment, $formRenderer);
         $compiler = new Compiler($environment);

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -33,7 +33,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         $this->assertEquals(
             sprintf(
@@ -56,7 +56,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         $this->assertEquals(
             sprintf(
@@ -76,7 +76,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         $this->assertEquals(
             sprintf(
@@ -96,7 +96,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
@@ -118,7 +118,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
@@ -139,7 +139,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         $this->assertEquals(
             sprintf(
@@ -163,7 +163,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
@@ -192,7 +192,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         $this->assertEquals(
             sprintf(
@@ -220,7 +220,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
@@ -258,7 +258,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.

--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -30,7 +30,7 @@ class TransNodeTest extends TestCase
         $vars = new NameExpression('foo', 0);
         $node = new TransNode($body, null, null, $vars);
 
-        $env = new Environment($this->createMock(LoaderInterface::class), ['strict_variables' => true]);
+        $env = new Environment($this->createMock(LoaderInterface::class), ['strict_variables' => true, 'use_yield' => true]);
         $compiler = new Compiler($env);
 
         $this->assertEquals(

--- a/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationDefaultDomainNodeVisitorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationDefaultDomainNodeVisitorTest.php
@@ -27,7 +27,7 @@ class TranslationDefaultDomainNodeVisitorTest extends TestCase
     /** @dataProvider getDefaultDomainAssignmentTestData */
     public function testDefaultDomainAssignment(Node $node)
     {
-        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0, 'use_yield' => true]);
         $visitor = new TranslationDefaultDomainNodeVisitor();
 
         // visit trans_default_domain tag
@@ -53,7 +53,7 @@ class TranslationDefaultDomainNodeVisitorTest extends TestCase
     /** @dataProvider getDefaultDomainAssignmentTestData */
     public function testNewModuleWithoutDefaultDomainTag(Node $node)
     {
-        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0, 'use_yield' => true]);
         $visitor = new TranslationDefaultDomainNodeVisitor();
 
         // visit trans_default_domain tag

--- a/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationNodeVisitorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationNodeVisitorTest.php
@@ -26,7 +26,7 @@ class TranslationNodeVisitorTest extends TestCase
     /** @dataProvider getMessagesExtractionTestData */
     public function testMessagesExtraction(Node $node, array $expectedMessages)
     {
-        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0, 'use_yield' => true]);
         $visitor = new TranslationNodeVisitor();
         $visitor->enable();
         $visitor->enterNode($node, $env);

--- a/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
@@ -29,7 +29,7 @@ class FormThemeTokenParserTest extends TestCase
      */
     public function testCompile($source, $expected)
     {
-        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0, 'use_yield' => true]);
         $env->addTokenParser(new FormThemeTokenParser());
         $source = new Source($source, '');
         $stream = $env->tokenize($source);

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -35,6 +35,7 @@ class TwigExtractorTest extends TestCase
             'debug' => true,
             'cache' => false,
             'autoescape' => false,
+            'use_yield' => true,
         ]);
         $twig->addExtension(new TranslationExtension($this->createMock(TranslatorInterface::class)));
 
@@ -100,7 +101,7 @@ class TwigExtractorTest extends TestCase
      */
     public function testExtractSyntaxError($resources, array $messages)
     {
-        $twig = new Environment($this->createMock(LoaderInterface::class));
+        $twig = new Environment($this->createMock(LoaderInterface::class), ['use_yield' => true]);
         $twig->addExtension(new TranslationExtension($this->createMock(TranslatorInterface::class)));
 
         $extractor = new TwigExtractor($twig);
@@ -129,6 +130,7 @@ class TwigExtractorTest extends TestCase
             'debug' => true,
             'cache' => false,
             'autoescape' => false,
+            'use_yield' => true,
         ]);
         $twig->addExtension(new TranslationExtension($this->createMock(TranslatorInterface::class)));
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -63,7 +63,7 @@ class TemplateControllerTest extends TestCase
         $loader = new ArrayLoader();
         $loader->setTemplate($templateName, '<h1>{{param}}</h1>');
 
-        $twig = new Environment($loader);
+        $twig = new Environment($loader, ['use_yield' => true]);
         $controller = new TemplateController($twig);
 
         $this->assertEquals($expected, $controller->templateAction($templateName, null, null, null, $context)->getContent());
@@ -78,7 +78,7 @@ class TemplateControllerTest extends TestCase
         $loader = new ArrayLoader();
         $loader->setTemplate($templateName, '<h1>{{param}}</h1>');
 
-        $twig = new Environment($loader);
+        $twig = new Environment($loader, ['use_yield' => true]);
         $controller = new TemplateController($twig);
 
         $this->assertSame(201, $controller->templateAction($templateName, null, null, null, [], $statusCode)->getStatusCode());

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -137,6 +137,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('charset')->defaultValue('%kernel.charset%')->end()
                 ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                 ->booleanNode('strict_variables')->defaultValue('%kernel.debug%')->end()
+                ->booleanNode('use_yield')->defaultFalse()->end()
                 ->scalarNode('auto_reload')->end()
                 ->integerNode('optimizations')->min(-1)->end()
                 ->scalarNode('default_path')

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
@@ -25,6 +25,7 @@
         <xsd:attribute name="charset" type="xsd:string" />
         <xsd:attribute name="debug" type="xsd:string" />
         <xsd:attribute name="strict-variables" type="xsd:string" />
+        <xsd:attribute name="use-yield" type="xsd:string" />
         <xsd:attribute name="default-path" type="xsd:string" />
     </xsd:complexType>
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
@@ -76,7 +76,7 @@ class HIncludeFragmentRendererTest extends TestCase
 
     public function testRenderWithTwigAndDefaultText()
     {
-        $twig = new Environment($loader = new ArrayLoader());
+        $twig = new Environment($loader = new ArrayLoader(), ['use_yield' => true]);
         $strategy = new HIncludeFragmentRenderer($twig);
         $this->assertEquals('<hx:include src="/foo">loading...</hx:include>', $strategy->render('/foo', Request::create('/'), ['default' => 'loading...'])->getContent());
     }

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -331,7 +331,7 @@ EOTXT
         $out = fopen('php://memory', 'r+');
 
         require_once __DIR__.'/../Fixtures/Twig.php';
-        $twig = new \__TwigTemplate_VarDumperFixture_u75a09(new Environment(new FilesystemLoader()));
+        $twig = new \__TwigTemplate_VarDumperFixture_u75a09(new Environment(new FilesystemLoader(), ['use_yield' => true]));
 
         $dumper = new CliDumper();
         $dumper->setColors(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Adapting to upcoming changes in twig 3.9.
This will need a corresponding recipe update so that new projects don't start with a deprecation.