### PR TITLE
[Config] ConfigBuilderGenerator: define template types

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -128,8 +128,11 @@ public function NAME(): string
 
         $hasNormalizationClosures = $this->hasNormalizationClosures($node);
         $comment = $this->getComment($node);
+        $nodeTypes = $this->getParameterTypes($node);
+        $paramTypes = \in_array('mixed', $nodeTypes, true) ? 'mixed' : implode('|', $nodeTypes);
+
         if ($hasNormalizationClosures) {
-            $comment = sprintf(" * @template TValue\n * @param TValue \$value\n%s", $comment);
+            $comment = sprintf(" * @template TValue of %s\n * @param TValue \$value\n%s", $paramTypes, $comment);
             $comment .= sprintf(' * @return %s|$this'."\n", $childClass->getFqcn());
             $comment .= sprintf(' * @psalm-return (TValue is array ? %s : static)'."\n ", $childClass->getFqcn());
         }
@@ -141,7 +144,7 @@ public function NAME(): string
             $node->getName(),
             $this->getType($childClass->getFqcn(), $hasNormalizationClosures)
         );
-        $nodeTypes = $this->getParameterTypes($node);
+
         $body = $hasNormalizationClosures ? '
 COMMENTpublic function NAME(PARAM_TYPE $value = []): CLASS|static
 {
@@ -177,7 +180,7 @@ COMMENTpublic function NAME(array $value = []): CLASS
             'COMMENT' => $comment,
             'PROPERTY' => $property->getName(),
             'CLASS' => $childClass->getFqcn(),
-            'PARAM_TYPE' => \in_array('mixed', $nodeTypes, true) ? 'mixed' : implode('|', $nodeTypes),
+            'PARAM_TYPE' => $paramTypes,
         ]);
 
         $this->buildNode($node, $childClass, $this->getSubNamespace($childClass));
@@ -280,8 +283,11 @@ public function NAME(string $VAR, TYPE $VALUE): static
         );
 
         $comment = $this->getComment($node);
+        $resolvedParamTypes = null === $node->getKeyAttribute() ? $nodeParameterTypes : $prototypeParameterTypes;
+        $paramTypes = \in_array('mixed', $resolvedParamTypes, true) ? 'mixed' : implode('|', $resolvedParamTypes);
+
         if ($hasNormalizationClosures) {
-            $comment = sprintf(" * @template TValue\n * @param TValue \$value\n%s", $comment);
+            $comment = sprintf(" * @template TValue of %s\n * @param TValue \$value\n%s", $paramTypes, $comment);
             $comment .= sprintf(' * @return %s|$this'."\n", $childClass->getFqcn());
             $comment .= sprintf(' * @psalm-return (TValue is array ? %s : static)'."\n ", $childClass->getFqcn());
         }
@@ -312,7 +318,7 @@ COMMENTpublic function NAME(array $value = []): CLASS
                 'COMMENT' => $comment,
                 'PROPERTY' => $property->getName(),
                 'CLASS' => $childClass->getFqcn(),
-                'PARAM_TYPE' => \in_array('mixed', $nodeParameterTypes, true) ? 'mixed' : implode('|', $nodeParameterTypes),
+                'PARAM_TYPE' => $paramTypes,
             ]);
         } else {
             $body = $hasNormalizationClosures ? '
@@ -351,7 +357,7 @@ COMMENTpublic function NAME(string $VAR, array $VALUE = []): CLASS
                 'CLASS' => $childClass->getFqcn(),
                 'VAR' => '' === $key ? 'key' : $key,
                 'VALUE' => 'value' === $key ? 'data' : 'value',
-                'PARAM_TYPE' => \in_array('mixed', $prototypeParameterTypes, true) ? 'mixed' : implode('|', $prototypeParameterTypes),
+                'PARAM_TYPE' => $paramTypes,
             ]);
         }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
@@ -17,7 +17,7 @@ class NestedConfig
     private $_usedProperties = [];
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @default {"enabled":null}
      * @return \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig|$this
@@ -43,7 +43,7 @@ class NestedConfig
     }
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @return \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig : static)

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -48,7 +48,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @default {"enabled":null}
      * @return \Symfony\Config\ScalarNormalizedTypes\ObjectConfig|$this
@@ -74,7 +74,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @return \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig : static)
@@ -92,7 +92,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @return \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig : static)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

This helps phpstan to properly identify the return types, in our case for the `$framework->messenger()->transport('async')->dsn(env('MESSENGER_TRANSPORT_DSN'));`

Where `->dns()`  failed with the following Phpstan error:
`Call to an undefined method Symfony\Config\Framework\Messenger\TransportConfig|Symfony\Config\Framework\MessengerConfig::dsn()`
