### PR TITLE
[Filesystem] Add the `readFile()` method

### DIFF
--- a/link
+++ b/link
@@ -49,7 +49,7 @@ $directories = array_merge(...array_values(array_map(function ($part) {
 $directories[] = __DIR__.'/src/Symfony/Contracts';
 foreach ($directories as $dir) {
     if ($filesystem->exists($composer = "$dir/composer.json")) {
-        $sfPackages[json_decode(file_get_contents($composer))->name] = $dir;
+        $sfPackages[json_decode($filesystem->readFile($composer), flags: JSON_THROW_ON_ERROR)->name] = $dir;
     }
 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -260,7 +260,7 @@ EOT
             return $defaultPublicDir;
         }
 
-        $composerConfig = json_decode(file_get_contents($composerFilePath), true);
+        $composerConfig = json_decode($this->filesystem->readFile($composerFilePath), true, flags: \JSON_THROW_ON_ERROR);
 
         return $composerConfig['extra']['public-dir'] ?? $defaultPublicDir;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -232,7 +232,7 @@ EOF
         $search = [$warmupDir, str_replace('\\', '\\\\', $warmupDir)];
         $replace = str_replace('\\', '/', $realBuildDir);
         foreach (Finder::create()->files()->in($warmupDir) as $file) {
-            $content = str_replace($search, $replace, file_get_contents($file), $count);
+            $content = str_replace($search, $replace, $this->filesystem->readFile($file), $count);
             if ($count) {
                 file_put_contents($file, $content);
             }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -71,6 +71,7 @@ use Symfony\Component\Dotenv\Command\DebugCommand;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\Glob;
 use Symfony\Component\Form\Extension\HtmlSanitizer\Type\TextTypeHtmlSanitizerExtension;
@@ -3141,7 +3142,7 @@ class FrameworkExtension extends Extension
         }
 
         $container->addResource(new FileResource($composerFilePath));
-        $composerConfig = json_decode(file_get_contents($composerFilePath), true);
+        $composerConfig = json_decode((new Filesystem())->readFile($composerFilePath), true, flags: \JSON_THROW_ON_ERROR);
 
         return isset($composerConfig['extra']['public-dir']) ? $projectDir.'/'.$composerConfig['extra']['public-dir'] : $defaultPublicDir;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -75,7 +75,7 @@ class CacheClearCommandTest extends TestCase
         $kernelRef = new \ReflectionObject($this->kernel);
         $kernelFile = $kernelRef->getFileName();
         /** @var ResourceInterface[] $meta */
-        $meta = unserialize(file_get_contents($containerMetaFile));
+        $meta = unserialize($this->fs->readFile($containerMetaFile));
         $found = false;
         foreach ($meta as $resource) {
             if ((string) $resource === $kernelFile) {
@@ -93,7 +93,7 @@ class CacheClearCommandTest extends TestCase
         );
         $this->assertMatchesRegularExpression(
             sprintf('/\'kernel.container_class\'\s*=>\s*\'%s\'/', $containerClass),
-            file_get_contents($containerFile),
+            $this->fs->readFile($containerFile),
             'kernel.container_class is properly set on the dumped container'
         );
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
@@ -21,16 +21,18 @@ use Symfony\Component\Filesystem\Filesystem;
 class SodiumVaultTest extends TestCase
 {
     private string $secretsDir;
+    private Filesystem $filesystem;
 
     protected function setUp(): void
     {
+        $this->filesystem = new Filesystem();
         $this->secretsDir = sys_get_temp_dir().'/sf_secrets/test/';
-        (new Filesystem())->remove($this->secretsDir);
+        $this->filesystem->remove($this->secretsDir);
     }
 
     protected function tearDown(): void
     {
-        (new Filesystem())->remove($this->secretsDir);
+        $this->filesystem->remove($this->secretsDir);
     }
 
     public function testGenerateKeys()
@@ -41,8 +43,8 @@ class SodiumVaultTest extends TestCase
         $this->assertFileExists($this->secretsDir.'/test.encrypt.public.php');
         $this->assertFileExists($this->secretsDir.'/test.decrypt.private.php');
 
-        $encKey = file_get_contents($this->secretsDir.'/test.encrypt.public.php');
-        $decKey = file_get_contents($this->secretsDir.'/test.decrypt.private.php');
+        $encKey = $this->filesystem->readFile($this->secretsDir.'/test.encrypt.public.php');
+        $decKey = $this->filesystem->readFile($this->secretsDir.'/test.decrypt.private.php');
 
         $this->assertFalse($vault->generateKeys());
         $this->assertStringEqualsFile($this->secretsDir.'/test.encrypt.public.php', $encKey);

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/filesystem": "^6.4|^7.0",
+        "symfony/filesystem": "^7.1",
         "symfony/finder": "^6.4|^7.0",
         "symfony/routing": "^6.4|^7.0"
     },

--- a/src/Symfony/Component/AssetMapper/CompiledAssetMapperConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/CompiledAssetMapperConfigReader.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\AssetMapper;
 
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
 /**
@@ -18,8 +19,12 @@ use Symfony\Component\Filesystem\Path;
  */
 class CompiledAssetMapperConfigReader
 {
-    public function __construct(private readonly string $directory)
-    {
+    private readonly Filesystem $filesystem;
+
+    public function __construct(
+        private readonly string $directory,
+    ) {
+        $this->filesystem = new Filesystem();
     }
 
     public function configExists(string $filename): bool
@@ -29,7 +34,7 @@ class CompiledAssetMapperConfigReader
 
     public function loadConfig(string $filename): array
     {
-        return json_decode(file_get_contents(Path::join($this->directory, $filename)), true, 512, \JSON_THROW_ON_ERROR);
+        return json_decode($this->filesystem->readFile(Path::join($this->directory, $filename)), true, 512, \JSON_THROW_ON_ERROR);
     }
 
     public function saveConfig(string $filename, array $data): string

--- a/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Decorates the asset factory to load MappedAssets from cache when possible.
@@ -36,7 +37,7 @@ class CachedMappedAssetFactory implements MappedAssetFactoryInterface
         $configCache = new ConfigCache($cachePath, $this->debug);
 
         if ($configCache->isFresh()) {
-            return unserialize(file_get_contents($cachePath));
+            return unserialize((new Filesystem())->readFile($cachePath));
         }
 
         $mappedAsset = $this->innerFactory->createMappedAsset($logicalPath, $sourcePath);

--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -16,6 +16,7 @@ use Symfony\Component\AssetMapper\Exception\CircularAssetsException;
 use Symfony\Component\AssetMapper\Exception\RuntimeException;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Creates MappedAsset objects by reading their contents & passing it through compilers.
@@ -104,7 +105,7 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
             return null;
         }
 
-        $content = file_get_contents($asset->sourcePath);
+        $content = (new Filesystem())->readFile($asset->sourcePath);
         $compiled = $this->compiler->compile($content, $asset);
 
         return $compiled !== $content ? $compiled : null;

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
@@ -48,10 +48,9 @@ class AssetMapperCompileCommandTest extends TestCase
             $this->filesystem->remove($targetBuildDir);
         }
         // put old "built" versions to make sure the system skips using these
-        $this->filesystem->mkdir($targetBuildDir);
-        file_put_contents($targetBuildDir.'/manifest.json', '{}');
-        file_put_contents($targetBuildDir.'/importmap.json', '{}');
-        file_put_contents($targetBuildDir.'/entrypoint.file6.json', '[]');
+        $this->filesystem->dumpFile($targetBuildDir.'/manifest.json', '{}');
+        $this->filesystem->dumpFile($targetBuildDir.'/importmap.json', '{}');
+        $this->filesystem->dumpFile($targetBuildDir.'/entrypoint.file6.json', '[]');
 
         $command = $application->find('asset-map:compile');
         $tester = new CommandTester($command);
@@ -65,7 +64,7 @@ class AssetMapperCompileCommandTest extends TestCase
         import '../file4.js';
         console.log('file5.js');
 
-        EOF, file_get_contents($targetBuildDir.'/subdir/file5-f4fdc37375c7f5f2629c5659a0579967.js'));
+        EOF, $this->filesystem->readFile($targetBuildDir.'/subdir/file5-f4fdc37375c7f5f2629c5659a0579967.js'));
 
         $finder = new Finder();
         $finder->in($targetBuildDir)->files();
@@ -83,10 +82,10 @@ class AssetMapperCompileCommandTest extends TestCase
             'vendor/@hotwired/stimulus/stimulus.index.js',
             'vendor/lodash/lodash.index.js',
             'voilà.css',
-        ], array_keys(json_decode(file_get_contents($targetBuildDir.'/manifest.json'), true)));
+        ], array_keys(json_decode($this->filesystem->readFile($targetBuildDir.'/manifest.json'), true)));
 
         $this->assertFileExists($targetBuildDir.'/importmap.json');
-        $actualImportMap = json_decode(file_get_contents($targetBuildDir.'/importmap.json'), true);
+        $actualImportMap = json_decode($this->filesystem->readFile($targetBuildDir.'/importmap.json'), true);
         $this->assertSame([
             '@hotwired/stimulus', // in importmap
             'lodash', // in importmap
@@ -102,7 +101,7 @@ class AssetMapperCompileCommandTest extends TestCase
         $this->assertSame('js', $actualImportMap['@hotwired/stimulus']['type']);
 
         $this->assertFileExists($targetBuildDir.'/entrypoint.file6.json');
-        $entrypointData = json_decode(file_get_contents($targetBuildDir.'/entrypoint.file6.json'), true);
+        $entrypointData = json_decode($this->filesystem->readFile($targetBuildDir.'/entrypoint.file6.json'), true);
         $this->assertSame([
             '/assets/subdir/file5.js',
             '/assets/file4.js',

--- a/src/Symfony/Component/AssetMapper/Tests/CompiledAssetMapperConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/CompiledAssetMapperConfigReaderTest.php
@@ -55,7 +55,7 @@ class CompiledAssetMapperConfigReaderTest extends TestCase
     {
         $reader = new CompiledAssetMapperConfigReader($this->writableRoot);
         $this->assertEquals($this->writableRoot.\DIRECTORY_SEPARATOR.'foo.json', realpath($reader->saveConfig('foo.json', ['foo' => 'bar'])));
-        $this->assertEquals(['foo' => 'bar'], json_decode(file_get_contents($this->writableRoot.'/foo.json'), true));
+        $this->assertEquals(['foo' => 'bar'], json_decode($this->filesystem->readFile($this->writableRoot.'/foo.json'), true));
     }
 
     public function testRemoveConfig()

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
@@ -131,7 +131,7 @@ class CachedMappedAssetFactoryTest extends TestCase
     {
         $cachedPath = $this->getConfigCachePath($mappedAsset).'.meta';
 
-        return unserialize(file_get_contents($cachedPath));
+        return unserialize($this->filesystem->readFile($cachedPath));
     }
 
     private function saveConfigCache(MappedAsset $mappedAsset): void

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageDownloaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageDownloaderTest.php
@@ -79,12 +79,12 @@ class RemotePackageDownloaderTest extends TestCase
         $this->assertFileExists(self::$writableRoot.'/assets/vendor/foo/foo.index.js');
         $this->assertFileExists(self::$writableRoot.'/assets/vendor/bar.js/file.js');
         $this->assertFileExists(self::$writableRoot.'/assets/vendor/baz/baz.index.css');
-        $this->assertEquals('foo content', file_get_contents(self::$writableRoot.'/assets/vendor/foo/foo.index.js'));
+        $this->assertEquals('foo content', $this->filesystem->readFile(self::$writableRoot.'/assets/vendor/foo/foo.index.js'));
         $this->assertFileExists(self::$writableRoot.'/assets/vendor/foo/path/to/extra-file.woff');
-        $this->assertEquals('extra file contents', file_get_contents(self::$writableRoot.'/assets/vendor/foo/path/to/extra-file.woff'));
-        $this->assertEquals('bar content', file_get_contents(self::$writableRoot.'/assets/vendor/bar.js/file.js'));
-        $this->assertEquals('baz content', file_get_contents(self::$writableRoot.'/assets/vendor/baz/baz.index.css'));
-        $this->assertEquals('different content', file_get_contents(self::$writableRoot.'/assets/vendor/custom_specifier/custom_specifier.index.js'));
+        $this->assertEquals('extra file contents', $this->filesystem->readFile(self::$writableRoot.'/assets/vendor/foo/path/to/extra-file.woff'));
+        $this->assertEquals('bar content', $this->filesystem->readFile(self::$writableRoot.'/assets/vendor/bar.js/file.js'));
+        $this->assertEquals('baz content', $this->filesystem->readFile(self::$writableRoot.'/assets/vendor/baz/baz.index.css'));
+        $this->assertEquals('different content', $this->filesystem->readFile(self::$writableRoot.'/assets/vendor/custom_specifier/custom_specifier.index.js'));
 
         $installed = require self::$writableRoot.'/assets/vendor/installed.php';
         $this->assertEquals(
@@ -150,9 +150,9 @@ class RemotePackageDownloaderTest extends TestCase
         $this->assertFileExists(self::$writableRoot.'/assets/vendor/foo/foo.index.js');
         $this->assertFileExists(self::$writableRoot.'/assets/vendor/bar.js/file.js');
         $this->assertFileExists(self::$writableRoot.'/assets/vendor/baz/baz.index.css');
-        $this->assertEquals('original foo content', file_get_contents(self::$writableRoot.'/assets/vendor/foo/foo.index.js'));
-        $this->assertEquals('new bar content', file_get_contents(self::$writableRoot.'/assets/vendor/bar.js/file.js'));
-        $this->assertEquals('new baz content', file_get_contents(self::$writableRoot.'/assets/vendor/baz/baz.index.css'));
+        $this->assertEquals('original foo content', $this->filesystem->readFile(self::$writableRoot.'/assets/vendor/foo/foo.index.js'));
+        $this->assertEquals('new bar content', $this->filesystem->readFile(self::$writableRoot.'/assets/vendor/bar.js/file.js'));
+        $this->assertEquals('new baz content', $this->filesystem->readFile(self::$writableRoot.'/assets/vendor/baz/baz.index.css'));
         $this->assertFileExists(self::$writableRoot.'/assets/vendor/has-missing-extra/has-missing-extra.index.js');
 
         $installed = require self::$writableRoot.'/assets/vendor/installed.php';

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
@@ -70,7 +70,7 @@ class RemotePackageStorageTest extends TestCase
         $storage->save($entry, 'any content');
         $targetPath = self::$writableRoot.'/assets/vendor/module_specifier/module_specifier.index.js';
         $this->assertFileExists($targetPath);
-        $this->assertEquals('any content', file_get_contents($targetPath));
+        $this->assertEquals('any content', $this->filesystem->readFile($targetPath));
     }
 
     public function testSaveExtraFile()
@@ -80,7 +80,7 @@ class RemotePackageStorageTest extends TestCase
         $storage->saveExtraFile($entry, '/path/to/extra-file.woff2', 'any content');
         $targetPath = self::$writableRoot.'/assets/vendor/module_specifier/path/to/extra-file.woff2';
         $this->assertFileExists($targetPath);
-        $this->assertEquals('any content', file_get_contents($targetPath));
+        $this->assertEquals('any content', $this->filesystem->readFile($targetPath));
     }
 
     /**

--- a/src/Symfony/Component/AssetMapper/Tests/Path/LocalPublicAssetsFilesystemTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Path/LocalPublicAssetsFilesystemTest.php
@@ -38,7 +38,7 @@ class LocalPublicAssetsFilesystemTest extends TestCase
         $filesystem = new LocalPublicAssetsFilesystem(self::$writableRoot);
         $filesystem->write('foo/bar.js', 'foobar');
         $this->assertFileExists(self::$writableRoot.'/foo/bar.js');
-        $this->assertSame('foobar', file_get_contents(self::$writableRoot.'/foo/bar.js'));
+        $this->assertSame('foobar', $this->filesystem->readFile(self::$writableRoot.'/foo/bar.js'));
 
         // with a directory
         $filesystem->write('foo/baz/bar.js', 'foobar');
@@ -50,6 +50,6 @@ class LocalPublicAssetsFilesystemTest extends TestCase
         $filesystem = new LocalPublicAssetsFilesystem(self::$writableRoot);
         $filesystem->copy(__DIR__.'/../Fixtures/importmaps/assets/pizza/index.js', 'foo/bar.js');
         $this->assertFileExists(self::$writableRoot.'/foo/bar.js');
-        $this->assertSame("console.log('pizza/index.js');", trim(file_get_contents(self::$writableRoot.'/foo/bar.js')));
+        $this->assertSame("console.log('pizza/index.js');", trim($this->filesystem->readFile(self::$writableRoot.'/foo/bar.js')));
     }
 }

--- a/src/Symfony/Component/AssetMapper/composer.json
+++ b/src/Symfony/Component/AssetMapper/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "composer/semver": "^3.0",
         "symfony/deprecation-contracts": "^2.1|^3",
-        "symfony/filesystem": "^6.4|^7.0",
+        "symfony/filesystem": "^7.1",
         "symfony/http-client": "^6.4|^7.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -134,7 +134,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
     private function safelyUnserialize(string $file): mixed
     {
         $meta = false;
-        $content = file_get_contents($file);
+        $content = (new Filesystem())->readFile($file);
         $signalingException = new \UnexpectedValueException();
         $prevUnserializeHandler = ini_set('unserialize_callback_func', self::class.'::handleUnserializeCallback');
         $prevErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler, $signalingException) {

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Config\Util;
 
 use Symfony\Component\Config\Util\Exception\InvalidXmlException;
 use Symfony\Component\Config\Util\Exception\XmlParsingException;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * XMLUtils is a bunch of utility methods to XML operations.
@@ -79,7 +80,7 @@ class XmlUtils
                     $valid = false;
                 }
             } elseif (is_file($schemaOrCallable)) {
-                $schemaSource = file_get_contents((string) $schemaOrCallable);
+                $schemaSource = (new Filesystem())->readFile((string) $schemaOrCallable);
                 $valid = @$dom->schemaValidateSource($schemaSource);
             } else {
                 libxml_use_internal_errors($internalErrors);
@@ -122,7 +123,7 @@ class XmlUtils
             throw new \InvalidArgumentException(sprintf('File "%s" is not readable.', $file));
         }
 
-        $content = @file_get_contents($file);
+        $content = (new Filesystem())->readFile($file);
 
         if ('' === trim($content)) {
             throw new \InvalidArgumentException(sprintf('File "%s" does not contain valid XML, it is empty.', $file));

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/filesystem": "^6.4|^7.0",
+        "symfony/filesystem": "^7.1",
         "symfony/polyfill-ctype": "~1.8"
     },
     "require-dev": {

--- a/src/Symfony/Component/Emoji/composer.json
+++ b/src/Symfony/Component/Emoji/composer.json
@@ -20,7 +20,7 @@
         "ext-intl": "*"
     },
     "require-dev": {
-        "symfony/filesystem": "^6.4|^7.0",
+        "symfony/filesystem": "^7.1",
         "symfony/finder": "^6.4|^7.0",
         "symfony/var-exporter": "^6.4|^7.0"
     },

--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add the `Filesystem::readFile()` method
+
 7.0
 ---
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -694,6 +694,25 @@ class Filesystem
         }
     }
 
+    /**
+     * Returns the content of a file as a string.
+     *
+     * @throws IOException If the file cannot be read
+     */
+    public function readFile(string $filename): string
+    {
+        if (is_dir($filename)) {
+            throw new IOException(sprintf('Failed to read file "%s": File is a directory.', $filename));
+        }
+
+        $content = self::box('file_get_contents', $filename);
+        if (false === $content) {
+            throw new IOException(sprintf('Failed to read file "%s": ', $filename).self::$lastError, 0, null, $filename);
+        }
+
+        return $content;
+    }
+
     private function toIterable(string|iterable $files): iterable
     {
         return is_iterable($files) ? $files : [$files];

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1802,6 +1802,43 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFilePermissions(745, $filename);
     }
 
+    public function testReadFile()
+    {
+        $licenseFile = \dirname(__DIR__).'/LICENSE';
+
+        $this->assertStringEqualsFile($licenseFile, $this->filesystem->readFile($licenseFile));
+    }
+
+    public function testReadNonExistentFile()
+    {
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessageMatches('#^Failed to read file ".+/Tests/invalid"\\: file_get_contents\\(.+/Tests/invalid\\)\\: Failed to open stream\\: No such file or directory$#');
+
+        $this->filesystem->readFile(__DIR__.'/invalid');
+    }
+
+    public function testReadDirectory()
+    {
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessageMatches('#^Failed to read file ".+/Tests"\\: File is a directory\\.$#');
+
+        $this->filesystem->readFile(__DIR__);
+    }
+
+    public function testReadUnreadableFile()
+    {
+        $this->markAsSkippedIfChmodIsMissing();
+
+        $filename = $this->workspace.'/unreadable.txt';
+        file_put_contents($filename, 'Hello World');
+        chmod($filename, 0o000);
+
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessageMatches('#^Failed to read file ".+/unreadable.txt"\\: file_get_contents\\(.+/unreadable.txt\\)\\: Failed to open stream\\: Permission denied$#');
+
+        $this->filesystem->readFile($filename);
+    }
+
     public function testCopyShouldKeepExecutionPermission()
     {
         $this->markAsSkippedIfChmodIsMissing();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #47215
| License       | MIT

Our `Filesystem` class is a tool for leveraging PHP's native filesystem functions is a sane way.

For example, it provides a method `dumpFile()` which attempts to write the contents of a string to a file and throws if that attempt fails. However, it lacks a method to read the content of a file. The native function for this task, `file_get_contents()` comes with a couple of traps that I don't want to think about or step into when working with a file system:

* If reading a file fails, `file_get_contents()` returns `false` and triggers an `E_WARNING`. I need to check the return value against `false` and if I want feedback on the failure, I need to work with custom error handlers. Yuck.
* Passing the path to a directory to `file_get_contents()` is almost certainly a mistake that I would want to get an exception for. However, `file_get_contents()` will return an empty string in that case. Fun times.

With this PR, I'm proposing to add a `readFile()` method that either returns the content of a given file or throws an `IOException`. Furthermore, I'm dogfooding this method in components that already depend on the Filesystem component.

