### PR TITLE
Cast env vars to null or bool when referencing them using `#[Autowire(env: '...')]` depending on the signature of the corresponding parameter

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Make `ContainerBuilder::registerAttributeForAutoconfiguration()` propagate to attribute classes that extend the registered class
  * Add argument `$prepend` to `FileLoader::construct()` to prepend loaded configuration instead of appending it
  * [BC BREAK] When used in the `prependExtension()` method, the `ContainerConfigurator::import()` method now prepends the configuration instead of appending it
+ * Cast env vars to null or bool when referencing them using `#[Autowire(env: '...')]` depending on the signature of the corresponding parameter
 
 7.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1397,4 +1397,18 @@ class AutowirePassTest extends TestCase
             $this->assertSame('Using both attributes #[Lazy] and #[Autowire] on an argument is not allowed; use the "lazy" parameter of #[Autowire] instead.', $e->getMessage());
         }
     }
+
+    public function testAutowireAttributeWithEnvVar()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', AutowireAttributeEnv::class)->setAutowired(true);
+
+        (new AutowirePass())->process($container);
+
+        $definition = $container->getDefinition('foo');
+
+        $this->assertSame('%env(bool:ENABLED)%', $container->resolveEnvPlaceholders($definition->getArguments()[0]));
+        $this->assertSame('%env(default::OPTIONAL)%', $container->resolveEnvPlaceholders($definition->getArguments()[1]));
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -81,6 +81,17 @@ class AutowireAttributeNullFallback
     }
 }
 
+class AutowireAttributeEnv
+{
+    public function __construct(
+        #[Autowire(env: 'ENABLED')]
+        public bool $enabled,
+        #[Autowire(env: 'OPTIONAL')]
+        public ?string $optional = null,
+    ) {
+    }
+}
+
 interface AsDecoratorInterface
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53918
| License       | MIT

See https://github.com/symfony/symfony/issues/53918

This PR automatically adds `bool` [Environment Variable Processors](https://symfony.com/doc/current/configuration/env_var_processors.html#built-in-environment-variable-processors) on `#[Autowire(env: 'KEY')] bool $key` arguments. 

The idea behind this, is to prevent mistakes being made. If you omit the `bool` env var processor, passing `KEY=false` will become true-ish and thus mark `$key` as `true`. 

With the `bool` env processor, `KEY=false` becomes `false`.

It also automatically adds the `default::` prefix if the default value of an argument is `null`.