### PR TITLE
[DoctrineBridge] prevent deprecated message

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -129,8 +129,8 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
         if ($ret && isset($ret[0]->fieldMappings[$property]) && !$ret[0]->hasAssociation($property)) {
             $mapping = $ret[0]->getFieldMapping($property);
 
-            if (isset($mapping['length'])) {
-                return new ValueGuess($mapping['length'], Guess::HIGH_CONFIDENCE);
+            if (isset($mapping->length)) {
+                return new ValueGuess($mapping->length, Guess::HIGH_CONFIDENCE);
             }
 
             if (\in_array($ret[0]->getTypeOfField($property), [Types::DECIMAL, Types::FLOAT])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | 
| License       | MIT

prevent this deprecation :
User Deprecated: Using ArrayAccess on Doctrine\ORM\Mapping\FieldMapping is deprecated and will not be possible in Doctrine ORM 4.0. Use the corresponding property instead. (ArrayAccessImplementation.php:18 called by DoctrineOrmTypeGuesser.php:132, https://github.com/doctrine/orm/pull/11211, package doctrine/orm)

same as https://github.com/symfony/doctrine-bridge/pull/15
