### PR TITLE
[Workflow] Add support for executing custom workflow definition validators during the container compilation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -55,6 +55,7 @@ CHANGELOG
  * Allow configuring compound rate limiters
  * Make `ValidatorCacheWarmer` use `kernel.build_dir` instead of `cache_dir`
  * Make `SerializeCacheWarmer` use `kernel.build_dir` instead of `cache_dir`
+ * Support executing custom workflow validators during container compilation
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -77,6 +77,7 @@ use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\Registry;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowDebugPass;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowGuardListenerPass;
+use Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass;
 
 // Help opcache.preload discover always-needed symbols
 class_exists(ApcuAdapter::class);
@@ -173,6 +174,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new CachePoolPrunerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $this->addCompilerPassIfExists($container, FormPass::class);
         $this->addCompilerPassIfExists($container, WorkflowGuardListenerPass::class);
+        $this->addCompilerPassIfExists($container, WorkflowValidatorPass::class);
         $container->addCompilerPass(new ResettableServicePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
         $container->addCompilerPass(new RegisterLocaleAwareServicesPass());
         $container->addCompilerPass(new TestServiceContainerWeakRefPass(), PassConfig::TYPE_BEFORE_REMOVING, -32);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -449,6 +449,7 @@
             <xsd:element name="initial-marking" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="marking-store" type="marking_store" minOccurs="0" maxOccurs="1" />
             <xsd:element name="support" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="definition-validator" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="event-to-dispatch" type="event_to_dispatch" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="place" type="place" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="transition" type="transition" minOccurs="0" maxOccurs="unbounded" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/Workflow/Validator/DefinitionValidator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/Workflow/Validator/DefinitionValidator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Validator;
+
+use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\Validator\DefinitionValidatorInterface;
+
+class DefinitionValidator implements DefinitionValidatorInterface
+{
+    public static bool $called = false;
+
+    public function validate(Definition $definition, string $name): void
+    {
+        self::$called = true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -13,6 +13,9 @@ $container->loadFromExtension('framework', [
             'supports' => [
                 FrameworkExtensionTestCase::class,
             ],
+            'definition_validators' => [
+                Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Validator\DefinitionValidator::class,
+            ],
             'initial_marking' => ['draft'],
             'metadata' => [
                 'title' => 'article workflow',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
@@ -13,6 +13,7 @@
             <framework:audit-trail enabled="true"/>
             <framework:initial-marking>draft</framework:initial-marking>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
+            <framework:definition-validator>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Validator\DefinitionValidator</framework:definition-validator>
             <framework:place name="draft" />
             <framework:place name="wait_for_journalist" />
             <framework:place name="approved_by_journalist" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
@@ -9,6 +9,8 @@ framework:
             type: workflow
             supports:
                 - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase
+            definition_validators:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Validator\DefinitionValidator
             initial_marking: [draft]
             metadata:
                 title: article workflow

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -67,7 +67,7 @@
         "symfony/twig-bundle": "^6.4|^7.0",
         "symfony/type-info": "^7.1",
         "symfony/validator": "^6.4|^7.0",
-        "symfony/workflow": "^6.4|^7.0",
+        "symfony/workflow": "^7.3",
         "symfony/yaml": "^6.4|^7.0",
         "symfony/property-info": "^6.4|^7.0",
         "symfony/json-streamer": "7.3.*",
@@ -108,7 +108,7 @@
         "symfony/validator": "<6.4",
         "symfony/web-profiler-bundle": "<6.4",
         "symfony/webhook": "<7.2",
-        "symfony/workflow": "<6.4"
+        "symfony/workflow": "<7.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\FrameworkBundle\\": "" },

--- a/src/Symfony/Component/Workflow/DependencyInjection/WorkflowValidatorPass.php
+++ b/src/Symfony/Component/Workflow/DependencyInjection/WorkflowValidatorPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\DependencyInjection;
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class WorkflowValidatorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('workflow') as $attributes) {
+            foreach ($attributes as $attribute) {
+                foreach ($attribute['definition_validators'] ?? [] as $validatorClass) {
+                    $container->addResource(new FileResource($container->getReflectionClass($validatorClass)->getFileName()));
+
+                    $realDefinition = $container->get($attribute['definition_id'] ?? throw new \LogicException('The "definition_id" attribute is required.'));
+                    (new $validatorClass())->validate($realDefinition, $attribute['name'] ?? throw new \LogicException('The "name" attribute is required.'));
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Workflow/Tests/DependencyInjection/WorkflowValidatorPassTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DependencyInjection/WorkflowValidatorPassTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass;
+use Symfony\Component\Workflow\Validator\DefinitionValidatorInterface;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+class WorkflowValidatorPassTest extends TestCase
+{
+    private ContainerBuilder $container;
+    private WorkflowValidatorPass $compilerPass;
+
+    protected function setUp(): void
+    {
+        $this->container = new ContainerBuilder();
+        $this->compilerPass = new WorkflowValidatorPass();
+    }
+
+    public function testNothingToDo()
+    {
+        $this->compilerPass->process($this->container);
+
+        $this->assertFalse(DefinitionValidator::$called);
+    }
+
+    public function testValidate()
+    {
+        $this
+            ->container
+            ->register('my.workflow', WorkflowInterface::class)
+            ->addTag('workflow', [
+                'definition_id' => 'my.workflow.definition',
+                'name' => 'my.workflow',
+                'definition_validators' => [DefinitionValidator::class],
+            ])
+        ;
+
+        $this
+            ->container
+            ->register('my.workflow.definition', Definition::class)
+            ->setArguments([
+                '$places' => [],
+                '$transitions' => [],
+            ])
+        ;
+
+        $this->compilerPass->process($this->container);
+
+        $this->assertTrue(DefinitionValidator::$called);
+    }
+}
+
+class DefinitionValidator implements DefinitionValidatorInterface
+{
+    public static bool $called = false;
+
+    public function validate(Definition $definition, string $name): void
+    {
+        self::$called = true;
+    }
+}

--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -25,6 +25,7 @@
     },
     "require-dev": {
         "psr/log": "^1|^2|^3",
+        "symfony/config": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/error-handler": "^6.4|^7.0",
         "symfony/event-dispatcher": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54034
| License       | MIT


---

Usage:

```yaml
framework:
    workflows:
        article:
            definition_validators:
                - App\Workflow\Validator\ArticleValidator
```

```php
class ArticleValidator implements DefinitionValidatorInterface
{
    public function validate(Definition $definition, string $name): void
    {
        if (!$definition->getMetadataStore()->getMetadata('title')) {
            throw new InvalidDefinitionException(sprintf('The workflow metadata title is missing in Workflow "%s".', $name));
        }
    }
}
```

This code will ensure the title is defined here:
```yaml
framework:
    workflows:
        article:
            metadata:
                # title: Manage article # Commented, so it will throw an exception
```

![image](https://github.com/user-attachments/assets/949c5c69-a677-4e8d-be10-f974e1574455)
