### PR TITLE
[Process] Fix the `command -v` exception

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -72,7 +72,7 @@ class ExecutableFinder
             }
         }
 
-        $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v';
+        $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v --';
         if (\function_exists('exec') && ($executablePath = strtok(@exec($command.' '.escapeshellarg($name)), \PHP_EOL)) && @is_executable($executablePath)) {
             return $executablePath;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #53479 
| License       | MIT

This PR is a continuation of the fixes made in PR #53481 to address the issue. The previous PR partially addressed the problem, but after further review and testing, it was determined that additional changes were needed.

Fix the `command -v` exception when the command option with a dash prefix.
