### PR TITLE
[Messenger] Passing actual `Envelope` to `WorkerMessageRetriedEvent` 

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -77,7 +77,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
             $retryEnvelope = $this->withLimitedHistory($envelope, new DelayStamp($delay), new RedeliveryStamp($retryCount));
 
             // re-send the message for retry
-            $this->getSenderForTransport($event->getReceiverName())->send($retryEnvelope);
+            $retryEnvelope = $this->getSenderForTransport($event->getReceiverName())->send($retryEnvelope);
 
             if (null !== $this->eventDispatcher) {
                 $this->eventDispatcher->dispatch(new WorkerMessageRetriedEvent($retryEnvelope, $event->getReceiverName()));

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
@@ -13,13 +13,16 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageRetriedEvent;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
 use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -185,6 +188,49 @@ class SendFailedMessageForRetryListenerTest extends TestCase
         $retryStrategyLocator->expects($this->once())->method('get')->willReturn($retryStrategy);
 
         $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
+
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
+
+        $listener->onMessageFailed($event);
+    }
+
+    public function testRetriedEnvelopePassesToRetriedEvent()
+    {
+        $exception = new \Exception('no!');
+        $envelope = new Envelope(new \stdClass());
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->once())->method('send')->willReturnCallback(static function (Envelope $envelope) {
+            return $envelope->with(new TransportMessageIdStamp(123));
+        });
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())->method('dispatch')->willReturnCallback(
+            function (WorkerMessageRetriedEvent $retriedEvent) {
+                $envelope = $retriedEvent->getEnvelope();
+
+                $transportIdStamp = $envelope->last(TransportMessageIdStamp::class);
+                $this->assertNotNull($transportIdStamp);
+
+                return $retriedEvent;
+            });
+
+        $senderLocator = new Container();
+        $senderLocator->set('my_receiver', $sender);
+
+        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStrategy->expects($this->once())->method('isRetryable')->willReturn(true);
+        $retryStrategy->expects($this->once())->method('getWaitingTime')->willReturn(1000);
+
+        $retryStrategyLocator = new Container();
+        $retryStrategyLocator->set('my_receiver', $retryStrategy);
+
+        $listener = new SendFailedMessageForRetryListener(
+            $senderLocator,
+            $retryStrategyLocator,
+            null,
+            $eventDispatcher
+        );
 
         $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52914 
| License       | MIT

In `SendFailedMessageForRetryListener` fixed the `Envelope` instance that passes to `WorkerMessageRetriedEvent`. Now it is instance of `Envelope` the that is returned by transport sender and could include such stamps as `TransportMessageIdStamp`. Previously to the event passed the not actual envelope that is created before passed to `send()`

- changes in SendFailedMessageForRetryListener
- added new test for this case in `SendFailedMessageForRetryListenerTest`