### PR TITLE
[Messenger] Fix SQS visibility_timeout type

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -129,7 +129,7 @@ class Connection
             'buffer_size' => (int) $options['buffer_size'],
             'wait_time' => (int) $options['wait_time'],
             'poll_timeout' => $options['poll_timeout'],
-            'visibility_timeout' => $options['visibility_timeout'],
+            'visibility_timeout' => null !== $options['visibility_timeout'] ? (int) $options['visibility_timeout'] : null,
             'auto_setup' => filter_var($options['auto_setup'], \FILTER_VALIDATE_BOOLEAN),
             'queue_name' => (string) $options['queue_name'],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Introduced in #53524
| License       | MIT

Getting an error after `composer update`:

```
Error thrown while running command "messenger:consume -- async". Message: "HTTP 400 returned for "https://sqs.eu-west-1.amazonaws.com/)".

Code:    SerializationException
Message: STRING_VALUE can not be converted to an Integer
Type:    
Detail:  "
```

`async-aws/sqs` v2 is using JSON instead of `x-www-form-urlencoded` so now all of the sudden, types do matter. If you set `visibility_timeout` in the DSN, it will be sent as a string to SQS – so we need to cast it explicitly.