### PR TITLE
[ErrorHandler] Add `ErrorHandler::unregister()`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -108,6 +108,11 @@ class FrameworkBundle extends Bundle
         }
     }
 
+    public function shutdown(): void
+    {
+        ErrorHandler::unregister();
+    }
+
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);

--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Add `ErrorHandler::unregister()`
+
 6.4
 ---
 

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -68,6 +68,36 @@ class ErrorHandlerTest extends TestCase
         }
     }
 
+    public function testUnregister()
+    {
+        $errorHandler = function () {};
+        $exceptionHandler = function () {};
+
+        $initialErrorHandler = set_error_handler($errorHandler);
+        $initialExceptionHandler = set_exception_handler($exceptionHandler);
+
+        $handler = ErrorHandler::register();
+
+        try {
+            $h = set_error_handler('var_dump');
+            restore_error_handler();
+            $this->assertSame([$handler, 'handleError'], $h);
+
+            ErrorHandler::unregister();
+
+            $h = set_error_handler('var_dump');
+            restore_error_handler();
+            $this->assertSame($errorHandler, $h);
+
+            $h = set_exception_handler('var_dump');
+            restore_exception_handler();
+            $this->assertSame($exceptionHandler, $h);
+        } finally {
+            set_exception_handler($initialExceptionHandler);
+            set_error_handler($initialErrorHandler);
+        }
+    }
+
     public function testErrorGetLast()
     {
         $logger = $this->createMock(LoggerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53812
| License       | MIT

This new method allows to unregister the error handler, primarily to avoid conflicts with PHPUnit 11. This can be used like this:

```php
class HomeControllerTest extends KernelTestCase
{
    protected function tearDown(): void
    {
        ErrorHandler::unregister();
    }

    public function testIndex(): void
    {
        self::bootKernel();

        // ...
    }
}
```