### PR TITLE
[VarDumper] prevent error in value to Typed property must not be accessed before initialization

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/Stub.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Stub.php
@@ -35,7 +35,7 @@ class Stub
 
     public int $type = self::TYPE_REF;
     public string|int|null $class = '';
-    public mixed $value;
+    public mixed $value = null;
     public int $cut = 0;
     public int $handle = 0;
     public int $refCount = 0;


### PR DESCRIPTION
…
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| License       | MIT

Using Road Runner in webprofiler bundle the following error appears from vendor/symfony/web-profiler-bundle/Resources/views/Profiler/bag.html.twig:12:

An exception has been thrown during the rendering of a template ("Typed property Symfony\Component\VarDumper\Cloner\Stub::$value must not be accessed before initialization").

This helps to prevent that Twig\Error\RuntimeError
