### PR TITLE
[HttpClient] Preserve float in JsonMockResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/JsonMockResponse.php
@@ -21,7 +21,7 @@ class JsonMockResponse extends MockResponse
     public function __construct(mixed $body = [], array $info = [])
     {
         try {
-            $json = json_encode($body, \JSON_THROW_ON_ERROR);
+            $json = json_encode($body, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION);
         } catch (\JsonException $e) {
             throw new InvalidArgumentException('JSON encoding failed: '.$e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Symfony/Component/HttpClient/Tests/Response/JsonMockResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/JsonMockResponseTest.php
@@ -59,6 +59,22 @@ final class JsonMockResponseTest extends TestCase
         $this->assertSame('application/json', $response->getHeaders()['content-type'][0]);
     }
 
+    public function testJsonEncodeFloat()
+    {
+        $client = new MockHttpClient(new JsonMockResponse([
+            'foo' => 1.23,
+            'ccc' => 1.0,
+            'baz' => 10.,
+        ]));
+        $response = $client->request('GET', 'https://symfony.com');
+
+        $this->assertSame([
+            'foo' => 1.23,
+            'ccc' => 1.,
+            'baz' => 10.,
+        ], $response->toArray());
+    }
+
     /**
      * @dataProvider responseHeadersProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Hello, 

I am mocking an API Response that can send float in values : 

```
{
    "values": 1.0
}
```

Converting this to a php array and giving it to JsonMockResponse return me an int after, because the missing json_encode flag to keep zero fraction, and leds to issue when I want to deserialize it into a float property.

In my mind it's a bugfix, but if it's considered as a new feature, I can target 7.1. 
