### PR TITLE
[DependencyInjection] Better error message when a param is not defined

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -56,7 +57,14 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
                     BaseNode::setPlaceholderUniquePrefix($resolvingBag->getEnvPlaceholderUniquePrefix());
                 }
             }
-            $config = $resolvingBag->resolveValue($config);
+
+            try {
+                $config = $resolvingBag->resolveValue($config);
+            } catch (ParameterNotFoundException $e) {
+                $e->setSourceExtensionName($name);
+
+                throw $e;
+            }
 
             try {
                 $tmpContainer = new MergeExtensionConfigurationContainerBuilder($extension, $resolvingBag);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -127,9 +128,30 @@ class MergeExtensionConfigurationPassTest extends TestCase
             $pass->process($container);
             $this->fail('An exception should have been thrown.');
         } catch (\Exception $e) {
+            $this->assertSame('here', $e->getMessage());
         }
 
         $this->assertSame(['FOO'], array_keys($container->getParameterBag()->getEnvPlaceholders()));
+    }
+
+    public function testMissingParameterIncludesExtension()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new FooExtension());
+        $container->prependExtensionConfig('foo', [
+            'foo' => '%missing_parameter%',
+        ]);
+
+        $pass = new MergeExtensionConfigurationPass();
+        try {
+            $pass = new MergeExtensionConfigurationPass();
+            $pass->process($container);
+            $this->fail('An exception should have been thrown.');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(ParameterNotFoundException::class, $e);
+            $this->assertSame('You have requested a non-existent parameter "missing_parameter" while loading extension "foo".', $e->getMessage());
+        }
+
     }
 
     public function testReuseEnvPlaceholderGeneratedByPreviousExtension()
@@ -210,7 +232,7 @@ class ThrowingExtension extends Extension
 
     public function load(array $configs, ContainerBuilder $container): void
     {
-        throw new \Exception();
+        throw new \Exception('here');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

---

I'm migrating an application to flex, and bundles loading is important.
So let's enhance error reporting

## Before:

```
orpi /var/www/projects/frontend bin/console                                                                                                                                                  

In ParameterBag.php line 93:                                                                                                                                                                 

  You have requested a non-existent parameter "orpi.ocom_domain". Did you mean one of these: "orpi_domain", "orpi_ocom_subdomain"?
```

## After

```
orpi /var/www/projects/frontend bin/console  -v

In ParameterBag.php line 93:

  [Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]                                                                                               
  You have requested a non-existent parameter "orpi.ocom_domain" while loading extension "fos_http_cache". Did you mean one of these: "orpi_domain", "orpi_ocom_subdomain"?  

```
