### PR TITLE
[Messenger] Improve deadlock handling on `ack()` and `reject()`

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -95,6 +96,82 @@ class ConnectionTest extends TestCase
             ->willReturn($stmt);
 
         $connection = new Connection([], $driverConnection);
+        $doctrineEnvelope = $connection->get();
+        $this->assertNull($doctrineEnvelope);
+    }
+
+    public function testGetWithSkipLockedWithForUpdateMethod()
+    {
+        if (!method_exists(QueryBuilder::class, 'forUpdate')) {
+            $this->markTestSkipped('This test is for when forUpdate method exists.');
+        }
+
+        $queryBuilder = $this->getQueryBuilderMock();
+        $driverConnection = $this->getDBALConnectionMock();
+        $stmt = $this->getResultMock(false);
+
+        $queryBuilder
+            ->method('getParameters')
+            ->willReturn([]);
+        $queryBuilder
+            ->method('getParameterTypes')
+            ->willReturn([]);
+        $queryBuilder
+            ->method('forUpdate')
+            ->with(ConflictResolutionMode::SKIP_LOCKED)
+            ->willReturn($queryBuilder);
+        $queryBuilder
+            ->method('getSQL')
+            ->willReturn('SELECT FOR UPDATE SKIP LOCKED');
+        $driverConnection->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+        $driverConnection->expects($this->never())
+            ->method('update');
+        $driverConnection
+            ->method('executeQuery')
+            ->with($this->callback(function ($sql) {
+                return str_contains($sql, 'SKIP LOCKED');
+            }))
+            ->willReturn($stmt);
+
+        $connection = new Connection(['skip_locked' => true], $driverConnection);
+        $doctrineEnvelope = $connection->get();
+        $this->assertNull($doctrineEnvelope);
+    }
+
+    public function testGetWithSkipLockedWithoutForUpdateMethod()
+    {
+        if (method_exists(QueryBuilder::class, 'forUpdate')) {
+            $this->markTestSkipped('This test is for when forUpdate method does not exist.');
+        }
+
+        $queryBuilder = $this->getQueryBuilderMock();
+        $driverConnection = $this->getDBALConnectionMock();
+        $stmt = $this->getResultMock(false);
+
+        $queryBuilder
+            ->method('getParameters')
+            ->willReturn([]);
+        $queryBuilder
+            ->method('getParameterTypes')
+            ->willReturn([]);
+        $queryBuilder
+            ->method('getSQL')
+            ->willReturn('SELECT');
+        $driverConnection->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+        $driverConnection->expects($this->never())
+            ->method('update');
+        $driverConnection
+            ->method('executeQuery')
+            ->with($this->callback(function ($sql) {
+                return str_contains($sql, 'SKIP LOCKED');
+            }))
+            ->willReturn($stmt);
+
+        $connection = new Connection(['skip_locked' => true], $driverConnection);
         $doctrineEnvelope = $connection->get();
         $this->assertNull($doctrineEnvelope);
     }
@@ -507,20 +584,20 @@ class ConnectionTest extends TestCase
 
         yield 'SQL Server' => [
             class_exists(SQLServerPlatform::class) && !class_exists(SQLServer2012Platform::class) ? new SQLServerPlatform() : new SQLServer2012Platform(),
-            'SELECT m.* FROM messenger_messages m WITH (UPDLOCK, ROWLOCK) WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY  ',
+            'SELECT m.* FROM messenger_messages m WITH (UPDLOCK, ROWLOCK, READPAST) WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY  ',
         ];
 
         if (!class_exists(MySQL57Platform::class)) {
             // DBAL >= 4
             yield 'Oracle' => [
                 new OraclePlatform(),
-                'SELECT w.id AS "id", w.body AS "body", w.headers AS "headers", w.queue_name AS "queue_name", w.created_at AS "created_at", w.available_at AS "available_at", w.delivered_at AS "delivered_at" FROM messenger_messages w WHERE w.id IN (SELECT m.id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC FETCH NEXT 1 ROWS ONLY) FOR UPDATE',
+                'SELECT w.id AS "id", w.body AS "body", w.headers AS "headers", w.queue_name AS "queue_name", w.created_at AS "created_at", w.available_at AS "available_at", w.delivered_at AS "delivered_at" FROM messenger_messages w WHERE w.id IN (SELECT m.id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC FETCH NEXT 1 ROWS ONLY) FOR UPDATE SKIP LOCKED',
             ];
         } else {
             // DBAL < 4
             yield 'Oracle' => [
                 new OraclePlatform(),
-                'SELECT w.id AS "id", w.body AS "body", w.headers AS "headers", w.queue_name AS "queue_name", w.created_at AS "created_at", w.available_at AS "available_at", w.delivered_at AS "delivered_at" FROM messenger_messages w WHERE w.id IN (SELECT a.id FROM (SELECT m.id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC) a WHERE ROWNUM <= 1) FOR UPDATE',
+                'SELECT w.id AS "id", w.body AS "body", w.headers AS "headers", w.queue_name AS "queue_name", w.created_at AS "created_at", w.available_at AS "available_at", w.delivered_at AS "delivered_at" FROM messenger_messages w WHERE w.id IN (SELECT a.id FROM (SELECT m.id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC) a WHERE ROWNUM <= 1) FOR UPDATE SKIP LOCKED',
             ];
         }
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlIntegrationTest.php
@@ -66,6 +66,19 @@ class DoctrinePostgreSqlIntegrationTest extends TestCase
         $this->assertNull($this->connection->get());
     }
 
+    public function testSkipLocked()
+    {
+        $connection = new PostgreSqlConnection(['table_name' => 'queue_table', 'skip_locked' => true], $this->driverConnection);
+
+        $connection->send('{"message": "Hi"}', ['type' => DummyMessage::class]);
+
+        $encoded = $connection->get();
+        $this->assertEquals('{"message": "Hi"}', $encoded['body']);
+        $this->assertEquals(['type' => DummyMessage::class], $encoded['headers']);
+
+        $this->assertNull($connection->get());
+    }
+
     private function createSchemaManager(): AbstractSchemaManager
     {
         return method_exists($this->driverConnection, 'createSchemaManager')

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlRegularIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlRegularIntegrationTest.php
@@ -57,6 +57,20 @@ class DoctrinePostgreSqlRegularIntegrationTest extends TestCase
         $this->assertNull($this->connection->get());
     }
 
+    public function testSendAndGetWithSkipLockedEnabled()
+    {
+        $connection = new Connection(['table_name' => 'queue_table', 'skip_locked' => true], $this->driverConnection);
+        $connection->setup();
+
+        $connection->send('{"message": "Hi"}', ['type' => DummyMessage::class]);
+
+        $encoded = $connection->get();
+        $this->assertSame('{"message": "Hi"}', $encoded['body']);
+        $this->assertSame(['type' => DummyMessage::class], $encoded['headers']);
+
+        $this->assertNull($this->connection->get());
+    }
+
     protected function setUp(): void
     {
         if (!$host = getenv('POSTGRES_HOST')) {

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
@@ -128,6 +128,188 @@ class DoctrineReceiverTest extends TestCase
         $this->assertEquals(new DummyMessage('Hi'), $actualEnvelope->getMessage());
     }
 
+    public function testAck()
+    {
+        $serializer = $this->createSerializer();
+        $connection = $this->createMock(Connection::class);
+
+        $envelope = new Envelope(new \stdClass(), [new DoctrineReceivedStamp('1')]);
+        $receiver = new DoctrineReceiver($connection, $serializer);
+
+        $connection
+            ->expects($this->once())
+            ->method('ack')
+            ->with('1')
+            ->willReturn(true);
+
+        $receiver->ack($envelope);
+    }
+
+    public function testAckThrowsRetryableException()
+    {
+        $serializer = $this->createSerializer();
+        $connection = $this->createMock(Connection::class);
+
+        $envelope = new Envelope(new \stdClass(), [new DoctrineReceivedStamp('1')]);
+        $receiver = new DoctrineReceiver($connection, $serializer);
+
+        $driverException = class_exists(Exception::class) ? Exception::new(new \PDOException('Deadlock', 40001)) : new PDOException(new \PDOException('Deadlock', 40001));
+        if (!class_exists(Version::class)) {
+            // This is doctrine/dbal 3.x
+            $deadlockException = new DeadlockException($driverException, null);
+        } else {
+            $deadlockException = new DeadlockException('Deadlock', $driverException);
+        }
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('ack')
+            ->with('1')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException($deadlockException),
+                true,
+            );
+
+        $receiver->ack($envelope);
+    }
+
+    public function testAckThrowsRetryableExceptionAndRetriesFail()
+    {
+        $serializer = $this->createSerializer();
+        $connection = $this->createMock(Connection::class);
+
+        $envelope = new Envelope(new \stdClass(), [new DoctrineReceivedStamp('1')]);
+        $receiver = new DoctrineReceiver($connection, $serializer);
+
+        $driverException = class_exists(Exception::class) ? Exception::new(new \PDOException('Deadlock', 40001)) : new PDOException(new \PDOException('Deadlock', 40001));
+        if (!class_exists(Version::class)) {
+            // This is doctrine/dbal 3.x
+            $deadlockException = new DeadlockException($driverException, null);
+        } else {
+            $deadlockException = new DeadlockException('Deadlock', $driverException);
+        }
+
+        $connection
+            ->expects($this->exactly(4))
+            ->method('ack')
+            ->with('1')
+            ->willThrowException($deadlockException);
+
+        self::expectException(TransportException::class);
+        $receiver->ack($envelope);
+    }
+
+    public function testAckThrowsException()
+    {
+        $serializer = $this->createSerializer();
+        $connection = $this->createMock(Connection::class);
+
+        $envelope = new Envelope(new \stdClass(), [new DoctrineReceivedStamp('1')]);
+        $receiver = new DoctrineReceiver($connection, $serializer);
+
+        $exception = new \RuntimeException();
+
+        $connection
+            ->expects($this->once())
+            ->method('ack')
+            ->with('1')
+            ->willThrowException($exception);
+
+        self::expectException($exception::class);
+        $receiver->ack($envelope);
+    }
+
+    public function testReject()
+    {
+        $serializer = $this->createSerializer();
+        $connection = $this->createMock(Connection::class);
+
+        $envelope = new Envelope(new \stdClass(), [new DoctrineReceivedStamp('1')]);
+        $receiver = new DoctrineReceiver($connection, $serializer);
+
+        $connection
+            ->expects($this->once())
+            ->method('reject')
+            ->with('1')
+            ->willReturn(true);
+
+        $receiver->reject($envelope);
+    }
+
+    public function testRejectThrowsRetryableException()
+    {
+        $serializer = $this->createSerializer();
+        $connection = $this->createMock(Connection::class);
+
+        $envelope = new Envelope(new \stdClass(), [new DoctrineReceivedStamp('1')]);
+        $receiver = new DoctrineReceiver($connection, $serializer);
+
+        $driverException = class_exists(Exception::class) ? Exception::new(new \PDOException('Deadlock', 40001)) : new PDOException(new \PDOException('Deadlock', 40001));
+        if (!class_exists(Version::class)) {
+            // This is doctrine/dbal 3.x
+            $deadlockException = new DeadlockException($driverException, null);
+        } else {
+            $deadlockException = new DeadlockException('Deadlock', $driverException);
+        }
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('reject')
+            ->with('1')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException($deadlockException),
+                true,
+            );
+
+        $receiver->reject($envelope);
+    }
+
+    public function testRejectThrowsRetryableExceptionAndRetriesFail()
+    {
+        $serializer = $this->createSerializer();
+        $connection = $this->createMock(Connection::class);
+
+        $envelope = new Envelope(new \stdClass(), [new DoctrineReceivedStamp('1')]);
+        $receiver = new DoctrineReceiver($connection, $serializer);
+
+        $driverException = class_exists(Exception::class) ? Exception::new(new \PDOException('Deadlock', 40001)) : new PDOException(new \PDOException('Deadlock', 40001));
+        if (!class_exists(Version::class)) {
+            // This is doctrine/dbal 3.x
+            $deadlockException = new DeadlockException($driverException, null);
+        } else {
+            $deadlockException = new DeadlockException('Deadlock', $driverException);
+        }
+
+        $connection
+            ->expects($this->exactly(4))
+            ->method('reject')
+            ->with('1')
+            ->willThrowException($deadlockException);
+
+        self::expectException(TransportException::class);
+        $receiver->reject($envelope);
+    }
+
+    public function testRejectThrowsException()
+    {
+        $serializer = $this->createSerializer();
+        $connection = $this->createMock(Connection::class);
+
+        $envelope = new Envelope(new \stdClass(), [new DoctrineReceivedStamp('1')]);
+        $receiver = new DoctrineReceiver($connection, $serializer);
+
+        $exception = new \RuntimeException();
+
+        $connection
+            ->expects($this->once())
+            ->method('reject')
+            ->with('1')
+            ->willThrowException($exception);
+
+        self::expectException($exception::class);
+        $receiver->reject($envelope);
+    }
+
     private function createDoctrineEnvelope(): array
     {
         return [

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -186,15 +187,22 @@ class Connection implements ResetInterface
                     ->setParameters($query->getParameters(), $query->getParameterTypes());
 
                 if (method_exists(QueryBuilder::class, 'forUpdate')) {
-                    $query->forUpdate();
+                    $query->forUpdate(ConflictResolutionMode::SKIP_LOCKED);
                 }
 
                 $sql = $query->getSQL();
             } elseif (method_exists(QueryBuilder::class, 'forUpdate')) {
-                $query->forUpdate();
+                $query->forUpdate(ConflictResolutionMode::SKIP_LOCKED);
                 try {
                     $sql = $query->getSQL();
                 } catch (DBALException $e) {
+                    // If SKIP_LOCKED is not supported, fallback to without SKIP_LOCKED
+                    $query->forUpdate();
+
+                    try {
+                        $sql = $query->getSQL();
+                    } catch (DBALException $e) {
+                    }
                 }
             } elseif (preg_match('/FROM (.+) WHERE/', (string) $sql, $matches)) {
                 $fromClause = $matches[1];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54103
| License       | MIT

We started getting this deadlock recently. It has happened only twice so far under high load.

```
SQLSTATE[40P01]: Deadlock detected: 7 ERROR:  deadlock detected
DETAIL:  Process 221664 waits for ShareLock on transaction 59539641; blocked by process 221671.
Process 221671 waits for AccessExclusiveLock on tuple (77,27) of relation 16455 of database 16385; blocked by process 221605.
Process 221605 waits for ShareLock on transaction 59539646; blocked by process 221606.
Process 221606 waits for AccessExclusiveLock on tuple (69,16) of relation 16455 of database 16385; blocked by process 221664.
HINT:  See server log for query details.
CONTEXT:  while deleting tuple (69,16) in relation "messenger_messages"
Process 221664 waits for ShareLock on transaction 59539641;
blocked by process 221671.
```

Here are the queries for each process:

```
Process 221664 waits for ShareLock on transaction 59539641;
blocked by process 221671.

221671
SELECT m.* FROM messenger_messages m WHERE (m.queue_name = $1) AND (m.delivered_at is null OR m.delivered_at < $2) AND (m.available_at <= $3) ORDER BY available_at ASC LIMIT 1 FOR UPDATE

221605
SELECT m.* FROM messenger_messages m WHERE (m.queue_name = $1) AND (m.delivered_at is null OR m.delivered_at < $2) AND (m.available_at <= $3) ORDER BY available_at ASC LIMIT 1 FOR UPDATE

221606
SELECT m.* FROM messenger_messages m WHERE (m.queue_name = $1) AND (m.delivered_at is null OR m.delivered_at < $2) AND (m.available_at <= $3) ORDER BY available_at ASC LIMIT 1 FOR UPDATE

221664
DELETE FROM messenger_messages WHERE id = $1
```

Open for discussion if this is the right way to handle this or not.

TODO:

- [x] Should there be a retry delay/exponential backoff/jitter? Retrying the failed delete that deadlocked immediately may not help.
- [x] Should `skip_locked` even be an option or should we always use skip locked?
- [x] Should we add `SKIP LOCKED` to the `FOR UPDATE`? It will reduce contention further. I was looking at how SolidQueue in Ruby On Rails handles this and it appears they use `SKIP LOCKED FOR UPDATE` https://github.com/basecamp/solid_queue/blob/fe57349a126efc381fe0adf4c1ec444bd8a4f53f/app/models/solid_queue/record.rb#L11