### PR TITLE
[Serializer] Fix object normalizer when properties has the same name as their accessor

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -106,7 +106,7 @@ class AnnotationLoader implements LoaderInterface
 
             $accessorOrMutator = preg_match('/^(get|is|has|set)(.+)$/i', $method->name, $matches);
             if ($accessorOrMutator) {
-                $attributeName = lcfirst($matches[2]);
+                $attributeName = $reflectionClass->hasProperty($method->name) ? $method->name : lcfirst($matches[2]);
 
                 if (isset($attributesMetadata[$attributeName])) {
                     $attributeMetadata = $attributesMetadata[$attributeName];

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -86,17 +86,25 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
             if (str_starts_with($name, 'get') || str_starts_with($name, 'has')) {
                 // getters and hassers
-                $attributeName = substr($name, 3);
+                $attributeName = $name;
 
                 if (!$reflClass->hasProperty($attributeName)) {
-                    $attributeName = lcfirst($attributeName);
+                    $attributeName = substr($attributeName, 3);
+
+                    if (!$reflClass->hasProperty($attributeName)) {
+                        $attributeName = lcfirst($attributeName);
+                    }
                 }
             } elseif (str_starts_with($name, 'is')) {
                 // issers
-                $attributeName = substr($name, 2);
+                $attributeName = $name;
 
                 if (!$reflClass->hasProperty($attributeName)) {
-                    $attributeName = lcfirst($attributeName);
+                    $attributeName = substr($attributeName, 2);
+
+                    if (!$reflClass->hasProperty($attributeName)) {
+                        $attributeName = lcfirst($attributeName);
+                    }
                 }
             }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/SamePropertyAsMethodDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/SamePropertyAsMethodDummy.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class SamePropertyAsMethodDummy
+{
+    private $freeTrial;
+    private $hasSubscribe;
+    private $getReady;
+    private $isActive;
+
+    public function __construct($freeTrial, $hasSubscribe, $getReady, $isActive)
+    {
+        $this->freeTrial = $freeTrial;
+        $this->hasSubscribe = $hasSubscribe;
+        $this->getReady = $getReady;
+        $this->isActive = $isActive;
+    }
+
+    public function getFreeTrial()
+    {
+        return $this->freeTrial;
+    }
+
+    public function hasSubscribe()
+    {
+        return $this->hasSubscribe;
+    }
+
+    public function getReady()
+    {
+        return $this->getReady;
+    }
+
+    public function isActive()
+    {
+        return $this->isActive;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/SamePropertyAsMethodWithMethodSerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/SamePropertyAsMethodWithMethodSerializedNameDummy.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+class SamePropertyAsMethodWithMethodSerializedNameDummy
+{
+    private $freeTrial;
+    private $hasSubscribe;
+    private $getReady;
+    private $isActive;
+
+    public function __construct($freeTrial, $hasSubscribe, $getReady, $isActive)
+    {
+        $this->freeTrial = $freeTrial;
+        $this->hasSubscribe = $hasSubscribe;
+        $this->getReady = $getReady;
+        $this->isActive = $isActive;
+    }
+
+    /**
+     * @SerializedName("free_trial_method")
+     */
+    public function getFreeTrial()
+    {
+        return $this->freeTrial;
+    }
+
+    /**
+     * @SerializedName("has_subscribe_method")
+     */
+    public function hasSubscribe()
+    {
+        return $this->hasSubscribe;
+    }
+
+    /**
+     * @SerializedName("get_ready_method")
+     */
+    public function getReady()
+    {
+        return $this->getReady;
+    }
+
+    /**
+     * @SerializedName("is_active_method")
+     */
+    public function isActive()
+    {
+        return $this->isActive;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/SamePropertyAsMethodWithPropertySerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/SamePropertyAsMethodWithPropertySerializedNameDummy.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+class SamePropertyAsMethodWithPropertySerializedNameDummy
+{
+    /**
+     * @SerializedName("free_trial_property")
+     */
+    private $freeTrial;
+
+    /**
+     * @SerializedName("has_subscribe_property")
+     */
+    private $hasSubscribe;
+
+    /**
+     * @SerializedName("get_ready_property")
+     */
+    private $getReady;
+
+    /**
+     * @SerializedName("is_active_property")
+     */
+    private $isActive;
+
+    public function __construct($freeTrial, $hasSubscribe, $getReady, $isActive)
+    {
+        $this->freeTrial = $freeTrial;
+        $this->hasSubscribe = $hasSubscribe;
+        $this->getReady = $getReady;
+        $this->isActive = $isActive;
+    }
+
+    public function getFreeTrial()
+    {
+        return $this->freeTrial;
+    }
+
+    public function hasSubscribe()
+    {
+        return $this->hasSubscribe;
+    }
+
+    public function getReady()
+    {
+        return $this->getReady;
+    }
+
+    public function isActive()
+    {
+        return $this->isActive;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -40,6 +40,9 @@ use Symfony\Component\Serializer\Tests\Fixtures\OtherSerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74DummyPrivate;
 use Symfony\Component\Serializer\Tests\Fixtures\Php80Dummy;
+use Symfony\Component\Serializer\Tests\Fixtures\SamePropertyAsMethodDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\SamePropertyAsMethodWithMethodSerializedNameDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\SamePropertyAsMethodWithPropertySerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\AttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CacheableObjectAttributesTestTrait;
@@ -868,6 +871,53 @@ class ObjectNormalizerTest extends TestCase
         $o2->baz = 'baz';
 
         $this->assertSame(['baz' => 'baz'], $this->normalizer->normalize($o2));
+    }
+
+    public function testSamePropertyAsMethod()
+    {
+        $object = new SamePropertyAsMethodDummy('free_trial', 'has_subscribe', 'get_ready', 'is_active');
+        $expected = [
+            'freeTrial' => 'free_trial',
+            'hasSubscribe' => 'has_subscribe',
+            'getReady' => 'get_ready',
+            'isActive' => 'is_active',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($object));
+    }
+
+    public function testSamePropertyAsMethodWithPropertySerializedName()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $this->normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        $this->normalizer->setSerializer($this->serializer);
+
+        $object = new SamePropertyAsMethodWithPropertySerializedNameDummy('free_trial', 'has_subscribe', 'get_ready', 'is_active');
+        $expected = [
+            'free_trial_property' => 'free_trial',
+            'has_subscribe_property' => 'has_subscribe',
+            'get_ready_property' => 'get_ready',
+            'is_active_property' => 'is_active',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($object));
+    }
+
+    public function testSamePropertyAsMethodWithMethodSerializedName()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $this->normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        $this->normalizer->setSerializer($this->serializer);
+
+        $object = new SamePropertyAsMethodWithMethodSerializedNameDummy('free_trial', 'has_subscribe', 'get_ready', 'is_active');
+        $expected = [
+            'free_trial_method' => 'free_trial',
+            'has_subscribe_method' => 'has_subscribe',
+            'get_ready_method' => 'get_ready',
+            'is_active_method' => 'is_active',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($object));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54109
| License       | MIT

Hello,

This PR fix a bug in object normalization when properties has the same name as their accessor. The current behavior mess up class metadata between properties and methods so the keys in the normalized format does not match the object properties, and metadata are not correctly applied (`SerializedName` in our exemple). 

This bug also affects versions 6.4 and 7+, but I'm not sure if we can merge this PR in these branches without refactoring. Let me know if another PR should be open for version 6.4 and 7.
