### PR TITLE
[Routing] Enhance error handling in StaticPrefixCollection for compatibility with libpcre2-10.43

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
@@ -200,6 +200,7 @@ class StaticPrefixCollection
 
     public static function handleError(int $type, string $msg)
     {
-        return str_contains($msg, 'Compilation failed: lookbehind assertion is not fixed length');
+        return str_contains($msg, 'Compilation failed: lookbehind assertion is not fixed length')
+            || str_contains($msg, 'Compilation failed: length of lookbehind assertion is not limited');
     }
 }


### PR DESCRIPTION
The error handling function in the StaticPrefixCollection class has been extended. A new check for 'Compilation failed: length of lookbehind assertion is not limited' message error was added to improve the error capture process.

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54067
| License       | MIT

Recent changes in libpcre2 have changed the error message we are trying to catch in StaticPrefixCollection. The change comes from this commit (please take a look at changes in `src/pcre2_error.c`):

https://github.com/PCRE2Project/pcre2/commit/1e78b77382564b4cc9991e486652d4b105d8ee35

This PR checks for both possible error messages for backwards-compatible way of handling errors.

I did not add any tests as current tests are throwing PHP warnings when run with newer libpcre2, which are gone after the proposed change and I'm unsure how to proceed with that fact.
