### PR TITLE
[Console] [FramworkBundle] Add AsLockedCommand attribute to automatically lock commands

### DIFF
--- a/src/Symfony/Component/Console/Attribute/AsLockedCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsLockedCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsLockedCommand
+{
+    /**
+     * @param string|bool|array $lock     The string used as the key to create lock, or a boolean to use the command's name, or callable which returns a string
+     * @param bool              $blocking Is this lock should be blocking ? true to wait until the lock is available, false otherwise
+     */
+    public function __construct(
+        public string|bool|array $lock = true,
+        public bool $blocking = false,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `ArgvInput::getRawTokens()`
+ * Add `#[AsLockedCommand]` attribute to automatically lock commands
 
 7.0
 ---

--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -25,7 +25,6 @@ use Symfony\Component\Lock\Store\SemaphoreStore;
 trait LockableTrait
 {
     private ?LockInterface $lock = null;
-
     private ?LockFactory $lockFactory = null;
 
     /**
@@ -52,6 +51,7 @@ trait LockableTrait
         }
 
         $this->lock = $this->lockFactory->createLock($name ?: $this->getName());
+
         if (!$this->lock->acquire($blocking)) {
             $this->lock = null;
 

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -118,6 +118,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
 
                 $lazyCommandRefs[$id] = new Reference('.'.$id.'.lazy');
             }
+
+            if ($container->hasDefinition('lock.default.factory')) {
+                $definition->addMethodCall('setLockFactory', [$container->getDefinition('lock.default.factory')]);
+            }
         }
 
         $container

--- a/src/Symfony/Component/Console/Tests/Command/AsLockedCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/AsLockedCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\FlockStore;
+
+class AsLockedCommandTest extends TestCase
+{
+    protected static string $fixturesPath;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$fixturesPath = __DIR__.'/../Fixtures/';
+        require_once self::$fixturesPath.'/AsLockedTestCommand.php';
+        require_once self::$fixturesPath.'/AsLockedThrowsLogicExceptionTestCommand.php';
+        require_once self::$fixturesPath.'/AsLockedWithCallableTestCommand.php';
+    }
+
+    public function testLockIsReleased()
+    {
+        $lockFactory = new LockFactory(new FlockStore());
+        $command = new \AsLockedTestCommand();
+        $command->setLockFactory($lockFactory);
+
+        $tester = new CommandTester($command);
+        $this->assertSame(Command::SUCCESS, $tester->execute([]));
+        $this->assertSame(Command::SUCCESS, $tester->execute([]));
+    }
+
+    public function testCommandFailsIfAlreadyLockedByAnotherCommand()
+    {
+        $lockFactory = new LockFactory(new FlockStore());
+        $command = new \AsLockedTestCommand();
+        $command->setLockFactory($lockFactory);
+
+        $lock = $lockFactory->createLock($command->getName());
+        $lock->acquire();
+
+        $tester = new CommandTester($command);
+        $this->assertSame(Command::FAILURE, $tester->execute([]));
+
+        $lock->release();
+        $this->assertSame(Command::SUCCESS, $tester->execute([]));
+    }
+
+    public function testMultipleLockCallsThrowLogicException()
+    {
+        $command = new \AsLockedThrowsLogicExceptionTestCommand();
+        $lockFactory = new LockFactory(new FlockStore());
+        $command->setLockFactory($lockFactory);
+        $lockFactory->createLock($command->getName());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A lock is already in place.');
+
+        $tester = new CommandTester($command);
+        $this->assertSame(Command::FAILURE, $tester->execute([]));
+    }
+
+    public function testLockFromCallable()
+    {
+        $lockFactory = new LockFactory(new FlockStore());
+        $command = new \AsLockedWithCallableTestCommand();
+        $command->setLockFactory($lockFactory);
+
+        $lock = $lockFactory->createLock('lock-test1');
+        $lock->acquire();
+
+        $tester = new CommandTester($command);
+        $this->assertSame(Command::FAILURE, $tester->execute(['key' => 'test1']));
+        $this->assertSame(Command::SUCCESS, $tester->execute(['key' => 'test2']));
+
+        $lock->release();
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/AsLockedTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/AsLockedTestCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\AsLockedCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'as:locked:command',
+)]
+#[AsLockedCommand]
+class AsLockedTestCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/AsLockedThrowsLogicExceptionTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/AsLockedThrowsLogicExceptionTestCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\AsLockedCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'as:locked-throws:command',
+)]
+#[AsLockedCommand]
+class AsLockedThrowsLogicExceptionTestCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->createLock($input);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/AsLockedWithCallableTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/AsLockedWithCallableTestCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\AsLockedCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'as:callable-locked:command',
+)]
+#[AsLockedCommand(
+    lock: [self::class, 'getLockKey']
+)]
+class AsLockedWithCallableTestCommand extends Command
+{
+    public function configure(): void
+    {
+        $this->addArgument('key', InputArgument::REQUIRED);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return Command::SUCCESS;
+    }
+
+    public static function getLockKey(InputInterface $input): string
+    {
+        return sprintf('lock-%s', $input->getArgument('key'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This new feature allows developer to use the new `AsLockedCommand` attribute to automatically sets a lock on their commands, instead of using the `LockableTrait`.

For documentation, see https://github.com/symfony/symfony-docs/pull/19577