### PR TITLE
[DependencyInjection] Add `#[AutowireMethodOf]` attribute to autowire a method of a service as a callable

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireMethodOf.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireMethodOf.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Tells which method should be turned into a Closure based on the name of the parameter it's attached to.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class AutowireMethodOf extends AutowireCallable
+{
+    /**
+     * @param string            $service The service containing the method to autowire
+     * @param bool|class-string $lazy    Whether to use lazy-loading for this argument
+     */
+    public function __construct(string $service, bool|string $lazy = false)
+    {
+        parent::__construct([new Reference($service)], lazy: $lazy);
+    }
+
+    public function buildDefinition(mixed $value, ?string $type, \ReflectionParameter $parameter): Definition
+    {
+        $value[1] = $parameter->name;
+
+        return parent::buildDefinition($value, $type, $parameter);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add argument `$prepend` to `ContainerConfigurator::extension()` to prepend the configuration instead of appending it
  * Have `ServiceLocator` implement `ServiceCollectionInterface`
  * Add `#[Lazy]` attribute as shortcut for `#[Autowire(lazy: [bool|string])]` and `#[Autoconfigure(lazy: [bool|string])]`
+ * Add `#[AutowireMethodOf]` attribute to autowire a method of a service as a callable
 
 7.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
@@ -47,7 +47,7 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
         if (!$value instanceof Reference) {
             return parent::processValue($value, $isRoot);
         }
-        if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE < $value->getInvalidBehavior() || $this->container->has($id = (string) $value)) {
+        if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE < $value->getInvalidBehavior() || $this->container->has((string) $value)) {
             return $value;
         }
 
@@ -83,7 +83,7 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
         $this->throwServiceNotFoundException($value, $currentId, $value);
     }
 
-    private function throwServiceNotFoundException(Reference $ref, string $sourceId, $value): void
+    private function throwServiceNotFoundException(Reference $ref, string $sourceId, mixed $value): void
     {
         $id = (string) $ref;
         $alternatives = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireMethodOfTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireMethodOfTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Attribute\AutowireMethodOf;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AutowireMethodOfTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $a = new AutowireMethodOf('foo');
+
+        $this->assertEquals([new Reference('foo')], $a->value);
+    }
+
+    public function testBuildDefinition(?\Closure $dummy = null)
+    {
+        $a = new AutowireMethodOf('foo');
+        $r = new \ReflectionParameter([__CLASS__, __FUNCTION__], 0);
+
+        $this->assertEquals([[new Reference('foo'), 'dummy']], $a->buildDefinition($a->value, 'Closure', $r)->getArguments());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -55,8 +55,10 @@ final class ServiceValueResolver implements ValueResolverInterface
         try {
             return [$this->container->get($controller)->get($argument->getName())];
         } catch (RuntimeException $e) {
-            $what = sprintf('argument $%s of "%s()"', $argument->getName(), $controller);
-            $message = preg_replace('/service "\.service_locator\.[^"]++"/', $what, $e->getMessage());
+            $what = 'argument $'.$argument->getName();
+            $message = str_replace(sprintf('service "%s"', $argument->getName()), $what, $e->getMessage());
+            $what .= sprintf(' of "%s()"', $controller);
+            $message = preg_replace('/service "\.service_locator\.[^"]++"/', $what, $message);
 
             if ($e->getMessage() === $message) {
                 $message = sprintf('Cannot resolve %s: %s', $what, $message);

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -123,6 +123,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
 
                 // create a per-method map of argument-names to service/type-references
                 $args = [];
+                $erroredIds = 0;
                 foreach ($parameters as $p) {
                     /** @var \ReflectionParameter $p */
                     $type = preg_replace('/(^|[(|&])\\\\/', '\1', $target = ltrim(ProxyHelper::exportType($p) ?? '', '?'));
@@ -171,10 +172,8 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         $value = $parameterBag->resolveValue($attribute->value);
 
                         if ($attribute instanceof AutowireCallable) {
-                            $value = $attribute->buildDefinition($value, $type, $p);
-                        }
-
-                        if ($value instanceof Reference) {
+                            $args[$p->name] = $attribute->buildDefinition($value, $type, $p);
+                        } elseif ($value instanceof Reference) {
                             $args[$p->name] = $type ? new TypedReference($value, $type, $invalidBehavior, $p->name) : new Reference($value, $invalidBehavior);
                         } else {
                             $args[$p->name] = new Reference('.value.'.$container->hash($value));
@@ -198,6 +197,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                             ->addError($message);
 
                         $args[$p->name] = new Reference($erroredId, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE);
+                        ++$erroredIds;
                     } else {
                         $target = preg_replace('/(^|[(|&])\\\\/', '\1', $target);
                         $args[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, Target::parseName($p)) : new Reference($target, $invalidBehavior);
@@ -205,7 +205,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                 }
                 // register the maps as a per-method service-locators
                 if ($args) {
-                    $controllers[$id.'::'.$r->name] = ServiceLocatorTagPass::register($container, $args);
+                    $controllers[$id.'::'.$r->name] = ServiceLocatorTagPass::register($container, $args, \count($args) !== $erroredIds ? $id.'::'.$r->name.'()' : null);
 
                     foreach ($publicAliases[$id] ?? [] as $alias) {
                         $controllers[$alias.'::'.$r->name] = clone $controllers[$id.'::'.$r->name];

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
@@ -29,6 +29,10 @@ class RemoveEmptyControllerArgumentLocatorsPass implements CompilerPassInterface
         foreach ($controllers as $controller => $argumentRef) {
             $argumentLocator = $container->getDefinition((string) $argumentRef->getValues()[0]);
 
+            if ($argumentLocator->getFactory()) {
+                $argumentLocator = $container->getDefinition($argumentLocator->getFactory()[0]);
+            }
+
             if (!$argumentLocator->getArgument(0)) {
                 // remove empty argument locators
                 $reason = sprintf('Removing service-argument resolver for controller "%s": no corresponding services exist for the referenced types.', $controller);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
@@ -89,7 +89,7 @@ class ServiceValueResolverTest extends TestCase
     public function testErrorIsTruncated()
     {
         $this->expectException(NearMissValueResolverException::class);
-        $this->expectExceptionMessage('Cannot autowire argument $dummy of "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyController::index()": it references class "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyService" but no such service exists.');
+        $this->expectExceptionMessage('Cannot autowire argument $dummy required by "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyController::index()": it references class "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyService" but no such service exists.');
         $container = new ContainerBuilder();
         $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass());
 

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -143,6 +143,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $this->assertInstanceof(ServiceClosureArgument::class, $locator['foo::fooAction']);
 
         $locator = $container->getDefinition((string) $locator['foo::fooAction']->getValues()[0]);
+        $locator = $container->getDefinition((string) $locator->getFactory()[0]);
 
         $this->assertSame(ServiceLocator::class, $locator->getClass());
         $this->assertFalse($locator->isPublic());
@@ -166,6 +167,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
         $locator = $container->getDefinition((string) $locator['foo::fooAction']->getValues()[0]);
+        $locator = $container->getDefinition((string) $locator->getFactory()[0]);
 
         $expected = ['bar' => new ServiceClosureArgument(new TypedReference('bar', ControllerDummy::class, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE))];
         $this->assertEquals($expected, $locator->getArgument(0));
@@ -185,6 +187,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
         $locator = $container->getDefinition((string) $locator['foo::fooAction']->getValues()[0]);
+        $locator = $container->getDefinition((string) $locator->getFactory()[0]);
 
         $expected = ['bar' => new ServiceClosureArgument(new TypedReference('bar', ControllerDummy::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE))];
         $this->assertEquals($expected, $locator->getArgument(0));
@@ -306,8 +309,8 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
 
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
-
         $locator = $container->getDefinition((string) $locator['foo::fooAction']->getValues()[0]);
+        $locator = $container->getDefinition((string) $locator->getFactory()[0]);
 
         $expected = ['bar' => new ServiceClosureArgument(new Reference('foo'))];
         $this->assertEquals($expected, $locator->getArgument(0));
@@ -372,7 +375,8 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
         $this->assertInstanceOf(ServiceClosureArgument::class, $locator['child::fooAction']);
 
-        $locator = $container->getDefinition((string) $locator['child::fooAction']->getValues()[0])->getArgument(0);
+        $locator = $container->getDefinition((string) $locator['child::fooAction']->getValues()[0]);
+        $locator = $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0);
         $this->assertInstanceOf(ServiceClosureArgument::class, $locator['someArg']);
         $this->assertEquals(new Reference('parent'), $locator['someArg']->getValues()[0]);
     }
@@ -439,6 +443,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
         $locator = $container->getDefinition((string) $locator['foo::fooAction']->getValues()[0]);
+        $locator = $container->getDefinition((string) $locator->getFactory()[0]);
 
         $expected = [
             'apiKey' => new ServiceClosureArgument(new Reference('the_api_key')),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Let's take a controller for example, with one action that has this argument:
```php
        #[AutowireMethodOf(CommentRepository::class)]
        \Closure $getCommentPaginator,
```

The proposed attribute tells Symfony to create a closure that will call `CommentRepository::getCommentPaginator()`. The name of the method to be called is inferred from the name of the parameter.

This is already doable with this syntax, so that the proposed attribute is just a shortcut for this:
```php
        #[AutowireCallable(service: CommentRepository::class, method: 'getCommentPaginator')]
        \Closure $getCommentPaginator,
```

Using this style allows turning e.g. entity repositories into query functions, which are way more flexible. But because the existing syntax is quite verbose, i looked for a more concise alternative, so here we are with this proposal.

Benefits:
- Increased Flexibility: Allows developers to inject specific methods as Closures, providing greater control over what functionality is injected into 
- Improved Readability: By using the attribute, the intention behind the dependency injection is made explicit, improving code clarity.
-  **Enhanced Modularity: Facilitates a more modular architecture by decoupling services from direct dependencies on specific class methods, making the codebase more maintainable and testable.**

Because we leverage the existing code infrastructure for AutowireCallable, if I declare this interface:
```php
interface GetCommentPaginatorInterface
{
    public function __invoke(Conference $conference, int $page): Paginator;
}
```

then I can also do native types (vs a closure) without doing anything else:
```php
        #[AutowireMethodOf(CommentRepository::class)]
        GetCommentPaginatorInterface $getCommentPaginator,
```
