### PR TITLE
[Cache][Lock] Identify missing table in pgsql correctly and address failing integration tests

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -600,10 +600,10 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
     private function isTableMissing(\PDOException $exception): bool
     {
         $driver = $this->driver;
-        $code = $exception->errorInfo ? $exception->errorInfo[1] : $exception->getCode();
+        [$sqlState, $code] = $exception->errorInfo ?? [null, $exception->getCode()];
 
         switch (true) {
-            case 'pgsql' === $driver && '42P01' === $code:
+            case 'pgsql' === $driver && '42P01' === $sqlState:
             case 'sqlite' === $driver && str_contains($exception->getMessage(), 'no such table:'):
             case 'oci' === $driver && 942 === $code:
             case 'sqlsrv' === $driver && 208 === $code:

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -330,10 +330,10 @@ class PdoStore implements PersistingStoreInterface
     private function isTableMissing(\PDOException $exception): bool
     {
         $driver = $this->getDriver();
-        $code = $exception->errorInfo ? $exception->errorInfo[1] : $exception->getCode();
+        [$sqlState, $code] = $exception->errorInfo ?? [null, $exception->getCode()];
 
         switch (true) {
-            case 'pgsql' === $driver && '42P01' === $code:
+            case 'pgsql' === $driver && '42P01' === $sqlState:
             case 'sqlite' === $driver && str_contains($exception->getMessage(), 'no such table:'):
             case 'oci' === $driver && 942 === $code:
             case 'sqlsrv' === $driver && 208 === $code:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | 
| License       | MIT

## Description

The existing code snippet is as follows: 
```php
$code = $exception->errorInfo ? $exception->errorInfo[1] : $exception->getCode();

switch (true) {
    case 'pgsql' === $driver && '42P01' === $code:
```

When we print `$exception->errorInfo[1]`, it yields 7, which is interpreted as false. This behavior has been rectified.

**Additionally, this pull request fixes the integration tests that have been failing persistently until now.**

![image](https://github.com/symfony/symfony/assets/45073703/050fe625-4ff6-423d-9c89-ed183f36e670)

