### PR TITLE
Add an experimental CI job for PHP 8.4

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,8 @@ jobs:
           - php: '8.2'
             mode: low-deps
           - php: '8.3'
-            #mode: experimental
+          - php: '8.4'
+            mode: experimental
       fail-fast: false
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Relates to #54180
| License       | MIT

This adds the CI job requested in #54180. This PR does not focus on making tests green on 8.4 but the CI job is marked as experimental so that the CI job will still be green (to not block PRs) even when tests are failing. The test report will show failures when looking at the output of the step running tests, which allows moving forward incrementally to make tests green.
