### PR TITLE
[RateLimiter] Fix retryAfter value on last token consume (SlidingWindow).

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -74,7 +74,14 @@ final class SlidingWindowLimiter implements LimiterInterface
             if ($availableTokens >= $tokens) {
                 $window->add($tokens);
 
-                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->limit));
+                if ($availableTokens === $tokens) {
+                    $resetDuration = $window->calculateTimeForTokens($this->limit, $tokens);
+                    $retryAfter = $now + $resetDuration;
+                } else {
+                    $retryAfter = $now;
+                }
+
+                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->limit));
             } else {
                 $waitDuration = $window->calculateTimeForTokens($this->limit, $tokens);
 

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -75,7 +75,7 @@ final class SlidingWindowLimiter implements LimiterInterface
                 $window->add($tokens);
 
                 if ($availableTokens === $tokens) {
-                    $resetDuration = $window->calculateTimeForTokens($this->limit, $tokens);
+                    $resetDuration = $window->calculateTimeForTokens($this->limit, $window->getHitCount());
                     $retryAfter = $now + $resetDuration;
                 } else {
                     $retryAfter = $now;

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -70,6 +70,21 @@ class SlidingWindowLimiterTest extends TestCase
         $this->assertTrue($limiter->consume()->isAccepted());
     }
 
+    public function testConsumeLastToken()
+    {
+        $limiter = $this->createLimiter();
+        $limiter->reset();
+        $limiter->consume(9);
+
+        $rateLimit = $limiter->consume(1);
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(
+            \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true) + 12 / 10)),
+            $rateLimit->getRetryAfter()
+        );
+    }
+
     public function testReserve()
     {
         $limiter = $this->createLimiter();

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -80,7 +80,7 @@ class SlidingWindowLimiterTest extends TestCase
         $this->assertSame(0, $rateLimit->getRemainingTokens());
         $this->assertTrue($rateLimit->isAccepted());
         $this->assertEquals(
-            \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true) + 12 / 10)),
+            \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true) + 12)),
             $rateLimit->getRetryAfter()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Fix retryAfter value when the last tokens are consumed ($availableTokens === $tokens).

/cc @wouterj 🙏