### PR TITLE
[ErrorHandler] Fix `ErrorHandlerTest::tearDown()` visibility

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\ErrorHandler\Tests\Fixtures\LoggerThatSetAnErrorHandler;
  */
 class ErrorHandlerTest extends TestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $r = new \ReflectionProperty(ErrorHandler::class, 'exitCode');
         $r->setAccessible(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The visibility defined in the parent class is `protected`.