### PR TITLE
[Security] Validate that CSRF token in form login is string similar to username/password

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -161,6 +161,10 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
             throw new BadRequestHttpException(sprintf('The key "%s" must be a string, "%s" given.', $this->options['password_parameter'], \gettype($credentials['password'])));
         }
 
+        if (!\is_string($credentials['csrf_token'] ?? '') && (!\is_object($credentials['csrf_token']) || !method_exists($credentials['csrf_token'], '__toString'))) {
+            throw new BadRequestHttpException(sprintf('The key "%s" must be a string, "%s" given.', $this->options['csrf_parameter'], \gettype($credentials['csrf_token'])));
+        }
+
         return $credentials;
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -165,6 +165,54 @@ class FormLoginAuthenticatorTest extends TestCase
         $this->assertSame('s$cr$t', $credentialsBadge->getPassword());
     }
 
+    /**
+     * @dataProvider postOnlyDataProvider
+     */
+    public function testHandleNonStringCsrfTokenWithArray($postOnly)
+    {
+        $request = Request::create('/login_check', 'POST', ['_username' => 'foo', 'password' => 'bar', '_csrf_token' => []]);
+        $request->setSession($this->createSession());
+
+        $this->setUpAuthenticator(['post_only' => $postOnly]);
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('The key "_csrf_token" must be a string, "array" given.');
+
+        $this->authenticator->authenticate($request);
+    }
+
+    /**
+     * @dataProvider postOnlyDataProvider
+     */
+    public function testHandleNonStringCsrfTokenWithInt($postOnly)
+    {
+        $request = Request::create('/login_check', 'POST', ['_username' => 'foo', 'password' => 'bar', '_csrf_token' => 42]);
+        $request->setSession($this->createSession());
+
+        $this->setUpAuthenticator(['post_only' => $postOnly]);
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('The key "_csrf_token" must be a string, "integer" given.');
+
+        $this->authenticator->authenticate($request);
+    }
+
+    /**
+     * @dataProvider postOnlyDataProvider
+     */
+    public function testHandleNonStringCsrfTokenWithObject($postOnly)
+    {
+        $request = Request::create('/login_check', 'POST', ['_username' => 'foo', 'password' => 'bar', '_csrf_token' => new \stdClass()]);
+        $request->setSession($this->createSession());
+
+        $this->setUpAuthenticator(['post_only' => $postOnly]);
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('The key "_csrf_token" must be a string, "object" given.');
+
+        $this->authenticator->authenticate($request);
+    }
+
     public static function postOnlyDataProvider()
     {
         yield [true];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | See exception output below
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Fixes
```
Uncaught Error: Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge::__construct(): Argument #2 ($csrfToken) must be of type ?string, array given, called in /vendor/symfony/security-http/Authenticator/FormLoginAuthenticator.php on line 88
```