### PR TITLE
[Console] Add a way to use custom lock factory in lockableTrait

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
 use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 
@@ -26,6 +27,7 @@ class LockableTraitTest extends TestCase
         self::$fixturesPath = __DIR__.'/../Fixtures/';
         require_once self::$fixturesPath.'/FooLockCommand.php';
         require_once self::$fixturesPath.'/FooLock2Command.php';
+        require_once self::$fixturesPath.'/FooLock3Command.php';
     }
 
     public function testLockIsReleased()
@@ -62,6 +64,20 @@ class LockableTraitTest extends TestCase
         $command = new \FooLock2Command();
 
         $tester = new CommandTester($command);
+        $this->assertSame(1, $tester->execute([]));
+    }
+
+    public function testCustomLockFactoryIsUsed()
+    {
+        $lockFactory = $this->createMock(LockFactory::class);
+        $command = new \FooLock3Command($lockFactory);
+
+        $tester = new CommandTester($command);
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(false);
+
+        $lockFactory->expects(static::once())->method('createLock')->willReturn($lock);
         $this->assertSame(1, $tester->execute([]));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/FooLock3Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/FooLock3Command.php
@@ -1,0 +1,35 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Lock\LockFactory;
+
+class FooLock3Command extends Command
+{
+    use LockableTrait;
+
+    public function __construct(LockFactory $lockFactory)
+    {
+        parent::__construct();
+
+        $this->lockFactory = $lockFactory;
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('foo:lock3');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            return 1;
+        }
+
+        $this->release();
+
+        return 2;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

The LockableTrait only use SemaphoreStore or FlockStore, but currently we cannot use MemcachedStore or RedisStore.

When using a custom LockFactory everywhere in the codebase, it would be useful to chose if the commande need a server-related store or not.

I'm not sure if I have a way to  provide autowire to the `setLockFactory` method without introducing a BC break for people who rely on the fact that the LockableTrait use a different LockFactory than the one configured the `framework.lock` dsn.