### PR TITLE
[Messenger] [Amqp] Add default exchange support

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -1,10 +1,15 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add default exchange support
+
 7.1
 ---
 
-* Implement the `CloseableTransportInterface` to allow closing the AMQP connection
+ * Implement the `CloseableTransportInterface` to allow closing the AMQP connection
  * Add option `delay[arguments]` in the transport definition
 
 6.0

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -75,6 +75,36 @@ class AmqpExtIntegrationTest extends TestCase
         $this->assertSame([], iterator_to_array($receiver->get()));
     }
 
+    public function testItSendsAndReceivesMessagesThroughDefaultExchange()
+    {
+        $serializer = $this->createSerializer();
+
+        $connection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'), ['exchange' => ['name' => '']]);
+        $connection->setup();
+        $connection->purgeQueues();
+
+        $sender = new AmqpSender($connection, $serializer);
+        $receiver = new AmqpReceiver($connection, $serializer);
+
+        $sender->send($first = new Envelope(new DummyMessage('First'), [new AmqpStamp('messages')]));
+        $sender->send($second = new Envelope(new DummyMessage('Second'), [new AmqpStamp('messages')]));
+
+        $envelopes = iterator_to_array($receiver->get());
+        $this->assertCount(1, $envelopes);
+        /** @var Envelope $envelope */
+        $envelope = $envelopes[0];
+        $this->assertEquals($first->getMessage(), $envelope->getMessage());
+        $this->assertInstanceOf(AmqpReceivedStamp::class, $envelope->last(AmqpReceivedStamp::class));
+
+        $envelopes = iterator_to_array($receiver->get());
+        $this->assertCount(1, $envelopes);
+        /** @var Envelope $envelope */
+        $envelope = $envelopes[0];
+        $this->assertEquals($second->getMessage(), $envelope->getMessage());
+
+        $this->assertEmpty(iterator_to_array($receiver->get()));
+    }
+
     public function testRetryAndDelay()
     {
         $connection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'));

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -875,6 +875,55 @@ class ConnectionTest extends TestCase
 
         return Connection::fromDsn('amqp://localhost', [], $factory);
     }
+
+    public function testGettingDefaultExchange()
+    {
+        $factory = $this->createMock(AmqpFactory::class);
+
+        $amqpExchange = $this->createMock(\AMQPExchange::class);
+        $amqpExchange->expects($this->once())->method('setName')->with('');
+        $amqpExchange->expects($this->once())->method('setType')->with(\AMQP_EX_TYPE_DIRECT);
+        $amqpExchange->expects($this->never())->method('setFlags');
+        $amqpExchange->expects($this->never())->method('setArguments');
+
+        $factory->expects($this->once())->method('createExchange')->willReturn($amqpExchange);
+
+        $connection = new Connection([
+            'host' => 'localhost',
+            'port' => 5672,
+            'vhost' => '/',
+        ], [
+            'name' => '',
+        ], [
+            '' => [],
+        ], $factory);
+
+        $connection->exchange();
+    }
+
+    public function testBindIsNotCalledWhenPublishingInDefaultExchange()
+    {
+        $factory = $this->createMock(AmqpFactory::class);
+
+        $amqpExchange = $this->createMock(\AMQPExchange::class);
+        $amqpExchange->expects($this->never())->method('declareExchange');
+
+        $factory->expects($this->once())->method('createExchange')->willReturn($amqpExchange);
+        $factory->expects($this->once())->method('createQueue')->willReturn($queue = $this->createMock(\AMQPQueue::class));
+        $queue->expects($this->never())->method('bind');
+
+        $connection = new Connection([
+            'host' => 'localhost',
+            'port' => 5672,
+            'vhost' => '/',
+        ], [
+            'name' => '',
+        ], [
+            '' => [],
+        ], $factory);
+
+        $connection->publish('body');
+    }
 }
 
 class TestAmqpFactory extends AmqpFactory


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #45784
| License       | MIT

Usage:
```yaml
transports:
  my_queue:
    dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
    options:
      exchange:
        # Indicates that the default Exchange is to be used
        name: ''
        default_publish_routing_key: my_queue

      queues:
        my_queue: ~
```

It is not a breaking change, because currently using `name: ''` leads to the `Could not declare exchange. Exchanges must have a name` error. This PR allows using the default exchange instead.

It's also possible to add more queues and then use them directly with a stamp:
```
          queues:
            foo: ~
            bar: ~
```
```
$messageBus->dispatch(new MyMessage(), [new AmqpStamp('bar')]);
```