### PR TITLE
[VarDumper] Fix serialization of stubs with null or uninitialized values

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/Internal/NoDefault.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Internal/NoDefault.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Cloner\Internal;
+
+/**
+ * Flags a typed property that has no default value.
+ *
+ * This dummy object is used to distinguish a property with a default value of null
+ * from a property that is uninitialized by default.
+ *
+ * @internal
+ */
+enum NoDefault
+{
+    case NoDefault;
+}

--- a/src/Symfony/Component/VarDumper/Tests/Cloner/StubTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Cloner/StubTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Cloner;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+final class StubTest extends TestCase
+{
+    public function testUnserializeNullValue()
+    {
+        $stub = new Stub();
+        $stub->value = null;
+
+        $stub = unserialize(serialize($stub));
+
+        self::assertNull($stub->value);
+    }
+
+    public function testUnserializeNullInTypedProperty()
+    {
+        $stub = new MyStub();
+        $stub->myProp = null;
+
+        $stub = unserialize(serialize($stub));
+
+        self::assertNull($stub->myProp);
+    }
+
+    public function testUninitializedStubPropertiesAreLeftUninitialized()
+    {
+        $stub = new MyStub();
+
+        $stub = unserialize(serialize($stub));
+
+        $r = new \ReflectionProperty(MyStub::class, 'myProp');
+        self::assertFalse($r->isInitialized($stub));
+    }
+}
+
+final class MyStub extends Stub
+{
+    public mixed $myProp;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53905
| License       | MIT

The`Stub::__sleep()` implementation excludes properties from the serialized representation that are set to their defaults, but it cannot tell apart properties with a null value from properties that don't have a default. This is an issue for typed properties that are uninitialized by default.