### PR TITLE
[AssetMapper] Remove undefined $path variable

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -64,7 +64,7 @@ class ImportMapConfigReader
 
             $version = $data['version'] ?? null;
 
-            if (null === $version && null === $path) {
+            if (null === $version) {
                 throw new RuntimeException(sprintf('The importmap entry "%s" must have either a "path" or "version" option.', $importName));
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

The `$path` variable was originally removed in this commit, https://github.com/symfony/symfony/commit/c80a1abf8b448e4444448032d79764b9e8aeefdb#diff-ac1411bcebc4a2a31db403a027cb257f5a5c0e06936516435b88235149234a0fR73 However, it appears to have been reintroduced during subsequent merges.

The variable is not in the [6.4 code](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php)
