### PR TITLE
[Security] Add retrieval of parent role names

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -48,6 +48,8 @@ HttpKernel
 Security
 --------
 
+ * Add `getParentRoleNames()` method to `RoleHierarchyInterface`
+ * Make `RoleHierarchyInterface::getReachableRoleNames()` return roles as both keys and values
  * Deprecate `SameOriginCsrfTokenManager::onKernelResponse()`, `SameOriginCsrfTokenManager::clearCookies()` and `SameOriginCsrfTokenManager::persistStrategy()`; this logic is now handled automatically by `SameOriginCsrfListener`
 
 Uid

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add support for enums in `SignatureHasher::computeSignatureHash()`
+ * Add `getParentRoleNames()` method to `RoleHierarchyInterface`
+ * Make `RoleHierarchyInterface::getReachableRoleNames()` return roles as both keys and values
 
 8.0
 ---

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Security\Core\Role;
  */
 class RoleHierarchy implements RoleHierarchyInterface
 {
-    /** @var array<string, list<string>> */
+    /** @var array<string, array<string, string>> */
     protected array $map;
 
     /**
@@ -30,9 +30,11 @@ class RoleHierarchy implements RoleHierarchyInterface
 
     public function getReachableRoleNames(array $roles): array
     {
-        $reachableRoles = array_combine($roles, $roles);
+        $reachableRoles = [];
 
         foreach ($roles as $role) {
+            $reachableRoles[$role] = $role;
+
             if (!isset($this->map[$role])) {
                 continue;
             }
@@ -42,18 +44,41 @@ class RoleHierarchy implements RoleHierarchyInterface
             }
         }
 
-        return array_keys($reachableRoles);
+        return $reachableRoles;
+    }
+
+    /**
+     * @param string[] $roles
+     *
+     * @return array<string, string>
+     */
+    public function getParentRoleNames(array $roles): array
+    {
+        $parentRoles = [];
+
+        foreach ($roles as $role) {
+            $parentRoles[$role] = $role;
+
+            foreach ($this->map as $parent => $children) {
+                if (isset($children[$role])) {
+                    $parentRoles[$parent] = $parent;
+                }
+            }
+        }
+
+        return $parentRoles;
     }
 
     protected function buildRoleMap(): void
     {
         $this->map = [];
         foreach ($this->hierarchy as $main => $roles) {
-            $this->map[$main] = $roles;
+            $map = [];
             $visited = [];
             $additionalRoles = $roles;
             while (null !== $role = key($additionalRoles)) {
                 $role = $additionalRoles[$role];
+                $map[$role] = $role;
 
                 if (!isset($this->hierarchy[$role])) {
                     next($additionalRoles);
@@ -63,7 +88,7 @@ class RoleHierarchy implements RoleHierarchyInterface
                 $visited[] = $role;
 
                 foreach ($this->hierarchy[$role] as $roleToAdd) {
-                    $this->map[$main][] = $roleToAdd;
+                    $map[$roleToAdd] = $roleToAdd;
                 }
 
                 foreach (array_diff($this->hierarchy[$role], $visited) as $additionalRole) {
@@ -73,7 +98,7 @@ class RoleHierarchy implements RoleHierarchyInterface
                 next($additionalRoles);
             }
 
-            $this->map[$main] = array_unique($this->map[$main]);
+            $this->map[$main] = $map;
         }
     }
 }

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Security\Core\Role;
 /**
  * RoleHierarchyInterface is the interface for a role hierarchy.
  *
+ * @method array<string, string> getParentRoleNames(string[] $roles)
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface RoleHierarchyInterface
@@ -21,7 +23,7 @@ interface RoleHierarchyInterface
     /**
      * @param string[] $roles
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getReachableRoleNames(array $roles): array;
 }

--- a/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
@@ -23,11 +23,28 @@ class RoleHierarchyTest extends TestCase
             'ROLE_SUPER_ADMIN' => ['ROLE_ADMIN', 'ROLE_FOO'],
         ]);
 
-        $this->assertEqualsCanonicalizing(['ROLE_USER'], $role->getReachableRoleNames(['ROLE_USER']));
-        $this->assertEqualsCanonicalizing(['ROLE_FOO'], $role->getReachableRoleNames(['ROLE_FOO']));
-        $this->assertEqualsCanonicalizing(['ROLE_ADMIN', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_ADMIN']));
-        $this->assertEqualsCanonicalizing(['ROLE_FOO', 'ROLE_ADMIN', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_FOO', 'ROLE_ADMIN']));
-        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN']));
-        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_USER']));
+        $this->assertEqualsCanonicalizing(['ROLE_FOO' => 'ROLE_FOO'], $role->getReachableRoleNames(['ROLE_FOO']));
+        $this->assertEqualsCanonicalizing(['ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_FOO' => 'ROLE_FOO', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_FOO', 'ROLE_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_FOO' => 'ROLE_FOO', 'ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_FOO' => 'ROLE_FOO', 'ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
+    }
+
+    public function testGetParentRoleNames()
+    {
+        $role = new RoleHierarchy([
+            'ROLE_ADMIN' => ['ROLE_USER'],
+            'ROLE_SUPER_ADMIN' => ['ROLE_ADMIN', 'ROLE_FOO'],
+            'ROLE_USER' => ['ROLE_BAR'],
+        ]);
+
+        $this->assertEquals(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN']));
+        $this->assertEquals(['ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_ADMIN']));
+        $this->assertEquals(['ROLE_USER' => 'ROLE_USER', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_USER']));
+        $this->assertEquals(['ROLE_BAR' => 'ROLE_BAR', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_USER' => 'ROLE_USER'], $role->getParentRoleNames(['ROLE_BAR']));
+        $this->assertEquals(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
+        $this->assertEquals(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_USER' => 'ROLE_USER', 'ROLE_ADMIN' => 'ROLE_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_USER']));
+        $this->assertEquals(['ROLE_BAR' => 'ROLE_BAR', 'ROLE_FOO' => 'ROLE_FOO', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_USER' => 'ROLE_USER'], $role->getParentRoleNames(['ROLE_BAR', 'ROLE_FOO']));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

The aim of this method is to provide a handy way of getting the roles that encompass (or are parent of) an array of roles.

It is similar to the `RoleHierarchyInterface::getReachableRoleNames(array $roles)` but instead of retrieving the roles and children roles it retrieves the roles and parent roles.

A typical use case would be when we get a user role from a database and need to get all the roles that also have access to whatever this role can access.

Also what do you guys think of renaming  the existing`getReachableRoleNames` (that retrieves the "children roles" of an array of roles) as well as `getEncompassingRoleNames` (that retrieves the "parent roles" of an array of roles) to `getParentRoles`  and  `getChildrenRoles` in order to better reflect their intention ? 

For the sake of this PR I tried to use a naming that is consistent with the existing `getReachableRoleNames`  method.

