### PR TITLE
[WebProfilerBundle] disable turbo in web profiler toolbar to avoid link prefetching

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -6,7 +6,7 @@
 </div>
 <div id="sfToolbarClearer-{{ token }}" class="sf-toolbar-clearer"></div>
 
-<div id="sfToolbarMainContent-{{ token }}" class="sf-toolbarreset clear-fix" data-no-turbolink>
+<div id="sfToolbarMainContent-{{ token }}" class="sf-toolbarreset clear-fix" data-no-turbolink data-turbo="false">
     {% for name, template in templates %}
         {% if block('toolbar', template) is defined %}
             {% with {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | [symfony/ux#1520](https://github.com/symfony/ux/issues/1520)
| License       | MIT

This adds `data-turbo="false"` to the web profiler toolbar html. It [has been added already a while ago](https://github.com/symfony/symfony/pull/49226) to the mini-toolbar, and there is already the old `data-no-turbolink` attribute present.

This [fixes an issue](https://github.com/symfony/ux/issues/1520) with prefetching links in Turbo 8, which causes the Ajax pane to behave weirdly and can even cause unwanted logouts (via the logout link inside the security pane).
