### PR TITLE
[HttpKernel] Make ArgumentResolver write to Request->attributes

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/ArgumentValueResolver/PsrServerRequestResolverTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/ArgumentValueResolver/PsrServerRequestResolverTest.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 
@@ -28,6 +29,7 @@ final class PsrServerRequestResolverTest extends TestCase
     public function testServerRequest()
     {
         $symfonyRequest = $this->createMock(Request::class);
+        $symfonyRequest->attributes = new ParameterBag();
         $psrRequest = $this->createMock(ServerRequestInterface::class);
 
         $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);
@@ -38,6 +40,8 @@ final class PsrServerRequestResolverTest extends TestCase
     public function testRequest()
     {
         $symfonyRequest = $this->createMock(Request::class);
+
+        $symfonyRequest->attributes = new ParameterBag();
         $psrRequest = $this->createMock(ServerRequestInterface::class);
 
         $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);
@@ -48,6 +52,8 @@ final class PsrServerRequestResolverTest extends TestCase
     public function testMessage()
     {
         $symfonyRequest = $this->createMock(Request::class);
+
+        $symfonyRequest->attributes = new ParameterBag();
         $psrRequest = $this->createMock(ServerRequestInterface::class);
 
         $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add method `isKernelTerminating()` to `ExceptionEvent` that allows to check if an exception was thrown while the kernel is being terminated
  * Add `HttpException::fromStatusCode()`
  * Add `$validationFailedStatusCode` argument to `#[MapQueryParameter]` that allows setting a custom HTTP status code when validation fails
+ * `ArgumentResolver` will add resolved values to the Request attributes
 
 7.0
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -87,6 +87,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
                 foreach ($resolver->resolve($request, $metadata) as $argument) {
                     ++$count;
                     $arguments[] = $argument;
+                    $request->attributes->set($metadata->getName(), $argument);
                 }
 
                 if (1 < $count && !$metadata->isVariadic()) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -56,6 +56,23 @@ class ArgumentResolverTest extends TestCase
         $this->assertEquals(['foo'], self::getResolver()->getArguments($request, $controller), '->getArguments() returns an array of arguments for the controller method');
     }
 
+    public function testResolvedValueIsAddedToRequestAttributes()
+    {
+        $request = Request::create('/');
+        $controller = [new ArgumentResolverTestController(), 'controllerWithFoo'];
+
+        $customResolver = new class() implements ValueResolverInterface {
+            public function resolve(Request $request, ArgumentMetadata $argument): iterable
+            {
+                return ['some_value'];
+            }
+        };
+        $output = self::getResolver([$customResolver])->getArguments($request, $controller);
+        $this->assertEquals(['some_value'], $output);
+        $this->assertTrue($request->attributes->has('foo'), 'Resolved value is added to request attributes');
+        $this->assertEquals('some_value', $request->attributes->get('foo'), 'Resolved value is added to request attributes');
+    }
+
     public function testGetArgumentsReturnsEmptyArrayWhenNoArguments()
     {
         $request = Request::create('/');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I am migrating an app from ParamConverter to use ArgumentResolver. But I do find an issue. Some of my ParamConverters have a dependency between each other. 

Ie, I have a controller with two values `$a` and `$b`. To properly resolve `$b`, I do need to access value `$a`. As far as I can tell this scenario is not supported, but it was supported with ParamConverter. 

This PR will use the same "trick" as ParamConverter to make sure different "resolve processes" can share data. 