### PR TITLE
[AssetMapper] Minor: Reword warning message

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -89,7 +89,7 @@ EOT
 
         if ($this->isDebug) {
             $io->warning(sprintf(
-                'You are compiling assets in development. Symfony will not serve any changed assets until you delete the files in the "%s" directory.',
+                'Debug mode is enabled in your project: Symfony will not serve any changed assets until you delete the files in the "%s" directory again.',
                 $this->shortenPath(\dirname($manifestPath))
             ));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

"in development" is somewhat unclear.
But since the criteria is `if ($this->isDebug)`, the new "in dev enviroment" isn't completely true either, so maybe rephrase it to something like "in an environment with debug mode enabled"?