### PR TITLE
[PhpUnitBridge] Enhance CoverageListenerTests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -17,29 +17,17 @@ class CoverageListenerTest extends TestCase
 {
     public function test()
     {
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test cannot be run on Windows.');
-        }
-
-        exec('type phpdbg 2> /dev/null', $output, $returnCode);
-
-        if (0 === $returnCode) {
-            $php = 'phpdbg -qrr';
-        } else {
-            exec('php --ri xdebug -d zend_extension=xdebug.so 2> /dev/null', $output, $returnCode);
-            if (0 !== $returnCode) {
-                $this->markTestSkipped('Xdebug is required to run this test.');
-            }
-            $php = 'php -d zend_extension=xdebug.so';
-        }
-
         $dir = __DIR__.'/../Tests/Fixtures/coverage';
         $phpunit = $_SERVER['argv'][0];
 
+        $php = $this->findCoverageDriver();
+
+        $output = '';
         exec("$php $phpunit -c $dir/phpunit-without-listener.xml.dist $dir/tests/ --coverage-text --colors=never 2> /dev/null", $output);
         $output = implode("\n", $output);
         $this->assertMatchesRegularExpression('/FooCov\n\s*Methods:\s+100.00%[^\n]+Lines:\s+100.00%/', $output);
 
+        $output = '';
         exec("$php $phpunit -c $dir/phpunit-with-listener.xml.dist $dir/tests/ --coverage-text --colors=never 2> /dev/null", $output);
         $output = implode("\n", $output);
 
@@ -53,5 +41,29 @@ class CoverageListenerTest extends TestCase
         $this->assertStringNotContainsString("CoversTest::test\nCould not find the tested class.", $output);
         $this->assertStringNotContainsString("CoversDefaultClassTest::test\nCould not find the tested class.", $output);
         $this->assertStringNotContainsString("CoversNothingTest::test\nCould not find the tested class.", $output);
+    }
+
+    private function findCoverageDriver(): string
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test cannot be run on Windows.');
+        }
+
+        exec('php --ri xdebug -d zend_extension=xdebug 2> /dev/null', $output, $returnCode);
+        if (0 === $returnCode) {
+            return 'php -d zend_extension=xdebug';
+        }
+
+        exec('php --ri pcov -d zend_extension=pcov 2> /dev/null', $output, $returnCode);
+        if (0 === $returnCode) {
+            return 'php -d zend_extension=pcov';
+        }
+
+        exec('type phpdbg 2> /dev/null', $output, $returnCode);
+        if (0 === $returnCode) {
+            return 'phpdbg -qrr';
+        }
+
+        $this->markTestSkipped('Xdebug or pvoc is required to run this test.');
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/coverage/phpunit-with-listener.xml.dist
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/coverage/phpunit-with-listener.xml.dist
@@ -1,30 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="tests/bootstrap.php"
-         failOnRisky="true"
-         failOnWarning="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="false"
+    colors="true"
+    bootstrap="tests/bootstrap.php"
+    failOnRisky="true"
+    failOnWarning="true"
 >
-
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Fixtures/coverage Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
-
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\CoverageListener">
             <arguments>
-                <null/>
+                <null />
                 <boolean>true</boolean>
             </arguments>
         </listener>

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/coverage/phpunit-without-listener.xml.dist
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/coverage/phpunit-without-listener.xml.dist
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="tests/bootstrap.php"
-         failOnRisky="true"
-         failOnWarning="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="false"
+    colors="true"
+    bootstrap="tests/bootstrap.php"
+    failOnRisky="true"
+    failOnWarning="true"
 >
-
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Fixtures/coverage Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The test were broken on my laptop, so I dig it a bit and:

* Add support support for pvoc
* Change priority of driver, it's now xdebug > pcov > phpdbg (reflects
  more real usages)
* Update deprecated phpunit.xml.dist configuration
* Ensure the $output buffer is empty before running sub-tests
* open php bug report because phpdbg segfault, see https://github.com/php/php-src/issues/13707
