### PR TITLE
[Form] properly parse dates before the Gregorian calendar

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ install:
     - echo max_execution_time=1200 >> php.ini-min
     - echo post_max_size=2047M >> php.ini-min
     - echo upload_max_filesize=2047M >> php.ini-min
-    - echo date.timezone="America/Los_Angeles" >> php.ini-min
+    - echo date.timezone="UTC" >> php.ini-min
     - echo extension_dir=ext >> php.ini-min
     - echo extension=php_xsl.dll >> php.ini-min
     - copy /Y php.ini-min php.ini-max

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -1160,4 +1160,19 @@ class DateTypeTest extends BaseTypeTestCase
     {
         return ['widget' => 'choice'];
     }
+
+    public function testSubmitDateBeforeBeginningOfGregorianCalendar()
+    {
+        if (\PHP_INT_SIZE < 8) {
+            $this->markTestSkipped('Parsing three digits years requires a 64bit PHP.');
+        }
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'single_text',
+        ]);
+        $form->submit('950-12-19');
+
+        $this->assertSame('0950-12-19', $form->getData()->format('Y-m-d'));
+        $this->assertSame('0950-12-19', $form->getViewData());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |  #29610 #31057
| License       | MIT

Summoning #31374 by @xabbuh 

Although it's no longer obvious why the appveyor didn't run 4 years ago, I tried it in my own fork and was able to get the tests to run. Let's try again.
