### PR TITLE
Update `changed-translation-files` step with native git diff command

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -198,10 +198,14 @@ jobs:
       #    sudo rm -rf .phpunit
       #    [ -d .phpunit.bak ] && mv .phpunit.bak .phpunit
 
-      - uses: marceloprado/has-changed-path@v1.0.1
+      - name: Check for changes in translation files
         id: changed-translation-files
-        with:
-          paths: src/**/Resources/translations/*.xlf
+        run: |
+          if git diff --quiet HEAD~1 HEAD -- 'src/**/Resources/translations/*.xlf'; then
+            echo "{changed}={true}" >> $GITHUB_OUTPUT
+          else
+            echo "{changed}={false}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Check Translation Status
         if: steps.changed-translation-files.outputs.changed == 'true'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

## Description

The **Integration workflow** currently relies on the [marceloprado/has-changed-path action](https://github.com/MarceloPrado/has-changed-path) to detect changes in translation files. However, this action is still utilizing Node.js version 16. Consequently, warnings about the deprecation of Node.js 16 actions appear whenever the Integration workflow is executed.

![image](https://github.com/symfony/symfony/assets/45073703/8a2691ab-7352-4110-ade7-74d979d2277d)

This pull request proposes the removal of the `marceloprado/has-changed-path` action. Instead, it leverages the native git diff command, accessible through actions/checkout. This approach ensures smoother integration and avoids reliance on deprecated Node.js versions. Also, this PR gives a name to that step.
