### PR TITLE
[AssetMapper] Revert "Fix JavaScript compiler load imports from JS strings"

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -27,31 +27,8 @@ use Symfony\Component\Filesystem\Path;
  */
 final class JavaScriptImportPathCompiler implements AssetCompilerInterface
 {
-    /**
-     * @see https://regex101.com/r/1iBAIb/1
-     */
-    private const IMPORT_PATTERN = '/
-        ^
-            (?:\/\/.*)                     # Lines that start with comments
-        |
-            (?:
-                \'(?:[^\'\\\\]|\\\\.)*\'   # Strings enclosed in single quotes
-            |
-                "(?:[^"\\\\]|\\\\.)*"      # Strings enclosed in double quotes
-            )
-        |
-            (?:                            # Import statements (script captured)
-                import\s*
-                    (?:
-                        (?:\*\s*as\s+\w+|\s+[\w\s{},*]+)
-                        \s*from\s*
-                    )?
-            |
-                \bimport\(
-            )
-            \s*[\'"`](\.\/[^\'"`]+|(\.\.\/)*[^\'"`]+)[\'"`]\s*[;\)]
-        ?
-    /mx';
+    // https://regex101.com/r/fquriB/1
+    private const IMPORT_PATTERN = '/(?:import\s*(?:(?:\*\s*as\s+\w+|[\w\s{},*]+)\s*from\s*)?|\bimport\()\s*[\'"`](\.\/[^\'"`]+|(\.\.\/)*[^\'"`]+)[\'"`]\s*[;\)]?/m';
 
     public function __construct(
         private readonly ImportMapConfigReader $importMapConfigReader,
@@ -64,11 +41,6 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
     {
         return preg_replace_callback(self::IMPORT_PATTERN, function ($matches) use ($asset, $assetMapper, $content) {
             $fullImportString = $matches[0][0];
-
-            // Ignore matches that did not capture import statements
-            if (!isset($matches[1][0])) {
-                return $fullImportString;
-            }
 
             if ($this->isCommentedOut($matches[0][1], $content)) {
                 return $fullImportString;

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -67,7 +67,6 @@ class JavaScriptImportPathCompilerTest extends TestCase
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
-                    '/project/assets/foo.js' => new MappedAsset('foo.js', '/can/be/anything.js', publicPathWithoutDigest: '/assets/foo.js'),
                     '/project/assets/other.js' => new MappedAsset('other.js', '/can/be/anything.js', publicPathWithoutDigest: '/assets/other.js'),
                     '/project/assets/subdir/foo.js' => new MappedAsset('subdir/foo.js', '/can/be/anything.js', publicPathWithoutDigest: '/assets/subdir/foo.js'),
                     '/project/assets/styles.css' => new MappedAsset('styles.css', '/can/be/anything.js', publicPathWithoutDigest: '/assets/styles.css'),
@@ -182,11 +181,6 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'expectedJavaScriptImports' => [],
         ];
 
-        yield 'commented_import_on_one_line_then_import_on_next_is_ok' => [
-            'input' => "// import\nimport { Foo } from './other.js';",
-            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
-        ];
-
         yield 'importing_a_css_file_is_included' => [
             'input' => "import './styles.css';",
             'expectedJavaScriptImports' => ['/assets/styles.css' => ['lazy' => false, 'asset' => 'styles.css', 'add' => true]],
@@ -278,63 +272,6 @@ class JavaScriptImportPathCompilerTest extends TestCase
                 EOF
             ,
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true]],
-        ];
-
-        yield 'import_in_double_quoted_string_is_ignored' => [
-            'input' => <<<EOF
-                const fun;
-                console.log("import('./foo.js')");
-                EOF
-            ,
-            'expectedJavaScriptImports' => [],
-        ];
-
-        yield 'import_in_double_quoted_string_with_escaped_quote_is_ignored' => [
-            'input' => <<<EOF
-                const fun;
-                console.log(" foo \" import('./foo.js')");
-                EOF
-            ,
-            'expectedJavaScriptImports' => [],
-        ];
-
-        yield 'import_in_single_quoted_string_is_ignored' => [
-            'input' => <<<EOF
-                const fun;
-                console.log('import("./foo.js")');
-                EOF
-            ,
-            'expectedJavaScriptImports' => [],
-        ];
-
-        yield 'import_after_a_string_is_parsed' => [
-            'input' => <<<EOF
-                const fun;
-                console.log("import('./other.js')"); import("./foo.js");
-                EOF
-            ,
-            'expectedJavaScriptImports' => ['/assets/foo.js' => ['lazy' => true, 'asset' => 'foo.js', 'add' => true]],
-        ];
-
-        yield 'import_before_a_string_is_parsed' => [
-            'input' => <<<EOF
-                const fun;
-                import("./other.js"); console.log("import('./foo.js')");
-                EOF
-            ,
-            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true]],
-        ];
-
-        yield 'import_before_and_after_a_string_is_parsed' => [
-            'input' => <<<EOF
-                const fun;
-                import("./other.js"); console.log("import('./foo.js')"); import("./subdir/foo.js");
-                EOF
-            ,
-            'expectedJavaScriptImports' => [
-                '/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true],
-                '/assets/subdir/foo.js' => ['lazy' => true, 'asset' => 'subdir/foo.js', 'add' => true],
-            ],
         ];
 
         yield 'bare_import_not_in_importmap' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This reverts commit 4fe782889311e75888b814e6e47df6561c9b9edd, reversing changes made to ad1563b1aecd6cd45189ec3c8ef74fc79b9de98c.

Reverts #53652 because it breaks loading app.css on a webapp skeleton.
There are two reasons for this:
1. the string regexp generates a JIT stack overflow - this can be fixed by making the internal pattern greedy
2. but then it still fails because app.js uses `import './styles/app.css'` and this is matched by the "quoted strings" subpart of the current pattern and thus ignored by the "import" subpart.

I don't know how this would be fixed using the regexp only so I'm proposing to revert so that we can consider this before the next release.

/cc @smnandre and @weaverryan 

I'm wondering what's the plan on this topic? Couldn't the CDN we use provide some API endpoint that'd prevent us from parsing any JS? Is there any effort ongoing on the topic? Alternatively, shouldn't we switch to a regexp-less parser? (a small state machine that'd be able to split apart comments, strings and code)?