### PR TITLE
[HttpClient] [EventSourceHttpClient] Fix consuming SSEs with \r\n separator

### DIFF
--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -121,7 +121,7 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
                 return;
             }
 
-            $rx = '/((?:\r\n|[\r\n]){2,})/';
+            $rx = '/((?:\r\n){2,}|\r{2,}|\n{2,})/';
             $content = $state->buffer.$chunk->getContent();
 
             if ($chunk->isLast()) {

--- a/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
@@ -27,9 +27,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class EventSourceHttpClientTest extends TestCase
 {
-    public function testGetServerSentEvents()
+    /**
+     * @testWith ["\n"]
+     *           ["\r"]
+     *           ["\r\n"]
+     */
+    public function testGetServerSentEvents(string $sep)
     {
-        $data = <<<TXT
+        $data = str_replace("\n", $sep, <<<TXT
 event: builderror
 id: 46
 data: {"foo": "bar"}
@@ -57,7 +62,7 @@ data: </tag>
 
 id: 60
 data
-TXT;
+TXT);
 
         $chunk = new DataChunk(0, $data);
         $response = new MockResponse('', ['canceled' => false, 'http_method' => 'GET', 'url' => 'http://localhost:8080/events', 'response_headers' => ['content-type: text/event-stream']]);
@@ -83,11 +88,11 @@ TXT;
 
         $expected = [
             new FirstChunk(),
-            new ServerSentEvent("event: builderror\nid: 46\ndata: {\"foo\": \"bar\"}\n\n"),
-            new ServerSentEvent("event: reload\nid: 47\ndata: {}\n\n"),
-            new ServerSentEvent("event: reload\nid: 48\ndata: {}\n\n"),
-            new ServerSentEvent("data: test\ndata:test\nid: 49\nevent: testEvent\n\n\n"),
-            new ServerSentEvent("id: 50\ndata: <tag>\ndata\ndata:   <foo />\ndata\ndata: </tag>\n\n"),
+            new ServerSentEvent(str_replace("\n", $sep, "event: builderror\nid: 46\ndata: {\"foo\": \"bar\"}\n\n")),
+            new ServerSentEvent(str_replace("\n", $sep, "event: reload\nid: 47\ndata: {}\n\n")),
+            new ServerSentEvent(str_replace("\n", $sep, "event: reload\nid: 48\ndata: {}\n\n")),
+            new ServerSentEvent(str_replace("\n", $sep, "data: test\ndata:test\nid: 49\nevent: testEvent\n\n\n")),
+            new ServerSentEvent(str_replace("\n", $sep, "id: 50\ndata: <tag>\ndata\ndata:   <foo />\ndata\ndata: </tag>\n\n")),
         ];
         $i = 0;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`\r\n` separator never worked because it splits on every line because of `[\r\n]`.