### PR TITLE
[HttpFoundation] Improve the return type of ParameterBag::getEnum

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -83,6 +83,8 @@ final class InputBag extends ParameterBag
      * @param ?T              $default
      *
      * @return ?T
+     *
+     * @psalm-return ($default is null ? T|null : T)
      */
     public function getEnum(string $key, string $class, ?\BackedEnum $default = null): ?\BackedEnum
     {

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -160,6 +160,8 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * @param ?T              $default
      *
      * @return ?T
+     *
+     * @psalm-return ($default is null ? T|null : T)
      */
     public function getEnum(string $key, string $class, ?\BackedEnum $default = null): ?\BackedEnum
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

The return value can only be null when using null as default value. when providing an enum instance as default value, we know that the return value will always be an enum instance.

This will help projects using static analysis tools. See https://phpstan.org/r/885d8322-b16c-4ebb-97ab-e5babfa8b692 which corresponds to the behavior with this PR applied vs https://phpstan.org/r/14693953-bad8-4e61-b026-527bf33cf342 which corresponds to the current behavior.

