### PR TITLE
[SecurityBundle] Use "event" monolog channel in traceable firewall event dispatcher

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/MakeFirewallsEventDispatcherTraceablePass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/MakeFirewallsEventDispatcherTraceablePass.php
@@ -50,7 +50,9 @@ class MakeFirewallsEventDispatcherTraceablePass implements CompilerPassInterface
                     new Reference('debug.stopwatch'),
                     new Reference('logger', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                     new Reference('request_stack', ContainerInterface::NULL_ON_INVALID_REFERENCE),
-                ]);
+                ])
+                ->addTag('monolog.logger', ['channel' => 'event'])
+                ->addTag('kernel.reset', ['method' => 'reset']);
         }
 
         foreach (['kernel.event_subscriber', 'kernel.event_listener'] as $tagName) {

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -104,6 +104,6 @@ class SecurityBundle extends Bundle
         )));
 
         // must be registered before DecoratorServicePass
-        $container->addCompilerPass(new MakeFirewallsEventDispatcherTraceablePass(), PassConfig::TYPE_OPTIMIZE, 10);
+        $container->addCompilerPass(new MakeFirewallsEventDispatcherTraceablePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | n/a
| License       | MIT

I think since https://github.com/symfony/symfony/pull/49021 was merged, security events in debug mode are logged inside the "app" (default) channel.

This is very annoying in an API use case as every request generates about 10 _useless_ log entries. 

This PR changes the monolog channel of the traceable event dispatcher to `event` and also tags it with `kernel.reset`. This matches the behavior of `debug.event_dispatcher`.

