### PR TITLE
[Routing] Update AttributeClassLoader.php

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -18,6 +18,8 @@ use Symfony\Component\Routing\Attribute\Route as RouteAnnotation;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
+use function Symfony\Component\String\u;
+
 /**
  * AttributeClassLoader loads routing information from a PHP class and its methods.
  *
@@ -236,7 +238,7 @@ abstract class AttributeClassLoader implements LoaderInterface
     protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
     {
         $name = str_replace('\\', '_', $class->name).'_'.$method->name;
-        $name = \function_exists('mb_strtolower') && preg_match('//u', $name) ? mb_strtolower($name, 'UTF-8') : strtolower($name);
+        $name = u($name)->snake();
         if ($this->defaultRouteIndex > 0) {
             $name .= '_'.$this->defaultRouteIndex;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53237
| License       | MIT

Symfony generates an automatic route name with the action method name.
When the action method name has a capital letter like `changePassword`, it gives `changepassword`.

In the following example, the route name is `app_account_security_changepassword`.
It would be interesting to have instead `app_account_security_change_password`

So I created a PR to resolve this issue.

What do you think ?