### PR TITLE
[HtmlSanitizer] Fix fetching data in `W3CReferenceTest` on AppVeyor

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/Reference/W3CReferenceTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/Reference/W3CReferenceTest.php
@@ -36,7 +36,7 @@ class W3CReferenceTest extends TestCase
         sort($referenceElements);
 
         $this->assertSame(
-            json_decode(file_get_contents(self::STANDARD_RESOURCES['elements']), true, 512, \JSON_THROW_ON_ERROR),
+            $this->getResourceData(self::STANDARD_RESOURCES['elements']),
             $referenceElements
         );
     }
@@ -48,8 +48,18 @@ class W3CReferenceTest extends TestCase
         }
 
         $this->assertSame(
-            json_decode(file_get_contents(self::STANDARD_RESOURCES['attributes']), true, 512, \JSON_THROW_ON_ERROR),
+            $this->getResourceData(self::STANDARD_RESOURCES['attributes']),
             array_keys(W3CReference::ATTRIBUTES)
+        );
+    }
+
+    private function getResourceData(string $resource): array
+    {
+        return json_decode(
+            file_get_contents($resource, false, stream_context_create(['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]])),
+            true,
+            512,
+            \JSON_THROW_ON_ERROR
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Fix for issue on AppVeyor:
```
PHPUnit 9.6.16 by Sebastian Bergmann and contributors.
Testing C:\projects\symfony\src\Symfony\Component\HtmlSanitizer
E.
Time: 00:28.765, Memory: 4.00 MB
There was 1 error:
1) Symfony\Component\HtmlSanitizer\Tests\Reference\W3CReferenceTest::testElements
file_get_contents(): SSL operation failed with code 1. OpenSSL Error messages:
error:0A000086:SSL routines::certificate verify failed
C:\projects\symfony\src\Symfony\Component\HtmlSanitizer\Tests\Reference\W3CReferenceTest.php:39
ERRORS!
```

Working tests on AppVeyor (seems like PR has not the latest linked): https://ci.appveyor.com/project/fabpot/symfony/builds/49178473

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
