### PR TITLE
[Messenger] Rollback if possible

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
@@ -34,7 +34,9 @@ class DoctrineTransactionMiddleware extends AbstractDoctrineMiddleware
 
             return $envelope;
         } catch (\Throwable $exception) {
-            $entityManager->getConnection()->rollBack();
+            if ($entityManager->getConnection()->isTransactionActive()) {
+                $entityManager->getConnection()->rollBack();
+            }
 
             if ($exception instanceof HandlerFailedException) {
                 // Remove all HandledStamp from the envelope so the retry will execute all handlers again.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

An exception thrown from `flush()/commit()` after the transaction was finished might lead to an `There is no active transaction` in the caught block, caused by `rollBack()`.

Im not sure what's causing it for us, but it's probably related to doctrine event listeners :smile: 

Better preserve the original exception at all cost.

Should solve https://github.com/symfony/symfony/issues/53642#issuecomment-1929030220