### PR TITLE
[ErrorHandler] Skip failing tests when "xdebug.file_link_format" option is defined

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/FileLinkFormatterTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/FileLinkFormatterTest.php
@@ -27,6 +27,11 @@ class FileLinkFormatterTest extends TestCase
 
     public function testAfterUnserialize()
     {
+        if (get_cfg_var('xdebug.file_link_format')) {
+            // There is not way to override "xdebug.file_link_format" option in a test.
+            $this->markTestSkipped('php.ini has a custom option for "xdebug.file_link_format".');
+        }
+
         $ide = $_ENV['SYMFONY_IDE'] ?? $_SERVER['SYMFONY_IDE'] ?? null;
         $_ENV['SYMFONY_IDE'] = $_SERVER['SYMFONY_IDE'] = null;
         $sut = unserialize(serialize(new FileLinkFormatter()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

This test annoys me since ... many years!
So let's skip it.
