### PR TITLE
[HttpFoundation] Add phpstan-pure to UriSigner to avoid unhandled checks

### DIFF
--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -37,6 +37,8 @@ class UriSigner
      *
      * The given URI is signed by adding the query string parameter
      * which value depends on the URI and the secret.
+     *
+     * @phpstan-pure
      */
     public function sign(string $uri): string
     {
@@ -55,6 +57,8 @@ class UriSigner
 
     /**
      * Checks that a URI contains the correct hash.
+     *
+     * @phpstan-pure
      */
     public function check(string $uri): bool
     {
@@ -75,6 +79,9 @@ class UriSigner
         return hash_equals($this->computeHash($this->buildUrl($url, $params)), $hash);
     }
 
+    /**
+     * @phpstan-pure
+     */
     public function checkRequest(Request $request): bool
     {
         $qs = ($qs = $request->server->get('QUERY_STRING')) ? '?'.$qs : '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | ~~5.4~~ 7.1
| Bug fix?      | yes // kind of help fixes bugs/security issues in projects
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

In a project I did refactor some controllers I did stumble over the following code:

```php
    public function acceptAction(Request $request): Response
    {
        $this->uriSigner->checkRequest($request);
        
        // ...
```

Why it may first looks correctly this does nothing and even opens a security issue for the project. Via `phpstan-pure` static code analyzers can find such kind of issue and show a error that this method call was not handled.

https://phpstan.org/r/12844f00-e8d8-4f01-8893-8d43ca4efdfe

Adding phpstan-pure was suggested by Ondrej here: https://github.com/phpstan/phpstan-symfony/issues/387.

Technical `phpstan-pure` means that method does not have any sideeffects (editing any internal state), so most service methods could be pure.