### PR TITLE
[DependencyInjection] Fix computing error messages involving service locators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
@@ -82,7 +82,11 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testWithErroredServiceLocator()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testWithErroredServiceLocator(bool $inline)
     {
         $this->expectException(ServiceNotFoundException::class);
         $this->expectExceptionMessage('The service "foo" in the container provided to "bar" has a dependency on a non-existent service "baz".');
@@ -91,11 +95,17 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
         ServiceLocatorTagPass::register($container, ['foo' => new Reference('baz')], 'bar');
 
         (new AnalyzeServiceReferencesPass())->process($container);
-        (new InlineServiceDefinitionsPass())->process($container);
+        if ($inline) {
+            (new InlineServiceDefinitionsPass())->process($container);
+        }
         $this->process($container);
     }
 
-    public function testWithErroredHiddenService()
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testWithErroredHiddenService(bool $inline)
     {
         $this->expectException(ServiceNotFoundException::class);
         $this->expectExceptionMessage('The service "bar" has a dependency on a non-existent service "foo".');
@@ -104,7 +114,9 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
         ServiceLocatorTagPass::register($container, ['foo' => new Reference('foo')], 'bar');
 
         (new AnalyzeServiceReferencesPass())->process($container);
-        (new InlineServiceDefinitionsPass())->process($container);
+        if ($inline) {
+            (new InlineServiceDefinitionsPass())->process($container);
+        }
         $this->process($container);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Issues        | -
| License       | MIT

I just realized that #39151 broke the logic in CheckExceptionOnInvalidReferenceBehaviorPass because it relied on inlining pass doing its job. This makes the pass work with and without inlining.