### PR TITLE
[TwigBridge] foundation 5 layout: use form_label_content block for checkbox and radio labels

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -269,7 +269,9 @@
     {% endif %}
     <label{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
         {{ widget|raw }}
-        {{ translation_domain is same as(false) ? label : label|trans(label_translation_parameters, translation_domain) }}
+        {%- if label is not same as(false) -%}
+            {{- block('form_label_content') -}}
+        {%- endif -%}
     </label>
 {%- endblock checkbox_radio_label %}
 


### PR DESCRIPTION
…dio labels

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53925 
| License       | MIT

[Twig Bridge] Foundation5 Form Layout

use the block `form_label_content` to display the label content of checkboxes and radios in order to support the `label_html` flag
