### PR TITLE
[AssetMapper] adds: "asset_mapper.public_prefix" parameter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1337,6 +1337,7 @@ class FrameworkExtension extends Extension
             ->setArgument(2, $excludedPathPatterns)
             ->setArgument(3, $config['exclude_dotfiles']);
 
+        $container->setParameter('asset_mapper.public_prefix', $config['public_prefix']);
         $container->getDefinition('asset_mapper.public_assets_path_resolver')
             ->setArgument(0, $config['public_prefix']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | none
| License       | MIT

This PR adds the asset mapper public prefix configuration option as container parameter "asset_mapper-public_prefix". This will allow applications or bundles that need this information to get it without duplication.