### PR TITLE
[Form] Allow more permissive form input name and ID

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate not configuring the `default_protocol` option of the `UrlType`, it will default to `null` in 8.0
  * Add a `keep_as_list` option to `CollectionType`
  * Add a new `model_type` option to `MoneyType`, to be able to cast the transformed value to `integer`
+ * Allow more permissive form input name and id
 
 7.0
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -75,11 +75,6 @@ abstract class BaseType extends AbstractType
             $id = \is_string($options['form_attr']) ? $options['form_attr'] : $name;
             $fullName = $name;
             $uniqueBlockPrefix = '_'.$blockName;
-
-            // Strip leading underscores and digits. These are allowed in
-            // form names, but not in HTML4 ID attributes.
-            // https://www.w3.org/TR/html401/struct/global#adef-id
-            $id = ltrim($id, '_0123456789');
         }
 
         $blockPrefixes = [];

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -632,7 +632,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     final public static function validateName(?string $name): void
     {
         if (!self::isValidName($name)) {
-            throw new InvalidArgumentException(sprintf('The name "%s" contains illegal characters. Names should start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").', $name));
+            throw new InvalidArgumentException(sprintf('The name "%s" contains illegal characters or equals to "isindex". Names should only contain letters, digits, underscores ("_"), hyphens ("-") and colons (":").', $name));
         }
     }
 
@@ -642,12 +642,12 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      * A name is accepted if it
      *
      *   * is empty
-     *   * starts with a letter, digit or underscore
      *   * contains only letters, digits, numbers, underscores ("_"),
      *     hyphens ("-") and colons (":")
+     *   * is not equal to "isindex"
      */
     final public static function isValidName(?string $name): bool
     {
-        return '' === $name || null === $name || preg_match('/^[a-zA-Z0-9_][a-zA-Z0-9_\-:]*$/D', $name);
+        return ('' === $name || null === $name || preg_match('/^[a-zA-Z0-9_\-:]*$/D', $name)) && 'isindex' !== $name;
     }
 }

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -42,7 +42,7 @@ class ButtonBuilderTest extends TestCase
     public function testNameContainingIllegalCharacters()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The name "button[]" contains illegal characters. Names should start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").');
+        $this->expectExceptionMessage('The name "button[]" contains illegal characters or equals to "isindex".');
 
         $this->assertInstanceOf(ButtonBuilder::class, new ButtonBuilder('button[]'));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2084,7 +2084,7 @@ class ChoiceTypeTest extends BaseTypeTestCase
         $this->assertEquals('name', $view->vars['full_name']);
     }
 
-    public function testAllowLeadingUnderscoreAndDigitsFromId()
+    public function testAllowLeadingUnderscoresAndDigitsFromId()
     {
         $view = $this->factory->createNamed('_09name', static::TESTED_TYPE, null)
             ->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2084,12 +2084,12 @@ class ChoiceTypeTest extends BaseTypeTestCase
         $this->assertEquals('name', $view->vars['full_name']);
     }
 
-    public function testStripLeadingUnderscoresAndDigitsFromId()
+    public function testAllowLeadingUnderscoreAndDigitsFromId()
     {
         $view = $this->factory->createNamed('_09name', static::TESTED_TYPE, null)
             ->createView();
 
-        $this->assertEquals('name', $view->vars['id']);
+        $this->assertEquals('_09name', $view->vars['id']);
         $this->assertEquals('_09name', $view->vars['name']);
         $this->assertEquals('_09name', $view->vars['full_name']);
     }

--- a/src/Symfony/Component/Form/Tests/FormConfigTest.php
+++ b/src/Symfony/Component/Form/Tests/FormConfigTest.php
@@ -24,18 +24,20 @@ class FormConfigTest extends TestCase
 {
     public static function provideInvalidFormInputName(): iterable
     {
-        yield ['isindex'];
+        return [
+            ['isindex'],
+            ['#'],
+            ['a#'],
+            ['a$'],
+            ['a%'],
+            ['a '],
+            ["a\t"],
+            ["a\n"],
 
-        yield ['#'];
-        yield ['a#'];
-        yield ['a$'];
-        yield ['a%'];
-        yield ['a '];
-        yield ["a\t"];
-        yield ["a\n"];
-        // Periods are allowed by the HTML4 spec, but disallowed by us
-        // because they break the generated property paths
-        yield ['a.'];
+            // Periods are allowed by the HTML4 spec, but disallowed by us
+            // because they break the generated property paths
+            ['a.'],
+        ];
     }
 
     /**
@@ -51,42 +53,48 @@ class FormConfigTest extends TestCase
 
     public static function provideValidFormInputName(): iterable
     {
-        yield ['z0'];
-        yield ['A0'];
-        yield ['A9'];
-        yield ['Z0'];
-        yield ['a-'];
-        yield ['a_'];
-        yield ['a:'];
-        // Contrary to the HTML4 spec, we allow names starting with a
-        // number, otherwise naming fields by collection indices is not
-        // possible.
-        // For root forms, leading digits will be stripped from the
-        // "id" attribute to produce valid HTML4.
-        yield ['0'];
-        yield ['9'];
-        // Contrary to the HTML4 spec, we allow names starting with an
-        // underscore, since this is already a widely used practice in
-        // Symfony.
-        // For root forms, leading underscores will be stripped from the
-        // "id" attribute to produce valid HTML4.
-        yield ['_'];
-        // Integers are allowed
-        yield [0];
-        yield [123];
-        // NULL is allowed
-        yield [null];
+        return [
+            ['z0'],
+            ['A0'],
+            ['A9'],
+            ['Z0'],
+            ['a-'],
+            ['a_'],
+            ['a:'],
 
-        // Allowed in HTML 5 specification
-        // See: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name
-        yield ['_charset_'];
-        yield ['-x'];
-        yield [':x'];
-        yield ['isINDEX'];
+            // Contrary to the HTML4 spec, we allow names starting with a
+            // number, otherwise naming fields by collection indices is not
+            // possible.
+            // For root forms, leading digits will be stripped from the
+            // "id" attribute to produce valid HTML4.
+            ['0'],
+            ['9'],
 
-        // This value shouldn't be allowed.
-        // However, many tests in Form component require empty name
-        yield [''];
+            // Contrary to the HTML4 spec, we allow names starting with an
+            // underscore, since this is already a widely used practice in
+            // Symfony.
+            // For root forms, leading underscores will be stripped from the
+            // "id" attribute to produce valid HTML4.
+            ['_'],
+
+            // Integers are allowed
+            [0],
+            [123],
+
+            // NULL is allowed
+            [null],
+
+            // Allowed in HTML 5 specification
+            // See: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name
+            ['_charset_'],
+            ['-x'],
+            [':x'],
+            ['isINDEX'],
+
+            // This value shouldn't be allowed.
+            // However, many tests in Form component require empty name
+            [''],
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53977
|                  | Fix #53976 
| License       | MIT

Changes in this PR:
1. `testNameAcceptsOnlyNamesValidAsIdsInHtml4` has been split into 2 functions: `testInvalidFormInputName` and `testValidFormInputName`,
2. Allow input names to start with hyphens ("-") and colons (":"),
3. Disallow `isindex` as an input name.
4. Allow more permissive form input id
