### PR TITLE
[AssetMapper] Deprecate unused method `splitPackageNameAndFilePath`

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 7.0 to 7.1
 =======================
 
+AssetMapper
+-----------
+
+ * Deprecate `ImportMapConfigReader::splitPackageNameAndFilePath()`, use `ImportMapEntry::splitPackageNameAndFilePath()` instead
+
 Cache
 -----
 

--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Deprecate `ImportMapConfigReader::splitPackageNameAndFilePath()`, use `ImportMapEntry::splitPackageNameAndFilePath()` instead
+
 6.4
 ---
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -172,8 +172,13 @@ class ImportMapConfigReader
         return \dirname($this->importMapConfigPath);
     }
 
+    /**
+     * @deprecated since Symfony 7.1, use ImportMapEntry::splitPackageNameAndFilePath() instead
+     */
     public static function splitPackageNameAndFilePath(string $packageName): array
     {
+        trigger_deprecation('symfony/asset-mapper', '7.1', 'The method "%s()" is deprecated and will be removed in 8.0. Use ImportMapEntry::splitPackageNameAndFilePath() instead.', __METHOD__);
+
         $filePath = '';
         $i = strpos($packageName, '/');
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\AssetMapper\Tests\ImportMap;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntries;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
@@ -21,6 +22,8 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class ImportMapConfigReaderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private Filesystem $filesystem;
 
     protected function setUp(): void
@@ -161,5 +164,14 @@ EOF;
         $entry = $configReader->findRootImportMapEntry('file2');
         $this->assertSame('file2', $entry->importName);
         $this->assertSame('file2.js', $entry->path);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedMethodTriggerDeprecation()
+    {
+        $this->expectDeprecation('Since symfony/asset-mapper 7.1: The method "Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader::splitPackageNameAndFilePath()" is deprecated and will be removed in 8.0. Use ImportMapEntry::splitPackageNameAndFilePath() instead.');
+        ImportMapConfigReader::splitPackageNameAndFilePath('foo');
     }
 }

--- a/src/Symfony/Component/AssetMapper/composer.json
+++ b/src/Symfony/Component/AssetMapper/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.2",
         "composer/semver": "^3.0",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/filesystem": "^6.4|^7.0",
         "symfony/http-client": "^6.4|^7.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #54123
| License       | MIT

This method is not used in the codebase, and duplicates` ImportMapEntry::splitPackageNameAndFilePath()`