### PR TITLE
[Workflow]Fix Marking when it must contains more than one tokens

### DIFF
--- a/src/Symfony/Component/Workflow/Marking.php
+++ b/src/Symfony/Component/Workflow/Marking.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Workflow;
 class Marking
 {
     private $places = [];
-    private $context = null;
+    private $context;
 
     /**
      * @param int[] $representation Keys are the place name and values should be 1
@@ -27,23 +27,46 @@ class Marking
     public function __construct(array $representation = [])
     {
         foreach ($representation as $place => $nbToken) {
-            $this->mark($place);
+            $this->mark($place, $nbToken);
         }
     }
 
-    public function mark(string $place)
+    public function mark(string $place, int $nbToken = 1)
     {
-        $this->places[$place] = 1;
+        if ($nbToken < 1) {
+            throw new \LogicException(sprintf('The number of tokens must be greater than 0, "%s" given.', $nbToken));
+        }
+
+        if (!\array_key_exists($place, $this->places)) {
+            $this->places[$place] = 0;
+        }
+        $this->places[$place] += $nbToken;
     }
 
-    public function unmark(string $place)
+    public function unmark(string $place, int $nbToken = 1)
     {
-        unset($this->places[$place]);
+        if ($nbToken < 1) {
+            throw new \LogicException(sprintf('The number of tokens must be greater than 0, "%s" given.', $nbToken));
+        }
+
+        if (!$this->has($place)) {
+            throw new \LogicException(sprintf('The place "%s" is not marked.', $place));
+        }
+
+        $this->places[$place] -= $nbToken;
+
+        if (0 > $this->places[$place]) {
+            throw new \LogicException(sprintf('The place "%s" could not contain a negative token number.', $place));
+        }
+
+        if (0 === $this->places[$place]) {
+            unset($this->places[$place]);
+        }
     }
 
     public function has(string $place)
     {
-        return isset($this->places[$place]);
+        return \array_key_exists($place, $this->places);
     }
 
     public function getPlaces()

--- a/src/Symfony/Component/Workflow/Tests/MarkingTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingTest.php
@@ -22,24 +22,70 @@ class MarkingTest extends TestCase
 
         $this->assertTrue($marking->has('a'));
         $this->assertFalse($marking->has('b'));
-        $this->assertSame(['a' => 1], $marking->getPlaces());
+        $this->assertPlaces(['a' => 1], $marking);
 
         $marking->mark('b');
 
         $this->assertTrue($marking->has('a'));
         $this->assertTrue($marking->has('b'));
-        $this->assertSame(['a' => 1, 'b' => 1], $marking->getPlaces());
+        $this->assertPlaces(['a' => 1, 'b' => 1], $marking);
 
         $marking->unmark('a');
 
         $this->assertFalse($marking->has('a'));
         $this->assertTrue($marking->has('b'));
-        $this->assertSame(['b' => 1], $marking->getPlaces());
+        $this->assertPlaces(['b' => 1], $marking);
 
         $marking->unmark('b');
 
         $this->assertFalse($marking->has('a'));
         $this->assertFalse($marking->has('b'));
-        $this->assertSame([], $marking->getPlaces());
+        $this->assertPlaces([], $marking);
+
+        $marking->mark('a');
+        $this->assertPlaces(['a' => 1], $marking);
+
+        $marking->mark('a');
+        $this->assertPlaces(['a' => 2], $marking);
+
+        $marking->unmark('a');
+        $this->assertPlaces(['a' => 1], $marking);
+
+        $marking->unmark('a');
+        $this->assertPlaces([], $marking);
+    }
+
+    public function testGuardNotMarked()
+    {
+        $marking = new Marking([]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The place "a" is not marked.');
+        $marking->unmark('a');
+    }
+
+    public function testGuardNotNbTokenLowerThanZero()
+    {
+        $marking = new Marking(['a' => 1]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The place "a" could not contain a negative token number.');
+        $marking->unmark('a', 2);
+    }
+
+    public function testGuardNotNbTokenEquals0()
+    {
+        $marking = new Marking(['a' => 1]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The number of tokens must be greater than 0, "0" given.');
+        $marking->unmark('a', 0);
+    }
+
+    private function assertPlaces(array $expected, Marking $marking)
+    {
+        $places = $marking->getPlaces();
+        ksort($places);
+        $this->assertSame($expected, $places);
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowBuilderTrait.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowBuilderTrait.php
@@ -158,4 +158,43 @@ EOTXT;
         //             |  d  | -------------+
         //             +-----+
     }
+
+    private static function createWorkflowWithSameNameBackTransition(): Definition
+    {
+        $places = range('a', 'c');
+
+        $transitions = [];
+        $transitions[] = new Transition('a_to_bc', 'a', ['b', 'c']);
+        $transitions[] = new Transition('back1', 'b', 'a');
+        $transitions[] = new Transition('back1', 'c', 'b');
+        $transitions[] = new Transition('back2', 'c', 'b');
+        $transitions[] = new Transition('back2', 'b', 'a');
+        $transitions[] = new Transition('c_to_cb', 'c', ['b', 'c']);
+
+        return new Definition($places, $transitions);
+
+        // The graph looks like:
+        //   +-----------------------------------------------------------------+
+        //   |                                                                 |
+        //   |                                                                 |
+        //   |         +---------------------------------------------+         |
+        //   v         |                                             v         |
+        // +---+     +---------+     +-------+     +---------+     +---+     +-------+
+        // | a | --> | a_to_bc | --> |       | --> |  back2  | --> |   | --> | back2 |
+        // +---+     +---------+     |       |     +---------+     |   |     +-------+
+        //   ^                       |       |                     |   |
+        //   |                       |   c   | <-----+             | b |
+        //   |                       |       |       |             |   |
+        //   |                       |       |     +---------+     |   |     +-------+
+        //   |                       |       | --> | c_to_cb | --> |   | --> | back1 |
+        //   |                       +-------+     +---------+     +---+     +-------+
+        //   |                         |                             ^         |
+        //   |                         |                             |         |
+        //   |                         v                             |         |
+        //   |                       +-------+                       |         |
+        //   |                       | back1 | ----------------------+         |
+        //   |                       +-------+                                 |
+        //   |                                                                 |
+        //   +-----------------------------------------------------------------+
+    }
 }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -330,28 +330,32 @@ class WorkflowTest extends TestCase
 
         $marking = $workflow->apply($subject, 'a_to_bc');
 
-        $this->assertFalse($marking->has('a'));
-        $this->assertTrue($marking->has('b'));
-        $this->assertTrue($marking->has('c'));
+        $this->assertPlaces([
+            'b' => 1,
+            'c' => 1,
+        ], $marking);
 
         $marking = $workflow->apply($subject, 'to_a');
 
-        $this->assertTrue($marking->has('a'));
-        $this->assertFalse($marking->has('b'));
-        $this->assertFalse($marking->has('c'));
+        // Two tokens in "a"
+        $this->assertPlaces([
+            'a' => 2,
+        ], $marking);
 
         $workflow->apply($subject, 'a_to_bc');
         $marking = $workflow->apply($subject, 'b_to_c');
 
-        $this->assertFalse($marking->has('a'));
-        $this->assertFalse($marking->has('b'));
-        $this->assertTrue($marking->has('c'));
+        $this->assertPlaces([
+            'a' => 1,
+            'c' => 2,
+        ], $marking);
 
         $marking = $workflow->apply($subject, 'to_a');
 
-        $this->assertTrue($marking->has('a'));
-        $this->assertFalse($marking->has('b'));
-        $this->assertFalse($marking->has('c'));
+        $this->assertPlaces([
+            'a' => 2,
+            'c' => 1,
+        ], $marking);
     }
 
     public function testApplyWithSameNameTransition2()
@@ -784,6 +788,63 @@ class WorkflowTest extends TestCase
         $this->assertSame('b_to_c', $transitions[0]->getName());
         $this->assertSame('to_a', $transitions[1]->getName());
         $this->assertSame('to_a', $transitions[2]->getName());
+    }
+
+    /**
+     * @@testWith ["back1"]
+     *            ["back2"]
+     */
+    public function testApplyWithSameNameBackTransition(string $transition)
+    {
+        $definition = $this->createWorkflowWithSameNameBackTransition();
+        $workflow = new Workflow($definition, new MethodMarkingStore());
+
+        $subject = new Subject();
+
+        $marking = $workflow->apply($subject, 'a_to_bc');
+        $this->assertPlaces([
+            'b' => 1,
+            'c' => 1,
+        ], $marking);
+
+        $marking = $workflow->apply($subject, $transition);
+        $this->assertPlaces([
+            'a' => 1,
+            'b' => 1,
+        ], $marking);
+
+        $marking = $workflow->apply($subject, $transition);
+        $this->assertPlaces([
+            'a' => 2,
+        ], $marking);
+
+        $marking = $workflow->apply($subject, 'a_to_bc');
+        $this->assertPlaces([
+            'a' => 1,
+            'b' => 1,
+            'c' => 1,
+        ], $marking);
+
+        $marking = $workflow->apply($subject, 'c_to_cb');
+        $this->assertPlaces([
+            'a' => 1,
+            'b' => 2,
+            'c' => 1,
+        ], $marking);
+
+        $marking = $workflow->apply($subject, 'c_to_cb');
+        $this->assertPlaces([
+            'a' => 1,
+            'b' => 3,
+            'c' => 1,
+        ], $marking);
+    }
+
+    private function assertPlaces(array $expected, Marking $marking)
+    {
+        $places = $marking->getPlaces();
+        ksort($places);
+        $this->assertSame($expected, $places);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53179
| License       | MIT
