### PR TITLE
[WIP] [AssetMapper] Allow Asset Mapper to use other package resolvers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -23,6 +23,7 @@ class UnusedTagsPass implements CompilerPassInterface
 {
     private const KNOWN_TAGS = [
         'asset_mapper.compiler',
+        'asset_mapper.importmap.resolver',
         'assets.package',
         'auto_alias',
         'cache.pool',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -40,7 +40,6 @@ use Symfony\Component\AssetMapper\ImportMap\ImportMapVersionChecker;
 use Symfony\Component\AssetMapper\ImportMap\RemotePackageDownloader;
 use Symfony\Component\AssetMapper\ImportMap\RemotePackageStorage;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\JsDelivrEsmResolver;
-use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverRegistry;
 use Symfony\Component\AssetMapper\MapperAwareAssetPackage;
 use Symfony\Component\AssetMapper\Path\LocalPublicAssetsFilesystem;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -169,7 +169,7 @@ return static function (ContainerConfigurator $container) {
                 service('asset_mapper'),
                 service('asset_mapper.importmap.config_reader'),
                 service('asset_mapper.importmap.remote_package_downloader'),
-                service('asset_mapper.importmap.resolver'),
+                service('asset_mapper.importmap.resolver_registry'),
             ])
         ->alias(ImportMapManager::class, 'asset_mapper.importmap.manager')
 
@@ -235,7 +235,6 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('asset_mapper.importmap.manager'),
                 service('asset_mapper.importmap.version_checker'),
-                service('asset_mapper.importmap.resolver_registry'),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
@@ -73,6 +73,13 @@ To add an importmap entry pointing to a local file, use the <info>path</info> op
 
     <info>php %command.full_name% "any_module_name" --path=./assets/some_file.js</info>
 
+To add an importmap entry pointing to a different resolver, use the <info>resolver</info> option:
+
+    <info>php %command.full_name% "any_module_name" --resolver=unpkg</info>
+
+The default resolver is <comment>jsdelivr</comment>. You can also set a different resolver
+in the <comment>importmap.php</comment> file.
+
 EOT
             );
     }

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapManager;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapVersionChecker;
 use Symfony\Component\AssetMapper\ImportMap\PackageRequireOptions;
-use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -35,7 +34,6 @@ final class ImportMapRequireCommand extends Command
     public function __construct(
         private readonly ImportMapManager $importMapManager,
         private readonly ImportMapVersionChecker $importMapVersionChecker,
-        private readonly PackageResolverRegistry $resolverRegistry,
     ) {
         parent::__construct();
     }
@@ -46,7 +44,7 @@ final class ImportMapRequireCommand extends Command
             ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The packages to add')
             ->addOption('entrypoint', null, InputOption::VALUE_NONE, 'Make the package(s) an entrypoint?')
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The local path where the package lives relative to the project root')
-            ->addOption('resolver', null, InputOption::VALUE_REQUIRED, 'The alias of the package resolver to use', 'jsdelivr')
+            ->addOption('resolver', null, InputOption::VALUE_REQUIRED, 'The alias of the package resolver to use')
             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command adds packages to <comment>importmap.php</comment> usually
 by finding a CDN URL for the given package and version.
@@ -109,15 +107,11 @@ EOT
                 $parts['version'] ?? null,
                 $parts['alias'] ?? null,
                 $path,
+                $input->getOption('resolver'),
                 $input->getOption('entrypoint'),
             );
         }
 
-        $this->importMapManager->setResolver(
-            $this->resolverRegistry->getResolver(
-                $input->getOption('resolver')
-            )
-        );
         $newPackages = $this->importMapManager->require($packages);
 
         $this->renderVersionProblems($this->importMapVersionChecker, $output);

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -64,7 +64,8 @@ class ImportMapConfigReader
 
             $version = $data['version'] ?? null;
 
-            if (null === $version && null === $path) {
+            // At this point, the path is not set, so we must have a version
+            if (null === $version) {
                 throw new RuntimeException(sprintf('The importmap entry "%s" must have either a "path" or "version" option.', $importName));
             }
 
@@ -98,8 +99,8 @@ class ImportMapConfigReader
                 $config['entrypoint'] = true;
             }
 
-            if ($entry->resolver) {
-                $config['resolver'] = $entry->resolver;
+            if ($entry->resolverAlias) {
+                $config['resolver'] = $entry->resolverAlias;
             }
 
             $importMapConfig[$entry->importName] = $config;

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
@@ -26,7 +26,7 @@ final class ImportMapEntry
          */
         public readonly string $path,
         public readonly bool $isEntrypoint,
-        public readonly ?string $resolver,
+        public readonly ?string $resolverAlias,
         /**
          * The version of the package (remote only).
          */

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
@@ -26,6 +26,7 @@ final class ImportMapEntry
          */
         public readonly string $path,
         public readonly bool $isEntrypoint,
+        public readonly ?string $resolver,
         /**
          * The version of the package (remote only).
          */
@@ -39,12 +40,12 @@ final class ImportMapEntry
 
     public static function createLocal(string $importName, ImportMapType $importMapType, string $path, bool $isEntrypoint): self
     {
-        return new self($importName, $importMapType, $path, $isEntrypoint, null, null);
+        return new self($importName, $importMapType, $path, $isEntrypoint, null, null, null);
     }
 
-    public static function createRemote(string $importName, ImportMapType $importMapType, string $path, string $version, string $packageModuleSpecifier, bool $isEntrypoint): self
+    public static function createRemote(string $importName, ImportMapType $importMapType, string $path, string $version, string $packageModuleSpecifier, bool $isEntrypoint, ?string $resolver = null): self
     {
-        return new self($importName, $importMapType, $path, $isEntrypoint, $version, $packageModuleSpecifier);
+        return new self($importName, $importMapType, $path, $isEntrypoint, $resolver, $version, $packageModuleSpecifier);
     }
 
     public function getPackageName(): string

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -192,6 +192,7 @@ class ImportMapManager
                 $resolvedPackage->version,
                 $resolvedPackage->requireOptions->packageModuleSpecifier,
                 $resolvedPackage->requireOptions->entrypoint,
+                $this->resolver->getAlias()
             );
             $importMapEntries->add($newEntry);
             $addedEntries[] = $newEntry;

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -27,8 +27,19 @@ class ImportMapManager
         private readonly AssetMapperInterface $assetMapper,
         private readonly ImportMapConfigReader $importMapConfigReader,
         private readonly RemotePackageDownloader $packageDownloader,
-        private readonly PackageResolverInterface $resolver,
+        private ?PackageResolverInterface $resolver = null,
     ) {
+    }
+
+    /**
+     * Sets the package resolver.
+     * This is useful when you want to customize the package resolution process.
+     *
+     * @param PackageResolverInterface $resolver
+     */
+    public function setResolver(PackageResolverInterface $resolver): void
+    {
+        $this->resolver = $resolver;
     }
 
     /**

--- a/src/Symfony/Component/AssetMapper/ImportMap/PackageRequireOptions.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/PackageRequireOptions.php
@@ -28,6 +28,7 @@ final class PackageRequireOptions
         public readonly ?string $versionConstraint = null,
         ?string $importName = null,
         public readonly ?string $path = null,
+        public readonly ?string $resolver = null,
         public readonly bool $entrypoint = false,
     ) {
         $this->importName = $importName ?: $packageModuleSpecifier;

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -40,7 +40,6 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         $this->httpClient = $httpClient ?? HttpClient::create();
     }
 
-
     public function getAlias(): string
     {
         return 'jsdelivr';

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -40,6 +40,12 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         $this->httpClient = $httpClient ?? HttpClient::create();
     }
 
+
+    public function getAlias(): string
+    {
+        return 'jsdelivr';
+    }
+
     public function resolvePackages(array $packagesToRequire): array
     {
         $resolvedPackages = [];

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/PackageResolverInterface.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/PackageResolverInterface.php
@@ -40,4 +40,9 @@ interface PackageResolverInterface
      * @return array<string, array{content: string, dependencies: string[], extraFiles: array<string, string>}>
      */
     public function downloadPackages(array $importMapEntries, ?callable $progressCallback = null): array;
+
+    /**
+     * Returns the alias of the resolver.
+     */
+    public function getAlias(): string;
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/PackageResolverRegistry.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/PackageResolverRegistry.php
@@ -17,8 +17,8 @@ class PackageResolverRegistry
 
     public function __construct(private ?PackageResolverInterface $defaultResolver = null, iterable $resolvers = [])
     {
-        foreach ($resolvers as $name => $resolver) {
-            $this->addResolver($name, $resolver);
+        foreach ($resolvers as $resolver) {
+            $this->addResolver($resolver);
         }
     }
 
@@ -27,9 +27,9 @@ class PackageResolverRegistry
         $this->defaultResolver = $defaultResolver;
     }
 
-    public function addResolver(string $name, PackageResolverInterface $resolver): void
+    public function addResolver(PackageResolverInterface $resolver): void
     {
-        $this->resolvers[$name] = $resolver;
+        $this->resolvers[$resolver->getAlias()] = $resolver;
     }
 
     public function getResolver(?string $name = null): PackageResolverInterface

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/PackageResolverRegistry.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/PackageResolverRegistry.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\ImportMap\Resolver;
+
+class PackageResolverRegistry
+{
+    private array $resolvers = [];
+
+    public function __construct(private ?PackageResolverInterface $defaultResolver = null, iterable $resolvers = [])
+    {
+        foreach ($resolvers as $name => $resolver) {
+            $this->addResolver($name, $resolver);
+        }
+    }
+
+    public function setDefaultResolver(?PackageResolverInterface $defaultResolver): void
+    {
+        $this->defaultResolver = $defaultResolver;
+    }
+
+    public function addResolver(string $name, PackageResolverInterface $resolver): void
+    {
+        $this->resolvers[$name] = $resolver;
+    }
+
+    public function getResolver(?string $name = null): PackageResolverInterface
+    {
+        if (null === $name) {
+            if (null === $this->defaultResolver) {
+                throw new \LogicException('No default resolver is defined.');
+            }
+
+            return $this->defaultResolver;
+        }
+
+        if (!isset($this->resolvers[$name])) {
+            throw new \InvalidArgumentException(sprintf('The resolver "%s" does not exist.', $name));
+        }
+
+        return $this->resolvers[$name];
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperRequireCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperRequireCommandTest.php
@@ -40,4 +40,22 @@ class AssetMapperRequireCommandTest extends TestCase
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('lodash', $output);
     }
+
+    public function testRequireWithInvalidResolverCommand()
+    {
+        $this->kernel->boot();
+        $application = new Application($this->kernel);
+        $command = $application->find('importmap:require');
+        $commandTester = new CommandTester($command);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The resolver "invalid" does not exist.');
+
+        $commandTester->execute([
+            'packages' => ['lodash'],
+            '--resolver' => 'invalid',
+        ]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+    }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperRequireCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperRequireCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Symfony\Component\AssetMapper\Tests\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\TwigBundle\Tests\TestCase;
+use Symfony\Component\AssetMapper\Tests\Fixtures\AssetMapperTestAppKernel;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class AssetMapperRequireCommandTest extends TestCase
+{
+    private AssetMapperTestAppKernel $kernel;
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->kernel = new AssetMapperTestAppKernel('test', true);
+
+        $this->filesystem->rename($this->kernel->getProjectDir().'/importmap.php', $this->kernel->getProjectDir().'/importmap.php.bak');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->kernel->getProjectDir().'/importmap.php');
+        $this->filesystem->rename($this->kernel->getProjectDir().'/importmap.php.bak', $this->kernel->getProjectDir().'/importmap.php');
+    }
+
+    public function testDefaultRequireCommand()
+    {
+        $this->kernel->boot();
+        $application = new Application($this->kernel);
+        $command = $application->find('importmap:require');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'packages' => ['lodash'],
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('lodash', $output);
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperRequireCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperRequireCommandTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\AssetMapper\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -39,6 +48,7 @@ class AssetMapperRequireCommandTest extends TestCase
 
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('lodash', $output);
+        $commandTester->assertCommandIsSuccessful();
     }
 
     public function testRequireWithInvalidResolverCommand()

--- a/src/Symfony/Component/AssetMapper/Tests/Command/ImportMapRequireCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/ImportMapRequireCommandTest.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\AssetMapper\Tests\Command;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Component\AssetMapper\Tests\Fixtures\AssetMapperTestAppKernel;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
-class AssetMapperRequireCommandTest extends TestCase
+class ImportMapRequireCommandTest extends TestCase
 {
     private AssetMapperTestAppKernel $kernel;
     private Filesystem $filesystem;

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
 use Symfony\Component\AssetMapper\ImportMap\PackageRequireOptions;
 use Symfony\Component\AssetMapper\ImportMap\RemotePackageDownloader;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface;
+use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverRegistry;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\ResolvedImportMapPackage;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\Filesystem\Filesystem;
@@ -30,6 +31,7 @@ class ImportMapManagerTest extends TestCase
 {
     private AssetMapperInterface&MockObject $assetMapper;
     private PackageResolverInterface&MockObject $packageResolver;
+    private PackageResolverRegistry&MockObject $packageResolverRegistry;
     private ImportMapConfigReader&MockObject $configReader;
     private RemotePackageDownloader&MockObject $remotePackageDownloader;
     private ImportMapManager $importMapManager;
@@ -375,6 +377,11 @@ class ImportMapManagerTest extends TestCase
         $this->assetMapper = $this->createMock(AssetMapperInterface::class);
         $this->configReader = $this->createMock(ImportMapConfigReader::class);
         $this->packageResolver = $this->createMock(PackageResolverInterface::class);
+        $this->packageResolverRegistry = $this->createMock(PackageResolverRegistry::class);
+        $this->packageResolverRegistry->expects($this->any())
+            ->method('getResolver')
+            ->willReturn($this->packageResolver)
+        ;
         $this->remotePackageDownloader = $this->createMock(RemotePackageDownloader::class);
 
         // mock this to behave like normal
@@ -390,7 +397,7 @@ class ImportMapManagerTest extends TestCase
             $this->assetMapper,
             $this->configReader,
             $this->remotePackageDownloader,
-            $this->packageResolver,
+            $this->packageResolverRegistry,
         );
     }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/PackageResolverRegistryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/PackageResolverRegistryTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverRegistry;
 
 class PackageResolverRegistryTest extends TestCase
 {
-    public function testCanSetDefaultResolver(): void
+    public function testCanSetDefaultResolver()
     {
         $defaultResolver = $this->createMock(PackageResolverInterface::class);
         $registry = new PackageResolverRegistry();
@@ -27,7 +27,7 @@ class PackageResolverRegistryTest extends TestCase
         $this->assertSame($defaultResolver, $registry->getResolver());
     }
 
-    public function testThrowsExceptionWhenNoDefaultResolverIsDefined(): void
+    public function testThrowsExceptionWhenNoDefaultResolverIsDefined()
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('No default resolver is defined.');
@@ -36,7 +36,7 @@ class PackageResolverRegistryTest extends TestCase
         $registry->getResolver();
     }
 
-    public function testCanAddAndRetrieveResolver(): void
+    public function testCanAddAndRetrieveResolver()
     {
         $resolver = $this->createMock(PackageResolverInterface::class);
         $resolver->expects($this->once())->method('getAlias')->willReturn('custom');
@@ -48,7 +48,7 @@ class PackageResolverRegistryTest extends TestCase
         $this->assertSame($resolver, $registry->getResolver('custom'));
     }
 
-    public function testThrowsExceptionWhenResolverDoesNotExist(): void
+    public function testThrowsExceptionWhenResolverDoesNotExist()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The resolver "nonexistent" does not exist.');

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/PackageResolverRegistryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/PackageResolverRegistryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Component\AssetMapper\Tests\ImportMap\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\PackageInterface;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverRegistry;
+use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface;
+
+class PackageResolverRegistryTest extends TestCase
+{
+    public function testCanSetDefaultResolver(): void
+    {
+        $defaultResolver = $this->createMock(PackageResolverInterface::class);
+        $registry = new PackageResolverRegistry();
+
+        $registry->setDefaultResolver($defaultResolver);
+
+        $this->assertSame($defaultResolver, $registry->getResolver());
+    }
+
+    public function testThrowsExceptionWhenNoDefaultResolverIsDefined(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('No default resolver is defined.');
+
+        $registry = new PackageResolverRegistry();
+        $registry->getResolver();
+    }
+
+    public function testCanAddAndRetrieveResolver(): void
+    {
+        $resolver = $this->createMock(PackageResolverInterface::class);
+        $registry = new PackageResolverRegistry();
+
+        $registry->addResolver('custom', $resolver);
+
+        $this->assertSame($resolver, $registry->getResolver('custom'));
+    }
+
+    public function testThrowsExceptionWhenResolverDoesNotExist(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The resolver "nonexistent" does not exist.');
+
+        $registry = new PackageResolverRegistry();
+        $registry->getResolver('nonexistent');
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/PackageResolverRegistryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/PackageResolverRegistryTest.php
@@ -1,12 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\AssetMapper\Tests\ImportMap\Resolver;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Asset\PackageInterface;
-use Symfony\Component\Asset\Packages;
-use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverRegistry;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface;
+use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverRegistry;
 
 class PackageResolverRegistryTest extends TestCase
 {

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/PackageResolverRegistryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/PackageResolverRegistryTest.php
@@ -32,9 +32,11 @@ class PackageResolverRegistryTest extends TestCase
     public function testCanAddAndRetrieveResolver(): void
     {
         $resolver = $this->createMock(PackageResolverInterface::class);
+        $resolver->expects($this->once())->method('getAlias')->willReturn('custom');
+
         $registry = new PackageResolverRegistry();
 
-        $registry->addResolver('custom', $resolver);
+        $registry->addResolver($resolver);
 
         $this->assertSame($resolver, $registry->getResolver('custom'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #53999
| License       | MIT

This PR allows to provide a specific package resolver when running the `importmap:require` command.
This is useful when the required package cannot be built or found with the default package resolver (JsDeliver).

It adds a `resolver` option to the command that resolves to the default package resolver when none is provided.
The default package resolver can also be changed by mapping the `asset_mapper.importmap.resolver` service to a custom resolver implementing `\Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface`.
So the command will look like :
`bin/console importmap:require some-package --resolver=resolver`

For now only the base implementation is added. I'll provide one or two package resolvers as example

- [ ] submit changes to the documentation
- [ ] add more resolvers (unpkg ? jspm ?)