### PR TITLE
[HttpFoundation] When calling UploadedFile::getErrorMessage() to a file which has no error and is uploaded successfully, it should not return an error

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -184,22 +184,30 @@ class UploadedFile extends File
 
         switch ($this->error) {
             case \UPLOAD_ERR_INI_SIZE:
-                throw new IniSizeFileException($this->getErrorMessage());
+                throw new IniSizeFileException($this->getExceptionMessage());
             case \UPLOAD_ERR_FORM_SIZE:
-                throw new FormSizeFileException($this->getErrorMessage());
+                throw new FormSizeFileException($this->getExceptionMessage());
             case \UPLOAD_ERR_PARTIAL:
-                throw new PartialFileException($this->getErrorMessage());
+                throw new PartialFileException($this->getExceptionMessage());
             case \UPLOAD_ERR_NO_FILE:
-                throw new NoFileException($this->getErrorMessage());
+                throw new NoFileException($this->getExceptionMessage());
             case \UPLOAD_ERR_CANT_WRITE:
-                throw new CannotWriteFileException($this->getErrorMessage());
+                throw new CannotWriteFileException($this->getExceptionMessage());
             case \UPLOAD_ERR_NO_TMP_DIR:
-                throw new NoTmpDirFileException($this->getErrorMessage());
+                throw new NoTmpDirFileException($this->getExceptionMessage());
             case \UPLOAD_ERR_EXTENSION:
-                throw new ExtensionFileException($this->getErrorMessage());
+                throw new ExtensionFileException($this->getExceptionMessage());
         }
 
-        throw new FileException($this->getErrorMessage());
+        throw new FileException($this->getExceptionMessage());
+    }
+
+    /**
+     * Retrieves a user-friendly error message for file upload issues, if any.
+     */
+    public function getErrorMessage(): string
+    {
+        return \UPLOAD_ERR_OK !== $this->error ? $this->getExceptionMessage() : '';
     }
 
     /**
@@ -248,7 +256,7 @@ class UploadedFile extends File
     /**
      * Returns an informative upload error message.
      */
-    public function getErrorMessage(): string
+    private function getExceptionMessage(): string
     {
         static $errors = [
             \UPLOAD_ERR_INI_SIZE => 'The file "%s" exceeds your upload_max_filesize ini directive (limit is %d KiB).',

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -119,6 +119,32 @@ class UploadedFileTest extends TestCase
         $this->assertEquals(\UPLOAD_ERR_OK, $file->getError());
     }
 
+    public function testInvalidFile()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/gif',
+        );
+
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('The file "original.gif" was not uploaded due to an unknown error.');
+
+        $file->move(__DIR__.'/Fixtures/directory');
+    }
+
+    public function testNoErrorMessageIfErrorIsUploadErrOk()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/gif',
+            null
+        );
+
+        $this->assertSame('', $file->getErrorMessage());
+    }
+
     public function testGetClientOriginalName()
     {
         $file = new UploadedFile(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no 
| License       | MIT

When calling `Symfony\Component\HttpFoundation\File\UploadedFile::getErrorMessage()` for an uploaded file which has no error and is uploaded successfully, should not give any error message.
Before this changes it returned The file "%s" was not uploaded due to an unknown error..
After this changes, it will return an empty string.
