### PR TITLE
[HttpClient] Make retry strategy work again

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -65,7 +65,8 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
             while (true) {
                 foreach (self::stream([$response], $timeout) as $chunk) {
                     if ($chunk->isTimeout() && $response->passthru) {
-                        foreach (self::passthru($response->client, $response, new ErrorChunk($response->offset, $chunk->getError())) as $chunk) {
+                        // Timeouts thrown during initialization are transport errors
+                        foreach (self::passthru($response->client, $response, new ErrorChunk($response->offset, new TransportException($chunk->getError()))) as $chunk) {
                             if ($chunk->isFirst()) {
                                 return false;
                             }

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -13,13 +13,14 @@ namespace Symfony\Component\HttpClient\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\Exception\ServerException;
-use Symfony\Component\HttpClient\Exception\TimeoutException;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
+use Symfony\Component\HttpClient\Retry\RetryStrategyInterface;
 use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\Test\TestHttpServer;
@@ -247,32 +248,36 @@ class RetryableHttpClientTest extends TestCase
         self::assertSame('Test out content', $response->getContent(), 'Content should be buffered');
     }
 
-    /**
-     * @testWith ["GET"]
-     *           ["POST"]
-     *           ["PUT"]
-     *           ["PATCH"]
-     *           ["DELETE"]
-     */
-    public function testRetryOnHeaderTimeout(string $method)
+    public function testRetryOnTimeout()
     {
         $client = HttpClient::create();
 
-        if ($client instanceof NativeHttpClient) {
-            $this->markTestSkipped('NativeHttpClient cannot timeout before receiving headers');
-        }
-
         TestHttpServer::start();
 
-        $client = new RetryableHttpClient($client);
-        $response = $client->request($method, 'http://localhost:8057/timeout-header', ['timeout' => 0.1]);
+        $strategy = new class() implements RetryStrategyInterface {
+            public $isCalled = false;
+
+            public function shouldRetry(AsyncContext $context, ?string $responseContent, ?TransportExceptionInterface $exception): ?bool
+            {
+                $this->isCalled = true;
+
+                return false;
+            }
+
+            public function getDelay(AsyncContext $context, ?string $responseContent, ?TransportExceptionInterface $exception): int
+            {
+                return 0;
+            }
+        };
+        $client = new RetryableHttpClient($client, $strategy);
+        $response = $client->request('GET', 'http://localhost:8057/timeout-header', ['timeout' => 0.1]);
 
         try {
             $response->getStatusCode();
-            $this->fail(TimeoutException::class.' expected');
-        } catch (TimeoutException $e) {
+            $this->fail(TransportException::class.' expected');
+        } catch (TransportException $e) {
         }
 
-        $this->assertSame('Idle timeout reached for "http://localhost:8057/timeout-header".', $response->getInfo('error'));
+        $this->assertTrue($strategy->isCalled, 'The HTTP retry strategy should be called');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53886
| License       | MIT

PR #53506 accidentally disabled the retry functionality. I reverted that PR and added a small test to make sure this does not happen again. 

Thank you @ldebrouwer for reporting this. 

FYI @nicolas-grekas @rmikalkenas, I will try to find an other solution to fix #52587. But I'll do that in a separate PR to get a quick merge on this one. 