### PR TITLE
[Console] Add `ArgvInput::getRawTokens()`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `ArgvInput::getRawTokens()`
+
 7.0
 ---
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -346,6 +346,16 @@ class ArgvInput extends Input
     }
 
     /**
+     * Returns un-parsed and not validated tokens.
+     *
+     * @return list<string>
+     */
+    public function getRawTokens(): array
+    {
+        return $this->tokens;
+    }
+
+    /**
      * Returns a stringified representation of the args passed to the command.
      */
     public function __toString(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Many times, I had to access raw tokens, and each time I used reflection or other hacks
to get theses values. So I think it's time to expose this property properly.

For example, if you want to create a command that wrap a proces, with "pass thru" arguments,
you need that.

---

Examples:

```php
#!/usr/bin/env php
<?php

use Symfony\Component\Console\SingleCommandApplication;
use Symfony\Component\Process\Process;

require __DIR__ . '/vendor/autoload.php';

$command = new SingleCommandApplication('ls');
$command->ignoreValidationErrors();
$command->setCode(function ($input) {
    $p = new Process(['ls', ...$input->getRawTokens()]);
    $p->setTty(true);
    $p->mustRun();
});
$command->run();
```

![image](https://github.com/symfony/symfony/assets/408368/d16d28ae-5aff-4df8-9978-216448bf1491)


---

> [!NOTE]
> In castor, we also strip all options until the command name
> ```php
> $parameters = [];
> $keep = false;
> foreach ($input->getRawTokens() as $value) {
>     if ($value === $input->getFirstArgument()) {
>         $keep = true;
> 
>         continue;
>     }
>     if ($keep) {
>         $parameters[] = $value;
>     }
> }
> ```
> It could be nice to add support for this too?
