### PR TITLE
[VarExporter] add `#[Ignore]` to proxy-related methods to prevent them from being serialized

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectTrait.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectTrait.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\VarExporter\Internal;
 
+use Symfony\Component\Serializer\Attribute\Ignore;
+
 if (\PHP_VERSION_ID >= 80300) {
     /**
      * @internal
      */
     trait LazyObjectTrait
     {
+        #[Ignore]
         private readonly LazyObjectState $lazyObjectState;
     }
 } else {
@@ -25,6 +28,7 @@ if (\PHP_VERSION_ID >= 80300) {
      */
     trait LazyObjectTrait
     {
+        #[Ignore]
         private LazyObjectState $lazyObjectState;
     }
 }

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarExporter;
 
+use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
@@ -61,6 +62,7 @@ trait LazyGhostTrait
      *
      * @param $partial Whether partially initialized objects should be considered as initialized
      */
+    #[Ignore]
     public function isLazyObjectInitialized(bool $partial = false): bool
     {
         if (!$state = $this->lazyObjectState ?? null) {
@@ -389,6 +391,7 @@ trait LazyGhostTrait
         }
     }
 
+    #[Ignore]
     private function setLazyObjectAsInitialized(bool $initialized): void
     {
         $state = $this->lazyObjectState ?? null;

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarExporter;
 
+use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\VarExporter\Hydrator as PublicHydrator;
 use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
@@ -50,6 +51,7 @@ trait LazyProxyTrait
      *
      * @param $partial Whether partially initialized objects should be considered as initialized
      */
+    #[Ignore]
     public function isLazyObjectInitialized(bool $partial = false): bool
     {
         return !isset($this->lazyObjectState) || isset($this->lazyObjectState->realInstance) || Registry::$noInitializerState === $this->lazyObjectState->initializer;

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/SimpleObject.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/SimpleObject.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures;
+
+class SimpleObject
+{
+    public function getMethod(): string
+    {
+        return 'method';
+    }
+
+    public string $property = 'property';
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\VarExporter\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
 use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildMagicClass;
@@ -22,6 +25,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\LazyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\MagicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ReadOnlyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\TestClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\SimpleObject;
 
 class LazyGhostTraitTest extends TestCase
 {
@@ -459,6 +463,19 @@ class LazyGhostTraitTest extends TestCase
         $this->expectExceptionMessage('Typed property Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ClassWithUninitializedObjectProperty::$property must not be accessed before initialization');
 
         $object->property;
+    }
+
+    public function testNormalization()
+    {
+        $object = $this->createLazyGhost(SimpleObject::class, function ($instance) {});
+
+        $loader = new AttributeLoader();
+        $metadataFactory = new ClassMetadataFactory($loader);
+        $serializer = new ObjectNormalizer($metadataFactory);
+
+        $output = $serializer->normalize($object);
+
+        $this->assertSame(['property' => 'property', 'method' => 'method'], $output);
     }
 
     /**

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\VarExporter\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Component\VarExporter\ProxyHelper;
@@ -22,6 +25,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestOverwritePropClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestUnserializeClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestWakeupClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\SimpleObject;
 
 class LazyProxyTraitTest extends TestCase
 {
@@ -279,6 +283,19 @@ class LazyProxyTraitTest extends TestCase
         };
 
         $this->assertSame(['foo' => 123], (array) $obj->getDep());
+    }
+
+    public function testNormalization()
+    {
+        $object = $this->createLazyProxy(SimpleObject::class, fn () => new SimpleObject());
+
+        $loader = new AttributeLoader();
+        $metadataFactory = new ClassMetadataFactory($loader);
+        $serializer = new ObjectNormalizer($metadataFactory);
+
+        $output = $serializer->normalize($object);
+
+        $this->assertSame(['property' => 'property', 'method' => 'method'], $output);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Adds `#[Ignore]` to proxy-related methods so they are not included in serialization.

Previously, serializing a lazy object will result in something like this:

```
{
  "lazyObjectInitialized": false,
  "foo": "bar"
}
```