### PR TITLE
[ExpressionLanguage] Add more configurability to the parsing/linting methods

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add support for PHP `min` and `max` functions
+ * Add `Parser::IGNORE_UNKNOWN_VARIABLES` and `Parser::IGNORE_UNKNOWN_FUNCTIONS` flags to control whether
+   parsing and linting should check for unknown variables and functions.
 
 7.0
 ---

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -461,7 +461,7 @@ class ExpressionLanguageTest extends TestCase
     public function testLintDoesntThrowOnValidExpression()
     {
         $el = new ExpressionLanguage();
-        $el->lint('1 + 1', null);
+        $el->lint('1 + 1', []);
 
         $this->expectNotToPerformAssertions();
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -295,7 +295,7 @@ class ParserTest extends TestCase
     /**
      * @dataProvider getLintData
      */
-    public function testLint($expression, $names, ?string $exception = null)
+    public function testLint($expression, $names, int $checks = 0, ?string $exception = null)
     {
         if ($exception) {
             $this->expectException(SyntaxError::class);
@@ -304,7 +304,7 @@ class ParserTest extends TestCase
 
         $lexer = new Lexer();
         $parser = new Parser([]);
-        $parser->lint($lexer->tokenize($expression), $names);
+        $parser->lint($lexer->tokenize($expression), $names, $checks);
 
         // Parser does't return anything when the correct expression is passed
         $this->expectNotToPerformAssertions();
@@ -321,9 +321,20 @@ class ParserTest extends TestCase
                 'expression' => 'foo["some_key"]?.callFunction(a ? b)',
                 'names' => ['foo', 'a', 'b'],
             ],
-            'allow expression without names' => [
+            'allow expression with unknown names' => [
                 'expression' => 'foo.bar',
-                'names' => null,
+                'names' => [],
+                'checks' => Parser::IGNORE_UNKNOWN_VARIABLES,
+            ],
+            'allow expression with unknown functions' => [
+                'expression' => 'foo()',
+                'names' => [],
+                'checks' => Parser::IGNORE_UNKNOWN_FUNCTIONS,
+            ],
+            'allow expression with unknown functions and names' => [
+                'expression' => 'foo(bar)',
+                'names' => [],
+                'checks' => Parser::IGNORE_UNKNOWN_FUNCTIONS | Parser::IGNORE_UNKNOWN_VARIABLES,
             ],
             'array with trailing comma' => [
                 'expression' => '[value1, value2, value3,]',
@@ -333,10 +344,17 @@ class ParserTest extends TestCase
                 'expression' => '{val1: value1, val2: value2, val3: value3,}',
                 'names' => ['value1', 'value2', 'value3'],
             ],
-            'disallow expression without names' => [
+            'disallow expression with unknown names by default' => [
                 'expression' => 'foo.bar',
                 'names' => [],
+                'checks' => 0,
                 'exception' => 'Variable "foo" is not valid around position 1 for expression `foo.bar',
+            ],
+            'disallow expression with unknown functions by default' => [
+                'expression' => 'foo()',
+                'names' => [],
+                'checks' => 0,
+                'exception' => 'The function "foo" does not exist around position 1 for expression `foo()',
             ],
             'operator collisions' => [
                 'expression' => 'foo.not in [bar]',
@@ -345,18 +363,21 @@ class ParserTest extends TestCase
             'incorrect expression ending' => [
                 'expression' => 'foo["a"] foo["b"]',
                 'names' => ['foo'],
+                'checks' => 0,
                 'exception' => 'Unexpected token "name" of value "foo" '.
                     'around position 10 for expression `foo["a"] foo["b"]`.',
             ],
             'incorrect operator' => [
                 'expression' => 'foo["some_key"] // 2',
                 'names' => ['foo'],
+                'checks' => 0,
                 'exception' => 'Unexpected token "operator" of value "/" '.
                     'around position 18 for expression `foo["some_key"] // 2`.',
             ],
             'incorrect array' => [
                 'expression' => '[value1, value2 value3]',
                 'names' => ['value1', 'value2', 'value3'],
+                'checks' => 0,
                 'exception' => 'An array element must be followed by a comma. '.
                     'Unexpected token "name" of value "value3" ("punctuation" expected with value ",") '.
                     'around position 17 for expression `[value1, value2 value3]`.',
@@ -364,26 +385,31 @@ class ParserTest extends TestCase
             'incorrect array element' => [
                 'expression' => 'foo["some_key")',
                 'names' => ['foo'],
+                'checks' => 0,
                 'exception' => 'Unclosed "[" around position 3 for expression `foo["some_key")`.',
             ],
             'incorrect hash key' => [
                 'expression' => '{+: value1}',
                 'names' => ['value1'],
+                'checks' => 0,
                 'exception' => 'A hash key must be a quoted string, a number, a name, or an expression enclosed in parentheses (unexpected token "operator" of value "+" around position 2 for expression `{+: value1}`.',
             ],
             'missed array key' => [
                 'expression' => 'foo[]',
                 'names' => ['foo'],
+                'checks' => 0,
                 'exception' => 'Unexpected token "punctuation" of value "]" around position 5 for expression `foo[]`.',
             ],
             'missed closing bracket in sub expression' => [
                 'expression' => 'foo[(bar ? bar : "default"]',
                 'names' => ['foo', 'bar'],
+                'checks' => 0,
                 'exception' => 'Unclosed "(" around position 4 for expression `foo[(bar ? bar : "default"]`.',
             ],
             'incorrect hash following' => [
                 'expression' => '{key: foo key2: bar}',
                 'names' => ['foo', 'bar'],
+                'checks' => 0,
                 'exception' => 'A hash value must be followed by a comma. '.
                     'Unexpected token "name" of value "key2" ("punctuation" expected with value ",") '.
                     'around position 11 for expression `{key: foo key2: bar}`.',
@@ -391,11 +417,13 @@ class ParserTest extends TestCase
             'incorrect hash assign' => [
                 'expression' => '{key => foo}',
                 'names' => ['foo'],
+                'checks' => 0,
                 'exception' => 'Unexpected character "=" around position 5 for expression `{key => foo}`.',
             ],
             'incorrect array as hash using' => [
                 'expression' => '[foo: foo]',
                 'names' => ['foo'],
+                'checks' => 0,
                 'exception' => 'An array element must be followed by a comma. '.
                     'Unexpected token "punctuation" of value ":" ("punctuation" expected with value ",") '.
                     'around position 5 for expression `[foo: foo]`.',

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/cache": "^6.4|^7.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fixes #50144
| License       | MIT

When linting/parsing an expression, two kinds of errors can be thrown: a syntax error (for which the parser cannot recover) or an unknown variable/function error (which does not block the parser).

When linting an expression, currently you can ignore unknown variables by passing `null` instead of the valid variable names to `lint()` or `parse()`, but you cannot ignore unknown functions. For some use cases, it might be needed to just validate the syntax.

This PR allows developers to ignore functions and/or variables the "proper way" with flags as a new argument to these methods:

```php
$parser->lint($expr, flags: Parser::IGNORE_UNKNOWN_FUNCTIONS | Parser::IGNORE_UNKNOWN_VARIABLES);
$parser->parse($expr, flags: Parser::IGNORE_UNKNOWN_FUNCTIONS | Parser::IGNORE_UNKNOWN_VARIABLES);
```

Passing `null` to the `$names` argument is deprecated:

**Before**:
```php
$parser->lint($expr, null);
```

**After**:

```php
$parser->lint($expr, flags: Parser::IGNORE_UNKNOWN_VARIABLES);
```
