### PR TITLE
[ErrorHandler] Fix exit code when an exception occurs and the exception handler has been unregistered

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -669,6 +669,10 @@ class ErrorHandler
             set_exception_handler($h);
         }
         if (!$handler) {
+            if (null === $error && $exitCode = self::$exitCode) {
+                register_shutdown_function('register_shutdown_function', function () use ($exitCode) { exit($exitCode); });
+            }
+
             return;
         }
         if ($handler !== $h) {
@@ -704,8 +708,7 @@ class ErrorHandler
             // Ignore this re-throw
         }
 
-        if ($exit && self::$exitCode) {
-            $exitCode = self::$exitCode;
+        if ($exit && $exitCode = self::$exitCode) {
             register_shutdown_function('register_shutdown_function', function () use ($exitCode) { exit($exitCode); });
         }
     }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53946
| License       | MIT

PHP 8.3 introduced a change (see https://github.com/php/php-src/issues/13446) that highlighted a fragility in ErrorHandler::handleFatalError, leading to the linked issued. This fixes it.

What this doesn't fix is turning fatal errors into fake exceptions, which PHP 8.3 broke. For this, the fix is on the side of PHP.

Testing is not obvious :see_no_evil: 