### PR TITLE
[Security] Fix impersonation exit route not used

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -124,10 +124,10 @@ class SwitchUserListener extends AbstractListener
         if (!$this->stateless) {
             $request->query->remove($this->usernameParameter);
             $request->server->set('QUERY_STRING', http_build_query($request->query->all(), '', '&'));
-            
+
             if (self::EXIT_VALUE === $username) {
                 // Redirect to the via "impersonation_exit_url(exitTo = null)" defined url if given
-                $response = new RedirectResponse($this->urlGenerator && $request->attributes->get('_route') ? $this->urlGenerator->generate($request->attributes->get('_route')) : $request->getUri(), 302);    
+                $response = new RedirectResponse($this->urlGenerator && $request->attributes->get('_route') ? $this->urlGenerator->generate($request->attributes->get('_route')) : $request->getUri(), 302);
             } else {
                 $response = new RedirectResponse($this->urlGenerator && $this->targetRoute ? $this->urlGenerator->generate($this->targetRoute) : $request->getUri(), 302);
             }

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -124,7 +124,13 @@ class SwitchUserListener extends AbstractListener
         if (!$this->stateless) {
             $request->query->remove($this->usernameParameter);
             $request->server->set('QUERY_STRING', http_build_query($request->query->all(), '', '&'));
-            $response = new RedirectResponse($this->urlGenerator && $this->targetRoute ? $this->urlGenerator->generate($this->targetRoute) : $request->getUri(), 302);
+            
+            if (self::EXIT_VALUE === $username) {
+                // Redirect to the via "impersonation_exit_url(exitTo = null)" defined url if given
+                $response = new RedirectResponse($this->urlGenerator && $request->attributes->get('_route') ? $this->urlGenerator->generate($request->attributes->get('_route')) : $request->getUri(), 302);    
+            } else {
+                $response = new RedirectResponse($this->urlGenerator && $this->targetRoute ? $this->urlGenerator->generate($this->targetRoute) : $request->getUri(), 302);
+            }
 
             $event->setResponse($response);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53873
| License       | MIT

This fix takes in mind that a user may have provided a route he wants to be redirect when exiting impersonation using the twig impersonation_exit_path(exitTo = null) function. For further info see issue #53873 