### PR TITLE
[Serializer] Fix unknown types normalization type when know type

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -410,10 +410,16 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         continue;
                     }
 
+                    $constructorParameterType = 'unknown';
+                    $reflectionType = $constructorParameter->getType();
+                    if ($reflectionType instanceof \ReflectionNamedType) {
+                        $constructorParameterType = $reflectionType->getName();
+                    }
+
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(
                         sprintf('Failed to create object because the class misses the "%s" property.', $constructorParameter->name),
                         $data,
-                        ['unknown'],
+                        [$constructorParameterType],
                         $context['deserialization_path'],
                         true
                     );

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1308,7 +1308,7 @@ class SerializerTest extends TestCase
             [
                 'currentType' => 'array',
                 'expectedTypes' => [
-                    'unknown',
+                    'string',
                 ],
                 'path' => 'string',
                 'useMessageForUser' => true,
@@ -1317,7 +1317,7 @@ class SerializerTest extends TestCase
             [
                 'currentType' => 'array',
                 'expectedTypes' => [
-                    'unknown',
+                    'int',
                 ],
                 'path' => 'int',
                 'useMessageForUser' => true,
@@ -1548,7 +1548,7 @@ class SerializerTest extends TestCase
             [
                 'currentType' => 'array',
                 'expectedTypes' => [
-                    'unknown',
+                    'string',
                 ],
                 'path' => 'two',
                 'useMessageForUser' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When we use the normalizer with Promotion Constructor, a Non Normalizable Value Exception occurs with unknown type even when the type is known. This Pull request fix this error.

Previously, a PR #53945 was proposed for extraction, in which @mtarld asked to change the target branch to 5.4