### PR TITLE
[Translation] Fix extracting qualified `t()` function calls

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/Visitor/TransMethodVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/TransMethodVisitor.php
@@ -39,7 +39,7 @@ final class TransMethodVisitor extends AbstractVisitor implements NodeVisitor
             return null;
         }
 
-        $name = (string) $node->name;
+        $name = $node->name instanceof Node\Name ? $node->name->getLast() : (string) $node->name;
 
         if ('trans' === $name || 't' === $name) {
             $firstNamedArgumentIndex = $this->nodeFirstNamedArgumentIndex($node);

--- a/src/Symfony/Component/Translation/Tests/Extractor/PhpAstExtractorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/PhpAstExtractorTest.php
@@ -82,6 +82,17 @@ EOF;
                 'translatable-short '.$expectedNowdoc => 'prefixtranslatable-short '.$expectedNowdoc,
                 'translatable-short concatenated message with heredoc and nowdoc' => 'prefixtranslatable-short concatenated message with heredoc and nowdoc',
                 'translatable-short default domain' => 'prefixtranslatable-short default domain',
+                'translatable-short-fqn single-quoted key' => 'prefixtranslatable-short-fqn single-quoted key',
+                'translatable-short-fqn double-quoted key' => 'prefixtranslatable-short-fqn double-quoted key',
+                'translatable-short-fqn heredoc key' => 'prefixtranslatable-short-fqn heredoc key',
+                'translatable-short-fqn nowdoc key' => 'prefixtranslatable-short-fqn nowdoc key',
+                "translatable-short-fqn double-quoted key with whitespace and escaped \$\n\" sequences" => "prefixtranslatable-short-fqn double-quoted key with whitespace and escaped \$\n\" sequences",
+                'translatable-short-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences' => 'prefixtranslatable-short-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences',
+                'translatable-short-fqn single-quoted key with "quote mark at the end"' => 'prefixtranslatable-short-fqn single-quoted key with "quote mark at the end"',
+                'translatable-short-fqn '.$expectedHeredoc => 'prefixtranslatable-short-fqn '.$expectedHeredoc,
+                'translatable-short-fqn '.$expectedNowdoc => 'prefixtranslatable-short-fqn '.$expectedNowdoc,
+                'translatable-short-fqn concatenated message with heredoc and nowdoc' => 'prefixtranslatable-short-fqn concatenated message with heredoc and nowdoc',
+                'translatable-short-fqn default domain' => 'prefixtranslatable-short-fqn default domain',
                 'single-quoted key' => 'prefixsingle-quoted key',
                 'double-quoted key' => 'prefixdouble-quoted key',
                 'heredoc key' => 'prefixheredoc key',
@@ -113,6 +124,11 @@ EOF;
                 'translatable-short other-domain-test-params-short-array' => 'prefixtranslatable-short other-domain-test-params-short-array',
                 'translatable-short other-domain-test-params-long-array' => 'prefixtranslatable-short other-domain-test-params-long-array',
                 'translatable-short typecast' => 'prefixtranslatable-short typecast',
+                'translatable-short-fqn other-domain-test-no-params-short-array' => 'prefixtranslatable-short-fqn other-domain-test-no-params-short-array',
+                'translatable-short-fqn other-domain-test-no-params-long-array' => 'prefixtranslatable-short-fqn other-domain-test-no-params-long-array',
+                'translatable-short-fqn other-domain-test-params-short-array' => 'prefixtranslatable-short-fqn other-domain-test-params-short-array',
+                'translatable-short-fqn other-domain-test-params-long-array' => 'prefixtranslatable-short-fqn other-domain-test-params-long-array',
+                'translatable-short-fqn typecast' => 'prefixtranslatable-short-fqn typecast',
                 'other-domain-test-no-params-short-array' => 'prefixother-domain-test-no-params-short-array',
                 'other-domain-test-no-params-long-array' => 'prefixother-domain-test-no-params-long-array',
                 'other-domain-test-params-short-array' => 'prefixother-domain-test-params-short-array',
@@ -159,6 +175,10 @@ EOF;
         $this->assertEquals(['sources' => [$filename.':2']], $catalogue->getMetadata('translatable-short single-quoted key'));
         $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('translatable-short other-domain-test-no-params-short-array', 'not_messages'));
 
+        $filename = str_replace(\DIRECTORY_SEPARATOR, '/', __DIR__).'/../Fixtures/extractor-ast/translatable-short-fqn.html.php';
+        $this->assertEquals(['sources' => [$filename.':2']], $catalogue->getMetadata('translatable-short-fqn single-quoted key'));
+        $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('translatable-short-fqn other-domain-test-no-params-short-array', 'not_messages'));
+
         $filename = str_replace(\DIRECTORY_SEPARATOR, '/', __DIR__).'/../Fixtures/extractor-ast/translation.html.php';
         $this->assertEquals(['sources' => [$filename.':2']], $catalogue->getMetadata('single-quoted key'));
         $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('other-domain-test-no-params-short-array', 'not_messages'));
@@ -199,7 +219,7 @@ EOF;
             if ($fileInfo->isDot()) {
                 continue;
             }
-            if (\in_array($fileInfo->getBasename(), ['translatable.html.php', 'translatable-fqn.html.php', 'translatable-short.html.php', 'translation.html.php', 'validator-constraints.php'], true)) {
+            if (\in_array($fileInfo->getBasename(), ['translatable.html.php', 'translatable-fqn.html.php', 'translatable-short.html.php', 'translatable-short-fqn.html.php', 'translation.html.php', 'validator-constraints.php'], true)) {
                 $phpFiles[] = $fileInfo->getPathname();
             }
             $splFiles[] = $fileInfo->getFileInfo();

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-ast/translatable-short-fqn.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-ast/translatable-short-fqn.html.php
@@ -1,0 +1,47 @@
+This template is used for translation message extraction tests
+<?php \Symfony\Component\Translation\t('translatable-short-fqn single-quoted key'); ?>
+<?php \Symfony\Component\Translation\t('translatable-short-fqn double-quoted key'); ?>
+<?php \Symfony\Component\Translation\t(<<<EOF
+translatable-short-fqn heredoc key
+EOF
+); ?>
+<?php \Symfony\Component\Translation\t(<<<'EOF'
+translatable-short-fqn nowdoc key
+EOF
+); ?>
+<?php \Symfony\Component\Translation\t(
+    "translatable-short-fqn double-quoted key with whitespace and escaped \$\n\" sequences"
+); ?>
+<?php \Symfony\Component\Translation\t(
+    'translatable-short-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences'
+); ?>
+<?php \Symfony\Component\Translation\t(<<<EOF
+translatable-short-fqn heredoc key with whitespace and escaped \$\n sequences
+EOF
+); ?>
+<?php \Symfony\Component\Translation\t(<<<'EOF'
+translatable-short-fqn nowdoc key with whitespace and nonescaped \$\n sequences
+EOF
+); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn single-quoted key with "quote mark at the end"'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn concatenated'.' message'.<<<EOF
+ with heredoc
+EOF
+.<<<'EOF'
+ and nowdoc
+EOF
+); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn other-domain-test-no-params-short-array', [], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn other-domain-test-no-params-long-array', [], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn other-domain-test-params-short-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn other-domain-test-params-long-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn typecast', ['a' => (int) '123'], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn default domain', [], null); ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53835
| License       | MIT

`t()` calls are generally qualified. The visitor used to look at the full name for the function call, but since #53624 this is replaced by the qualified name.

This PR adjusts the comparison to only look at the last part of the qualified name.