### PR TITLE
[AssetMapper] create `PreAssetsCompileEvent` using `SymfonyStyle`

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -62,7 +62,7 @@ EOT
     {
         $io = new SymfonyStyle($input, $output);
 
-        $this->eventDispatcher?->dispatch(new PreAssetsCompileEvent($output));
+        $this->eventDispatcher?->dispatch(new PreAssetsCompileEvent($io));
 
         // remove existing config files
         $this->compiledConfigReader->removeConfig(AssetMapper::MANIFEST_FILE_NAME);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This will allow listeners to match the style of this this command.
