### PR TITLE
[VarDumper] Fixed broken CI

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -576,6 +576,7 @@ EOTXT
         ]);
 
         $dumper = new CliDumper();
+        $dumper->setColors(false);
         $dump = $dumper->dump($data, true);
 
         $this->assertSame(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Make sure we dont compare a "color output" with a plain one. 

I think this was introduced in https://github.com/symfony/symfony/pull/53794