### PR TITLE
[Security][Tests] Update functional tests to better reflect end-user scenarios

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
@@ -126,13 +126,13 @@ class AuthenticatorTest extends AbstractWebTestCase
 
         $client->request('POST', '/firewall1/login', [
             '_username' => 'jane@example.org',
-            '_password' => '',
+            '_password' => 'wrong',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/login');
 
         $client->request('POST', '/firewall1/dummy_login', [
             '_username' => 'jane@example.org',
-            '_password' => '',
+            '_password' => 'wrong',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/dummy_login');
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
@@ -68,6 +68,8 @@ class CsrfFormLoginTest extends AbstractWebTestCase
         });
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();
+        $form['user_login[username]'] = 'johannes';
+        $form['user_login[password]'] = 'test';
         $form['user_login[_token]'] = '';
         $client->submit($form);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Pinging @wouterj 

This PR is related to https://github.com/symfony/symfony/pull/53851 's Context.

> A person going through Symfony docs for the first time wanted to create their own LoginFormType as a next step in their learning Symfony journey and noticed that you can submit empty username/password with form login.
>
> They wanted to disallow this and tried to add validation. To validate a login form is not so straight forward as it either needs to be done with a custom authenticator (complex validation) or user provider if the data checks are simple.

Following comments: 

https://github.com/symfony/symfony/pull/53851#issuecomment-1937763662 
> Given the broken high-deps build, I wonder if this shouldn't even be done with a deprecation notice before making it throw in 8.0? 

https://github.com/symfony/symfony/pull/53851#issuecomment-1938289588
> These are 3 tests submitting an empty login form to trigger a CSRF token error. This new condition now takes precedence, meaning it returns the wrong error.
I don't think that is something we have to worry about (in both situations, login errors), it rather reveals a bad test in our codebase. I can't think of a use-case that would result in success and will become a failure after this merge.

https://github.com/symfony/symfony/pull/53851#issuecomment-1938596547 
> I think we need consensus on whether we find this a hard BC break that deserves a smooth upgrade path, but the test need to be fixed whatever the conclusion

