### PR TITLE
[Dotenv] Specify envKey while loading variables with the dotenv:dump

### DIFF
--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -95,9 +95,10 @@ EOF;
 
     private function loadEnv(string $dotenvPath, string $env, array $config): array
     {
-        $dotenv = new Dotenv();
         $envKey = $config['env_var_name'] ?? 'APP_ENV';
         $testEnvs = $config['test_envs'] ?? ['test'];
+
+        $dotenv = new Dotenv($envKey);
 
         $globalsBackup = [$_SERVER, $_ENV];
         unset($_SERVER[$envKey]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53864
| License       | MIT

`bin/console dotenv:dump` incorrectly detected envKey if it differs from APP_ENV