### PR TITLE
[OptionsResolver] Fix allowed types not defined as string

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -431,9 +431,7 @@ class OptionsResolver implements Options
      * passed to the closure is the value of the option after validating it
      * and before normalizing it.
      *
-     * @param string          $package The name of the composer package that is triggering the deprecation
-     * @param string          $version The version of the package that introduced the deprecation
-     * @param string|\Closure $message The deprecation message to use
+     * @param string $package The name of the composer package that is triggering the deprecation
      *
      * @return $this
      */
@@ -932,8 +930,6 @@ class OptionsResolver implements Options
      *
      * @param bool $triggerDeprecation Whether to trigger the deprecation or not (true by default)
      *
-     * @return mixed
-     *
      * @throws AccessException           If accessing this method outside of
      *                                   {@link resolve()}
      * @throws NoSuchOptionException     If the option is not set
@@ -1040,7 +1036,7 @@ class OptionsResolver implements Options
             $invalidTypes = [];
 
             foreach ($this->allowedTypes[$option] as $type) {
-                if ($valid = is_scalar($type) && $this->verifyTypes($type, $value, $invalidTypes)) {
+                if ($valid = \is_scalar($type) && $this->verifyTypes($type, $value, $invalidTypes)) {
                     break;
                 }
             }
@@ -1050,7 +1046,7 @@ class OptionsResolver implements Options
                 if (!$fmtProvidedTypes) {
                     $invalidTypes = $this->allowedTypes[$option];
                     array_walk($invalidTypes, static function (&$item) {
-                        $item = is_scalar($item) ? null : gettype($item);
+                        $item = \is_scalar($item) ? null : \gettype($item);
                     });
                     throw new InvalidOptionsException(sprintf('The option "%s" contains invalid non-scalar type definitions : "%s".', $this->formatOptions([$option]), implode(', ', array_unique($invalidTypes))));
                 }
@@ -1276,7 +1272,7 @@ class OptionsResolver implements Options
     private function formatValue($value): string
     {
         if (\is_object($value)) {
-            return \get_class($value);
+            return $value::class;
         }
 
         if (\is_array($value)) {

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -431,7 +431,9 @@ class OptionsResolver implements Options
      * passed to the closure is the value of the option after validating it
      * and before normalizing it.
      *
-     * @param string $package The name of the composer package that is triggering the deprecation
+     * @param string          $package The name of the composer package that is triggering the deprecation
+     * @param string          $version The version of the package that introduced the deprecation
+     * @param string|\Closure $message The deprecation message to use
      *
      * @return $this
      */
@@ -930,6 +932,8 @@ class OptionsResolver implements Options
      *
      * @param bool $triggerDeprecation Whether to trigger the deprecation or not (true by default)
      *
+     * @return mixed
+     *
      * @throws AccessException           If accessing this method outside of
      *                                   {@link resolve()}
      * @throws NoSuchOptionException     If the option is not set
@@ -1036,7 +1040,7 @@ class OptionsResolver implements Options
             $invalidTypes = [];
 
             foreach ($this->allowedTypes[$option] as $type) {
-                if ($valid = \is_scalar($type) && $this->verifyTypes($type, $value, $invalidTypes)) {
+                if ($valid = is_scalar($type) && $this->verifyTypes($type, $value, $invalidTypes)) {
                     break;
                 }
             }
@@ -1046,7 +1050,7 @@ class OptionsResolver implements Options
                 if (!$fmtProvidedTypes) {
                     $invalidTypes = $this->allowedTypes[$option];
                     array_walk($invalidTypes, static function (&$item) {
-                        $item = \is_scalar($item) ? null : \gettype($item);
+                        $item = is_scalar($item) ? null : gettype($item);
                     });
                     throw new InvalidOptionsException(sprintf('The option "%s" contains invalid non-scalar type definitions : %s.', $this->formatOptions([$option]), implode(', ', array_unique($invalidTypes))));
                 }
@@ -1272,7 +1276,7 @@ class OptionsResolver implements Options
     private function formatValue($value): string
     {
         if (\is_object($value)) {
-            return $value::class;
+            return \get_class($value);
         }
 
         if (\is_array($value)) {

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1040,7 +1040,7 @@ class OptionsResolver implements Options
             $invalidTypes = [];
 
             foreach ($this->allowedTypes[$option] as $type) {
-                if ($valid = is_scalar($type) && $this->verifyTypes($type, $value, $invalidTypes)) {
+                if ($valid = \is_scalar($type) && $this->verifyTypes($type, $value, $invalidTypes)) {
                     break;
                 }
             }
@@ -1050,7 +1050,7 @@ class OptionsResolver implements Options
                 if (!$fmtProvidedTypes) {
                     $invalidTypes = $this->allowedTypes[$option];
                     array_walk($invalidTypes, static function (&$item) {
-                        $item = is_scalar($item) ? null : gettype($item);
+                        $item = \is_scalar($item) ? null : \gettype($item);
                     });
                     throw new InvalidOptionsException(sprintf('The option "%s" contains invalid non-scalar type definitions : %s.', $this->formatOptions([$option]), implode(', ', array_unique($invalidTypes))));
                 }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -973,7 +973,7 @@ class OptionsResolver implements Options
             }
 
             if (!\is_array($value)) {
-                throw new InvalidOptionsException(sprintf('The nested option "%s" with value "%s" is expected to be of type array, but is of type "%s".', $this->formatOptions([$option]), $this->formatValue($value), get_debug_type($value)));
+                throw new InvalidOptionsException(sprintf('The nested option "%s" with value %s is expected to be of type array, but is of type "%s".', $this->formatOptions([$option]), $this->formatValue($value), get_debug_type($value)));
             }
 
             // The following section must be protected from cyclic calls.
@@ -1048,7 +1048,7 @@ class OptionsResolver implements Options
                     array_walk($invalidTypes, static function (&$item) {
                         $item = \is_scalar($item) ? null : \gettype($item);
                     });
-                    throw new InvalidOptionsException(sprintf('The option "%s" contains invalid non-scalar type definitions : "%s".', $this->formatOptions([$option]), implode(', ', array_unique($invalidTypes))));
+                    throw new InvalidOptionsException(sprintf('The option "%s" contains invalid non-scalar type definitions : %s.', $this->formatOptions([$option]), implode(', ', array_unique($invalidTypes))));
                 }
                 $fmtActualValue = $this->formatValue($value);
                 $fmtAllowedTypes = implode('" or "', $this->allowedTypes[$option]);
@@ -1057,10 +1057,10 @@ class OptionsResolver implements Options
                 })) > 0;
 
                 if (\is_array($value) && $allowedContainsArrayType) {
-                    throw new InvalidOptionsException(sprintf('The option "%s" with value "%s" is expected to be of type "%s", but one of the elements is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
+                    throw new InvalidOptionsException(sprintf('The option "%s" with value %s is expected to be of type "%s", but one of the elements is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
                 }
 
-                throw new InvalidOptionsException(sprintf('The option "%s" with value "%s" is expected to be of type "%s", but is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
+                throw new InvalidOptionsException(sprintf('The option "%s" with value %s is expected to be of type "%s", but is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
             }
         }
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -977,7 +977,7 @@ class OptionsResolver implements Options
             }
 
             if (!\is_array($value)) {
-                throw new InvalidOptionsException(sprintf('The nested option "%s" with value %s is expected to be of type array, but is of type "%s".', $this->formatOptions([$option]), $this->formatValue($value), get_debug_type($value)));
+                throw new InvalidOptionsException(sprintf('The nested option "%s" with value "%s" is expected to be of type array, but is of type "%s".', $this->formatOptions([$option]), $this->formatValue($value), get_debug_type($value)));
             }
 
             // The following section must be protected from cyclic calls.
@@ -1052,7 +1052,7 @@ class OptionsResolver implements Options
                     array_walk($invalidTypes, static function (&$item) {
                         $item = is_scalar($item) ? null : gettype($item);
                     });
-                    throw new InvalidOptionsException(sprintf('The option "%s" contains invalid non-scalar type definitions : %s.', $this->formatOptions([$option]), implode(', ', array_unique($invalidTypes))));
+                    throw new InvalidOptionsException(sprintf('The option "%s" contains invalid non-scalar type definitions : "%s".', $this->formatOptions([$option]), implode(', ', array_unique($invalidTypes))));
                 }
                 $fmtActualValue = $this->formatValue($value);
                 $fmtAllowedTypes = implode('" or "', $this->allowedTypes[$option]);
@@ -1061,10 +1061,10 @@ class OptionsResolver implements Options
                 })) > 0;
 
                 if (\is_array($value) && $allowedContainsArrayType) {
-                    throw new InvalidOptionsException(sprintf('The option "%s" with value %s is expected to be of type "%s", but one of the elements is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
+                    throw new InvalidOptionsException(sprintf('The option "%s" with value "%s" is expected to be of type "%s", but one of the elements is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
                 }
 
-                throw new InvalidOptionsException(sprintf('The option "%s" with value %s is expected to be of type "%s", but is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
+                throw new InvalidOptionsException(sprintf('The option "%s" with value "%s" is expected to be of type "%s", but is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
             }
         }
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -2593,4 +2593,13 @@ class OptionsResolverTest extends TestCase
 
         $this->assertSame($expectedOptions, $actualOptions);
     }
+
+    public function testInvalidOptionsExceptionOnNonScalarAllowedTypesDefinitions()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "foo" contains invalid non-scalar type definitions : array, object, NULL.');
+        $this->resolver->setDefault('foo', 'bar');
+        $this->resolver->setAllowedTypes('foo', [[], $this, null]);
+        $this->resolver->resolve([]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54131
| License       | MIT

## Issue
Misuse of `addAllowedTypes()` and `setAllowedTypes()` with non-scalar definitions returns different PHP fatal errors.
See all details and how to reproduce it in the issue https://github.com/symfony/symfony/issues/54131

## Solution
In this PR
 - Add an exception if allowed types not scalars
   .e.g : `The option "foo" contains invalid non-scalar type definitions : array, object, NULL.`
 - Add tests

