### PR TITLE
[HttpKernel] Fix a minor design issue in the Welcome Page

### DIFF
--- a/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
+++ b/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
@@ -178,7 +178,7 @@ SVG;
 
         @media (min-width: 768px) {
             @keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }
-            .sf-toolbar { opacity: 0; animation: fade-in 1s .2s forwards; z-index: 99999; }
+            .sf-toolbar { opacity: 0; animation: fade-in 1s .2s forwards; position: relative; z-index: 99999; }
             @media (prefers-reduced-motion) {
                 .sf-toolbar { animation: none !important; opacity: 1; }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This was spotted by @nicolas-grekas. In the Welcome Page, the toolbar needs a `position` CSS property because otherwise, the `z-index` property is ignored and the following happens:

https://github.com/symfony/symfony/assets/73419/e4fe8516-40b1-4cb4-8b67-e85ea6feb37f


