### PR TITLE
[Validator] UniqueValidator - normalize before reducing keys

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -43,11 +43,11 @@ class UniqueValidator extends ConstraintValidator
         $collectionElements = [];
         $normalizer = $this->getNormalizer($constraint);
         foreach ($value as $element) {
+            $element = $normalizer($element);
+
             if ($fields && !$element = $this->reduceElementKeys($fields, $element)) {
                 continue;
             }
-
-            $element = $normalizer($element);
 
             if (\in_array($element, $collectionElements, true)) {
                 $this->context->buildViolation($constraint->message)

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints\UniqueValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Dummy\DummyClassOne;
 
 class UniqueValidatorTest extends ConstraintValidatorTestCase
 {
@@ -281,6 +282,36 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
                 [['nullField' => null], ['nullField' => null]],
                 ['nullField'],
             ],
+        ];
+    }
+
+    public function testArrayOfObjectsUnique()
+    {
+        $array = [
+            new DummyClassOne(),
+            new DummyClassOne(),
+            new DummyClassOne(),
+        ];
+
+        $array[0]->code = '1';
+        $array[1]->code = '2';
+        $array[2]->code = '3';
+
+        $this->validator->validate(
+            $array,
+            new Unique(
+                normalizer: [self::class, 'normalizeDummyClassOne'],
+                fields: 'code'
+            )
+        );
+
+        $this->assertNoViolation();
+    }
+
+    public static function normalizeDummyClassOne(DummyClassOne $obj): array
+    {
+        return [
+            'code' => $obj->code,
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In https://github.com/symfony/symfony/pull/42403 checking for uniqueness of certain collection keys was enabled. Method `UniqueValidator::reduceElementKeys` removes all keys which are not specified.
Problem is that this happens before normalization, which in my opinion is not great because that method accepts array argument and if i have some object (DTO), TypeError will be thrown.

Example:

```php
class ParentDTO
{
    /**
     * @var ChildDTO[]
     */
    #[Assert\Unique(
        normalizer: [ChildDTO::class, 'normalize']
        fields: 'id'
    )]
    public array $children;
}
```

```php
class ChildDTO
{
    public string $id;
    public string $name;

    public static function normalize(self $obj): array
    {
        return [
            'id' => $obj->id,
            'name' => $obj->name
        ];
    }
}
```

Because normalization will happen after `reduceElementKeys` this will be thrown:
`TypeError: Symfony\Component\Validator\Constraints\UniqueValidator::reduceElementKeys(): Argument #2 ($element) must be of type array, ...\ChildDTO given, called in .../UniqueValidator.php on line 48`

If `$element = $normalizer($element);` is executed before `reduceElementKeys` it would enable using Assert\Unique with array of objects when correctly normalized
