### PR TITLE
[Validator] Allow BICs’ first four characters to be digits

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -102,16 +102,6 @@ class BicValidator extends ConstraintValidator
             return;
         }
 
-        // first 4 letters must be alphabetic (bank code)
-        if (!ctype_alpha(substr($canonicalize, 0, 4))) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setCode(Bic::INVALID_BANK_CODE_ERROR)
-                ->addViolation();
-
-            return;
-        }
-
         $bicCountryCode = substr($canonicalize, 4, 2);
         if (!isset(self::BIC_COUNTRY_TO_IBAN_COUNTRY_MAP[$bicCountryCode]) && !Countries::exists($bicCountryCode)) {
             $this->context->buildViolation($constraint->message)

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -199,7 +199,6 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
     public static function getValidBics()
     {
-        // http://formvalidation.io/validators/bic/
         return [
             ['ASPKAT2LXXX'],
             ['ASPKAT2L'],
@@ -207,6 +206,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
             ['UNCRIT2B912'],
             ['DABADKKK'],
             ['RZOOAT2L303'],
+            ['1SBACNBXSHA'],
         ];
     }
 
@@ -252,11 +252,6 @@ class BicValidatorTest extends ConstraintValidatorTestCase
             ['ASPKAT2LX', Bic::INVALID_LENGTH_ERROR],
             ['ASPKAT2LXXX1', Bic::INVALID_LENGTH_ERROR],
             ['DABADKK', Bic::INVALID_LENGTH_ERROR],
-            ['1SBACNBXSHA', Bic::INVALID_BANK_CODE_ERROR],
-            ['RZ00AT2L303', Bic::INVALID_BANK_CODE_ERROR],
-            ['D2BACNBXSHA', Bic::INVALID_BANK_CODE_ERROR],
-            ['DS3ACNBXSHA', Bic::INVALID_BANK_CODE_ERROR],
-            ['DSB4CNBXSHA', Bic::INVALID_BANK_CODE_ERROR],
             ['DEUT12HH', Bic::INVALID_COUNTRY_CODE_ERROR],
             ['DSBAC6BXSHA', Bic::INVALID_COUNTRY_CODE_ERROR],
             ['DSBA5NBXSHA', Bic::INVALID_COUNTRY_CODE_ERROR],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51975
| License       | MIT

While a lot of sources claim a BIC’s first four characters must be letters, this is not the case since ISO 9362:1994. The confusion may come from SWIFT (ISO 9362’s registration authority) saying that

> [We have] no plan to issue BICs with numeric characters in the first 4 characters.

[Source](https://www.swift.com/swift-resource/9586/download) (clicking this link will trigger a download)

However, the next paragraph says

> If applications have implemented restrictions on the allowed characters, it would be good practice to remove this restriction at the occasion of a software update to respect the standard specification of 4 alpha-numeric characters.

As @luxemate stumbled on such a valid BIC (see linked issue), this PR removes the `Bic::INVALID_BANK_CODE_ERROR` check. This constant won’t be referenced anymore so it may be deprecated and removed later.