### PR TITLE
[Lock] Make NoLock implement the SharedLockInterface

### DIFF
--- a/src/Symfony/Component/Lock/NoLock.php
+++ b/src/Symfony/Component/Lock/NoLock.php
@@ -19,8 +19,13 @@ namespace Symfony\Component\Lock;
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-final class NoLock implements LockInterface
+final class NoLock implements SharedLockInterface
 {
+    public function acquireRead(bool $blocking = false): bool
+    {
+        return true;
+    }
+
     public function acquire(bool $blocking = false): bool
     {
         return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53713
| License       | MIT

This PR updates the `Symfony\Component\Lock\NoLock` stub to implement `Symfony\Component\Lock\SharedLockInterface` and returns it to being compatible with the `Symfony\Component\Lock\LockFactory` return types.