### PR TITLE
[Mailer] Simplify fix

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -125,7 +125,7 @@
                                                         {# Email instance #}
                                                         <h2 class="m-t-10">{{ message.getSubject() ?? '(empty)' }}</h2>
                                                     {% elseif message.headers.has('subject') %}
-                                                        <h2 class="m-t-10">{{ message.headers.get('subject').toString()|split(': ', 2)[1]|default('(empty)') }}</h2>
+                                                        <h2 class="m-t-10">{{ message.headers.get('subject').bodyAsString()|default('(empty)') }}</h2>
                                                     {% else %}
                                                         <h2 class="m-t-10">(empty)</h2>
                                                     {% endif %}
@@ -136,7 +136,7 @@
                                                                 {# Email instance #}
                                                                 <pre class="prewrap">{{ message.getFrom()|map(addr => addr.toString())|join(', ')|default('(empty)') }}</pre>
                                                             {% elseif message.headers.has('from') %}
-                                                                <pre class="prewrap">{{ message.headers.get('from').toString()|split(': ', 2)[1]|default('(empty)') }}</pre>
+                                                                <pre class="prewrap">{{ message.headers.get('from').bodyAsString()|default('(empty)') }}</pre>
                                                             {% else %}
                                                                 <pre class="prewrap">(empty)</pre>
                                                             {% endif %}
@@ -146,7 +146,7 @@
                                                                 {# Email instance #}
                                                                 <pre class="prewrap">{{ message.getTo()|map(addr => addr.toString())|join(', ')|default('(empty)') }}</pre>
                                                             {% elseif message.headers.has('to') %}
-                                                                <pre class="prewrap">{{ message.headers.get('to').toString()|split(': ', 2)[1]|default('(empty)') }}</pre>
+                                                                <pre class="prewrap">{{ message.headers.get('to').bodyAsString()|default('(empty)') }}</pre>
                                                             {% else %}
                                                                 <pre class="prewrap">(empty)</pre>
                                                             {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #53934, I didn't notice the `getBodyAsString()` method, it simplifies the code nicely.

For 6.4+: https://github.com/HypeMC/symfony/commit/1bb254d7d281c20f4b87c9fc7e17cfb2c4eb6b61

```diff
diff --git a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
index a0d2d6388b..e220e73d4b 100644
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -282,7 +282,7 @@
                                         {% if event.message.subject is defined %}
                                             {{ event.message.getSubject() ?? '(No subject)' }}
                                         {% elseif event.message.headers.has('subject') %}
-                                            {{ event.message.headers.get('subject').toString()|split(': ', 2)[1]|default('(No subject)') }}
+                                            {{ event.message.headers.get('subject').bodyAsString()|default('(No subject)') }}
                                         {% else %}
                                             (No subject)
                                         {% endif %}
@@ -291,7 +291,7 @@
                                         {% if event.message.to is defined %}
                                             {{ event.message.getTo()|map(addr => addr.toString())|join(', ')|default('(empty)') }}
                                         {% elseif event.message.headers.has('to') %}
-                                            {{ event.message.headers.get('to').toString()|split(': ', 2)[1]|default('(empty)') }}
+                                            {{ event.message.headers.get('to').bodyAsString()|default('(empty)') }}
                                         {% else %}
                                             (empty)
                                         {% endif %}
@@ -342,7 +342,7 @@
                                 {% if message.subject is defined %}
                                     {{ message.getSubject() ?? '(No subject)' }}
                                 {% elseif message.headers.has('subject') %}
-                                    {{ message.headers.get('subject').toString()|split(': ', 2)[1]|default('(No subject)') }}
+                                    {{ message.headers.get('subject').bodyAsString()|default('(No subject)') }}
                                 {% else %}
                                     (No subject)
                                 {% endif %}
@@ -353,7 +353,7 @@
                                     {% if message.from is defined %}
                                         {{ message.getFrom()|map(addr => addr.toString())|join(', ')|default('(empty)') }}
                                     {% elseif message.headers.has('from') %}
-                                        {{ message.headers.get('from').toString()|split(': ', 2)[1]|default('(empty)') }}
+                                        {{ message.headers.get('from').bodyAsString()|default('(empty)') }}
                                     {% else %}
                                         (empty)
                                     {% endif %}
@@ -363,7 +363,7 @@
                                     {% if message.to is defined %}
                                         {{ message.getTo()|map(addr => addr.toString())|join(', ')|default('(empty)') }}
                                     {% elseif message.headers.has('to') %}
-                                        {{ message.headers.get('to').toString()|split(': ', 2)[1]|default('(empty)') }}
+                                        {{ message.headers.get('to').bodyAsString()|default('(empty)') }}
                                     {% else %}
                                         (empty)
                                     {% endif %}
```