### PR TITLE
[AssetMapper] Ignore comment lines in JavaScriptImportPathCompiler

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -177,6 +177,16 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
         ];
 
+        yield 'commented_import_on_one_line_then_module_name_on_next_is_not_ok' => [
+            'input' => "// import \n    './other.js';",
+            'expectedJavaScriptImports' => [],
+        ];
+
+        yield 'commented_import_on_one_line_then_import_on_next_is_ok' => [
+            'input' => "// import\nimport { Foo } from './other.js';",
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
         yield 'importing_a_css_file_is_included' => [
             'input' => "import './styles.css';",
             'expectedJavaScriptImports' => ['/assets/styles.css' => ['lazy' => false, 'asset' => 'styles.css', 'add' => true]],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53849
| License       | MIT

The following code was wrongly treated as _one_ line of comment

```js
// import
import "foo.js"
```

This PR updates the regexp to ignore comment lines (and fix #53849)

Also added a comment explaining how the regexp works for future maintenance. 
