### PR TITLE
[Mailer][Postmark][Webhook] Fix webhook testing in dockerized setups

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
@@ -27,6 +27,10 @@ final class PostmarkRequestParser extends AbstractRequestParser
 {
     public function __construct(
         private readonly PostmarkPayloadConverter $converter,
+
+        // https://postmarkapp.com/support/article/800-ips-for-firewalls#webhooks
+        // localhost is added for testing
+        private readonly array $allowedIPs = ['3.134.147.250', '50.31.156.6', '50.31.156.77', '18.217.206.57', '127.0.0.1'],
     ) {
     }
 
@@ -34,9 +38,7 @@ final class PostmarkRequestParser extends AbstractRequestParser
     {
         return new ChainRequestMatcher([
             new MethodRequestMatcher('POST'),
-            // https://postmarkapp.com/support/article/800-ips-for-firewalls#webhooks
-            // localhost is added for testing
-            new IpsRequestMatcher(['3.134.147.250', '50.31.156.6', '50.31.156.77', '18.217.206.57', '127.0.0.1']),
+            new IpsRequestMatcher($this->allowedIPs),
             new IsJsonRequestMatcher(),
         ]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Adding "127.0.0.1" to webhooks doesn't always cut it. Testing in e.g. dockerized setups the IP address will most certainly not be 127.0.0.1 when testing requests originate from the host.

I wasn't sure whether this is a bug or a feature. For us it's a bug (we cannot test webhooks here, if "test" means testing in our development environment). On the other hand, it could also be a feature (and "127.0.0.1" removed completely), if by "testing" only the Symfony tests were meant.

What do you think? Bug? Feature?