### PR TITLE
[Console] Better error handling when misuse of ArgvInput with arrays

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -47,6 +47,10 @@ class ArgvInput extends Input
     {
         $argv = $argv ?? $_SERVER['argv'] ?? [];
 
+        if (array_filter($argv, 'is_array')) {
+            throw new RuntimeException('Argument values expected to be all scalars, got array.');
+        }
+
         // strip the application name
         array_shift($argv);
 

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -327,6 +327,11 @@ class ArgvInputTest extends TestCase
                 new InputDefinition([new InputArgument('name', InputArgument::REQUIRED)]),
                 'Too many arguments, expected arguments "name".',
             ],
+            [
+                ['cli.php', ['array']],
+                new InputDefinition(),
+                'Argument values expected to be all scalars, got array.',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53836
| License       | MIT


### Issue
When we don't use `ArgvInput` correclty, and use array in $argv values, it returns different PHP fatal errors.
See all details and how to reproduce it in the issue https://github.com/symfony/symfony/issues/53836

### Solution
In this PR
 - Add some DX with an exception explaining the problem, to avoid PHP fatal errors
 - Add tests**

_____
Note : Old PR #53838