### PR TITLE
[Mailer] [Brevo] Check that tags is present in payload before calling setTags

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/RemoteEvent/BrevoPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/RemoteEvent/BrevoPayloadConverter.php
@@ -60,7 +60,10 @@ final class BrevoPayloadConverter implements PayloadConverterInterface
 
         $event->setDate($date);
         $event->setRecipientEmail($payload['email']);
-        $event->setTags($payload['tags']);
+
+        if (isset($payload['tags'])) {
+            $event->setTags($payload['tags']);
+        }
 
         return $event;
     }

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Webhook/Fixtures/request_without_tags.json
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Webhook/Fixtures/request_without_tags.json
@@ -1,0 +1,13 @@
+{
+  "id": 814119,
+  "email": "example@gmail.com",
+  "message-id": "<202305311313.92192897094@smtp-relay.mailin.fr>",
+  "date": "2023-05-31 15:13:08",
+  "event": "request",
+  "subject": "Subject Line",
+  "sending_ip": "127.0.0.1",
+  "ts_event": 1685538788,
+  "ts": 1685538788,
+  "reason": "sent",
+  "ts_epoch": 1685538788179
+}

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Webhook/Fixtures/request_without_tags.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Webhook/Fixtures/request_without_tags.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::RECEIVED, '<202305311313.92192897094@smtp-relay.mailin.fr>', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: JSON_THROW_ON_ERROR));
+$wh->setRecipientEmail('example@gmail.com');
+$wh->setDate(\DateTimeImmutable::createFromFormat('U', 1685538788));
+
+return $wh;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix [#54197](https://github.com/symfony/symfony/issues/54197)
| License       | MIT

`tags` was removed as a mandatory parameter from Brevo remote event requests in this [PR](https://github.com/symfony/symfony/pull/54089/files) by me. Sadly, I wasn't wary enough, and I didn't added payload check before calling setTags in the PayloadConverter, and it causes TypeErrors.

- With this fix, `setTags` won't be called anymore if tags are not present in the request
- `AbstractMailerEvent` defaults tags as empty array, so there is no need to call the setter with empty array parameter 