### PR TITLE
[FrameworkBundle] Fix mailer config with XML

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1559,7 +1559,7 @@ class Configuration implements ConfigurationInterface
                                     continue;
                                 }
                                 if (\is_array($scopedConfig['retry_failed'])) {
-                                    $scopedConfig['retry_failed'] = $scopedConfig['retry_failed'] + $config['default_options']['retry_failed'];
+                                    $scopedConfig['retry_failed'] += $config['default_options']['retry_failed'];
                                 }
                             }
 
@@ -1897,6 +1897,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('envelope')
                             ->info('Mailer Envelope configuration')
+                            ->fixXmlConfig('recipient')
                             ->children()
                                 ->scalarNode('sender')->end()
                                 ->arrayNode('recipients')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -703,7 +703,7 @@
     <xsd:complexType name="mailer_envelope">
         <xsd:sequence>
             <xsd:element name="sender" type="xsd:string" minOccurs="0" maxOccurs="1" />
-            <xsd:element name="recipients" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="recipient" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
     </xsd:complexType>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_dsn.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_dsn.php
@@ -8,7 +8,7 @@ return static function (ContainerConfigurator $container) {
             'dsn' => 'smtp://example.com',
             'envelope' => [
                 'sender' => 'sender@example.org',
-                'recipients' => ['redirected@example.org', 'redirected1@example.org'],
+                'recipients' => ['redirected@example.org'],
             ],
             'headers' => [
                 'from' => 'from@example.org',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
@@ -10,8 +10,7 @@
         <framework:mailer dsn="smtp://example.com">
             <framework:envelope>
                 <framework:sender>sender@example.org</framework:sender>
-                <framework:recipients>redirected@example.org</framework:recipients>
-                <framework:recipients>redirected1@example.org</framework:recipients>
+                <framework:recipient>redirected@example.org</framework:recipient>
             </framework:envelope>
             <framework:header name="from">from@example.org</framework:header>
             <framework:header name="bcc">bcc1@example.org</framework:header>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_transports.xml
@@ -12,8 +12,8 @@
             <framework:transport name="transport2">smtp://example2.com</framework:transport>
             <framework:envelope>
                 <framework:sender>sender@example.org</framework:sender>
-                <framework:recipients>redirected@example.org</framework:recipients>
-                <framework:recipients>redirected1@example.org</framework:recipients>
+                <framework:recipient>redirected@example.org</framework:recipient>
+                <framework:recipient>redirected1@example.org</framework:recipient>
             </framework:envelope>
             <framework:header name="from">from@example.org</framework:header>
             <framework:header name="bcc">bcc1@example.org</framework:header>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_dsn.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_dsn.yml
@@ -5,7 +5,6 @@ framework:
             sender: sender@example.org
             recipients:
                 - redirected@example.org
-                - redirected1@example.org
         headers:
             from: from@example.org
             bcc: [bcc1@example.org, bcc2@example.org]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
 
 class XmlFrameworkExtensionTest extends FrameworkExtensionTestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

I noticed that, while adding test for #54044

---

Before my patch, if I keep only one recipients:

```
>…ome/gregoire/dev/github.com/lyrixx/symfony(5.4 *) git di
diff --git a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
index be53f59bc3..5ccdefaf32 100644
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_dsn.xml
@@ -11,7 +11,7 @@
             <framework:envelope>
                 <framework:sender>sender@example.org</framework:sender>
                 <framework:recipients>redirected@example.org</framework:recipients>
-                <framework:recipients>redirected1@example.org</framework:recipients>
+                <!-- <framework:recipients>redirected1@example.org</framework:recipients> -->
             </framework:envelope>
             <framework:header name="from">from@example.org</framework:header>
             <framework:header name="bcc">bcc1@example.org</framework:header>
>…ome/gregoire/dev/github.com/lyrixx/symfony(5.4 *) ./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php --filter 'testMailer#0'
PHPUnit 9.6.16 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\XmlFrameworkExtensionTest
E                                                                   1 / 1 (100%)R

Time: 00:00.103, Memory: 21.88 MB

There was 1 error:

1) Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\XmlFrameworkExtensionTest::testMailer with data set #0 ('mailer_with_dsn', array('smtp://example.com'))
Symfony\Component\Config\Definition\Exception\InvalidTypeException: Invalid type for path "framework.mailer.envelope.recipients". Expected "array", but got "string"

```

And I cannot add more XML configuration, without this patch