### PR TITLE
[PropertyAccess] Fixes `getValue()` on an unitialized object property on a lazy ghost

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -423,7 +423,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 }
             } catch (\Error $e) {
                 // handle uninitialized properties in PHP >= 7.4
-                if (preg_match('/^Typed property ([\w\\\\@]+)::\$(\w+) must not be accessed before initialization$/', $e->getMessage(), $matches)) {
+                if (preg_match('/^Typed property ([\w\\\\@]+)::\$(\w+) must not be accessed before initialization$/', $e->getMessage(), $matches) || preg_match('/^Cannot access uninitialized non-nullable property ([\w\\\\@]+)::\$(\w+) by reference$/', $e->getMessage(), $matches)) {
                     $r = new \ReflectionProperty(str_contains($matches[1], '@anonymous') ? $class : $matches[1], $matches[2]);
                     $type = ($type = $r->getType()) instanceof \ReflectionNamedType ? $type->getName() : (string) $type;
 

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/UninitializedObjectProperty.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/UninitializedObjectProperty.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class UninitializedObjectProperty
+{
+    public \DateTimeInterface $uninitialized;
+    private \DateTimeInterface $privateUninitialized;
+
+    public function getPrivateUninitialized(): string
+    {
+        return $this->privateUninitialized;
+    }
+
+    public function setPrivateUninitialized(string $privateUninitialized): void
+    {
+        $this->privateUninitialized = $privateUninitialized;
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -37,8 +37,10 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TestPublicPropertyGetterOnOb
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularAndPluralProps;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Ticket5775Object;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TypeHinted;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedPrivateProperty;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedProperty;
+use Symfony\Component\VarExporter\ProxyHelper;
 
 class PropertyAccessorTest extends TestCase
 {
@@ -146,7 +148,8 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The method "class@anonymous::getUninitialized()" returned "null", but expected type "array". Did you forget to initialize a property or to make the return type nullable using "?array"?');
 
-        $object = new class() {
+        $object = new class()
+        {
             private $uninitialized;
 
             public function getUninitialized(): array
@@ -163,7 +166,8 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The property "class@anonymous::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
 
-        $object = new class() {
+        $object = new class()
+        {
             private string $uninitialized;
 
             public function getUninitialized(): string
@@ -180,7 +184,8 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The property "class@anonymous::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
 
-        $object = new class() {
+        $object = new class()
+        {
             public string $uninitialized;
         };
 
@@ -208,7 +213,8 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The method "stdClass@anonymous::getUninitialized()" returned "null", but expected type "array". Did you forget to initialize a property or to make the return type nullable using "?array"?');
 
-        $object = new class() extends \stdClass {
+        $object = new class() extends \stdClass
+        {
             private $uninitialized;
 
             public function getUninitialized(): array
@@ -225,7 +231,9 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The method "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedPrivateProperty@anonymous::getUninitialized()" returned "null", but expected type "array". Did you forget to initialize a property or to make the return type nullable using "?array"?');
 
-        $object = new class() extends \Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedPrivateProperty {};
+        $object = new class() extends \Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedPrivateProperty
+        {
+        };
 
         $this->propertyAccessor->getValue($object, 'uninitialized');
     }
@@ -762,7 +770,8 @@ class PropertyAccessorTest extends TestCase
 
     private function generateAnonymousClass($value)
     {
-        return new class($value) {
+        return new class($value)
+        {
             private $foo;
 
             public function __construct($foo)
@@ -957,5 +966,55 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->setValue($object, 'date_mutable', new \DateTimeImmutable());
 
         $this->assertInstanceOf(\DateTime::class, $object->getDate());
+    }
+
+    public function testGetValuePropertyThrowsExceptionIfUninitializedWithoutLazyGhost()
+    {
+        $this->expectException(UninitializedPropertyException::class);
+        $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty::$uninitialized" is not readable because it is typed "DateTimeInterface". You should initialize it or declare a default value instead.');
+
+        $this->propertyAccessor->getValue(new UninitializedObjectProperty, 'uninitialized');
+    }
+
+    public function testGetValueGetterThrowsExceptionIfUninitializedWithoutLazyGhost()
+    {
+        $this->expectException(UninitializedPropertyException::class);
+        $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty::$privateUninitialized" is not readable because it is typed "DateTimeInterface". You should initialize it or declare a default value instead.');
+
+        $this->propertyAccessor->getValue(new UninitializedObjectProperty, 'privateUninitialized');
+    }
+
+    private function createUninitializedObjectPropertyGhost(): UninitializedObjectProperty
+    {
+        $class = 'UninitializedObjectPropertyGhost';
+
+        if (!class_exists($class)) {
+            eval('class ' . $class . ProxyHelper::generateLazyGhost(new \ReflectionClass(UninitializedObjectProperty::class)));
+        }
+
+        $this->assertTrue(class_exists($class));
+
+        return $class::createLazyGhost(initializer: function ($instance) {
+        });
+    }
+
+    public function testGetValuePropertyThrowsExceptionIfUninitializedWithLazyGhost()
+    {
+        $this->expectException(UninitializedPropertyException::class);
+        $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty::$uninitialized" is not readable because it is typed "DateTimeInterface". You should initialize it or declare a default value instead.');
+
+        $lazyGhost = $this->createUninitializedObjectPropertyGhost();
+
+        $this->propertyAccessor->getValue($lazyGhost, 'uninitialized');
+    }
+
+    public function testGetValueGetterThrowsExceptionIfUninitializedWithLazyGhost()
+    {
+        $this->expectException(UninitializedPropertyException::class);
+        $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty::$privateUninitialized" is not readable because it is typed "DateTimeInterface". You should initialize it or declare a default value instead.');
+
+        $lazyGhost = $this->createUninitializedObjectPropertyGhost();
+
+        $this->propertyAccessor->getValue($lazyGhost, 'privateUninitialized');
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -148,8 +148,7 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The method "class@anonymous::getUninitialized()" returned "null", but expected type "array". Did you forget to initialize a property or to make the return type nullable using "?array"?');
 
-        $object = new class()
-        {
+        $object = new class() {
             private $uninitialized;
 
             public function getUninitialized(): array
@@ -166,8 +165,7 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The property "class@anonymous::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
 
-        $object = new class()
-        {
+        $object = new class() {
             private string $uninitialized;
 
             public function getUninitialized(): string
@@ -184,8 +182,7 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The property "class@anonymous::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
 
-        $object = new class()
-        {
+        $object = new class() {
             public string $uninitialized;
         };
 
@@ -213,8 +210,7 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The method "stdClass@anonymous::getUninitialized()" returned "null", but expected type "array". Did you forget to initialize a property or to make the return type nullable using "?array"?');
 
-        $object = new class() extends \stdClass
-        {
+        $object = new class() extends \stdClass {
             private $uninitialized;
 
             public function getUninitialized(): array
@@ -231,8 +227,7 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The method "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedPrivateProperty@anonymous::getUninitialized()" returned "null", but expected type "array". Did you forget to initialize a property or to make the return type nullable using "?array"?');
 
-        $object = new class() extends \Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedPrivateProperty
-        {
+        $object = new class() extends \Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedPrivateProperty {
         };
 
         $this->propertyAccessor->getValue($object, 'uninitialized');
@@ -770,8 +765,7 @@ class PropertyAccessorTest extends TestCase
 
     private function generateAnonymousClass($value)
     {
-        return new class($value)
-        {
+        return new class($value) {
             private $foo;
 
             public function __construct($foo)
@@ -973,7 +967,7 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty::$uninitialized" is not readable because it is typed "DateTimeInterface". You should initialize it or declare a default value instead.');
 
-        $this->propertyAccessor->getValue(new UninitializedObjectProperty, 'uninitialized');
+        $this->propertyAccessor->getValue(new UninitializedObjectProperty(), 'uninitialized');
     }
 
     public function testGetValueGetterThrowsExceptionIfUninitializedWithoutLazyGhost()
@@ -981,7 +975,7 @@ class PropertyAccessorTest extends TestCase
         $this->expectException(UninitializedPropertyException::class);
         $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty::$privateUninitialized" is not readable because it is typed "DateTimeInterface". You should initialize it or declare a default value instead.');
 
-        $this->propertyAccessor->getValue(new UninitializedObjectProperty, 'privateUninitialized');
+        $this->propertyAccessor->getValue(new UninitializedObjectProperty(), 'privateUninitialized');
     }
 
     private function createUninitializedObjectPropertyGhost(): UninitializedObjectProperty
@@ -989,7 +983,7 @@ class PropertyAccessorTest extends TestCase
         $class = 'UninitializedObjectPropertyGhost';
 
         if (!class_exists($class)) {
-            eval('class ' . $class . ProxyHelper::generateLazyGhost(new \ReflectionClass(UninitializedObjectProperty::class)));
+            eval('class '.$class.ProxyHelper::generateLazyGhost(new \ReflectionClass(UninitializedObjectProperty::class)));
         }
 
         $this->assertTrue(class_exists($class));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

With a lazy ghost that has an uninitialized property that should contain an object, attempting to `$propertyAccessor->getValue()` on it will previously throw `Error`, not the expected `UninitializedPropertyException`. This PR fixes the problem.