### PR TITLE
[VarDumper] Fix configuring CliDumper with SYMFONY_IDE env var

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/FileLinkFormatter.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/FileLinkFormatter.php
@@ -30,7 +30,7 @@ class FileLinkFormatter
     private \Closure|string|null $urlFormat;
 
     /**
-     * @param string|\Closure $urlFormat the URL format, or a closure that returns it on-demand
+     * @param string|\Closure $urlFormat The URL format, or a closure that returns it on-demand
      */
     public function __construct(string|array|null $fileLinkFormat = null, ?RequestStack $requestStack = null, ?string $baseDir = null, string|\Closure|null $urlFormat = null)
     {

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarDumper\Dumper;
 
+use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
 use Symfony\Component\VarDumper\Cloner\Cursor;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
@@ -82,7 +83,7 @@ class CliDumper extends AbstractDumper
             ]);
         }
 
-        $this->displayOptions['fileLinkFormat'] = \ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format') ?: 'file://%f#L%l';
+        $this->displayOptions['fileLinkFormat'] = class_exists(FileLinkFormatter::class) ? new FileLinkFormatter() : (\ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format') ?: 'file://%f#L%l');
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Caster\CutStub;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\Stub;
@@ -479,7 +480,7 @@ EOTXT
             ],
             [
                 'bar' => 123,
-            ]
+            ],
         ]);
 
         $dumper = new CliDumper();
@@ -498,5 +499,31 @@ EOTXT
             ,
             $dump
         );
+    }
+
+    public function testFileLinkFormat()
+    {
+        $data = new Data([
+            [
+                new ClassStub(self::class),
+            ],
+        ]);
+
+        $ide = $_ENV['SYMFONY_IDE'] ?? null;
+        $_ENV['SYMFONY_IDE'] = 'vscode';
+
+        try {
+            $dumper = new CliDumper();
+            $dumper->setColors(true);
+            $dump = $dumper->dump($data, true);
+
+            $this->assertStringMatchesFormat('%svscode:%sCliDumperTest%s', $dump);
+        } finally {
+            if (null === $ide) {
+                unset($_ENV['SYMFONY_IDE']);
+            } else {
+                $_ENV['SYMFONY_IDE'] = $ide;
+            }
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using `dump()` in a plain PHP script, `SYMFONY_IDE` is currently ignored. This fixes it when `FileLinkFormatter` is available.
