### PR TITLE
[Mailer] include message id provided by the MTA when dispatching the `SentMessageEvent`

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/DummyStream.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/DummyStream.php
@@ -77,7 +77,7 @@ class DummyStream extends AbstractStream
         } elseif (str_starts_with($bytes, 'QUIT')) {
             $this->nextResponse = '221 Goodbye';
         } else {
-            $this->nextResponse = '250 OK';
+            $this->nextResponse = '250 OK queued as 000501c4054c';
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52515
| License       | MIT