### PR TITLE
[Security] Correctly initialize the voter property

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -145,6 +145,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         // collect voters and access decision manager information
         if ($this->accessDecisionManager instanceof TraceableAccessDecisionManager) {
             $this->data['voter_strategy'] = $this->accessDecisionManager->getStrategy();
+            $this->data['voters'] = [];
 
             foreach ($this->accessDecisionManager->getVoters() as $voter) {
                 if ($voter instanceof TraceableVoter) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -400,6 +400,36 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertSame($dataCollector->getVoterStrategy(), $strategy, 'Wrong value returned by getVoterStrategy');
     }
 
+    public function testGetVotersIfAccessDecisionManagerHasNoVoters()
+    {
+        $strategy = MainConfiguration::STRATEGY_AFFIRMATIVE;
+
+        $accessDecisionManager = $this->createMock(TraceableAccessDecisionManager::class);
+
+        $accessDecisionManager
+            ->method('getStrategy')
+            ->willReturn($strategy);
+
+        $accessDecisionManager
+            ->method('getVoters')
+            ->willReturn([]);
+
+        $accessDecisionManager
+            ->method('getDecisionLog')
+            ->willReturn([[
+                'attributes' => ['view'],
+                'object' => new \stdClass(),
+                'result' => true,
+                'voterDetails' => [],
+            ]]);
+
+        $dataCollector = new SecurityDataCollector(null, null, null, $accessDecisionManager, null, null, true);
+
+        $dataCollector->collect(new Request(), new Response());
+
+        $this->assertEmpty($dataCollector->getVoters());
+    }
+
     public static function provideRoles(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/54225
| License       | MIT

This fixes the basic issue that causes https://github.com/symfony/symfony/issues/54225. If `getVoters()` returns an empty array, the `$this->data['voters']` property is never initialized, and therefore returns an invalid value.

@fritzmg or I will follow up if necessary with a fix about decorated access decision managers that cannot "provide" their voters for tracing.