### PR TITLE
[HttpKernel] Allow tagged controllers in ControllerResolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -45,6 +45,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
 
         $parameterBag = $container->getParameterBag();
         $controllers = [];
+        $controllerClasses = [];
 
         $publicAliases = [];
         foreach ($container->getAliases() as $id => $alias) {
@@ -73,6 +74,8 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
             if (!$r = $container->getReflectionClass($class)) {
                 throw new InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
             }
+
+            $controllerClasses[] = $class;
 
             // get regular public methods
             $methods = [];
@@ -227,5 +230,10 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
         }
 
         $container->setAlias('argument_resolver.controller_locator', (string) $controllerLocatorRef);
+
+        if ($container->hasDefinition('controller_resolver')) {
+            $container->getDefinition('controller_resolver')
+                ->addMethodCall('allowControllers', [array_unique($controllerClasses)]);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52471
| License       | MIT

If the request attribute `_check_controller_is_allowed` is set, only `TemplateController`, children of `AbstractController` and controllers that have the attribute `#[AsController]` are allowed by default. This change also adds controllers tagged with `controller.service_arguments` to the mix. It allows them to be used with different fragment renderers (e.g. `esi` and `ssi`) without having to add any of the above conditions.

This pull request is a follow up of [this discussion](https://github.com/symfony/symfony/pull/52471#issuecomment-1939403222).