### PR TITLE
[HttpKernel] Improve error reporting when requiring the wrong Request class

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add method `isKernelTerminating()` to `ExceptionEvent` that allows to check if an exception was thrown while the kernel is being terminated
  * Add `HttpException::fromStatusCode()`
  * Add `$validationFailedStatusCode` argument to `#[MapQueryParameter]` that allows setting a custom HTTP status code when validation fails
+ * `NearMissValueResolverException` is introduced that lets value resolvers tell when an argument could be under their watch but failed to be resolved
 
 7.0
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestValueResolver.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 
 /**
  * Yields the same instance as the request object passed along.
@@ -24,6 +25,14 @@ final class RequestValueResolver implements ValueResolverInterface
 {
     public function resolve(Request $request, ArgumentMetadata $argument): array
     {
-        return Request::class === $argument->getType() || is_subclass_of($argument->getType(), Request::class) ? [$request] : [];
+        if (Request::class === $argument->getType() || is_subclass_of($argument->getType(), Request::class)) {
+            return [$request];
+        }
+
+        if (str_ends_with($argument->getType() ?? '', '\\Request')) {
+            throw new NearMissValueResolverException(sprintf('Looks like you required a Request object with the wrong class name "%s". Did you mean to use "%s" instead?', $argument->getType(), Request::class));
+        }
+
+        return [];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 
 /**
  * Yields a service keyed by _controller and argument name.
@@ -61,10 +62,7 @@ final class ServiceValueResolver implements ValueResolverInterface
                 $message = sprintf('Cannot resolve %s: %s', $what, $message);
             }
 
-            $r = new \ReflectionProperty($e, 'message');
-            $r->setValue($e, $message);
-
-            throw $e;
+            throw new NearMissValueResolverException($message, $e->getCode(), $e);
         }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/NearMissValueResolverException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NearMissValueResolverException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * Lets value resolvers tell when an argument could be under their watch but failed to be resolved.
+ *
+ * Throwing this exception inside `ValueResolverInterface::resolve` does not interrupt the value resolvers chain.
+ */
+class NearMissValueResolverException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestValueResolverTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\BrowserKit\Request as RandomRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
+
+class RequestValueResolverTest extends TestCase
+{
+    public function testSameRequestReturned()
+    {
+        $resolver = new RequestValueResolver();
+        $expectedRequest = Request::create('/');
+        $actualRequest = $resolver->resolve($expectedRequest, new ArgumentMetadata('request', Request::class, false, false, null));
+        self::assertCount(1, $actualRequest);
+        self::assertSame($expectedRequest, $actualRequest[0] ?? null);
+    }
+
+    public function testRequestIsNotResolvedForRandomClass()
+    {
+        $resolver = new RequestValueResolver();
+        $expectedRequest = Request::create('/');
+        $actualRequest = $resolver->resolve($expectedRequest, new ArgumentMetadata('request', self::class, false, false, null));
+        self::assertCount(0, $actualRequest);
+    }
+
+    public function testExceptionThrownForRandomRequestClass()
+    {
+        $resolver = new RequestValueResolver();
+        $expectedRequest = Request::create('/');
+        $this->expectException(NearMissValueResolverException::class);
+        $resolver->resolve($expectedRequest, new ArgumentMetadata('request', RandomRequest::class, false, false, null));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ServiceValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\DependencyInjection\RegisterControllerArgumentLocatorsPass;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 
 class ServiceValueResolverTest extends TestCase
 {
@@ -88,7 +88,7 @@ class ServiceValueResolverTest extends TestCase
 
     public function testErrorIsTruncated()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(NearMissValueResolverException::class);
         $this->expectExceptionMessage('Cannot autowire argument $dummy of "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyController::index()": it references class "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyService" but no such service exists.');
         $container = new ContainerBuilder();
         $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54015 
| License       | MIT

`NearMissValueResolverException` is introduced to be used inside any implementer of `ValueResolverInterface` to specify why exactly a value cannot be resolved. It's later used in `ArgumentResolver` to compute an exception if no value resolvers can resolve the value.
