### PR TITLE
[FrameworkBundle] Fix PHP 8.4 deprecation on `ReflectionMethod`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -559,7 +559,7 @@ class TextDescriptor extends Descriptor
             } elseif (!\is_string($controller)) {
                 return $anchorText;
             } elseif (str_contains($controller, '::')) {
-                $r = new \ReflectionMethod($controller);
+                $r = new \ReflectionMethod(...explode('::', $controller, 2));
             } else {
                 $r = new \ReflectionFunction($controller);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Part of #54180
| License       | MIT

This fixes:

```
16x: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead
    4x in RouterDebugCommandTest::testDumpAllRoutes from Symfony\Bundle\FrameworkBundle\Tests\Functional
    4x in RouterDebugCommandTest::testSearchMultipleRoutesWithoutInteraction from Symfony\Bundle\FrameworkBundle\Tests\Functional
    4x in RouterDebugCommandTest::testShowAliases from Symfony\Bundle\FrameworkBundle\Tests\Functional
    2x in TextDescriptorTest::testDescribeRouteWithControllerLink from Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor
    1x in RouterDebugCommandTest::testDumpOneRoute from Symfony\Bundle\FrameworkBundle\Tests\Functional
    ...
```