### PR TITLE
[Mailer][Postmark][Webhook] Accept different date formats

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/RemoteEvent/PostmarkPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/RemoteEvent/PostmarkPayloadConverter.php
@@ -47,7 +47,14 @@ final class PostmarkPayloadConverter implements PayloadConverterInterface
             'SpamComplaint' => $payload['BouncedAt'],
             default => throw new ParseException(sprintf('Unsupported event "%s".', $payload['RecordType'])),
         };
-        if (!$date = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sT', $payloadDate)) {
+
+        $date = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $payloadDate)
+            // microseconds, 6 digits
+            ?: \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $payloadDate)
+            // microseconds, 7 digits
+            ?: \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u?P', $payloadDate);
+
+        if (!$date) {
             throw new ParseException(sprintf('Invalid date "%s".', $payloadDate));
         }
         $event->setDate($date);

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/bounce.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/bounce.json
@@ -16,7 +16,7 @@
     "Details": "Test bounce details",
     "Email": "john@example.com",
     "From": "sender@example.com",
-    "BouncedAt": "2022-09-02T14:29:19Z",
+    "BouncedAt": "2022-09-02T14:29:19.1234567Z",
     "DumpAvailable": true,
     "Inactive": true,
     "CanActivate": true,

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/bounce.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/bounce.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('john@example.com');
 $wh->setTags(['Test']);
 $wh->setMetadata(['example' => 'value', 'example_2' => 'value']);
 $wh->setReason('The server was unable to deliver your message (ex: unknown user, mailbox not found).');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sT', '2022-09-02T14:29:19Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2022-09-02T14:29:19.123456Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/delivery.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/delivery.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('john@example.com');
 $wh->setTags(['welcome-email']);
 $wh->setMetadata(['example' => 'value', 'example_2' => 'value']);
 $wh->setReason('');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sT', '2022-09-02T11:49:27Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, '2022-09-02T11:49:27Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/link_click.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/link_click.php
@@ -6,6 +6,6 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::CLICK, '00000000-0000-000
 $wh->setRecipientEmail('john@example.com');
 $wh->setTags(['welcome-email']);
 $wh->setMetadata(['example' => 'value', 'example_2' => 'value']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sT', '2022-09-02T14:31:09Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, '2022-09-02T14:31:09Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/open.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/open.php
@@ -6,6 +6,6 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::OPEN, '00000000-0000-0000
 $wh->setRecipientEmail('john@example.com');
 $wh->setTags(['welcome-email']);
 $wh->setMetadata(['example' => 'value', 'example_2' => 'value']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sT', '2022-09-02T14:30:47Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, '2022-09-02T14:30:47Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/spam_complaint.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/spam_complaint.json
@@ -16,7 +16,7 @@
     "Details": "Test spam complaint details",
     "Email": "john@example.com",
     "From": "sender@example.com",
-    "BouncedAt": "2022-09-02T14:29:57Z",
+    "BouncedAt": "2022-09-02T14:29:57.123456Z",
     "DumpAvailable": true,
     "Inactive": true,
     "CanActivate": false,

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/spam_complaint.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/spam_complaint.php
@@ -6,6 +6,5 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::SPAM, '00000000-0000-0000
 $wh->setRecipientEmail('john@example.com');
 $wh->setTags(['Test']);
 $wh->setMetadata(['example' => 'value', 'example_2' => 'value']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sT', '2022-09-02T14:29:57Z'));
-
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2022-09-02T14:29:57.123456Z'));
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/subscription_change.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/Fixtures/subscription_change.php
@@ -6,6 +6,6 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::UNSUBSCRIBE, '00000000-00
 $wh->setRecipientEmail('john@example.com');
 $wh->setTags(['welcome-email']);
 $wh->setMetadata(['example' => 'value', 'example_2' => 'value']);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sT', '2022-09-02T14:32:30Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, '2022-09-02T14:32:30Z'));
 
 return $wh;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53788
| License       | MIT

Postmark webhooks sometimes use "plain" ISO 6801 format, sometimes including 7 digits microseconds.
We're currently seeing `2024-02-07T09:41:16.7048881Z` for example.

As the PHP parameter only allows for 6 digits neither would parse without fallbacks.
