### PR TITLE
[HttpKernel] Fix datacollector caster for reference object property

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -70,9 +70,21 @@ abstract class DataCollector implements DataCollectorInterface
         $casters = [
             '*' => function ($v, array $a, Stub $s, $isNested) {
                 if (!$v instanceof Stub) {
+                    $b = $a;
                     foreach ($a as $k => $v) {
-                        if (\is_object($v) && !$v instanceof \DateTimeInterface && !$v instanceof Stub) {
-                            $a[$k] = new CutStub($v);
+                        if (!\is_object($v) || $v instanceof \DateTimeInterface || $v instanceof Stub) {
+                            continue;
+                        }
+
+                        try {
+                            $a[$k] = $s = new CutStub($v);
+
+                            if ($b[$k] === $s) {
+                                // we've hit a non-typed reference
+                                $a[$k] = $v;
+                            }
+                        } catch (\TypeError $e) {
+                            // we've hit a typed reference
                         }
                     }
                 }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DataCollectorTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Tests\Fixtures\DataCollector\CloneVarDataCollector;
+use Symfony\Component\HttpKernel\Tests\Fixtures\UsePropertyInDestruct;
+use Symfony\Component\HttpKernel\Tests\Fixtures\WithPublicObjectProperty;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 class DataCollectorTest extends TestCase
@@ -34,5 +36,69 @@ class DataCollectorTest extends TestCase
         $c->collect(new Request(), new Response());
 
         $this->assertSame($filePath, $c->getData()[0]);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testClassPublicObjectProperty()
+    {
+        $parent = new WithPublicObjectProperty();
+        $child = new WithPublicObjectProperty();
+
+        $child->parent = $parent;
+
+        $c = new CloneVarDataCollector($child);
+        $c->collect(new Request(), new Response());
+
+        $this->assertNotNull($c->getData()->parent);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testClassPublicObjectPropertyAsReference()
+    {
+        $parent = new WithPublicObjectProperty();
+        $child = new WithPublicObjectProperty();
+
+        $child->parent = &$parent;
+
+        $c = new CloneVarDataCollector($child);
+        $c->collect(new Request(), new Response());
+
+        $this->assertNotNull($c->getData()->parent);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testClassUsePropertyInDestruct()
+    {
+        $parent = new UsePropertyInDestruct();
+        $child = new UsePropertyInDestruct();
+
+        $child->parent = $parent;
+
+        $c = new CloneVarDataCollector($child);
+        $c->collect(new Request(), new Response());
+
+        $this->assertNotNull($c->getData()->parent);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testClassUsePropertyAsReferenceInDestruct()
+    {
+        $parent = new UsePropertyInDestruct();
+        $child = new UsePropertyInDestruct();
+
+        $child->parent = &$parent;
+
+        $c = new CloneVarDataCollector($child);
+        $c->collect(new Request(), new Response());
+
+        $this->assertNotNull($c->getData()->parent);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/UsePropertyInDestruct.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/UsePropertyInDestruct.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+class UsePropertyInDestruct
+{
+    public string $name;
+    public $parent = null;
+
+    public function __destruct()
+    {
+        if ($this->parent !== null) {
+            $this->parent->name = '';
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/WithPublicObjectProperty.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/WithPublicObjectProperty.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+class WithPublicObjectProperty
+{
+    public ?WithPublicObjectProperty $parent = null;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #49091
| License       | MIT

As discussed on https://github.com/symfony/symfony/issues/49091:

- fix story "when assigning a variable reference to a public object property"
- add test for story "use object property in destruct method" (relate to https://github.com/PrestaShop/PrestaShop/pull/35466 )

Unit tests FAIL "Error: KO src/Symfony/Component/HttpKernel" --> normal 
