### PR TITLE
[Mailer][Postmark][Webhook] Don't require tag and metadata

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/RemoteEvent/PostmarkPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/RemoteEvent/PostmarkPayloadConverter.php
@@ -52,8 +52,13 @@ final class PostmarkPayloadConverter implements PayloadConverterInterface
         }
         $event->setDate($date);
         $event->setRecipientEmail($payload['Recipient'] ?? $payload['Email']);
-        $event->setMetadata($payload['Metadata']);
-        $event->setTags([$payload['Tag']]);
+
+        if (isset($payload['Metadata'])) {
+            $event->setMetadata($payload['Metadata']);
+        }
+        if (isset($payload['Tag'])) {
+            $event->setTags([$payload['Tag']]);
+        }
 
         return $event;
     }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
@@ -48,8 +48,6 @@ final class PostmarkRequestParser extends AbstractRequestParser
             !isset($payload['RecordType'])
             || !isset($payload['MessageID'])
             || !(isset($payload['Recipient']) || isset($payload['Email']))
-            || !isset($payload['Metadata'])
-            || !isset($payload['Tag'])
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Postmark webhooks will fail if metadata or tag are missing. As both are optional they should not be required in parsing as well.

This was observed in our setup with all webhooks failing because `Tag` was missing.