### PR TITLE
[HttpKernel] Increase log level to "error" at least for all PHP errors

### DIFF
--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Increase log level to "error" at least for all PHP errors
+
 6.4
 ---
 

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -71,13 +71,13 @@ class ErrorHandler
     private array $loggers = [
         \E_DEPRECATED => [null, LogLevel::INFO],
         \E_USER_DEPRECATED => [null, LogLevel::INFO],
-        \E_NOTICE => [null, LogLevel::WARNING],
-        \E_USER_NOTICE => [null, LogLevel::WARNING],
-        \E_STRICT => [null, LogLevel::WARNING],
-        \E_WARNING => [null, LogLevel::WARNING],
-        \E_USER_WARNING => [null, LogLevel::WARNING],
-        \E_COMPILE_WARNING => [null, LogLevel::WARNING],
-        \E_CORE_WARNING => [null, LogLevel::WARNING],
+        \E_NOTICE => [null, LogLevel::ERROR],
+        \E_USER_NOTICE => [null, LogLevel::ERROR],
+        \E_STRICT => [null, LogLevel::ERROR],
+        \E_WARNING => [null, LogLevel::ERROR],
+        \E_USER_WARNING => [null, LogLevel::ERROR],
+        \E_COMPILE_WARNING => [null, LogLevel::ERROR],
+        \E_CORE_WARNING => [null, LogLevel::ERROR],
         \E_USER_ERROR => [null, LogLevel::CRITICAL],
         \E_RECOVERABLE_ERROR => [null, LogLevel::CRITICAL],
         \E_COMPILE_ERROR => [null, LogLevel::CRITICAL],
@@ -432,7 +432,7 @@ class ErrorHandler
                 return true;
             }
         } else {
-            if (PHP_VERSION_ID < 80303 && str_contains($message, '@anonymous')) {
+            if (\PHP_VERSION_ID < 80303 && str_contains($message, '@anonymous')) {
                 $backtrace = debug_backtrace(false, 5);
 
                 for ($i = 1; isset($backtrace[$i]); ++$i) {
@@ -448,7 +448,7 @@ class ErrorHandler
                 }
             }
 
-            if (false !== strpos($message, "@anonymous\0")) {
+            if (str_contains($message, "@anonymous\0")) {
                 $message = $this->parseAnonymousClass($message);
                 $logMessage = $this->levels[$type].': '.$message;
             }

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -194,13 +194,13 @@ class ErrorHandlerTest extends TestCase
             $loggers = [
                 \E_DEPRECATED => [null, LogLevel::INFO],
                 \E_USER_DEPRECATED => [null, LogLevel::INFO],
-                \E_NOTICE => [$logger, LogLevel::WARNING],
+                \E_NOTICE => [$logger, LogLevel::ERROR],
                 \E_USER_NOTICE => [$logger, LogLevel::CRITICAL],
-                \E_STRICT => [null, LogLevel::WARNING],
-                \E_WARNING => [null, LogLevel::WARNING],
-                \E_USER_WARNING => [null, LogLevel::WARNING],
-                \E_COMPILE_WARNING => [null, LogLevel::WARNING],
-                \E_CORE_WARNING => [null, LogLevel::WARNING],
+                \E_STRICT => [null, LogLevel::ERROR],
+                \E_WARNING => [null, LogLevel::ERROR],
+                \E_USER_WARNING => [null, LogLevel::ERROR],
+                \E_COMPILE_WARNING => [null, LogLevel::ERROR],
+                \E_CORE_WARNING => [null, LogLevel::ERROR],
                 \E_USER_ERROR => [null, LogLevel::CRITICAL],
                 \E_RECOVERABLE_ERROR => [null, LogLevel::CRITICAL],
                 \E_COMPILE_ERROR => [null, LogLevel::CRITICAL],
@@ -431,13 +431,13 @@ class ErrorHandlerTest extends TestCase
         $loggers = [
             \E_DEPRECATED => [$bootLogger, LogLevel::INFO],
             \E_USER_DEPRECATED => [$bootLogger, LogLevel::INFO],
-            \E_NOTICE => [$bootLogger, LogLevel::WARNING],
-            \E_USER_NOTICE => [$bootLogger, LogLevel::WARNING],
-            \E_STRICT => [$bootLogger, LogLevel::WARNING],
-            \E_WARNING => [$bootLogger, LogLevel::WARNING],
-            \E_USER_WARNING => [$bootLogger, LogLevel::WARNING],
-            \E_COMPILE_WARNING => [$bootLogger, LogLevel::WARNING],
-            \E_CORE_WARNING => [$bootLogger, LogLevel::WARNING],
+            \E_NOTICE => [$bootLogger, LogLevel::ERROR],
+            \E_USER_NOTICE => [$bootLogger, LogLevel::ERROR],
+            \E_STRICT => [$bootLogger, LogLevel::ERROR],
+            \E_WARNING => [$bootLogger, LogLevel::ERROR],
+            \E_USER_WARNING => [$bootLogger, LogLevel::ERROR],
+            \E_COMPILE_WARNING => [$bootLogger, LogLevel::ERROR],
+            \E_CORE_WARNING => [$bootLogger, LogLevel::ERROR],
             \E_USER_ERROR => [$bootLogger, LogLevel::CRITICAL],
             \E_RECOVERABLE_ERROR => [$bootLogger, LogLevel::CRITICAL],
             \E_COMPILE_ERROR => [$bootLogger, LogLevel::CRITICAL],
@@ -658,7 +658,7 @@ class ErrorHandlerTest extends TestCase
 
         $logs = $logger->cleanLogs();
 
-        $this->assertSame('warning', $logs[0][0]);
+        $this->assertSame('error', $logs[0][0]);
         $this->assertSame('Warning: assert(): assert(false) failed', $logs[0][1]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54036
| License       | MIT

reproducer: with a simple `$a = $b` in a controller.

Before
```
[PHP        ] [Fri Feb 23 17:14:26 2024] 127.0.0.1:42604 Accepted
[PHP        ] [Fri Feb 23 17:14:26 2024] 127.0.0.1:42604 [200]: GET /
[Web Server ] Feb 23 17:14:26 |INFO   | SERVER GET  (200) / ip="127.0.0.1"
[PHP        ] [Fri Feb 23 17:14:26 2024] 127.0.0.1:42604 Closing
```

After
```
[Web Server ] Feb 23 17:15:11 |INFO   | SERVER GET  (200) / ip="127.0.0.1"
[PHP        ] [Fri Feb 23 17:15:11 2024] 127.0.0.1:57906 Accepted
[PHP        ] {"message":"Matched route \"app_homepage_index\".","context":{"route":"app_homepage_index","route_parameters":{"_route":"app_homepage_index","_controller":"App\\Controller\\HomepageController::index"},"request_uri":"https://127.0.0.1:8000/","method":"GET"},"level":200,"level_name":"INFO","channel":"request","datetime":"2024-02-23T17:15:11.090004+01:00","extra":{}}
[PHP        ] {"message":"Checking for authenticator support.","context":{"firewall_name":"main","authenticators":0},"level":100,"level_name":"DEBUG","channel":"security","datetime":"2024-02-23T17:15:11.090469+01:00","extra":{}}
[PHP        ] {"message":"Warning: Undefined variable $b","context":{"exception":{"class":"ErrorException","message":"Warning: Undefined variable $b","code":0,"file":"/home/gregoire/dev/labs/symfony/symfony-7.1/src/Controller/HomepageController.php:20"}},"level":400,"level_name":"ERROR","channel":"php","datetime":"2024-02-23T17:15:11.090872+01:00","extra":{}}
[PHP        ] [Fri Feb 23 17:15:11 2024] 127.0.0.1:57906 [200]: GET /
[PHP        ] [Fri Feb 23 17:15:11 2024] 127.0.0.1:57906 Closing
```

