### PR TITLE
[HttpKernel] Improve compatibility with Roadrunner Response streaming

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -98,7 +98,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
                 $response->setCallback(static function () use ($request, $callback, $requestStack) {
                     $requestStack->push($request);
                     try {
-                        $callback();
+                        return $callback();
                     } finally {
                         $requestStack->pop();
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Returns the value of `$callback()`, which aids response streaming (when `$callback()` returns Generator).
See this [PR](https://github.com/Baldinof/roadrunner-bundle/pull/138) for full context.