### PR TITLE
[VarExporter] Uniform unitialized property error message under ghost and non-ghost objects

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -223,6 +223,10 @@ trait LazyGhostTrait
 
                 return $accessor['get']($this, $name, null !== $readonlyScope);
             } catch (\Error) {
+                if (preg_match('/^Cannot access uninitialized non-nullable property ([^ ]++) by reference$/', $e->getMessage(), $matches)) {
+                    throw new \Error('Typed property '.$matches[1].' must not be accessed before initialization', $e->getCode(), $e->getPrevious());
+                }
+
                 throw $e;
             }
         }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ClassWithUninitializedObjectProperty.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ClassWithUninitializedObjectProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+class ClassWithUninitializedObjectProperty
+{
+    public \DateTimeInterface $property;
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildMagicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildStdClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildTestClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ClassWithUninitializedObjectProperty;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\LazyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\MagicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ReadOnlyClass;
@@ -436,6 +437,28 @@ class LazyGhostTraitTest extends TestCase
         $proxy = $this->createLazyGhost(ReadOnlyClass::class, fn ($proxy) => $proxy->__construct(123));
 
         $this->assertSame(123, $proxy->foo);
+    }
+
+    public function testAccessingUninializedPropertyWithoutLazyGhost()
+    {
+        $object = new ClassWithUninitializedObjectProperty();
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Typed property Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ClassWithUninitializedObjectProperty::$property must not be accessed before initialization');
+
+        $object->property;
+    }
+
+    public function testAccessingUninializedPropertyWithLazyGhost()
+    {
+        $object = $this->createLazyGhost(ClassWithUninitializedObjectProperty::class, function ($instance) {});
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Typed property Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ClassWithUninitializedObjectProperty::$property must not be accessed before initialization');
+
+        $object->property;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Accessing an uninitialized property will previously give us a different error message on a lazy ghost and the real object. This PR changes so that doing it on a lazy ghost gives us the same error message as that with the real object.