### PR TITLE
[Mailer] [Brevo] Remove tags from mandatory event arguments

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Webhook/BrevoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Webhook/BrevoRequestParser.php
@@ -49,7 +49,6 @@ final class BrevoRequestParser extends AbstractRequestParser
             || !isset($content['email'])
             || !isset($content['message-id'])
             || !isset($content['ts_event'])
-            || !isset($content['tags'])
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }


### PR DESCRIPTION
'tags' in not mandatory part of an event
therefore it got removed from the validation process

| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix [54088](https://github.com/symfony/symfony/issues/54088)
| License       | MIT