### PR TITLE
[FrameworkBundle] Fix registration of the bundle path to translation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1349,7 +1349,7 @@ class FrameworkExtension extends Extension
         $defaultDir = $container->getParameterBag()->resolveValue($config['default_path']);
         foreach ($container->getParameter('kernel.bundles_metadata') as $name => $bundle) {
             if ($container->fileExists($dir = $bundle['path'].'/Resources/translations') || $container->fileExists($dir = $bundle['path'].'/translations')) {
-                $dirs[] = $dir;
+                $dirs[] = $transPaths[] = $dir;
             } else {
                 $nonExistingDirs[] = $dir;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

31d7a09bf5c423ad2003d6863d7372e49a195af1 had a small issue resulting in a lack of proper registration of path to translation resources in installed bundles. 

The issue is caused by the incomplete update of the code where the newly added `$transPaths` variable was not updated in all code branches ([1](https://github.com/symfony/symfony/blob/85d01657a1a1aa65f57d0e0077fc7a10466acdd8/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1330), [2](https://github.com/symfony/symfony/blob/85d01657a1a1aa65f57d0e0077fc7a10466acdd8/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1335), [3](https://github.com/symfony/symfony/blob/85d01657a1a1aa65f57d0e0077fc7a10466acdd8/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1340), but not [4](https://github.com/symfony/symfony/blob/85d01657a1a1aa65f57d0e0077fc7a10466acdd8/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1345))

The issue can be reproduced and tested like this:

```bash
composer create-project symfony/skeleton test
cd test
composer require easycorp/easyadmin-bundle
php bin/console debug:translation en --domain EasyAdminBundle
```

It will result in unexpected:

```
[WARNING] No defined or extracted messages for locale "en" and domain "EasyAdminBundle"
```

After applying the fix, clearing the cache and running the same command list of messages will be returned properly.