### PR TITLE
[Clock] rename get/setMicroseconds() to get/setMicrosecond()

### DIFF
--- a/src/Symfony/Component/Clock/CHANGELOG.md
+++ b/src/Symfony/Component/Clock/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.1
 ---
 
- * Add `DatePoint::get/setMicroseconds()`
+ * Add `DatePoint::get/setMicrosecond()`
 
 6.4
 ---

--- a/src/Symfony/Component/Clock/DatePoint.php
+++ b/src/Symfony/Component/Clock/DatePoint.php
@@ -118,23 +118,23 @@ final class DatePoint extends \DateTimeImmutable
         return parent::getTimezone() ?: throw new \DateInvalidTimeZoneException('The DatePoint object has no timezone.');
     }
 
-    public function setMicroseconds(int $microseconds): static
+    public function setMicrosecond(int $microsecond): static
     {
-        if ($microseconds < 0 || $microseconds > 999999) {
-            throw new \DateRangeError('DatePoint::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, '.$microseconds.' given');
+        if ($microsecond < 0 || $microsecond > 999999) {
+            throw new \DateRangeError('DatePoint::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, '.$microsecond.' given');
         }
 
         if (\PHP_VERSION_ID < 80400) {
-            return $this->setTime(...explode('.', $this->format('H.i.s.'.$microseconds)));
+            return $this->setTime(...explode('.', $this->format('H.i.s.'.$microsecond)));
         }
 
-        return parent::setMicroseconds($microseconds);
+        return parent::setMicrosecond($microsecond);
     }
 
-    public function getMicroseconds(): int
+    public function getMicrosecond(): int
     {
         if (\PHP_VERSION_ID >= 80400) {
-            return parent::getMicroseconds();
+            return parent::getMicrosecond();
         }
 
         return $this->format('u');

--- a/src/Symfony/Component/Clock/Tests/DatePointTest.php
+++ b/src/Symfony/Component/Clock/Tests/DatePointTest.php
@@ -58,19 +58,19 @@ class DatePointTest extends TestCase
         $date->modify('Bad Date');
     }
 
-    public function testMicroseconds()
+    public function testMicrosecond()
     {
         $date = new DatePoint('2010-01-28 15:00:00.123456');
 
         $this->assertSame('2010-01-28 15:00:00.123456', $date->format('Y-m-d H:i:s.u'));
 
-        $date = $date->setMicroseconds(789);
+        $date = $date->setMicrosecond(789);
 
         $this->assertSame('2010-01-28 15:00:00.000789', $date->format('Y-m-d H:i:s.u'));
-        $this->assertSame(789, $date->getMicroseconds());
+        $this->assertSame(789, $date->getMicrosecond());
 
         $this->expectException(\DateRangeError::class);
-        $this->expectExceptionMessage('DatePoint::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, 1000000 given');
-        $date->setMicroseconds(1000000);
+        $this->expectExceptionMessage('DatePoint::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, 1000000 given');
+        $date->setMicrosecond(1000000);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

follows php/php-src#13486