### PR TITLE
[Form] Add calendar DateType option

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -44,7 +44,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         ?string $outputTimezone = null,
         ?int $dateFormat = null,
         ?int $timeFormat = null,
-        private int $calendar = \IntlDateFormatter::GREGORIAN,
+        private int|\IntlCalendar $calendar = \IntlDateFormatter::GREGORIAN,
         private ?string $pattern = null,
     ) {
         parent::__construct($inputTimezone, $outputTimezone);

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -49,7 +49,7 @@ class DateType extends AbstractType
     {
         $dateFormat = \is_int($options['format']) ? $options['format'] : self::DEFAULT_FORMAT;
         $timeFormat = \IntlDateFormatter::NONE;
-        $calendar = $options['calendar'] !== null ? $options['calendar'] : \IntlDateFormatter::GREGORIAN;
+        $calendar = null !== $options['calendar'] ? $options['calendar'] : \IntlDateFormatter::GREGORIAN;
         $pattern = \is_string($options['format']) ? $options['format'] : '';
 
         if (!\in_array($dateFormat, self::ACCEPTED_FORMATS, true)) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -49,7 +49,7 @@ class DateType extends AbstractType
     {
         $dateFormat = \is_int($options['format']) ? $options['format'] : self::DEFAULT_FORMAT;
         $timeFormat = \IntlDateFormatter::NONE;
-        $calendar = \IntlDateFormatter::GREGORIAN;
+        $calendar = $options['calendar'] !== null ? $options['calendar'] : \IntlDateFormatter::GREGORIAN;
         $pattern = \is_string($options['format']) ? $options['format'] : '';
 
         if (!\in_array($dateFormat, self::ACCEPTED_FORMATS, true)) {
@@ -281,6 +281,7 @@ class DateType extends AbstractType
             'format' => $format,
             'model_timezone' => null,
             'view_timezone' => null,
+            'calendar' => null,
             'placeholder' => $placeholderDefault,
             'html5' => true,
             // Don't modify \DateTime classes by reference, we treat
@@ -320,6 +321,7 @@ class DateType extends AbstractType
         $resolver->setAllowedTypes('months', 'array');
         $resolver->setAllowedTypes('days', 'array');
         $resolver->setAllowedTypes('input_format', 'string');
+        $resolver->setAllowedTypes('calendar', ['null', \IntlCalendar::class]);
 
         $resolver->setNormalizer('html5', static function (Options $options, $html5) {
             if ($html5 && 'single_text' === $options['widget'] && self::HTML5_FORMAT !== $options['format']) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -185,7 +185,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         $locale = \Locale::getDefault();
         \Locale::setDefault('en_US');
 
-        $pattern = "y-MM-dd Y'w'w";
+        $pattern = "y-MM-dd y'w'w";
         $dateTime = new \DateTimeImmutable('2024-03-31');
 
         $transformer = new DateTimeToLocalizedStringTransformer(
@@ -297,7 +297,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         $locale = \Locale::getDefault();
         \Locale::setDefault('en_US');
 
-        $pattern = "y-MM-dd Y'w'w";
+        $pattern = "y-MM-dd y'w'w";
 
         $transformer = new DateTimeToLocalizedStringTransformer(
             null,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -180,6 +180,44 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         $this->assertEquals($dateTime->format('d.m.Y, H:i'), $transformer->transform($input));
     }
 
+    public function testTransformDateTimeWithCalendar()
+    {
+        $locale = \Locale::getDefault();
+        \Locale::setDefault('en_US');
+
+        $pattern = "y-MM-dd Y'w'w";
+        $dateTime = new \DateTimeImmutable('2024-03-31');
+
+        $transformer = new DateTimeToLocalizedStringTransformer(
+            null,
+            null,
+            null,
+            null,
+            \IntlDateFormatter::GREGORIAN,
+            $pattern,
+        );
+
+        $this->assertEquals('2024-03-31 2024w14', $transformer->transform($dateTime));
+
+        // ISO 8601
+        $calendar = \IntlCalendar::createInstance(null);
+        $calendar->setFirstDayOfWeek(\IntlCalendar::DOW_MONDAY);
+        $calendar->setMinimalDaysInFirstWeek(4);
+
+        $transformer = new DateTimeToLocalizedStringTransformer(
+            null,
+            null,
+            null,
+            null,
+            $calendar,
+            $pattern,
+        );
+
+        $this->assertEquals('2024-03-31 2024w13', $transformer->transform($dateTime));
+
+        \Locale::setDefault($locale);
+    }
+
     public function testTransformRequiresValidDateTime()
     {
         $this->expectException(TransformationFailedException::class);
@@ -252,6 +290,45 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         $dateTime = new \DateTime('2017-01-10 11:00', new \DateTimeZone('Europe/Berlin'));
 
         $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('2017-01-10'));
+    }
+
+    public function testReverseTransformDateTimeWithCalendar()
+    {
+        $locale = \Locale::getDefault();
+        \Locale::setDefault('en_US');
+
+        $pattern = "y-MM-dd Y'w'w";
+
+        $transformer = new DateTimeToLocalizedStringTransformer(
+            null,
+            null,
+            null,
+            null,
+            \IntlDateFormatter::GREGORIAN,
+            $pattern,
+        );
+
+        $dateTime = new \DateTime('2024-03-31');
+        $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('2024-03-31 2024w14'));
+
+        // ISO 8601
+        $calendar = \IntlCalendar::createInstance(null);
+        $calendar->setFirstDayOfWeek(\IntlCalendar::DOW_MONDAY);
+        $calendar->setMinimalDaysInFirstWeek(4);
+
+        $transformer = new DateTimeToLocalizedStringTransformer(
+            null,
+            null,
+            null,
+            null,
+            $calendar,
+            $pattern,
+        );
+
+        $dateTime = new \DateTime('2024-03-31');
+        $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('2024-03-31 2024w13'));
+
+        \Locale::setDefault($locale);
     }
 
     public function testReverseTransformWithDifferentPatterns()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -395,6 +395,54 @@ class DateTypeTest extends BaseTypeTestCase
         $this->assertEquals('06*2010*02', $form->getViewData());
     }
 
+    public function testSubmitWithCalendarOption()
+    {
+        // we test against "en_US", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('en_US');
+        
+        $format = "y-MM-dd y'w'w";
+
+        $output = [
+            'day' => '31',
+            'month' => '3',
+            'year' => '2024',
+        ];
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'format' => $format,
+            'html5' => false,
+            'widget' => 'single_text',
+            'input' => 'array',
+        ]);
+
+        $form->submit('2024-03-31 2024w14');
+
+        $this->assertEquals($output, $form->getData());
+        $this->assertEquals('2024-03-31 2024w14', $form->getViewData());
+    
+        // ISO 8601
+        $calendar = \IntlCalendar::createInstance();
+        $calendar->setFirstDayOfWeek(\IntlCalendar::DOW_MONDAY);
+        $calendar->setMinimalDaysInFirstWeek(4);
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'format' => $format,
+            'html5' => false,
+            'widget' => 'single_text',
+            'input' => 'array',
+            'calendar' => $calendar,
+        ]);
+
+        $form->submit('2024-03-31 2024w13');
+
+        $this->assertEquals($output, $form->getData());
+        $this->assertEquals('2024-03-31 2024w13', $form->getViewData());
+    }
+
     /**
      * @dataProvider provideDateFormats
      */
@@ -521,6 +569,45 @@ class DateTypeTest extends BaseTypeTestCase
         // 2010-06-02 00:00:00 UTC
         // 2010-06-01 20:00:00 UTC-4
         $this->assertEquals('01.06.2010', $form->getViewData());
+    }
+
+    public function testSetDataWithCalendarInput()
+    {
+        // we test against "en_US", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('en_US');
+
+        $format = "y-MM-dd Y'w'w";
+        $date = '2024-03-31';
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'format' => $format,
+            'html5' => false,
+            'input' => 'string',
+            'widget' => 'single_text',
+        ]);
+
+        $form->setData($date);
+
+        $this->assertEquals('2024-03-31 2024w14', $form->getViewData());
+
+        // ISO 8601
+        $calendar = \IntlCalendar::createInstance(null);
+        $calendar->setFirstDayOfWeek(\IntlCalendar::DOW_MONDAY);
+        $calendar->setMinimalDaysInFirstWeek(4);
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'format' => $format,
+            'html5' => false,
+            'input' => 'string',
+            'widget' => 'single_text',
+            'calendar' => $calendar,
+        ]);
+
+        $form->setData($date);
+
+        $this->assertEquals('2024-03-31 2024w13', $form->getViewData());
     }
 
     public function testSetDataWithNegativeTimezoneOffsetDateTimeInput()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -401,7 +401,7 @@ class DateTypeTest extends BaseTypeTestCase
         IntlTestHelper::requireFullIntl($this, false);
 
         \Locale::setDefault('en_US');
-        
+
         $format = "y-MM-dd y'w'w";
 
         $output = [
@@ -423,7 +423,7 @@ class DateTypeTest extends BaseTypeTestCase
 
         $this->assertEquals($output, $form->getData());
         $this->assertEquals('2024-03-31 2024w14', $form->getViewData());
-    
+
         // ISO 8601
         $calendar = \IntlCalendar::createInstance();
         $calendar->setFirstDayOfWeek(\IntlCalendar::DOW_MONDAY);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53894
| License       | MIT

Recently I required to render DateType in format with week of year [1] (week 13 of year 2024: `2024-03-31 2024w13`) with independent `IntlCalendar` specification than provided from currently set `Locale`.

For example when project (default) locale is `en_US` (`en`). But you need to output in "European's format" it is not possible with current implementation. You would get `2024-03-31 2024w14`, because first day of week configuration is taken from currently set locale.

This pull request adds `calendar` option to `DateType`.

```php
$calendar = \IntlCalendar::createInstance();
$calendar->setFirstDayOfWeek(\IntlCalendar::DOW_MONDAY);
$calendar->setMinimalDaysInFirstWeek(4);

$form->add('with_week', DateType::class, [
    'format' => "y-MM-dd y'w'w",
    'calendar' => $calendar,          
]);
```

[1] https://unicode.org/reports/tr35/tr35-dates.html#Date_Patterns_Week_Of_Year