### PR TITLE
[AssetMapper] Throw exception in Javascript compiler when PCRE error

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -115,7 +115,7 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
             $relativeImportPath = $this->makeRelativeForJavaScript($relativeImportPath);
 
             return str_replace($importedModule, $relativeImportPath, $fullImportString);
-        }, $content, -1, $count, \PREG_OFFSET_CAPTURE);
+        }, $content, -1, $count, \PREG_OFFSET_CAPTURE) ?? throw new RuntimeException(sprintf('Failed to compile JavaScript import paths in "%s". Error: "%s".', $asset->sourcePath, preg_last_error_msg()));
     }
 
     public function supports(MappedAsset $asset): bool

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -641,4 +641,23 @@ class JavaScriptImportPathCompilerTest extends TestCase
         // should not be caught.
         $this->assertSame($content, $compiled);
     }
+
+    public function testCompilerThrowsExceptionOnPcreError()
+    {
+        $compiler = new JavaScriptImportPathCompiler($this->createMock(ImportMapConfigReader::class));
+        $content = str_repeat('foo "import *  ', 50);
+        $javascriptAsset = new MappedAsset('app.js', '/project/assets/app.js', publicPathWithoutDigest: '/assets/app.js');
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to compile JavaScript import paths in "/project/assets/app.js". Error: "Backtrack limit exhausted".');
+
+        $limit = \ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', 10);
+        try {
+            $compiler->compile($content, $javascriptAsset, $assetMapper);
+        } finally {
+            ini_set('pcre.backtrack_limit', $limit);
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

`preg_match_callback` can return null when a PCRE error occured, leading there to a TypeError.

Let's throw an exception and expose the error message.


(follows #54078 / complementary to #54079 )


