### PR TITLE
[AssetMapper] Fix `JavaScriptImportPathCompiler` regression in regex

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -28,16 +28,15 @@ use Symfony\Component\Filesystem\Path;
 final class JavaScriptImportPathCompiler implements AssetCompilerInterface
 {
     /**
-     * @see https://regex101.com/r/1iBAIb/1
+     * @see https://regex101.com/r/1iBAIb/2
      */
     private const IMPORT_PATTERN = '/
-        ^
-            (?:\/\/.*)                     # Lines that start with comments
+            ^(?:\/\/.*)                     # Lines that start with comments
         |
             (?:
-                \'(?:[^\'\\\\\n]|\\\\.)*\'   # Strings enclosed in single quotes
+                \'(?:[^\'\\\\\n]|\\\\.)*+\'   # Strings enclosed in single quotes
             |
-                "(?:[^"\\\\\n]|\\\\.)*"      # Strings enclosed in double quotes
+                "(?:[^"\\\\\n]|\\\\.)*+"      # Strings enclosed in double quotes
             )
         |
             (?:                            # Import statements (script captured)
@@ -49,7 +48,7 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
             |
                 \bimport\(
             )
-            \s*[\'"`](\.\/[^\'"`\n]+|(\.\.\/)*[^\'"`\n]+)[\'"`]\s*[;\)]
+            \s*[\'"`](\.\/[^\'"`\n]++|(\.\.\/)*+[^\'"`\n]++)[\'"`]\s*[;\)]
         ?
     /mx';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #54078
| License       | MIT

Fixes regression in regex, fix provided by @nicolas-grekas in #54078 
