### PR TITLE
Fix Inconsistent Exit Status in `proc_get_status` for PHP Versions Below 8.3

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1291,12 +1291,10 @@ class Process implements \IteratorAggregate
         $this->processInformation = proc_get_status($this->process);
 
 	    /*
-	     * On PHP 8.2 and lower, when calling "proc_get_status" multiple times,
-	     * the only real status code is the first one. The process starts with "-1".
-         * We essentially mimick PHP 8.3 proc_get_status behavior on lower versions
-         * by caching the exit status code when the process returns it, before the
-         * process is discarded.
-	     */
+         * In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call. 
+         * Subsequent calls return -1 as the process is discarded. This workaround caches the first 
+         * retrieved exit status for consistent results in later calls, mimicking PHP 8.3 behavior.
+         */
         if (version_compare(PHP_VERSION, '8.3.0', '<')) {
             static $cachedExitCode = null;
         

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1299,11 +1299,11 @@ class Process implements \IteratorAggregate
          */
         if (version_compare(\PHP_VERSION, '8.3.0', '<')) {
             static $cachedExitCode = null;
-        
+
             if (null === $cachedExitCode && !$running && $this->processInformation['exitcode'] !== -1) {
                 $cachedExitCode = $this->processInformation['exitcode'];
             }
-        
+
             if (null !== $cachedExitCode && !$running && $this->processInformation['exitcode'] === -1) {
                 $this->processInformation['exitcode'] = $cachedExitCode;
             }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1292,8 +1292,8 @@ class Process implements \IteratorAggregate
 
         $running = $this->processInformation['running'];
 
-        // In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call. 
-        // Subsequent calls return -1 as the process is discarded. This workaround caches the first 
+        // In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call.
+        // Subsequent calls return -1 as the process is discarded. This workaround caches the first
         // retrieved exit status for consistent results in later calls, mimicking PHP 8.3 behavior.
         if (version_compare(\PHP_VERSION, '8.3.0', '<')) {
             static $cachedExitCode = null;

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1290,6 +1290,8 @@ class Process implements \IteratorAggregate
 
         $this->processInformation = proc_get_status($this->process);
 
+        $running = $this->processInformation['running'];
+
 	    /*
          * In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call. 
          * Subsequent calls return -1 as the process is discarded. This workaround caches the first 
@@ -1306,8 +1308,6 @@ class Process implements \IteratorAggregate
                 $this->processInformation['exitcode'] = $cachedExitCode;
             }
         }
-        
-        $running = $this->processInformation['running'];
 
         $this->readPipes($running && $blocking, '\\' !== \DIRECTORY_SEPARATOR || !$running);
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1292,19 +1292,17 @@ class Process implements \IteratorAggregate
 
         $running = $this->processInformation['running'];
 
-        /*
-         * In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call. 
-         * Subsequent calls return -1 as the process is discarded. This workaround caches the first 
-         * retrieved exit status for consistent results in later calls, mimicking PHP 8.3 behavior.
-         */
+         // In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call. 
+         // Subsequent calls return -1 as the process is discarded. This workaround caches the first 
+         // retrieved exit status for consistent results in later calls, mimicking PHP 8.3 behavior.
         if (version_compare(\PHP_VERSION, '8.3.0', '<')) {
             static $cachedExitCode = null;
 
-            if (null === $cachedExitCode && !$running && $this->processInformation['exitcode'] !== -1) {
+            if (null === $cachedExitCode && !$running && -1 !== $this->processInformation['exitcode']) {
                 $cachedExitCode = $this->processInformation['exitcode'];
             }
 
-            if (null !== $cachedExitCode && !$running && $this->processInformation['exitcode'] === -1) {
+            if (null !== $cachedExitCode && !$running && -1 === $this->processInformation['exitcode']) {
                 $this->processInformation['exitcode'] = $cachedExitCode;
             }
         }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1292,9 +1292,9 @@ class Process implements \IteratorAggregate
 
         $running = $this->processInformation['running'];
 
-         // In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call. 
-         // Subsequent calls return -1 as the process is discarded. This workaround caches the first 
-         // retrieved exit status for consistent results in later calls, mimicking PHP 8.3 behavior.
+        // In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call. 
+        // Subsequent calls return -1 as the process is discarded. This workaround caches the first 
+        // retrieved exit status for consistent results in later calls, mimicking PHP 8.3 behavior.
         if (version_compare(\PHP_VERSION, '8.3.0', '<')) {
             static $cachedExitCode = null;
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1292,19 +1292,19 @@ class Process implements \IteratorAggregate
 
         $running = $this->processInformation['running'];
 
-	    /*
+        /*
          * In PHP < 8.3, "proc_get_status" only returns the correct exit status on the first call. 
          * Subsequent calls return -1 as the process is discarded. This workaround caches the first 
          * retrieved exit status for consistent results in later calls, mimicking PHP 8.3 behavior.
          */
-        if (version_compare(PHP_VERSION, '8.3.0', '<')) {
+        if (version_compare(\PHP_VERSION, '8.3.0', '<')) {
             static $cachedExitCode = null;
         
-            if (is_null($cachedExitCode) && !$running && $this->processInformation['exitcode'] !== -1) {
+            if (null === $cachedExitCode && !$running && $this->processInformation['exitcode'] !== -1) {
                 $cachedExitCode = $this->processInformation['exitcode'];
             }
         
-            if (!is_null($cachedExitCode) && !$running && $this->processInformation['exitcode'] === -1) {
+            if (null !== $cachedExitCode && !$running && $this->processInformation['exitcode'] === -1) {
                 $this->processInformation['exitcode'] = $cachedExitCode;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4, 6.4, 7.0 <!-- Bug fix for maintained branches -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A <!-- No existing issue, direct PR -->
| License       | MIT

This PR addresses a bug in Symfony's Process component affecting PHP versions prior to 8.3. In these versions, calling `proc_get_status` multiple times on the same process resource only returns the correct exit status on the first call, with subsequent calls returning -1 due to the process being discarded. This behavior can lead to race conditions and incorrect process status reporting in Symfony applications.

To resolve this, the PR introduces a workaround that caches the first retrieved exit status. This cached status is then used for subsequent calls, ensuring consistent and accurate exit status reporting. This change aims to align the behavior with PHP 8.3, where this issue has been resolved natively.

### Changes:
- Added caching mechanism for the exit status in the Process component.
- Ensured the cached status is used for subsequent `proc_get_status` calls if PHP version is below 8.3.

### Proof of Concept:

To demonstrate the issue and the effectiveness of the fix, a proof of concept script is included below. This script uses Symfony's Process component to start a subprocess that outputs a message and exits with a specific status code. The script then attempts to retrieve the exit status of the process using getExitCode(). In PHP versions prior to 8.3, without the proposed fix, this script will often incorrectly report an exit code of -1 due to the race condition described earlier.

```php
<?php

if ( getenv( 'OUTPUT' ) ) {
	#echo 'This should fail when "wait" gets large';
	sleep( 2 );
	echo 'This should fail even when "wait" is small';
	die( 123 );
}

use Symfony\Component\Process\Process;

require_once __DIR__ . '/vendor/autoload.php';

do {
	// Increasingly bigger waits.
	static $wait = 0;
	$wait += 100000;
	echo sprintf( 'Wait: %s', $wait ) . PHP_EOL;

	$p = new Process( [ 'php', __FILE__ ], __DIR__, [
		'OUTPUT' => 1,
	] );

	$p->start( function ( string $type, string $out ) use ( $p ) {
		echo $out . PHP_EOL;

		/**
		 * Calling most methods in Symfony Process that triggers
		 * updateStatus() can potentially trigger the -1 bug.
		 *
		 * @see Process::updateStatus()
		 */
		echo sprintf( 'Is Running: %s', $p->isRunning() ? 'Yes' : 'No' ) . PHP_EOL;
		echo sprintf( 'Exit Code: %s', $p->getExitCode() ) . PHP_EOL;
	} );

	while ( $p->isRunning() ) {
		usleep( $wait );
	}

	if ( ! $p->isSuccessful() ) {
		break;
	}
} while ( true );

$is_started = $p->isStarted();
$is_running = $p->isRunning();
$exit_code  = $p->getExitCode();

echo sprintf( 'Started: %s, Running: %s, Exit code: %s', $is_started, $is_running, $exit_code ) . PHP_EOL;
```

### Impact:
- This change only affects Symfony applications running on PHP versions below 8.3.
- It improves the reliability of process status reporting in these environments.
- No breaking changes or backward compatibility issues are introduced.

### Testing:
I haven't added tests to this PR because:

- This bug involves racing conditions, which is hard to replicate.
- It's past 1 AM local time right now, and I've been debugging this for the past 6 hours.
- The provided "Proof of Concept" can serve as an initial check to confirm the bug.

I'm really not the type of developer that does not write tests, but I beg my pardon for the reasons above.

### Considerations
- Based on the [proc_open](https://github.com/php/php-src/blob/php-8.3.2/ext/standard/proc_open.c) implementation, this fix might not be needed on Windows.
- You can find additional context for this bug in this [Stack Overflow answer](https://stackoverflow.com/a/77951961/2056484).