### PR TITLE
Fix syntax error and update method call in RegisterListenersPass

### DIFF
--- a/src/Symfony/Component/Config/Tests/Fixtures/ParseError.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/ParseError.php
@@ -4,4 +4,7 @@ namespace Symfony\Component\Config\Tests\Fixtures;
 
 class ParseError
 {
+    
+}
 // missing closing bracket
+

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -204,7 +204,7 @@ class ExtractingEventDispatcher extends EventDispatcher implements EventSubscrib
     {
         $events = [];
 
-        foreach ([self::$subscriber, 'getSubscribedEvents']() as $eventName => $params) {
+        foreach (self::$subscriber::getSubscribedEvents() as $eventName => $params) {
             $events[self::$aliases[$eventName] ?? $eventName] = $params;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix syntax error and update method call in RegisterListenersPass
| License       | MIT

bugfix.

