### PR TITLE
[HttpKernel] Fix creating `ReflectionMethod` with only one argument

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
@@ -70,7 +70,7 @@ final class ControllerEvent extends KernelEvent
         if (\is_array($controller) && method_exists(...$controller)) {
             $this->controllerReflector = new \ReflectionMethod(...$controller);
         } elseif (\is_string($controller) && str_contains($controller, '::')) {
-            $this->controllerReflector = new \ReflectionMethod($controller);
+            $this->controllerReflector = new \ReflectionMethod(...explode('::', $controller, 2));
         } else {
             $this->controllerReflector = new \ReflectionFunction($controller(...));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #54180
| License       | MIT

Remaining PHP 8.4 deprecations on 6.4