### PR TITLE
[Form] Throw error if the number is too high on moneyTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -69,7 +69,16 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
         $value = parent::reverseTransform($value);
         if (null !== $value && 1 !== $this->divisor) {
             $value = (string) ($value * $this->divisor);
-            $value = 'integer' === $this->modelType ? (int) $value : (float) $value;
+
+            if ('float' === $this->modelType) {
+                return (float) $value;
+            }
+
+            if ($value > \PHP_INT_MAX || $value < \PHP_INT_MIN) {
+                throw new TransformationFailedException(sprintf("The value '%d' is too large you should pass the 'model_type' to 'float'.", $value));
+            }
+
+            $value = (int) $value;
         }
 
         return $value;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -118,4 +118,13 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         $this->assertSame('0,0035', $transformer->transform(12 / 34));
     }
+
+    public function testHighIntNumberConversion()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer(4, null, null, 100);
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(111111111111111110.00);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53929 
| License       | MIT

The `MoneyType` does not handle high numbers when using `'model_type' => 'integer` this leads to unexpected results :

Inputing for instance `111111111111111110,00` gets cast back to `9223372036854775807`.

I have added a verification with `\PHP_INT_MAX` to throw an error in such case
I'm not sure if this is the best approach.