### PR TITLE
[String] Leverage `Randomizer::getBytesFromString()`

### DIFF
--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\String;
 
+use Random\Randomizer;
 use Symfony\Component\String\Exception\ExceptionInterface;
 use Symfony\Component\String\Exception\InvalidArgumentException;
 use Symfony\Component\String\Exception\RuntimeException;
@@ -53,6 +54,10 @@ class ByteString extends AbstractString
         $bits = (int) ceil(log($alphabetSize, 2.0));
         if ($bits <= 0 || $bits > 56) {
             throw new InvalidArgumentException('The length of the alphabet must in the [2^1, 2^56] range.');
+        }
+
+        if (\PHP_VERSION_ID >= 80300) {
+            return new static((new Randomizer())->getBytesFromString($alphabet, $length));
         }
 
         $ret = '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

PHP 8.3 shipped a new method `Randomizer::getBytesFromString()` that can replace most of the logic in `ByteString::fromRandom()`. I propose to make use of it if we can.