### PR TITLE
[Process] Fix failing tests causing segfaults

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1570,7 +1570,7 @@ class ProcessTest extends TestCase
      */
     public function testLongRunningProcessWithMultipleCallsToProcGetStatus()
     {
-        $process = $this->getProcess('php -r "sleep(1); echo \'done\';"');
+        $process = $this->getProcess('sleep 1 && echo "done" && php -r "exit(0);"');
         $process->start(static function () use ($process) {
             return $process->isRunning();
         });
@@ -1585,7 +1585,7 @@ class ProcessTest extends TestCase
      */
     public function testLongRunningProcessWithMultipleCallsToProcGetStatusError()
     {
-        $process = $this->getProcess('php -r "sleep(1); echo \'failure\'; exit(123);"');
+        $process = $this->getProcess('sleep 1 && echo "failure" && php -r "exit(123);"');
         $process->start(static function () use ($process) {
             return $process->isRunning();
         });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix tests
| License       | MIT

[This PR](https://github.com/symfony/symfony/pull/53821) introduces some code that [triggers segfaults](https://github.com/symfony/symfony/actions/runs/7870905388/job/21473073396) in newer branches (7.x especially). We can achieve the same goal by using some bash script which is lighter and avoid the segfaults. I first tried this fix on 7.x and solved the issue (that does not happen on older branches).