### PR TITLE
[Serializer] Don't throw on BackedEnum values in BackedEnumNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -57,6 +57,14 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
             throw new InvalidArgumentException('The data must belong to a backed enumeration.');
         }
 
+        if ($data instanceof $type) {
+            return $data;
+        }
+
+        if ($data instanceof \BackedEnum) {
+            $data = $data->value;
+        }
+
         if (!\is_int($data) && !\is_string($data)) {
             throw NotNormalizableValueException::createForUnexpectedDataType('The data is neither an integer nor a string, you should pass an integer or a string that can be parsed as an enumeration case of type '.$type.'.', $data, [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
         }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/OtherStringBackedEnumDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/OtherStringBackedEnumDummy.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+enum OtherStringBackedEnumDummy: string
+{
+    case GET = 'GET';
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -80,7 +80,10 @@ class BackedEnumNormalizerTest extends TestCase
     public function testDenormalize()
     {
         $this->assertSame(StringBackedEnumDummy::GET, $this->normalizer->denormalize('GET', StringBackedEnumDummy::class));
+        $this->assertSame(StringBackedEnumDummy::GET, $this->normalizer->denormalize(StringBackedEnumDummy::GET, StringBackedEnumDummy::class));
+        $this->assertSame(StringBackedEnumDummy::GET, $this->normalizer->denormalize(OtherStringBackedEnumDummy::GET, StringBackedEnumDummy::class));
         $this->assertSame(IntegerBackedEnumDummy::SUCCESS, $this->normalizer->denormalize(200, IntegerBackedEnumDummy::class));
+        $this->assertSame(IntegerBackedEnumDummy::SUCCESS, $this->normalizer->denormalize(IntegerBackedEnumDummy::SUCCESS, IntegerBackedEnumDummy::class));
     }
 
     /**
@@ -121,6 +124,17 @@ class BackedEnumNormalizerTest extends TestCase
         $this->normalizer->denormalize('POST', StringBackedEnumDummy::class);
     }
 
+    /**
+     * @requires PHP 8.1
+     */
+    public function testDenormalizeIncompatibleEnumCaseThrowsException()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data must belong to a backed enumeration of type '.StringBackedEnumDummy::class);
+
+        $this->normalizer->denormalize(IntegerBackedEnumDummy::SUCCESS, StringBackedEnumDummy::class);
+    }
+
     public function testNormalizeShouldThrowExceptionForNonEnumObjects()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -141,4 +155,9 @@ class BackedEnumNormalizerTest extends TestCase
     {
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
+}
+
+enum OtherStringBackedEnumDummy : string
+{
+    case GET = 'GET';
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\IntegerBackedEnumDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\OtherStringBackedEnumDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\UnitEnumDummy;
 
@@ -155,9 +156,4 @@ class BackedEnumNormalizerTest extends TestCase
     {
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
-}
-
-enum OtherStringBackedEnumDummy : string
-{
-    case GET = 'GET';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 (and up)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

Working with BackedEnum values I found that the BackedEnumNormalizer expects data to be a string or int. In cases where data is already a case of the BackedEnum, it throws a `NotNormalizableValueException`.

This is utterly annoying so with this small and simple PR I decided to fix that.

This shouldn't break BC nor does it add a new feature (in my opinion) and I have pull requests ready for 6.4, 7,0 and 7.1 which I can post if this gets approved.

Please let me know what you think 👍🏻 