### PR TITLE
[Messenger] Revert "Resend failed retries back to failure transport "

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -52,6 +52,11 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
 
         $envelope = $event->getEnvelope();
 
+        // avoid re-sending to the failed sender
+        if (null !== $envelope->last(SentToFailureTransportStamp::class)) {
+            return;
+        }
+
         $envelope = $envelope->with(
             new SentToFailureTransportStamp($event->getReceiverName()),
             new DelayStamp(0),


### PR DESCRIPTION
Reverts #51848

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

See #53216, it's complex :')

I suggest to get rid of confusion between `messenger:consume failed` vs. `bin/console messenger:failed:retry` somehow.

cc @beermeat @guelosuperstart @javaDeveloperKid @fabpot