### PR TITLE
[Uid] Minor updates

### DIFF
--- a/src/Symfony/Component/Uid/Command/InspectUuidCommand.php
+++ b/src/Symfony/Component/Uid/Command/InspectUuidCommand.php
@@ -49,7 +49,6 @@ EOF
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
 
         try {
-            /** @var Uuid $uuid */
             $uuid = Uuid::fromString($input->getArgument('uuid'));
         } catch (\InvalidArgumentException $e) {
             $io->error($e->getMessage());
@@ -62,7 +61,7 @@ EOF
         } elseif (new MaxUuid() == $uuid) {
             $version = 'max';
         } else {
-            $version = uuid_type($uuid);
+            $version = hexdec($uuid->toRfc4122()[14]);
         }
 
         $rows = [

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -59,7 +59,7 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
     public static function fromString(string $ulid): static
     {
         if (36 === \strlen($ulid) && preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$}Di', $ulid)) {
-            $ulid = uuid_parse($ulid);
+            $ulid = hex2bin(str_replace('-', '', $ulid));
         } elseif (22 === \strlen($ulid) && 22 === strspn($ulid, BinaryUtil::BASE58[''])) {
             $ulid = str_pad(BinaryUtil::fromBase($ulid, BinaryUtil::BASE58), 16, "\0", \STR_PAD_LEFT);
         }

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -149,7 +149,7 @@ class Uuid extends AbstractUid
 
     public function toBinary(): string
     {
-        return uuid_parse($this->uid);
+        return hex2bin(str_replace('-', '', $this->uid));
     }
 
     /**

--- a/src/Symfony/Component/Uid/UuidV1.php
+++ b/src/Symfony/Component/Uid/UuidV1.php
@@ -38,7 +38,7 @@ class UuidV1 extends Uuid implements TimeBasedUidInterface
 
     public function getNode(): string
     {
-        return uuid_mac($this->uid);
+        return substr($this->uid, -12);
     }
 
     public function toV6(): UuidV6


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #
| License       | MIT

Some minor things i found while [playing with UuidV4](https://github.com/symfony/symfony/pull/53963).

In those places, calling the polyfill cost us a lot of operations, as we already did most of the checks, might as well running directly the expected code.

Full disclosure: at first, i wanted to remove entirely the uuid_ pecl / polyfill dependencies. But uuid_create is still used for UuidV1 / V7 generation, and more perorfmant than the polyfill.

After this PR, the extension (or the polyfills) are still used via 2 methods: `uuid_create` and `uuid_compare`.
