### PR TITLE
[Console] Document argv arrays for static analysis

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -40,9 +40,11 @@ use Symfony\Component\Console\Exception\RuntimeException;
  */
 class ArgvInput extends Input
 {
+    /** @var list<string> */
     private array $tokens;
     private array $parsed;
 
+    /** @param list<string>|null $argv */
     public function __construct(?array $argv = null, ?InputDefinition $definition = null)
     {
         $argv ??= $_SERVER['argv'] ?? [];
@@ -55,6 +57,7 @@ class ArgvInput extends Input
         parent::__construct($definition);
     }
 
+    /** @param list<string> $tokens */
     protected function setTokens(array $tokens): void
     {
         $this->tokens = $tokens;

--- a/src/Symfony/Component/Console/Input/StringInput.php
+++ b/src/Symfony/Component/Console/Input/StringInput.php
@@ -40,6 +40,8 @@ class StringInput extends ArgvInput
     /**
      * Tokenizes a string.
      *
+     * @return list<string>
+     *
      * @throws InvalidArgumentException When unable to parse input (should never happen)
      */
     private function tokenize(string $input): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #53836
| License       | MIT

This PR adds PHPDoc blocks for static analyzers that should make mistakes like the ones described in #53836 more discoverable.