### PR TITLE
[Config] Allow custom meta location in `ConfigCache`

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow custom meta location in `ResourceCheckerConfigCache`
+ * Allow custom meta location in `ConfigCache`
 
 7.0
 ---

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -26,19 +26,21 @@ use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
 class ConfigCache extends ResourceCheckerConfigCache
 {
     /**
-     * @param string $file  The absolute cache path
-     * @param bool   $debug Whether debugging is enabled or not
+     * @param string      $file     The absolute cache path
+     * @param bool        $debug    Whether debugging is enabled or not
+     * @param string|null $metaFile The absolute path to the meta file
      */
     public function __construct(
         string $file,
         private bool $debug,
+        ?string $metaFile = null,
     ) {
         $checkers = [];
         if (true === $this->debug) {
             $checkers = [new SelfCheckingResourceChecker()];
         }
 
-        parent::__construct($file, $checkers);
+        parent::__construct($file, $checkers, $metaFile);
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -13,21 +13,24 @@ namespace Symfony\Component\Config\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
 use Symfony\Component\Config\Tests\Resource\ResourceStub;
 
 class ConfigCacheTest extends TestCase
 {
     private string $cacheFile;
+    private string $metaFile;
 
     protected function setUp(): void
     {
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'config_');
+        $this->metaFile = tempnam(sys_get_temp_dir(), 'config_');
     }
 
     protected function tearDown(): void
     {
-        $files = [$this->cacheFile, $this->cacheFile.'.meta'];
+        $files = [$this->cacheFile, $this->cacheFile.'.meta', $this->metaFile];
 
         foreach ($files as $file) {
             if (file_exists($file)) {
@@ -102,5 +105,15 @@ class ConfigCacheTest extends TestCase
             [true],
             [false],
         ];
+    }
+
+    public function testCacheWithCustomMetaFile()
+    {
+        $this->assertStringEqualsFile($this->metaFile, '');
+
+        $cache = new ConfigCache($this->cacheFile, false, $this->metaFile);
+        $cache->write('foo', [new FileResource(__FILE__)]);
+
+        $this->assertStringNotEqualsFile($this->metaFile, '');
     }
 }

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\Config\Tests\Resource\ResourceStub;
 class ResourceCheckerConfigCacheTest extends TestCase
 {
     private string $cacheFile;
-
     private string $metaFile;
 
     protected function setUp(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

https://github.com/symfony/symfony/pull/52043 allow to configure meta location in `ResourceCheckerConfigCache`
`ConfigCache` extends this file.

This PR allow to configure meta location in `ConfigCache` 
