### PR TITLE
[ErrorHandler] return the unchanged text if preg_replace_callback() fails

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -329,7 +329,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     {
         return preg_replace_callback('/in ("|&quot;)?(.+?)\1(?: +(?:on|at))? +line (\d+)/s', function ($match) {
             return 'in '.$this->formatFile($match[2], $match[3]);
-        }, $text);
+        }, $text) ?? $text;
     }
 
     private function formatLogMessage(string $message, array $context)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51290
| License       | MIT
