### PR TITLE
[VarDumper] Fix test suite with PHP 8.4

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -116,10 +116,16 @@ class ReflectionCaster
 
     public static function castAttribute(\ReflectionAttribute $c, array $a, Stub $stub, bool $isNested)
     {
-        self::addMap($a, $c, [
+        $map = [
             'name' => 'getName',
             'arguments' => 'getArguments',
-        ]);
+        ];
+
+        if (\PHP_VERSION_ID >= 80400) {
+            unset($map['name']);
+        }
+
+        self::addMap($a, $c, $map);
 
         return $a;
     }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -599,13 +599,14 @@ EOTXT
     public function testReflectionClassWithAttribute()
     {
         $var = new \ReflectionClass(LotsOfAttributes::class);
+        $dumpedAttributeNameProperty = (\PHP_VERSION_ID < 80400 ? '' : '+').'name';
 
-        $this->assertDumpMatchesFormat(<<< 'EOTXT'
+        $this->assertDumpMatchesFormat(<<<EOTXT
 ReflectionClass {
   +name: "Symfony\Component\VarDumper\Tests\Fixtures\LotsOfAttributes"
 %A  attributes: array:1 [
     0 => ReflectionAttribute {
-      name: "Symfony\Component\VarDumper\Tests\Fixtures\MyAttribute"
+      $dumpedAttributeNameProperty: "Symfony\Component\VarDumper\Tests\Fixtures\MyAttribute"
       arguments: []
     }
   ]
@@ -621,14 +622,15 @@ EOTXT
     public function testReflectionMethodWithAttribute()
     {
         $var = new \ReflectionMethod(LotsOfAttributes::class, 'someMethod');
+        $dumpedAttributeNameProperty = (\PHP_VERSION_ID < 80400 ? '' : '+').'name';
 
-        $this->assertDumpMatchesFormat(<<< 'EOTXT'
+        $this->assertDumpMatchesFormat(<<<EOTXT
 ReflectionMethod {
   +name: "someMethod"
   +class: "Symfony\Component\VarDumper\Tests\Fixtures\LotsOfAttributes"
 %A  attributes: array:1 [
     0 => ReflectionAttribute {
-      name: "Symfony\Component\VarDumper\Tests\Fixtures\MyAttribute"
+      $dumpedAttributeNameProperty: "Symfony\Component\VarDumper\Tests\Fixtures\MyAttribute"
       arguments: array:1 [
         0 => "two"
       ]
@@ -646,14 +648,15 @@ EOTXT
     public function testReflectionPropertyWithAttribute()
     {
         $var = new \ReflectionProperty(LotsOfAttributes::class, 'someProperty');
+        $dumpedAttributeNameProperty = (\PHP_VERSION_ID < 80400 ? '' : '+').'name';
 
-        $this->assertDumpMatchesFormat(<<< 'EOTXT'
+        $this->assertDumpMatchesFormat(<<<EOTXT
 ReflectionProperty {
   +name: "someProperty"
   +class: "Symfony\Component\VarDumper\Tests\Fixtures\LotsOfAttributes"
 %A  attributes: array:1 [
     0 => ReflectionAttribute {
-      name: "Symfony\Component\VarDumper\Tests\Fixtures\MyAttribute"
+      $dumpedAttributeNameProperty: "Symfony\Component\VarDumper\Tests\Fixtures\MyAttribute"
       arguments: array:2 [
         0 => "one"
         "extra" => "hello"
@@ -671,8 +674,9 @@ EOTXT
     public function testReflectionClassConstantWithAttribute()
     {
         $var = new \ReflectionClassConstant(LotsOfAttributes::class, 'SOME_CONSTANT');
+        $dumpedAttributeNameProperty = (\PHP_VERSION_ID < 80400 ? '' : '+').'name';
 
-        $this->assertDumpMatchesFormat(<<< 'EOTXT'
+        $this->assertDumpMatchesFormat(<<<EOTXT
 ReflectionClassConstant {
   +name: "SOME_CONSTANT"
   +class: "Symfony\Component\VarDumper\Tests\Fixtures\LotsOfAttributes"
@@ -680,13 +684,13 @@ ReflectionClassConstant {
   value: "some value"
   attributes: array:2 [
     0 => ReflectionAttribute {
-      name: "Symfony\Component\VarDumper\Tests\Fixtures\RepeatableAttribute"
+      $dumpedAttributeNameProperty: "Symfony\Component\VarDumper\Tests\Fixtures\RepeatableAttribute"
       arguments: array:1 [
         0 => "one"
       ]
     }
     1 => ReflectionAttribute {
-      name: "Symfony\Component\VarDumper\Tests\Fixtures\RepeatableAttribute"
+      $dumpedAttributeNameProperty: "Symfony\Component\VarDumper\Tests\Fixtures\RepeatableAttribute"
       arguments: array:1 [
         0 => "two"
       ]
@@ -703,14 +707,15 @@ EOTXT
     public function testReflectionParameterWithAttribute()
     {
         $var = new \ReflectionParameter([LotsOfAttributes::class, 'someMethod'], 'someParameter');
+        $dumpedAttributeNameProperty = (\PHP_VERSION_ID < 80400 ? '' : '+').'name';
 
-        $this->assertDumpMatchesFormat(<<< 'EOTXT'
+        $this->assertDumpMatchesFormat(<<<EOTXT
 ReflectionParameter {
   +name: "someParameter"
   position: 0
   attributes: array:1 [
     0 => ReflectionAttribute {
-      name: "Symfony\Component\VarDumper\Tests\Fixtures\MyAttribute"
+      $dumpedAttributeNameProperty: "Symfony\Component\VarDumper\Tests\Fixtures\MyAttribute"
       arguments: array:1 [
         0 => "three"
       ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54180
| License       | MIT

Lately, attribute name has been added to `ReflectionAttribute`, which makes messed up with the CI a bit with PHP 8.4. Here is the PR: https://github.com/php/php-src/pull/12917

We can change the current virtual dump property to some "real" one by adding `name` in the caster when it doesn't exist yet. If it already exists, we're running PHP 8.4 or later. This way we avoid having different tests with the different PHP versions.

Should we add something in `ReflectionCaster` to remember to remove this part when the minimal PHP version Symfony requires is >= 8.4 ? If yes, what would be the best "syntax"?