### PR TITLE
[Validator] Simplify `NoSuspiciousCharactersValidator`

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharactersValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharactersValidator.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 /**
- * @author Mathieu Lechat <mathieu.lechat@les-tilleuls.coop>
+ * @author Mathieu Lechat <math.lechat@gmail.com>
  */
 class NoSuspiciousCharactersValidator extends ConstraintValidator
 {
@@ -94,18 +94,12 @@ class NoSuspiciousCharactersValidator extends ConstraintValidator
 
         $checker->setChecks($checks);
 
-        if (!$checker->isSuspicious($value)) {
+        if (!$checker->isSuspicious($value, $errorCode)) {
             return;
         }
 
         foreach (self::CHECK_ERROR as $check => $error) {
-            if (!($checks & $check)) {
-                continue;
-            }
-
-            $checker->setChecks($check);
-
-            if (!$checker->isSuspicious($value)) {
+            if (!($errorCode & $check)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

https://github.com/php/php-src/issues/10647 has been fixed in PHP 8.1.17. Now that Symfony requires PHP ≥ 8.2, we can avoid calling `Spoofchecker::isSuspicious` for every check by leveraging its `$errorCode` parameter.