### PR TITLE
[Messenger] trigger retry logic when message is a redelivery

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,7 +8,6 @@ CHANGELOG
  * Add `HandlerDescriptor::getOptions`
  * Add support for multiple Redis Sentinel hosts
  * Add `--all` option to the `messenger:failed:remove` command
- * `RejectRedeliveredMessageException` implements `UnrecoverableExceptionInterface` in order to not be retried
  * Add `WrappedExceptionsInterface` interface for exceptions that hold multiple individual exceptions
  * Deprecate `HandlerFailedException::getNestedExceptions()`, `HandlerFailedException::getNestedExceptionsOfClass()`
    and `DelayedMessageHandlingException::getExceptions()` which are replaced by a new `getWrappedExceptions()` method

--- a/src/Symfony/Component/Messenger/Exception/RejectRedeliveredMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/RejectRedeliveredMessageException.php
@@ -14,6 +14,6 @@ namespace Symfony\Component\Messenger\Exception;
 /**
  * @author Tobias Schultze <http://tobion.de>
  */
-class RejectRedeliveredMessageException extends RuntimeException implements UnrecoverableExceptionInterface
+class RejectRedeliveredMessageException extends RuntimeException
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52903 #53311
| License       | MIT

This PR rollbacks https://github.com/symfony/symfony/pull/51756 which was an error

ping @itcodeOstrowski @beermeat