### PR TITLE
[HttpClient] Add support for `amphp/http-client` v5

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -46,6 +46,7 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberIntersectionWithTrait.php'):
         case false !== strpos($file, '/src/Symfony/Component/ErrorHandler/Tests/Fixtures/'):
+        case false !== strpos($file, '/src/Symfony/Component/HttpClient/Internal/'):
         case false !== strpos($file, '/src/Symfony/Component/Form/Tests/Fixtures/Answer.php'):
         case false !== strpos($file, '/src/Symfony/Component/Form/Tests/Fixtures/Number.php'):
         case false !== strpos($file, '/src/Symfony/Component/Form/Tests/Fixtures/Suit.php'):

--- a/composer.json
+++ b/composer.json
@@ -122,9 +122,8 @@
         "symfony/yaml": "self.version"
     },
     "require-dev": {
-        "amphp/amp": "^2.5",
-        "amphp/http-client": "^4.2.1",
-        "amphp/http-tunnel": "^1.0",
+        "amphp/http-client": "^4.2.1|^5.0",
+        "amphp/http-tunnel": "^1.0|^2.0",
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0|^2.0",
         "async-aws/sns": "^1.0",
@@ -151,6 +150,7 @@
         "psr/http-client": "^1.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "seld/jsonlint": "^1.10",
+        "symfony/amphp-http-client-meta": "^1.0|^2.0",
         "symfony/mercure-bundle": "^0.3",
         "symfony/phpunit-bridge": "^6.4|^7.0",
         "symfony/runtime": "self.version",
@@ -162,6 +162,7 @@
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",
+        "amphp/amp": "<2.5",
         "async-aws/core": "<1.5",
         "doctrine/collections": "<1.8",
         "doctrine/dbal": "<3.6",

--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -12,17 +12,20 @@
 namespace Symfony\Component\HttpClient;
 
 use Amp\CancelledException;
+use Amp\DeferredFuture;
 use Amp\Http\Client\DelegateHttpClient;
 use Amp\Http\Client\InterceptedHttpClient;
 use Amp\Http\Client\PooledHttpClient;
 use Amp\Http\Client\Request;
+use Amp\Http\HttpMessage;
 use Amp\Http\Tunnel\Http1TunnelConnector;
-use Amp\Promise;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\HttpClient\Exception\TransportException;
-use Symfony\Component\HttpClient\Internal\AmpClientState;
-use Symfony\Component\HttpClient\Response\AmpResponse;
+use Symfony\Component\HttpClient\Internal\AmpClientStateV4;
+use Symfony\Component\HttpClient\Internal\AmpClientStateV5;
+use Symfony\Component\HttpClient\Response\AmpResponseV4;
+use Symfony\Component\HttpClient\Response\AmpResponseV5;
 use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -33,8 +36,8 @@ if (!interface_exists(DelegateHttpClient::class)) {
     throw new \LogicException('You cannot use "Symfony\Component\HttpClient\AmpHttpClient" as the "amphp/http-client" package is not installed. Try running "composer require amphp/http-client:^4.2.1".');
 }
 
-if (!interface_exists(Promise::class)) {
-    throw new \LogicException('You cannot use "Symfony\Component\HttpClient\AmpHttpClient" as the installed "amphp/http-client" is not compatible with this version of "symfony/http-client". Try downgrading "amphp/http-client" to "^4.2.1".');
+if (\PHP_VERSION_ID < 80400 && is_subclass_of(Request::class, HttpMessage::class)) {
+    throw new \LogicException('Using "Symfony\Component\HttpClient\AmpHttpClient" with amphp/http-client >= 5 requires PHP >= 8.4. Try running "composer require amphp/http-client:^4.2.1" or upgrade to PHP >= 8.4.');
 }
 
 /**
@@ -53,7 +56,7 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
 
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
     private static array $emptyDefaults = self::OPTIONS_DEFAULTS;
-    private AmpClientState $multi;
+    private AmpClientStateV4|AmpClientStateV5 $multi;
 
     /**
      * @param array         $defaultOptions     Default requests' options
@@ -72,7 +75,11 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
             [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, $this->defaultOptions);
         }
 
-        $this->multi = new AmpClientState($clientConfigurator, $maxHostConnections, $maxPendingPushes, $this->logger);
+        if (is_subclass_of(Request::class, HttpMessage::class)) {
+            $this->multi = new AmpClientStateV5($clientConfigurator, $maxHostConnections, $maxPendingPushes, $this->logger);
+        } else {
+            $this->multi = new AmpClientStateV4($clientConfigurator, $maxHostConnections, $maxPendingPushes, $this->logger);
+        }
     }
 
     /**
@@ -132,9 +139,10 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
             $request->addHeader($h[0], $h[1]);
         }
 
-        $request->setTcpConnectTimeout(1000 * $options['timeout']);
-        $request->setTlsHandshakeTimeout(1000 * $options['timeout']);
-        $request->setTransferTimeout(1000 * $options['max_duration']);
+        $coef = $request instanceof HttpMessage ? 1 : 1000;
+        $request->setTcpConnectTimeout($coef * $options['timeout']);
+        $request->setTlsHandshakeTimeout($coef * $options['timeout']);
+        $request->setTransferTimeout($coef * $options['max_duration']);
         if (method_exists($request, 'setInactivityTimeout')) {
             $request->setInactivityTimeout(0);
         }
@@ -145,25 +153,37 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
             $request->setHeader('Authorization', 'Basic '.base64_encode(implode(':', $auth)));
         }
 
-        return new AmpResponse($this->multi, $request, $options, $this->logger);
+        if ($request instanceof HttpMessage) {
+            return new AmpResponseV5($this->multi, $request, $options, $this->logger);
+        }
+
+        return new AmpResponseV4($this->multi, $request, $options, $this->logger);
     }
 
     public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
     {
-        if ($responses instanceof AmpResponse) {
+        if ($responses instanceof AmpResponseV4 || $responses instanceof AmpResponseV5) {
             $responses = [$responses];
         }
 
-        return new ResponseStream(AmpResponse::stream($responses, $timeout));
+        if ($this->multi instanceof AmpClientStateV5) {
+            return new ResponseStream(AmpResponseV5::stream($responses, $timeout));
+        }
+
+        return new ResponseStream(AmpResponseV4::stream($responses, $timeout));
     }
 
     public function reset(): void
     {
         $this->multi->dnsCache = [];
 
-        foreach ($this->multi->pushedResponses as $authority => $pushedResponses) {
+        foreach ($this->multi->pushedResponses as $pushedResponses) {
             foreach ($pushedResponses as [$pushedUrl, $pushDeferred]) {
-                $pushDeferred->fail(new CancelledException());
+                if ($pushDeferred instanceof DeferredFuture) {
+                    $pushDeferred->error(new CancelledException());
+                } else {
+                    $pushDeferred->fail(new CancelledException());
+                }
 
                 $this->logger?->debug(\sprintf('Unused pushed response: "%s"', $pushedUrl));
             }

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add support for amphp/http-client v5 on PHP 8.4+
+
 7.1
 ---
 

--- a/src/Symfony/Component/HttpClient/HttpClient.php
+++ b/src/Symfony/Component/HttpClient/HttpClient.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\HttpClient;
 
-use Amp\Http\Client\Connection\ConnectionLimitingPool;
-use Amp\Promise;
+use Amp\Http\Client\Request as AmpRequest;
+use Amp\Http\HttpMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -31,7 +31,7 @@ final class HttpClient
      */
     public static function create(array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 50): HttpClientInterface
     {
-        if ($amp = class_exists(ConnectionLimitingPool::class) && interface_exists(Promise::class)) {
+        if ($amp = class_exists(AmpRequest::class) && (\PHP_VERSION_ID >= 80400 || is_subclass_of(AmpRequest::class, HttpMessage::class))) {
             if (!\extension_loaded('curl')) {
                 return new AmpHttpClient($defaultOptions, null, $maxHostConnections, $maxPendingPushes);
             }

--- a/src/Symfony/Component/HttpClient/Internal/AmpBodyV4.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpBodyV4.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\Exception\TransportException;
  *
  * @internal
  */
-class AmpBody implements RequestBody, InputStream
+class AmpBodyV4 implements RequestBody, InputStream
 {
     private ResourceInputStream|\Closure|string $body;
     private array $info;

--- a/src/Symfony/Component/HttpClient/Internal/AmpBodyV5.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpBodyV5.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Amp\ByteStream\ReadableBuffer;
+use Amp\ByteStream\ReadableIterableStream;
+use Amp\ByteStream\ReadableResourceStream;
+use Amp\ByteStream\ReadableStream;
+use Amp\Cancellation;
+use Amp\Http\Client\HttpContent;
+use Symfony\Component\HttpClient\Exception\TransportException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class AmpBodyV5 implements HttpContent, ReadableStream, \IteratorAggregate
+{
+    private ReadableStream $body;
+    private ?string $content;
+    private array $info;
+    private ?int $offset = 0;
+    private int $length = -1;
+    private ?int $uploaded = null;
+
+    /**
+     * @param \Closure|resource|string $body
+     */
+    public function __construct(
+        $body,
+        &$info,
+        private \Closure $onProgress,
+    ) {
+        $this->info = &$info;
+
+        if (\is_resource($body)) {
+            $this->offset = ftell($body);
+            $this->length = fstat($body)['size'];
+            $this->body = new ReadableResourceStream($body);
+        } elseif (\is_string($body)) {
+            $this->length = \strlen($body);
+            $this->body = new ReadableBuffer($body);
+            $this->content = $body;
+        } else {
+            $this->body = new ReadableIterableStream((static function () use ($body) {
+                while ('' !== $data = ($body)(16372)) {
+                    if (!\is_string($data)) {
+                        throw new TransportException(\sprintf('Return value of the "body" option callback must be string, "%s" returned.', get_debug_type($data)));
+                    }
+
+                    yield $data;
+                }
+            })());
+        }
+    }
+
+    public function getContent(): ReadableStream
+    {
+        if (null !== $this->uploaded) {
+            $this->uploaded = null;
+
+            if (\is_string($this->body)) {
+                $this->offset = 0;
+            } elseif ($this->body instanceof ReadableResourceStream) {
+                fseek($this->body->getResource(), $this->offset);
+            }
+        }
+
+        return $this;
+    }
+
+    public function getContentType(): ?string
+    {
+        return null;
+    }
+
+    public function getContentLength(): ?int
+    {
+        return 0 <= $this->length ? $this->length - $this->offset : null;
+    }
+
+    public function read(?Cancellation $cancellation = null): ?string
+    {
+        $this->info['size_upload'] += $this->uploaded;
+        $this->uploaded = 0;
+        ($this->onProgress)();
+
+        if (null !== $data = $this->body->read($cancellation)) {
+            $this->uploaded = \strlen($data);
+        } else {
+            $this->info['upload_content_length'] = $this->info['size_upload'];
+        }
+
+        return $data;
+    }
+
+    public function isReadable(): bool
+    {
+        return $this->body->isReadable();
+    }
+
+    public function close(): void
+    {
+        $this->body->close();
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->body->isClosed();
+    }
+
+    public function onClose(\Closure $onClose): void
+    {
+        $this->body->onClose($onClose);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return $this->body;
+    }
+
+    public static function rewind(HttpContent $body): HttpContent
+    {
+        if (!$body instanceof self) {
+            return $body;
+        }
+
+        $body->uploaded = null;
+
+        if ($body->body instanceof ReadableResourceStream && !$body->body->isClosed()) {
+            fseek($body->body->getResource(), $body->offset);
+        }
+
+        if ($body->body instanceof ReadableBuffer) {
+            return new $body($body->content, $body->info, $body->onProgress);
+        }
+
+        return $body;
+    }
+}

--- a/src/Symfony/Component/HttpClient/Internal/AmpClientStateV4.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpClientStateV4.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Amp\CancellationToken;
+use Amp\Deferred;
+use Amp\Http\Client\Connection\ConnectionLimitingPool;
+use Amp\Http\Client\Connection\DefaultConnectionFactory;
+use Amp\Http\Client\InterceptedHttpClient;
+use Amp\Http\Client\Interceptor\RetryRequests;
+use Amp\Http\Client\PooledHttpClient;
+use Amp\Http\Client\Request;
+use Amp\Http\Client\Response;
+use Amp\Http\Tunnel\Http1TunnelConnector;
+use Amp\Http\Tunnel\Https1TunnelConnector;
+use Amp\Promise;
+use Amp\Socket\Certificate;
+use Amp\Socket\ClientTlsContext;
+use Amp\Socket\ConnectContext;
+use Amp\Socket\Connector;
+use Amp\Socket\DnsConnector;
+use Amp\Socket\SocketAddress;
+use Amp\Success;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Internal representation of the Amp client's state.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+final class AmpClientStateV4 extends ClientState
+{
+    public array $dnsCache = [];
+    public int $responseCount = 0;
+    public array $pushedResponses = [];
+
+    private array $clients = [];
+    private \Closure $clientConfigurator;
+
+    public function __construct(
+        ?callable $clientConfigurator,
+        private int $maxHostConnections,
+        private int $maxPendingPushes,
+        private ?LoggerInterface &$logger,
+    ) {
+        $clientConfigurator ??= static fn (PooledHttpClient $client) => new InterceptedHttpClient($client, new RetryRequests(2));
+        $this->clientConfigurator = $clientConfigurator(...);
+    }
+
+    /**
+     * @return Promise<Response>
+     */
+    public function request(array $options, Request $request, CancellationToken $cancellation, array &$info, \Closure $onProgress, &$handle): Promise
+    {
+        if ($options['proxy']) {
+            if ($request->hasHeader('proxy-authorization')) {
+                $options['proxy']['auth'] = $request->getHeader('proxy-authorization');
+            }
+
+            // Matching "no_proxy" should follow the behavior of curl
+            $host = $request->getUri()->getHost();
+            foreach ($options['proxy']['no_proxy'] as $rule) {
+                $dotRule = '.'.ltrim($rule, '.');
+
+                if ('*' === $rule || $host === $rule || str_ends_with($host, $dotRule)) {
+                    $options['proxy'] = null;
+                    break;
+                }
+            }
+        }
+
+        $request = clone $request;
+
+        if ($request->hasHeader('proxy-authorization')) {
+            $request->removeHeader('proxy-authorization');
+        }
+
+        if ($options['capture_peer_cert_chain']) {
+            $info['peer_certificate_chain'] = [];
+        }
+
+        $request->addEventListener(new AmpListenerV4($info, $options['peer_fingerprint']['pin-sha256'] ?? [], $onProgress, $handle));
+        $request->setPushHandler(fn ($request, $response): Promise => $this->handlePush($request, $response, $options));
+
+        ($request->hasHeader('content-length') ? new Success((int) $request->getHeader('content-length')) : $request->getBody()->getBodyLength())
+            ->onResolve(static function ($e, $bodySize) use (&$info) {
+                if (null !== $bodySize && 0 <= $bodySize) {
+                    $info['upload_content_length'] = ((1 + $info['upload_content_length']) ?? 1) - 1 + $bodySize;
+                }
+            });
+
+        [$client, $connector] = $this->getClient($options);
+        $response = $client->request($request, $cancellation);
+        $response->onResolve(static function ($e) use ($connector, &$handle) {
+            if (null === $e) {
+                $handle = $connector->handle;
+            }
+        });
+
+        return $response;
+    }
+
+    private function getClient(array $options): array
+    {
+        $options = [
+            'bindto' => $options['bindto'] ?: '0',
+            'verify_peer' => $options['verify_peer'],
+            'capath' => $options['capath'],
+            'cafile' => $options['cafile'],
+            'local_cert' => $options['local_cert'],
+            'local_pk' => $options['local_pk'],
+            'ciphers' => $options['ciphers'],
+            'capture_peer_cert_chain' => $options['capture_peer_cert_chain'] || $options['peer_fingerprint'],
+            'proxy' => $options['proxy'],
+            'crypto_method' => $options['crypto_method'],
+        ];
+
+        $key = hash('xxh128', serialize($options));
+
+        if (isset($this->clients[$key])) {
+            return $this->clients[$key];
+        }
+
+        $context = new ClientTlsContext('');
+        $options['verify_peer'] || $context = $context->withoutPeerVerification();
+        $options['cafile'] && $context = $context->withCaFile($options['cafile']);
+        $options['capath'] && $context = $context->withCaPath($options['capath']);
+        $options['local_cert'] && $context = $context->withCertificate(new Certificate($options['local_cert'], $options['local_pk']));
+        $options['ciphers'] && $context = $context->withCiphers($options['ciphers']);
+        $options['capture_peer_cert_chain'] && $context = $context->withPeerCapturing();
+        $options['crypto_method'] && $context = $context->withMinimumVersion($options['crypto_method']);
+
+        $connector = $handleConnector = new class implements Connector {
+            public DnsConnector $connector;
+            public string $uri;
+            /** @var resource|null */
+            public $handle;
+
+            public function connect(string $uri, ?ConnectContext $context = null, ?CancellationToken $token = null): Promise
+            {
+                $result = $this->connector->connect($this->uri ?? $uri, $context, $token);
+                $result->onResolve(function ($e, $socket) {
+                    $this->handle = $socket?->getResource();
+                });
+
+                return $result;
+            }
+        };
+        $connector->connector = new DnsConnector(new AmpResolverV4($this->dnsCache));
+
+        $context = (new ConnectContext())
+            ->withTcpNoDelay()
+            ->withTlsContext($context);
+
+        if ($options['bindto']) {
+            if (file_exists($options['bindto'])) {
+                $connector->uri = 'unix://'.$options['bindto'];
+            } else {
+                $context = $context->withBindTo($options['bindto']);
+            }
+        }
+
+        if ($options['proxy']) {
+            $proxyUrl = parse_url($options['proxy']['url']);
+            $proxySocket = new SocketAddress($proxyUrl['host'], $proxyUrl['port']);
+            $proxyHeaders = $options['proxy']['auth'] ? ['Proxy-Authorization' => $options['proxy']['auth']] : [];
+
+            if ('ssl' === $proxyUrl['scheme']) {
+                $connector = new Https1TunnelConnector($proxySocket, $context->getTlsContext(), $proxyHeaders, $connector);
+            } else {
+                $connector = new Http1TunnelConnector($proxySocket, $proxyHeaders, $connector);
+            }
+        }
+
+        $maxHostConnections = 0 < $this->maxHostConnections ? $this->maxHostConnections : \PHP_INT_MAX;
+        $pool = new DefaultConnectionFactory($connector, $context);
+        $pool = ConnectionLimitingPool::byAuthority($maxHostConnections, $pool);
+
+        return $this->clients[$key] = [($this->clientConfigurator)(new PooledHttpClient($pool)), $handleConnector];
+    }
+
+    private function handlePush(Request $request, Promise $response, array $options): Promise
+    {
+        $deferred = new Deferred();
+        $authority = $request->getUri()->getAuthority();
+
+        if ($this->maxPendingPushes <= \count($this->pushedResponses[$authority] ?? [])) {
+            $fifoUrl = key($this->pushedResponses[$authority]);
+            unset($this->pushedResponses[$authority][$fifoUrl]);
+            $this->logger?->debug(\sprintf('Evicting oldest pushed response: "%s"', $fifoUrl));
+        }
+
+        $url = (string) $request->getUri();
+        $this->logger?->debug(\sprintf('Queueing pushed response: "%s"', $url));
+        $this->pushedResponses[$authority][] = [$url, $deferred, $request, $response, [
+            'proxy' => $options['proxy'],
+            'bindto' => $options['bindto'],
+            'local_cert' => $options['local_cert'],
+            'local_pk' => $options['local_pk'],
+        ]];
+
+        return $deferred->promise();
+    }
+}

--- a/src/Symfony/Component/HttpClient/Internal/AmpClientStateV5.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpClientStateV5.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\HttpClient\Internal;
 
-use Amp\CancellationToken;
-use Amp\Deferred;
+use Amp\ByteStream\ResourceStream;
+use Amp\Cancellation;
+use Amp\DeferredFuture;
+use Amp\Future;
 use Amp\Http\Client\Connection\ConnectionLimitingPool;
 use Amp\Http\Client\Connection\DefaultConnectionFactory;
 use Amp\Http\Client\InterceptedHttpClient;
@@ -22,14 +24,13 @@ use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
 use Amp\Http\Tunnel\Http1TunnelConnector;
 use Amp\Http\Tunnel\Https1TunnelConnector;
-use Amp\Promise;
 use Amp\Socket\Certificate;
 use Amp\Socket\ClientTlsContext;
 use Amp\Socket\ConnectContext;
-use Amp\Socket\Connector;
-use Amp\Socket\DnsConnector;
+use Amp\Socket\DnsSocketConnector;
+use Amp\Socket\Socket;
 use Amp\Socket\SocketAddress;
-use Amp\Success;
+use Amp\Socket\SocketConnector;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -39,7 +40,7 @@ use Psr\Log\LoggerInterface;
  *
  * @internal
  */
-final class AmpClientState extends ClientState
+final class AmpClientStateV5 extends ClientState
 {
     public array $dnsCache = [];
     public int $responseCount = 0;
@@ -54,14 +55,11 @@ final class AmpClientState extends ClientState
         private int $maxPendingPushes,
         private ?LoggerInterface &$logger,
     ) {
-        $clientConfigurator ??= static fn (PooledHttpClient $client) => new InterceptedHttpClient($client, new RetryRequests(2));
+        $clientConfigurator ??= static fn (PooledHttpClient $client) => new InterceptedHttpClient($client, new RetryRequests(2), []);
         $this->clientConfigurator = $clientConfigurator(...);
     }
 
-    /**
-     * @return Promise<Response>
-     */
-    public function request(array $options, Request $request, CancellationToken $cancellation, array &$info, \Closure $onProgress, &$handle): Promise
+    public function request(array $options, Request $request, Cancellation $cancellation, array &$info, \Closure $onProgress, &$handle): Response
     {
         if ($options['proxy']) {
             if ($request->hasHeader('proxy-authorization')) {
@@ -80,8 +78,6 @@ final class AmpClientState extends ClientState
             }
         }
 
-        $request = clone $request;
-
         if ($request->hasHeader('proxy-authorization')) {
             $request->removeHeader('proxy-authorization');
         }
@@ -90,23 +86,16 @@ final class AmpClientState extends ClientState
             $info['peer_certificate_chain'] = [];
         }
 
-        $request->addEventListener(new AmpListener($info, $options['peer_fingerprint']['pin-sha256'] ?? [], $onProgress, $handle));
-        $request->setPushHandler(fn ($request, $response): Promise => $this->handlePush($request, $response, $options));
+        $request->addEventListener(new AmpListenerV5($info, $options['peer_fingerprint']['pin-sha256'] ?? [], $onProgress, $handle));
+        $request->setPushHandler(fn ($request, $response) => $this->handlePush($request, $response, $options));
 
-        ($request->hasHeader('content-length') ? new Success((int) $request->getHeader('content-length')) : $request->getBody()->getBodyLength())
-            ->onResolve(static function ($e, $bodySize) use (&$info) {
-                if (null !== $bodySize && 0 <= $bodySize) {
-                    $info['upload_content_length'] = ((1 + $info['upload_content_length']) ?? 1) - 1 + $bodySize;
-                }
-            });
+        if (0 <= $bodySize = $request->hasHeader('content-length') ? (int) $request->getHeader('content-length') : $request->getBody()->getContentLength() ?? -1) {
+            $info['upload_content_length'] = ((1 + $info['upload_content_length']) ?? 1) - 1 + $bodySize;
+        }
 
         [$client, $connector] = $this->getClient($options);
         $response = $client->request($request, $cancellation);
-        $response->onResolve(static function ($e) use ($connector, &$handle) {
-            if (null === $e) {
-                $handle = $connector->handle;
-            }
-        });
+        $handle = $connector->handle;
 
         return $response;
     }
@@ -141,23 +130,21 @@ final class AmpClientState extends ClientState
         $options['capture_peer_cert_chain'] && $context = $context->withPeerCapturing();
         $options['crypto_method'] && $context = $context->withMinimumVersion($options['crypto_method']);
 
-        $connector = $handleConnector = new class implements Connector {
-            public DnsConnector $connector;
+        $connector = $handleConnector = new class implements SocketConnector {
+            public DnsSocketConnector $connector;
             public string $uri;
             /** @var resource|null */
             public $handle;
 
-            public function connect(string $uri, ?ConnectContext $context = null, ?CancellationToken $token = null): Promise
+            public function connect(SocketAddress|string $uri, ?ConnectContext $context = null, ?Cancellation $cancellation = null): Socket
             {
-                $result = $this->connector->connect($this->uri ?? $uri, $context, $token);
-                $result->onResolve(function ($e, $socket) {
-                    $this->handle = $socket?->getResource();
-                });
+                $socket = $this->connector->connect($this->uri ?? $uri, $context, $cancellation);
+                $this->handle = $socket instanceof ResourceStream ? $socket->getResource() : false;
 
-                return $result;
+                return $socket;
             }
         };
-        $connector->connector = new DnsConnector(new AmpResolver($this->dnsCache));
+        $connector->connector = new DnsSocketConnector(new AmpResolverV5($this->dnsCache));
 
         $context = (new ConnectContext())
             ->withTcpNoDelay()
@@ -190,9 +177,9 @@ final class AmpClientState extends ClientState
         return $this->clients[$key] = [($this->clientConfigurator)(new PooledHttpClient($pool)), $handleConnector];
     }
 
-    private function handlePush(Request $request, Promise $response, array $options): Promise
+    private function handlePush(Request $request, Future $response, array $options): void
     {
-        $deferred = new Deferred();
+        $deferred = new DeferredFuture();
         $authority = $request->getUri()->getAuthority();
 
         if ($this->maxPendingPushes <= \count($this->pushedResponses[$authority] ?? [])) {
@@ -210,6 +197,6 @@ final class AmpClientState extends ClientState
             'local_pk' => $options['local_pk'],
         ]];
 
-        return $deferred->promise();
+        $deferred->getFuture()->await();
     }
 }

--- a/src/Symfony/Component/HttpClient/Internal/AmpListenerV4.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpListenerV4.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\Exception\TransportException;
  *
  * @internal
  */
-class AmpListener implements EventListener
+class AmpListenerV4 implements EventListener
 {
     private array $info;
 

--- a/src/Symfony/Component/HttpClient/Internal/AmpListenerV5.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpListenerV5.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Amp\Http\Client\ApplicationInterceptor;
+use Amp\Http\Client\Connection\Connection;
+use Amp\Http\Client\Connection\Stream;
+use Amp\Http\Client\EventListener;
+use Amp\Http\Client\NetworkInterceptor;
+use Amp\Http\Client\Request;
+use Amp\Http\Client\Response;
+use Symfony\Component\HttpClient\Exception\TransportException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class AmpListenerV5 implements EventListener
+{
+    private array $info;
+
+    /**
+     * @param resource|null $handle
+     */
+    public function __construct(
+        array &$info,
+        private array $pinSha256,
+        private \Closure $onProgress,
+        private &$handle,
+    ) {
+        $info += [
+            'connect_time' => 0.0,
+            'pretransfer_time' => 0.0,
+            'starttransfer_time' => 0.0,
+            'total_time' => 0.0,
+            'namelookup_time' => 0.0,
+            'primary_ip' => '',
+            'primary_port' => 0,
+        ];
+
+        $this->info = &$info;
+    }
+
+    public function requestStart(Request $request): void
+    {
+        $this->info['start_time'] ??= microtime(true);
+        ($this->onProgress)();
+    }
+
+    public function connectionAcquired(Request $request, Connection $connection, int $streamCount): void
+    {
+        $this->info['namelookup_time'] = microtime(true) - $this->info['start_time']; // see https://github.com/amphp/socket/issues/114
+        $this->info['connect_time'] = microtime(true) - $this->info['start_time'];
+        ($this->onProgress)();
+    }
+
+    public function requestHeaderStart(Request $request, Stream $stream): void
+    {
+        $host = $stream->getRemoteAddress()->toString();
+
+        if (str_contains($host, ':')) {
+            $host = '['.$host.']';
+        }
+
+        $this->info['primary_ip'] = $host;
+        $this->info['primary_port'] = $stream->getRemoteAddress()->getPort();
+        $this->info['pretransfer_time'] = microtime(true) - $this->info['start_time'];
+        $this->info['debug'] .= \sprintf("* Connected to %s (%s) port %d\n", $request->getUri()->getHost(), $host, $this->info['primary_port']);
+
+        if ((isset($this->info['peer_certificate_chain']) || $this->pinSha256) && null !== $tlsInfo = $stream->getTlsInfo()) {
+            foreach ($tlsInfo->getPeerCertificates() as $cert) {
+                $this->info['peer_certificate_chain'][] = openssl_x509_read($cert->toPem());
+            }
+
+            if ($this->pinSha256) {
+                $pin = openssl_pkey_get_public($this->info['peer_certificate_chain'][0]);
+                $pin = openssl_pkey_get_details($pin)['key'];
+                $pin = \array_slice(explode("\n", $pin), 1, -2);
+                $pin = base64_decode(implode('', $pin));
+                $pin = base64_encode(hash('sha256', $pin, true));
+
+                if (!\in_array($pin, $this->pinSha256, true)) {
+                    throw new TransportException(\sprintf('SSL public key does not match pinned public key for "%s".', $this->info['url']));
+                }
+            }
+        }
+        ($this->onProgress)();
+
+        $uri = $request->getUri();
+        $requestUri = $uri->getPath() ?: '/';
+
+        if ('' !== $query = $uri->getQuery()) {
+            $requestUri .= '?'.$query;
+        }
+
+        if ('CONNECT' === $method = $request->getMethod()) {
+            $requestUri = $uri->getHost().': '.($uri->getPort() ?? ('https' === $uri->getScheme() ? 443 : 80));
+        }
+
+        $this->info['debug'] .= \sprintf("> %s %s HTTP/%s \r\n", $method, $requestUri, $request->getProtocolVersions()[0]);
+
+        foreach ($request->getHeaderPairs() as [$name, $value]) {
+            $this->info['debug'] .= $name.': '.$value."\r\n";
+        }
+        $this->info['debug'] .= "\r\n";
+    }
+
+    public function requestBodyEnd(Request $request, Stream $stream): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function responseHeaderStart(Request $request, Stream $stream): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function requestEnd(Request $request, Response $response): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function requestFailed(Request $request, \Throwable $exception): void
+    {
+        $this->handle = null;
+        ($this->onProgress)();
+    }
+
+    public function requestHeaderEnd(Request $request, Stream $stream): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function requestBodyStart(Request $request, Stream $stream): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function requestBodyProgress(Request $request, Stream $stream): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function responseHeaderEnd(Request $request, Stream $stream, Response $response): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function responseBodyStart(Request $request, Stream $stream, Response $response): void
+    {
+        $this->info['starttransfer_time'] = microtime(true) - $this->info['start_time'];
+        ($this->onProgress)();
+    }
+
+    public function responseBodyProgress(Request $request, Stream $stream, Response $response): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function responseBodyEnd(Request $request, Stream $stream, Response $response): void
+    {
+        $this->handle = null;
+        ($this->onProgress)();
+    }
+
+    public function applicationInterceptorStart(Request $request, ApplicationInterceptor $interceptor): void
+    {
+    }
+
+    public function applicationInterceptorEnd(Request $request, ApplicationInterceptor $interceptor, Response $response): void
+    {
+    }
+
+    public function networkInterceptorStart(Request $request, NetworkInterceptor $interceptor): void
+    {
+    }
+
+    public function networkInterceptorEnd(Request $request, NetworkInterceptor $interceptor, Response $response): void
+    {
+    }
+
+    public function push(Request $request): void
+    {
+        ($this->onProgress)();
+    }
+
+    public function requestRejected(Request $request): void
+    {
+        $this->handle = null;
+        ($this->onProgress)();
+    }
+}

--- a/src/Symfony/Component/HttpClient/Internal/AmpResolverV4.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpResolverV4.php
@@ -23,7 +23,7 @@ use Amp\Success;
  *
  * @internal
  */
-class AmpResolver implements Dns\Resolver
+class AmpResolverV4 implements Dns\Resolver
 {
     public function __construct(
         private array &$dnsMap,

--- a/src/Symfony/Component/HttpClient/Internal/AmpResolverV5.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpResolverV5.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Amp\Cancellation;
+use Amp\Dns;
+use Amp\Dns\DnsRecord;
+use Amp\Dns\DnsResolver;
+
+/**
+ * Handles local overrides for the DNS resolver.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class AmpResolverV5 implements DnsResolver
+{
+    public function __construct(
+        private array &$dnsMap,
+    ) {
+    }
+
+    public function resolve(string $name, ?int $typeRestriction = null, ?Cancellation $cancellation = null): array
+    {
+        if (!isset($this->dnsMap[$name]) || !\in_array($typeRestriction, [DnsRecord::A, null], true)) {
+            return Dns\resolve($name, $typeRestriction, $cancellation);
+        }
+
+        return [new DnsRecord($this->dnsMap[$name], DnsRecord::A, null)];
+    }
+
+    public function query(string $name, int $type, ?Cancellation $cancellation = null): array
+    {
+        if (!isset($this->dnsMap[$name]) || DnsRecord::A !== $type) {
+            return Dns\resolve($name, $type, $cancellation);
+        }
+
+        return [new DnsRecord($this->dnsMap[$name], DnsRecord::A, null)];
+    }
+}

--- a/src/Symfony/Component/HttpClient/Response/AmpResponseV4.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponseV4.php
@@ -1,0 +1,451 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Amp\ByteStream\StreamException;
+use Amp\CancellationTokenSource;
+use Amp\Coroutine;
+use Amp\Deferred;
+use Amp\Http\Client\HttpException;
+use Amp\Http\Client\Request;
+use Amp\Http\Client\Response;
+use Amp\Loop;
+use Amp\Promise;
+use Amp\Success;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Chunk\FirstChunk;
+use Symfony\Component\HttpClient\Chunk\InformationalChunk;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\HttpClientTrait;
+use Symfony\Component\HttpClient\Internal\AmpBodyV4;
+use Symfony\Component\HttpClient\Internal\AmpClientStateV4;
+use Symfony\Component\HttpClient\Internal\Canary;
+use Symfony\Component\HttpClient\Internal\ClientState;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+final class AmpResponseV4 implements ResponseInterface, StreamableInterface
+{
+    use CommonResponseTrait;
+    use TransportResponseTrait;
+
+    private static string $nextId = 'a';
+
+    private ?array $options;
+    private \Closure $onProgress;
+
+    private static ?string $delay = null;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private AmpClientStateV4 $multi,
+        Request $request,
+        array $options,
+        ?LoggerInterface $logger,
+    ) {
+        $this->options = &$options;
+        $this->logger = $logger;
+        $this->timeout = $options['timeout'];
+        $this->shouldBuffer = $options['buffer'];
+
+        if ($this->inflate = \extension_loaded('zlib') && !$request->hasHeader('accept-encoding')) {
+            $request->setHeader('Accept-Encoding', 'gzip');
+        }
+
+        $this->initializer = static fn (self $response) => null !== $response->options;
+
+        $info = &$this->info;
+        $headers = &$this->headers;
+        $canceller = new CancellationTokenSource();
+        $handle = &$this->handle;
+
+        $info['url'] = (string) $request->getUri();
+        $info['http_method'] = $request->getMethod();
+        $info['start_time'] = null;
+        $info['redirect_url'] = null;
+        $info['original_url'] = $info['url'];
+        $info['redirect_time'] = 0.0;
+        $info['redirect_count'] = 0;
+        $info['size_upload'] = 0.0;
+        $info['size_download'] = 0.0;
+        $info['upload_content_length'] = -1.0;
+        $info['download_content_length'] = -1.0;
+        $info['user_data'] = $options['user_data'];
+        $info['max_duration'] = $options['max_duration'];
+        $info['debug'] = '';
+
+        $onProgress = $options['on_progress'] ?? static function () {};
+        $onProgress = $this->onProgress = static function () use (&$info, $onProgress) {
+            $info['total_time'] = microtime(true) - $info['start_time'];
+            $onProgress((int) $info['size_download'], ((int) (1 + $info['download_content_length']) ?: 1) - 1, (array) $info);
+        };
+
+        $pauseDeferred = new Deferred();
+        $pause = new Success();
+
+        $throttleWatcher = null;
+
+        $this->id = $id = self::$nextId++;
+        Loop::defer(static function () use ($request, $multi, $id, &$info, &$headers, $canceller, &$options, $onProgress, &$handle, $logger, &$pause) {
+            return new Coroutine(self::generateResponse($request, $multi, $id, $info, $headers, $canceller, $options, $onProgress, $handle, $logger, $pause));
+        });
+
+        $info['pause_handler'] = static function (float $duration) use (&$throttleWatcher, &$pauseDeferred, &$pause) {
+            if (null !== $throttleWatcher) {
+                Loop::cancel($throttleWatcher);
+            }
+
+            $pause = $pauseDeferred->promise();
+
+            if ($duration <= 0) {
+                $deferred = $pauseDeferred;
+                $pauseDeferred = new Deferred();
+                $deferred->resolve();
+            } else {
+                $throttleWatcher = Loop::delay(ceil(1000 * $duration), static function () use (&$pauseDeferred) {
+                    $deferred = $pauseDeferred;
+                    $pauseDeferred = new Deferred();
+                    $deferred->resolve();
+                });
+            }
+        };
+
+        $multi->lastTimeout = null;
+        $multi->openHandles[$id] = $id;
+        ++$multi->responseCount;
+
+        $this->canary = new Canary(static function () use ($canceller, $multi, $id) {
+            $canceller->cancel();
+            unset($multi->openHandles[$id], $multi->handlesActivity[$id]);
+        });
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        return null !== $type ? $this->info[$type] ?? null : $this->info;
+    }
+
+    public function __sleep(): array
+    {
+        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+    }
+
+    public function __wakeup(): void
+    {
+        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->doDestruct();
+        } finally {
+            // Clear the DNS cache when all requests completed
+            if (0 >= --$this->multi->responseCount) {
+                $this->multi->responseCount = 0;
+                $this->multi->dnsCache = [];
+            }
+        }
+    }
+
+    private static function schedule(self $response, array &$runningResponses): void
+    {
+        if (isset($runningResponses[0])) {
+            $runningResponses[0][1][$response->id] = $response;
+        } else {
+            $runningResponses[0] = [$response->multi, [$response->id => $response]];
+        }
+
+        if (!isset($response->multi->openHandles[$response->id])) {
+            $response->multi->handlesActivity[$response->id][] = null;
+            $response->multi->handlesActivity[$response->id][] = null !== $response->info['error'] ? new TransportException($response->info['error']) : null;
+        }
+    }
+
+    /**
+     * @param AmpClientStateV4 $multi
+     */
+    private static function perform(ClientState $multi, ?array &$responses = null): void
+    {
+        if ($responses) {
+            foreach ($responses as $response) {
+                try {
+                    if ($response->info['start_time']) {
+                        $response->info['total_time'] = microtime(true) - $response->info['start_time'];
+                        ($response->onProgress)();
+                    }
+                } catch (\Throwable $e) {
+                    $multi->handlesActivity[$response->id][] = null;
+                    $multi->handlesActivity[$response->id][] = $e;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param AmpClientStateV4 $multi
+     */
+    private static function select(ClientState $multi, float $timeout): int
+    {
+        $timeout += hrtime(true) / 1E9;
+        self::$delay = Loop::defer(static function () use ($timeout) {
+            if (0 < $timeout -= hrtime(true) / 1E9) {
+                self::$delay = Loop::delay(ceil(1000 * $timeout), Loop::stop(...));
+            } else {
+                Loop::stop();
+            }
+        });
+
+        Loop::run();
+
+        return null === self::$delay ? 1 : 0;
+    }
+
+    private static function generateResponse(Request $request, AmpClientStateV4 $multi, string $id, array &$info, array &$headers, CancellationTokenSource $canceller, array &$options, \Closure $onProgress, &$handle, ?LoggerInterface $logger, Promise &$pause): \Generator
+    {
+        $request->setInformationalResponseHandler(static function (Response $response) use ($multi, $id, &$info, &$headers) {
+            self::addResponseHeaders($response, $info, $headers);
+            $multi->handlesActivity[$id][] = new InformationalChunk($response->getStatus(), $response->getHeaders());
+            self::stopLoop();
+        });
+
+        try {
+            /* @var Response $response */
+            if (null === $response = yield from self::getPushedResponse($request, $multi, $info, $headers, $options, $logger)) {
+                $logger?->info(\sprintf('Request: "%s %s"', $info['http_method'], $info['url']));
+
+                $response = yield from self::followRedirects($request, $multi, $info, $headers, $canceller, $options, $onProgress, $handle, $logger, $pause);
+            }
+
+            $options = null;
+
+            $multi->handlesActivity[$id][] = new FirstChunk();
+
+            if ('HEAD' === $response->getRequest()->getMethod() || \in_array($info['http_code'], [204, 304], true)) {
+                $multi->handlesActivity[$id][] = null;
+                $multi->handlesActivity[$id][] = null;
+                self::stopLoop();
+
+                return;
+            }
+
+            if ($response->hasHeader('content-length')) {
+                $info['download_content_length'] = (float) $response->getHeader('content-length');
+            }
+
+            $body = $response->getBody();
+
+            while (true) {
+                self::stopLoop();
+
+                yield $pause;
+
+                if (null === $data = yield $body->read()) {
+                    break;
+                }
+
+                $info['size_download'] += \strlen($data);
+                $multi->handlesActivity[$id][] = $data;
+            }
+
+            $multi->handlesActivity[$id][] = null;
+            $multi->handlesActivity[$id][] = null;
+        } catch (\Throwable $e) {
+            $multi->handlesActivity[$id][] = null;
+            $multi->handlesActivity[$id][] = $e;
+        } finally {
+            $info['download_content_length'] = $info['size_download'];
+        }
+
+        self::stopLoop();
+    }
+
+    private static function followRedirects(Request $originRequest, AmpClientStateV4 $multi, array &$info, array &$headers, CancellationTokenSource $canceller, array $options, \Closure $onProgress, &$handle, ?LoggerInterface $logger, Promise &$pause): \Generator
+    {
+        yield $pause;
+
+        $originRequest->setBody(new AmpBodyV4($options['body'], $info, $onProgress));
+        $response = yield $multi->request($options, $originRequest, $canceller->getToken(), $info, $onProgress, $handle);
+        $previousUrl = null;
+
+        while (true) {
+            self::addResponseHeaders($response, $info, $headers);
+            $status = $response->getStatus();
+
+            if (!\in_array($status, [301, 302, 303, 307, 308], true) || null === $location = $response->getHeader('location')) {
+                return $response;
+            }
+
+            $urlResolver = new class {
+                use HttpClientTrait {
+                    parseUrl as public;
+                    resolveUrl as public;
+                }
+            };
+
+            try {
+                $previousUrl ??= $urlResolver::parseUrl($info['url']);
+                $location = $urlResolver::parseUrl($location);
+                $location = $urlResolver::resolveUrl($location, $previousUrl);
+                $info['redirect_url'] = implode('', $location);
+            } catch (InvalidArgumentException) {
+                return $response;
+            }
+
+            if (0 >= $options['max_redirects'] || $info['redirect_count'] >= $options['max_redirects']) {
+                return $response;
+            }
+
+            $logger?->info(\sprintf('Redirecting: "%s %s"', $status, $info['url']));
+
+            try {
+                // Discard body of redirects
+                while (null !== yield $response->getBody()->read()) {
+                }
+            } catch (HttpException|StreamException) {
+                // Ignore streaming errors on previous responses
+            }
+
+            ++$info['redirect_count'];
+            $info['url'] = $info['redirect_url'];
+            $info['redirect_url'] = null;
+            $previousUrl = $location;
+
+            $request = new Request($info['url'], $info['http_method']);
+            $request->setProtocolVersions($originRequest->getProtocolVersions());
+            $request->setTcpConnectTimeout($originRequest->getTcpConnectTimeout());
+            $request->setTlsHandshakeTimeout($originRequest->getTlsHandshakeTimeout());
+            $request->setTransferTimeout($originRequest->getTransferTimeout());
+
+            if (\in_array($status, [301, 302, 303], true)) {
+                $originRequest->removeHeader('transfer-encoding');
+                $originRequest->removeHeader('content-length');
+                $originRequest->removeHeader('content-type');
+
+                // Do like curl and browsers: turn POST to GET on 301, 302 and 303
+                if ('POST' === $response->getRequest()->getMethod() || 303 === $status) {
+                    $info['http_method'] = 'HEAD' === $response->getRequest()->getMethod() ? 'HEAD' : 'GET';
+                    $request->setMethod($info['http_method']);
+                }
+            } else {
+                $request->setBody(AmpBodyV4::rewind($response->getRequest()->getBody()));
+            }
+
+            foreach ($originRequest->getRawHeaders() as [$name, $value]) {
+                $request->addHeader($name, $value);
+            }
+
+            if ($request->getUri()->getAuthority() !== $originRequest->getUri()->getAuthority()) {
+                $request->removeHeader('authorization');
+                $request->removeHeader('cookie');
+                $request->removeHeader('host');
+            }
+
+            yield $pause;
+
+            $response = yield $multi->request($options, $request, $canceller->getToken(), $info, $onProgress, $handle);
+            $info['redirect_time'] = microtime(true) - $info['start_time'];
+        }
+    }
+
+    private static function addResponseHeaders(Response $response, array &$info, array &$headers): void
+    {
+        $info['http_code'] = $response->getStatus();
+
+        if ($headers) {
+            $info['debug'] .= "< \r\n";
+            $headers = [];
+        }
+
+        $h = \sprintf('HTTP/%s %s %s', $response->getProtocolVersion(), $response->getStatus(), $response->getReason());
+        $info['debug'] .= "< {$h}\r\n";
+        $info['response_headers'][] = $h;
+
+        foreach ($response->getRawHeaders() as [$name, $value]) {
+            $headers[strtolower($name)][] = $value;
+            $h = $name.': '.$value;
+            $info['debug'] .= "< {$h}\r\n";
+            $info['response_headers'][] = $h;
+        }
+
+        $info['debug'] .= "< \r\n";
+    }
+
+    /**
+     * Accepts pushed responses only if their headers related to authentication match the request.
+     */
+    private static function getPushedResponse(Request $request, AmpClientStateV4 $multi, array &$info, array &$headers, array $options, ?LoggerInterface $logger): \Generator
+    {
+        if ('' !== $options['body']) {
+            return null;
+        }
+
+        $authority = $request->getUri()->getAuthority();
+
+        foreach ($multi->pushedResponses[$authority] ?? [] as $i => [$pushedUrl, $pushDeferred, $pushedRequest, $pushedResponse, $parentOptions]) {
+            if ($info['url'] !== $pushedUrl || $info['http_method'] !== $pushedRequest->getMethod()) {
+                continue;
+            }
+
+            foreach ($parentOptions as $k => $v) {
+                if ($options[$k] !== $v) {
+                    continue 2;
+                }
+            }
+
+            foreach (['authorization', 'cookie', 'range', 'proxy-authorization'] as $k) {
+                if ($pushedRequest->getHeaderArray($k) !== $request->getHeaderArray($k)) {
+                    continue 2;
+                }
+            }
+
+            $response = yield $pushedResponse;
+
+            foreach ($response->getHeaderArray('vary') as $vary) {
+                foreach (preg_split('/\s*+,\s*+/', $vary) as $v) {
+                    if ('*' === $v || ($pushedRequest->getHeaderArray($v) !== $request->getHeaderArray($v) && 'accept-encoding' !== strtolower($v))) {
+                        $logger?->debug(\sprintf('Skipping pushed response: "%s"', $info['url']));
+                        continue 3;
+                    }
+                }
+            }
+
+            $pushDeferred->resolve();
+            $logger?->debug(\sprintf('Accepting pushed response: "%s %s"', $info['http_method'], $info['url']));
+            self::addResponseHeaders($response, $info, $headers);
+            unset($multi->pushedResponses[$authority][$i]);
+
+            if (!$multi->pushedResponses[$authority]) {
+                unset($multi->pushedResponses[$authority]);
+            }
+
+            return $response;
+        }
+    }
+
+    private static function stopLoop(): void
+    {
+        if (null !== self::$delay) {
+            Loop::cancel(self::$delay);
+            self::$delay = null;
+        }
+
+        Loop::defer(Loop::stop(...));
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -443,7 +443,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         ]);
 
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertStringContainsString("\r\nContent-Length: ", $response->getInfo('debug'));
+        $this->assertStringContainsStringIgnoringCase("\r\nContent-Length: ", $response->getInfo('debug'));
     }
 
     public function testNullBody()

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -29,14 +29,14 @@
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {
-        "amphp/amp": "^2.5",
-        "amphp/http-client": "^4.2.1",
-        "amphp/http-tunnel": "^1.0",
+        "amphp/http-client": "^4.2.1|^5.0",
+        "amphp/http-tunnel": "^1.0|^2.0",
         "amphp/socket": "^1.1",
         "guzzlehttp/promises": "^1.4|^2.0",
         "nyholm/psr7": "^1.0",
         "php-http/httplug": "^1.0|^2.0",
         "psr/http-client": "^1.0",
+        "symfony/amphp-http-client-meta": "^1.0|^2.0",
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/messenger": "^6.4|^7.0",
@@ -45,6 +45,7 @@
         "symfony/stopwatch": "^6.4|^7.0"
     },
     "conflict": {
+        "amphp/amp": "<2.5",
         "php-http/discovery": "<1.15",
         "symfony/http-foundation": "<6.4"
     },

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -100,6 +100,8 @@ abstract class AbstractCloner implements ClonerInterface
         'Symfony\Component\HttpClient\CurlHttpClient' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castHttpClient'],
         'Symfony\Component\HttpClient\NativeHttpClient' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castHttpClient'],
         'Symfony\Component\HttpClient\Response\AmpResponse' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castHttpClientResponse'],
+        'Symfony\Component\HttpClient\Response\AmpResponseV4' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castHttpClientResponse'],
+        'Symfony\Component\HttpClient\Response\AmpResponseV5' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castHttpClientResponse'],
         'Symfony\Component\HttpClient\Response\CurlResponse' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castHttpClientResponse'],
         'Symfony\Component\HttpClient\Response\NativeResponse' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castHttpClientResponse'],
         'Symfony\Component\HttpFoundation\Request' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castRequest'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #52008
| License       | MIT

This PR adds support for amphp/http-client version 5 as a transport for our HttpClient component.

It started as a draft at https://github.com/nicolas-grekas/symfony/pull/43, which helped spot that PHP is missing the capability to suspend fibers in destructors. This was reported as https://github.com/php/php-src/issues/11389 and is being fixed at https://github.com/php/php-src/pull/13460.

Since the fix for php-src is going to land on PHP 8.4, using amphp/http-client version 5 will require php >= 8.4.

The implementation duplicates the one we have for v4 with the needed changes to use the v5 API. The difference are not big in size of code, but they're very low level (generators vs fibers). That would be quite useless to factor IMHO.