### PR TITLE
[Lock] Check the correct SQLSTATE error code for MySQL

### DIFF
--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -239,7 +239,7 @@ class PdoStore implements PersistingStoreInterface
             'sqlite' => str_contains($exception->getMessage(), 'no such table:'),
             'oci' => 942 === $code,
             'sqlsrv' => 208 === $code,
-            'mysql' => 1146 === $code,
+            'mysql' => '42S02' === $code,
             default => false,
         };
     }


### PR DESCRIPTION
* Closes bug: #54091

| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54091
| License       | MIT


This PR fix a wrong check of the missing table on MySQL and MariaDB engines. See bug #54091 filled by myself which has the long explanation :wink: 