### PR TITLE
Improvements for uuidv4 generation in the 19th character

### DIFF
--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -19,6 +19,8 @@ namespace Symfony\Component\Uid;
 class UuidV4 extends Uuid
 {
     protected const TYPE = 4;
+
+    /** @var int<0, max> */
     private static ?int $PID = null;
 
     public function __construct(?string $uuid = null)

--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -34,7 +34,7 @@ class UuidV4 extends Uuid
             $uuid[14] = '4';
             // Set the UUID variant: the 19th char must be in [8, 9, a, b]
             // xxxxxxxx-xxxx-4xxx-?xxx-xxxxxxxxxxxx
-            $uuid[19] = ['8', '9', 'a', 'b', '8', '9', 'a', 'b', 'c' => '8', 'd' => '9', 'e' => 'a', 'f' => 'b'][$uuid[19]] ?? $uuid[19];
+            $uuid[19] = ['8','9','a','b'][ord($uuid[19]) & 0x3];
             $this->uid = $uuid;
         } else {
             parent::__construct($uuid, true);

--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -19,9 +19,14 @@ namespace Symfony\Component\Uid;
 class UuidV4 extends Uuid
 {
     protected const TYPE = 4;
+    private static int $PID = null;
 
     public function __construct(?string $uuid = null)
     {
+        if (self::$PID === null) {
+            self::$PID = getmypid();
+        }
+
         if (null === $uuid) {
             // Generate 36 random hex characters (144 bits)
             // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -34,7 +39,7 @@ class UuidV4 extends Uuid
             $uuid[14] = '4';
             // Set the UUID variant: the 19th char must be in [8, 9, a, b]
             // xxxxxxxx-xxxx-4xxx-?xxx-xxxxxxxxxxxx
-            $uuid[19] = ['8','9','a','b'][getmypid() % 4];
+            $uuid[19] = ['8','9','a','b'][self::$PID % 4];
             $this->uid = $uuid;
         } else {
             parent::__construct($uuid, true);

--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Uid;
 class UuidV4 extends Uuid
 {
     protected const TYPE = 4;
-    private static int $PID = null;
+    private static ?int $PID = null;
 
     public function __construct(?string $uuid = null)
     {

--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -34,7 +34,7 @@ class UuidV4 extends Uuid
             $uuid[14] = '4';
             // Set the UUID variant: the 19th char must be in [8, 9, a, b]
             // xxxxxxxx-xxxx-4xxx-?xxx-xxxxxxxxxxxx
-            $uuid[19] = ['8','9','a','b'][ord($uuid[19]) & 0x3];
+            $uuid[19] = ['8','9','a','b'][getmypid() % 4];
             $this->uid = $uuid;
         } else {
             parent::__construct($uuid, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #
| License       | MIT

## Description of Changes

This pull request enhances the generation of the 19th character in UUIDv4 in the Symfony UuidV4 class. The Process ID (PID) has been implemented as a sufficiently random and efficient source.

## Implementation Details

- A Singleton has been introduced to store the PID and avoid its repeated retrieval during script execution.
- The character at position 19 is now set using the remainder of the PID divided by 4, ensuring a uniform distribution among ['8','9','a','b'].

## Reasons for the Improvement

- The generation of the 19th character is done more efficiently by using the PID as a random source.
- The use of the Singleton ensures the PID is obtained only once during script execution.

## Tested Variants

- Variants 1 to 6 have been tested, and the PID-based Variant 7 has shown improvements in efficiency.

## Tests Performed

Performance tests have been conducted, and the results indicate improvements in efficiency with this implementation.

It was determined that the third approach provided the best performance. Additional testing and validation are encouraged.

 ## Benchmark & details
  
 https://github.com/rafageist/sf-uuidv4-bench