### PR TITLE
[Mailer] [Amazon] Add support for X-SES-LIST-MANAGEMENT-OPTIONS header

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+* Add support for `X-SES-LIST-MANAGEMENT-OPTIONS`
+
 6.1
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -91,6 +91,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             $this->assertSame('aws-source-arn', $content['FromEmailAddressIdentityArn']);
             $this->assertSame('bounces@example.com', $content['FeedbackForwardingEmailAddress']);
             $this->assertSame([['Name' => 'tagName1', 'Value' => 'tag Value1'], ['Name' => 'tagName2', 'Value' => 'tag Value2']], $content['EmailTags']);
+            $this->assertSame(['ContactListName' => 'TestContactList', 'TopicName' => 'TestNewsletter'], $content['ListManagementOptions']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -113,6 +114,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
         $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
+        $mail->getHeaders()->addTextHeader('X-SES-LIST-MANAGEMENT-OPTIONS', 'contactListName=TestContactList;topicName=TestNewsletter');
         $mail->getHeaders()->add(new MetadataHeader('tagName1', 'tag Value1'));
         $mail->getHeaders()->add(new MetadataHeader('tagName2', 'tag Value2'));
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -88,6 +88,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             $this->assertSame('aws-configuration-set-name', $body['ConfigurationSetName']);
             $this->assertSame('aws-source-arn', $body['FromEmailAddressIdentityArn']);
             $this->assertSame([['Name' => 'tagName1', 'Value' => 'tag Value1'], ['Name' => 'tagName2', 'Value' => 'tag Value2']], $body['EmailTags']);
+            $this->assertSame(['ContactListName' => 'TestContactList', 'TopicName' => 'TestNewsletter'], $body['ListManagementOptions']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -106,6 +107,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
         $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
+        $mail->getHeaders()->addTextHeader('X-SES-LIST-MANAGEMENT-OPTIONS', 'contactListName=TestContactList;topicName=TestNewsletter');
         $mail->getHeaders()->add(new MetadataHeader('tagName1', 'tag Value1'));
         $mail->getHeaders()->add(new MetadataHeader('tagName2', 'tag Value2'));
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -98,6 +98,11 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
         if ($header = $email->getHeaders()->get('X-SES-SOURCE-ARN')) {
             $request['FromEmailAddressIdentityArn'] = $header->getBodyAsString();
         }
+        if ($header = $email->getHeaders()->get('X-SES-LIST-MANAGEMENT-OPTIONS')) {
+            if (preg_match("/^(contactListName=)*(?<ContactListName>[^;]+)(;\s?topicName=(?<TopicName>.+))?$/ix", $header->getBodyAsString(), $listManagementOptions)) {
+                $request['ListManagementOptions'] = array_filter($listManagementOptions, fn ($e) => \in_array($e, ['ContactListName', 'TopicName']), \ARRAY_FILTER_USE_KEY);
+            }
+        }
         if ($email->getReturnPath()) {
             $request['FeedbackForwardingEmailAddress'] = $email->getReturnPath()->toString();
         }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -78,16 +78,20 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
             ],
         ];
 
-        if (($message->getOriginalMessage() instanceof Message)
-            && $configurationSetHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-CONFIGURATION-SET')) {
-            $request['ConfigurationSetName'] = $configurationSetHeader->getBodyAsString();
-        }
-        if (($message->getOriginalMessage() instanceof Message)
-            && $sourceArnHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-SOURCE-ARN')) {
-            $request['FromEmailAddressIdentityArn'] = $sourceArnHeader->getBodyAsString();
-        }
-        if ($message->getOriginalMessage() instanceof Message) {
-            foreach ($message->getOriginalMessage()->getHeaders()->all() as $header) {
+        $originalMessage = $message->getOriginalMessage();
+        if ($originalMessage instanceof Message) {
+            if ($configurationSetHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-CONFIGURATION-SET')) {
+                $request['ConfigurationSetName'] = $configurationSetHeader->getBodyAsString();
+            }
+            if ($sourceArnHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-SOURCE-ARN')) {
+                $request['FromEmailAddressIdentityArn'] = $sourceArnHeader->getBodyAsString();
+            }
+            if ($header = $message->getOriginalMessage()->getHeaders()->get('X-SES-LIST-MANAGEMENT-OPTIONS')) {
+                if (preg_match("/^(contactListName=)*(?<ContactListName>[^;]+)(;\s?topicName=(?<TopicName>.+))?$/ix", $header->getBodyAsString(), $listManagementOptions)) {
+                    $request['ListManagementOptions'] = array_filter($listManagementOptions, fn ($e) => \in_array($e, ['ContactListName', 'TopicName']), \ARRAY_FILTER_USE_KEY);
+                }
+            }
+            foreach ($originalMessage->getHeaders()->all() as $header) {
                 if ($header instanceof MetadataHeader) {
                     $request['EmailTags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
                 }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "async-aws/ses": "^1.0",
+        "async-aws/ses": "^1.3",
         "symfony/mailer": "^6.4|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| License       | MIT

Add Support for AWS SES List Management Feature
SES will provide the following features:

- adds Unsubscribe-Headers
- replaces {{amazonSESUnsubscribeUrl}} placeholder with an one-click unsubscribe link in mail body
- prevent sending mails to unsubscribed contacts (optional for a specific topic only)
- ref: https://docs.aws.amazon.com/ses/latest/dg/sending-email-subscription-management.html

Use:

- follow the AWS instructions to create a contact list
- optional: add a topic to the list
- `RawMessage->addTextHeader('X-SES-LIST-MANAGEMENT-OPTIONS','contactListName=MyListName;topicName=MyNewsletter')
`