### PR TITLE
[ExpressionLanguage] Fix error parsing for PHP 8.4

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -52,7 +52,7 @@ class BinaryNode extends Node
             }
 
             $compiler
-                ->raw('(static function ($regexp, $str) { set_error_handler(function ($t, $m) use ($regexp, $str) { throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr($m, 12)); }); try { return preg_match($regexp, (string) $str); } finally { restore_error_handler(); } })(')
+                ->raw('(static function ($regexp, $str) { set_error_handler(function ($t, $m) use ($regexp, $str) { throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr(strstr($m, "preg_match()"), 12)); }); try { return preg_match($regexp, (string) $str); } finally { restore_error_handler(); } })(')
                 ->compile($this->nodes['right'])
                 ->raw(', ')
                 ->compile($this->nodes['left'])
@@ -176,7 +176,7 @@ class BinaryNode extends Node
     private function evaluateMatches(string $regexp, ?string $str): int
     {
         set_error_handler(function ($t, $m) use ($regexp) {
-            throw new SyntaxError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12));
+            throw new SyntaxError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr(strstr($m, 'preg_match()'), 12));
         });
         try {
             return preg_match($regexp, (string) $str);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -116,7 +116,7 @@ class BinaryNodeTest extends AbstractNodeTestCase
 
             ['range(1, 3)', new BinaryNode('..', new ConstantNode(1), new ConstantNode(3))],
 
-            ['(static function ($regexp, $str) { set_error_handler(function ($t, $m) use ($regexp, $str) { throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr($m, 12)); }); try { return preg_match($regexp, (string) $str); } finally { restore_error_handler(); } })("/^[a-z]+\$/", "abc")', new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('/^[a-z]+$/'))],
+            ['(static function ($regexp, $str) { set_error_handler(function ($t, $m) use ($regexp, $str) { throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr(strstr($m, "preg_match()"), 12)); }); try { return preg_match($regexp, (string) $str); } finally { restore_error_handler(); } })("/^[a-z]+\$/", "abc")', new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('/^[a-z]+$/'))],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #54180
| License       | MIT

Prior to PHP 8.4, the parsed error looked like `preg_match(): Delimiter...`. But now, The FQCN of `BinaryNode` is added, making the error looks like `Symfony\Component\...\BinaryNode::preg_match(): ...`.

I updated the parsing to be future-proof with it by detecting where's the first occurence of `preg_match()`, then removing it from the string.

This fixes the following error of PHP 8.4 job:

```
Failed asserting that exception message 'Regexp "this is not a regexp" passed to "matches" is not validonent\ExpressionLanguage\Tests\Node\BinaryNodeTest::preg_match(): Delimiter must not be alphanumeric, backslash, or NUL byte around position 0.' contains 'Regexp "this is not a regexp" passed to "matches" is not valid: Delimiter must not be alphanumeric'.
```