### PR TITLE
[SecurityBundle] fix(security): user login programmatically with dedicated user checker on a firewall

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `$badges` argument to `Security::login`
  * Deprecate the `require_previous_session` config option. Setting it has no effect anymore
  * Add `LogoutRouteLoader`
+ * Add `ProgrammaticLoginEvent` event to handle user checks on programmatic login.
 
 6.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -88,7 +88,7 @@ return static function (ContainerConfigurator $container) {
                     'security.authenticator.managers_locator' => service('security.authenticator.managers_locator')->ignoreOnInvalid(),
                     'request_stack' => service('request_stack'),
                     'security.firewall.map' => service('security.firewall.map'),
-                    'security.user_checker' => service('security.user_checker'),
+                    'event_dispatcher' => service('event_dispatcher'),
                     'security.firewall.event_dispatcher_locator' => service('security.firewall.event_dispatcher_locator'),
                     'security.csrf.token_manager' => service('security.csrf.token_manager')->ignoreOnInvalid(),
                 ]),

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Event\ProgrammaticLoginEvent;
 use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Core\Security as LegacySecurity;
@@ -127,7 +128,7 @@ class Security extends InternalSecurity implements AuthorizationCheckerInterface
 
         $authenticator = $this->getAuthenticator($authenticatorName, $firewallName);
 
-        $this->container->get('security.user_checker')->checkPreAuth($user);
+        $this->container->get('event_dispatcher')->dispatch(new ProgrammaticLoginEvent($user));
 
         return $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request, $badges);
     }

--- a/src/Symfony/Component/Security/Core/Event/ProgrammaticLoginEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/ProgrammaticLoginEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Event;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * This event is dispatch when login programmatically.
+ *
+ * @internal
+ *
+ * @author Antoine Makdessi <amakdessi@me.com>
+ */
+class ProgrammaticLoginEvent extends Event
+{
+    private UserInterface $user;
+
+    public function __construct(UserInterface $user)
+    {
+        $this->user = $user;
+    }
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+}

--- a/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
+use Symfony\Component\Security\Core\Event\ProgrammaticLoginEvent;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticatedUserBadge;
@@ -52,11 +53,17 @@ class UserCheckerListener implements EventSubscriberInterface
         $this->userChecker->checkPostAuth($user);
     }
 
+    public function onProgrammaticLoginEvent(ProgrammaticLoginEvent $event): void
+    {
+        $this->userChecker->checkPreAuth($event->getUser());
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
             CheckPassportEvent::class => ['preCheckCredentials', 256],
             AuthenticationSuccessEvent::class => ['postCheckCredentials', 256],
+            ProgrammaticLoginEvent::class => ['onProgrammaticLoginEvent', 256],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix internal security user checker code call
| License       | MIT

---

Original PR at https://github.com/symfony/symfony/pull/41274 as of Symfony v6.2 => so lets target v6.4 here

When defining an [user checker](https://symfony.com/doc/current/security/user_checkers.html) on a firewall
This user checker logic for `checkPreAuth` is not called at all when using the `Symfony/Bundle/SecurityBundle/Security::login` feature
**=> this can lead to unwanted security issue**

---

In the reproducer, check the https://github.com/94noni/userchecker/blob/master/src/Security/UserChecker.php (logged in user must be enabled)
The controller https://github.com/94noni/userchecker/blob/master/src/Controller/AnonymousController.php get the user by its id and log 
=> the user checker is not called and the user is logged in even if not enabled
