### PR TITLE
[FrameworkBundle] Mark AbstractDataCollector::getName as final

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -16,6 +16,7 @@ FrameworkBundle
 ---------------
 
  * Mark classes `ConfigBuilderCacheWarmer`, `Router`, `SerializerCacheWarmer`, `TranslationsCacheWarmer`, `Translator` and `ValidatorCacheWarmer` as `final`
+ * Subclasses of `AbstractDataCollector` should not override `getName`
 
 Messenger
 ---------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `rate_limiter` tags to rate limiter services
  * Add `secrets:reveal` command
  * Add `rate_limiter` option to `http_client.default_options` and `http_client.scoped_clients`
+ * Mark `AbstractDataCollector::getName()` as `final`
 
 7.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/AbstractDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/AbstractDataCollector.php
@@ -18,6 +18,9 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
  */
 abstract class AbstractDataCollector extends DataCollector implements TemplateAwareDataCollectorInterface
 {
+    /**
+     * @final since Symfony 7.1
+     */
     public function getName(): string
     {
         return static::class;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | 
| License       | MIT

Since the name of a data collector, defined in a project, cannot be anything else than the class name (cf  https://github.com/symfony/symfony/blob/ba614efabe5dbbdce071a69ec68a1cc891069336/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ProfilerPass.php#L43), the `getName` method should not be overridden. 