### PR TITLE
[WebProfilerBundle] Allow to search inside profiler tables

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/bag.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/bag.html.twig
@@ -1,3 +1,4 @@
+<div class="table-with-search-field">
 <table class="{{ class|default('') }}">
     <thead>
         <tr>
@@ -18,3 +19,4 @@
         {% endfor %}
     </tbody>
 </table>
+</div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -12,6 +12,7 @@
     class SymfonyProfiler {
         constructor() {
             this.#createTabs();
+            this.#createTableSearchFields();
             this.#createToggles();
             this.#createCopyToClipboard();
             this.#convertDateTimesToUserTimezone();
@@ -102,6 +103,56 @@
                 });
 
                 tabGroup.setAttribute('data-processed', 'true');
+            });
+        }
+
+        #createTableSearchFields() {
+            document.querySelectorAll('div.table-with-search-field').forEach((tableWrapper, i) => {
+                const searchField = document.createElement('input');
+                searchField.type = 'search';
+                searchField.placeholder = 'search...';
+                searchField.id = `table-search-field-${i}`;
+                searchField.classList.add(`table-search-field-input`);
+                searchField.autocapitalize = 'off';
+                searchField.autocomplete = 'off';
+                searchField.autocorrect = 'off';
+                tableWrapper.insertBefore(searchField, tableWrapper.firstChild);
+
+                const labelField = document.createElement('label');
+                labelField.htmlFor = `table-search-field-${i}`;
+                labelField.classList.add(`table-search-field-label`);
+                labelField.textContent = 'Search inside the contents of the table';
+                tableWrapper.insertBefore(labelField, tableWrapper.firstChild);
+
+                searchField.addEventListener('input', () => {
+                    const query = searchField.value.toLowerCase();
+                    let allRowsAreHidden = true;
+                    tableWrapper.querySelectorAll('tbody tr').forEach((row) => {
+                        const rowMatchesQuery = row.textContent.toLowerCase().includes(query);
+                        row.style.display = rowMatchesQuery ? '' : 'none';
+
+                        if (rowMatchesQuery) {
+                            allRowsAreHidden = false;
+                        }
+                    });
+
+                    /* if there are no results and all rows are hidden, show a message to avoid confusion */
+                    const noResultsElement = tableWrapper.querySelector('.no-results-message');
+                    if (allRowsAreHidden) {
+                        if (null === noResultsElement) {
+                            const noResultsElement = document.createElement('p');
+                            noResultsElement.textContent = 'No results found.';
+                            noResultsElement.classList.add('no-results-message');
+                            tableWrapper.appendChild(noResultsElement);
+                        } else {
+                            noResultsElement.style.display = '';
+                        }
+                    } else {
+                        if (null !== noResultsElement) {
+                            noResultsElement.style.display = 'none';
+                        }
+                    }
+                });
             });
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -614,6 +614,29 @@ table tbody td.num-col {
     text-align: center;
 }
 
+div.table-with-search-field {
+    position: relative;
+}
+div.table-with-search-field label.table-search-field-label {
+    display: none;
+}
+div.table-with-search-field input.table-search-field-input {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    max-height: 27px; /* needed for Safari */
+}
+div.table-with-search-field .no-results-message {
+    background: var(--page-background);
+    border: solid var(--table-border-color);
+    border-width: 0 1px 1px;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    font-size: var(--table-font-size);
+    margin-top: -1em;
+    padding: 15px 10px;
+}
+
 {# Utility classes
    ========================================================================= #}
 .block {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/table.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/table.html.twig
@@ -1,3 +1,4 @@
+<div class="table-with-search-field">
 <table class="{{ class|default('') }}">
     <thead>
         <tr>
@@ -14,3 +15,4 @@
         {% endfor %}
     </tbody>
 </table>
+</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

In the profiler, sometimes tables are very long and it's hard to find things in all those rows. This PR injects a `<input type="search">` field in all tables to have a real-time filter on table contents:

![image](https://github.com/symfony/symfony/assets/73419/fac07bc4-035f-4521-bd87-8893d832c28a)

In action it looks like this:

![profiler-table-filter](https://github.com/symfony/symfony/assets/73419/e42f6ad5-d2ff-478e-a006-8f6bff9d8f2b)
