### PR TITLE
[PropertyAccess][VarExporter] `isReadable` fails on lazy objects’ non-existent properties

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/LazyObject.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/LazyObject.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+use Symfony\Component\VarExporter\LazyGhostTrait;
+
+class LazyObject
+{
+    use LazyGhostTrait;
+
+    public bool $readableProperty;
+
+    public function __construct()
+    {
+        self::createLazyGhost(initializer: $this->hydrate(...), instance: $this);
+    }
+
+    private function hydrate(): void
+    {
+        $this->readableProperty = true;
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\ExtendedUninitializedProperty;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\LazyObject;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\ReturnTyped;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestAdderRemoverInvalidArgumentLength;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestAdderRemoverInvalidMethods;
@@ -463,6 +464,14 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor = new PropertyAccessor(PropertyAccessor::MAGIC_CALL);
 
         $this->assertTrue($this->propertyAccessor->isReadable(new TestClassMagicCall('Bernhard'), 'magicCallProperty'));
+    }
+
+    public function testIsReadableReturnsFalseIfInitializedLazyObjectPropertyDoesNotExist()
+    {
+        $object = new LazyObject();
+        $object->initializeLazyObject();
+
+        $this->assertFalse($this->propertyAccessor->isReadable($object, 'nonExistentProperty'));
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -21,7 +21,8 @@
         "symfony/property-info": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
-        "symfony/cache": "^5.4|^6.0|^7.0"
+        "symfony/cache": "^5.4|^6.0|^7.0",
+        "symfony/var-exporter": "^6.2|^7.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\PropertyAccess\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | we’ll see
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51919
| License       | MIT

In the LexikJWTAuthenticationBundle, there is a call to `PropertyAccessor::isReadable` to access the correct user identifier (see https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1037). The issue is: if the user instance is a lazy object (because it is an entity fetched from a relation e.g.), this call will fail instead of returning `false`.

Following https://github.com/symfony/symfony/issues/51919#issuecomment-1938177346, this PR only contains a failing test case for now.