### PR TITLE
[Clock] Add attributes to support PHPUnit 10 + 11

### DIFF
--- a/src/Symfony/Component/Clock/Test/ClockSensitiveTrait.php
+++ b/src/Symfony/Component/Clock/Test/ClockSensitiveTrait.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Clock\Test;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
 use Symfony\Component\Clock\MockClock;
@@ -48,6 +51,8 @@ trait ClockSensitiveTrait
      *
      * @internal
      */
+    #[Before]
+    #[BeforeClass]
     public static function saveClockBeforeTest(bool $save = true): ClockInterface
     {
         static $originalClock;
@@ -64,6 +69,7 @@ trait ClockSensitiveTrait
      *
      * @internal
      */
+    #[After]
     protected static function restoreClockAfterTest(): void
     {
         Clock::set(self::saveClockBeforeTest(false));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT


While upgrading to PHPUnit 11 I noticed the following deprecation:

> Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

If we add the attribute too, it stops complaining. So this most be a way to support PHPUnit 11 and older versions.