### PR TITLE
[Console] Add descriptions to Fish completion output

### DIFF
--- a/src/Symfony/Component/Console/Completion/Output/FishCompletionOutput.php
+++ b/src/Symfony/Component/Console/Completion/Output/FishCompletionOutput.php
@@ -21,11 +21,14 @@ class FishCompletionOutput implements CompletionOutputInterface
 {
     public function write(CompletionSuggestions $suggestions, OutputInterface $output): void
     {
-        $values = $suggestions->getValueSuggestions();
+        $values = [];
+        foreach ($suggestions->getValueSuggestions() as $value) {
+            $values[] = $value->getValue().($value->getDescription() ? "\t".$value->getDescription() : '');
+        }
         foreach ($suggestions->getOptionSuggestions() as $option) {
-            $values[] = '--'.$option->getName();
+            $values[] = '--'.$option->getName().($option->getDescription() ? "\t".$option->getDescription() : '');
             if ($option->isNegatable()) {
-                $values[] = '--no-'.$option->getName();
+                $values[] = '--no-'.$option->getName().($option->getDescription() ? "\t".$option->getDescription() : '');
             }
         }
         $output->write(implode("\n", $values));

--- a/src/Symfony/Component/Console/Resources/completion.fish
+++ b/src/Symfony/Component/Console/Resources/completion.fish
@@ -19,11 +19,7 @@ function _sf_{{ COMMAND_NAME }}
 
     set completecmd $completecmd "-c$c"
 
-    set sfcomplete ($completecmd)
-
-    for i in $sfcomplete
-        echo $i
-    end
+    $completecmd
 end
 
 complete -c '{{ COMMAND_NAME }}' -a '(_sf_{{ COMMAND_NAME }})' -f

--- a/src/Symfony/Component/Console/Tests/Completion/Output/FishCompletionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Completion/Output/FishCompletionOutputTest.php
@@ -23,11 +23,11 @@ class FishCompletionOutputTest extends CompletionOutputTestCase
 
     public function getExpectedOptionsOutput(): string
     {
-        return "--option1\n--negatable\n--no-negatable";
+        return "--option1\tFirst Option\n--negatable\tCan be negative\n--no-negatable\tCan be negative";
     }
 
     public function getExpectedValuesOutput(): string
     {
-        return "Green\nRed\nYellow";
+        return "Green\tBeans are green\nRed\tRose are red\nYellow\tCanaries are yellow";
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This improves the completion output for the Fish shell to include descriptions. The `-a` option of Fish's [complete](https://fishshell.com/docs/current/cmds/complete.html) command accepts a list where each line is an argument with an optional description, separated by a tab. The fish script doesn't need to change, making this change backwards compatible.

Since the output is now identical to that of `ZshCompletionOutput`, code duplication could still be reduced by extracting to an abstract class (e.g. `TabSeparatedCompletionOutput`) that gets extended by `FishCompletionOutput` and `ZshCompletionOutput`.
