### PR TITLE
[Serializer] Add context for `CamelCaseToSnakeCaseNameConverter`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
+use Symfony\Component\Serializer\Exception\UnexpectedPropertyException;
 use Symfony\Component\Serializer\Exception\UnsupportedFormatException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -197,6 +198,8 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             throw new UnsupportedMediaTypeHttpException(sprintf('Unsupported format: "%s".', $format), $e);
         } catch (NotEncodableValueException $e) {
             throw new BadRequestHttpException(sprintf('Request payload contains invalid "%s" data.', $format), $e);
+        } catch (UnexpectedPropertyException $e) {
+            throw new BadRequestHttpException(sprintf('Request payload contains invalid "%s" property.', $e->property), $e);
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Exception/UnexpectedPropertyException.php
+++ b/src/Symfony/Component/Serializer/Exception/UnexpectedPropertyException.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * UnexpectedPropertyException.
+ *
+ * @author Aurélien Pillevesse <aurelienpillevesse@hotmail.fr>
+ */
+class UnexpectedPropertyException extends \UnexpectedValueException implements ExceptionInterface
+{
+    public function __construct(
+        public readonly string $property,
+        ?\Throwable $previous = null,
+    ) {
+        $msg = sprintf('Property is not allowed ("%s" is unknown).', $this->property);
+
+        parent::__construct($msg, 0, $previous);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
@@ -12,11 +12,13 @@
 namespace Symfony\Component\Serializer\Tests\NameConverter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\UnexpectedPropertyException;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Aurélien Pillevesse <aurelienpillevesse@hotmail.fr>
  */
 class CamelCaseToSnakeCaseNameConverterTest extends TestCase
 {
@@ -54,5 +56,21 @@ class CamelCaseToSnakeCaseNameConverterTest extends TestCase
             ['_kevin_dunglas', '_kevinDunglas', false],
             ['this_is_a_test', 'ThisIsATest', false],
         ];
+    }
+
+    public function testDenormalizeWithContext()
+    {
+        $nameConverter = new CamelCaseToSnakeCaseNameConverter(null, true);
+        $denormalizedValue = $nameConverter->denormalize('last_name', context: [CamelCaseToSnakeCaseNameConverter::REQUIRE_SNAKE_CASE_PROPERTIES]);
+
+        $this->assertSame($denormalizedValue, 'lastName');
+    }
+
+    public function testErrorDenormalizeWithContext()
+    {
+        $nameConverter = new CamelCaseToSnakeCaseNameConverter(null, true);
+
+        $this->expectException(UnexpectedPropertyException::class);
+        $nameConverter->denormalize('lastName', context: [CamelCaseToSnakeCaseNameConverter::REQUIRE_SNAKE_CASE_PROPERTIES => true]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

Currently, when we use a Symfony 7.0 project (or 6.4 for example) with the `symfony/serializer` component installed.

With the `#[MapRequestPayload]` feature and this configuration : 
```yaml
framework:
    serializer:
        name_converter: 'serializer.name_converter.camel_case_to_snake_case'
```

This configuration forces Symfony to return to the snake case format. 
But when sending these two `POST` requests : 
```json
{
    "lastName": "MyLastName"
}
```

```json
{
    "last_name": "MyLastName"
}
```
They will be handled exactly the same.

The idea is to add a context `CamelCaseToSnakeCaseNameConverter::REQUIRE_SNAKE_CASE_PROPERTIES` which can be used in `#[MapRequestPayload]` attribute to only accept the `POST` request with `last_name` attribute body.

Example : 
```php
class MyRouteInput
{
    public string $lastName;
}

#[MapRequestPayload(serializationContext: [CamelCaseToSnakeCaseNameConverter::REQUIRE_SNAKE_CASE_PROPERTIES => true])]
MyRouteInput $input
```

**[Note]**
This is a first draft to expose my idea. The exception thrown and where the new condition is added can probably be improved.
A possible improvement can be to use the existing logic with `PartialDenormalizationException`.
If for you it can added in 6.4 and 7.0 instead of 7.1, i'm OK.

