### PR TITLE
Throw TransformationFailedException when there is a null bytes injection

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -118,6 +118,10 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
             throw new TransformationFailedException('Expected a string.');
         }
 
+        if (true === str_contains($value, "\0")) {
+            throw new TransformationFailedException('Null bytes not allowed');
+        }
+
         $outputTz = new \DateTimeZone($this->outputTimezone);
         $dateTime = \DateTime::createFromFormat($this->parseFormat, $value, $outputTz);
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -118,7 +118,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
             throw new TransformationFailedException('Expected a string.');
         }
 
-        if (true === str_contains($value, "\0")) {
+        if (str_contains($value, "\0")) {
             throw new TransformationFailedException('Null bytes not allowed');
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -137,7 +137,7 @@ class DateTimeToStringTransformerTest extends BaseDateTimeTransformerTestCase
     {
         $transformer = new DateTimeToStringTransformer();
 
-        $nullByte = chr(0);
+        $nullByte = \chr(0);
         $value = '2024-03-15 21:11:00'.$nullByte;
 
         $this->expectException(TransformationFailedException::class);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -133,6 +133,19 @@ class DateTimeToStringTransformerTest extends BaseDateTimeTransformerTestCase
         $this->assertNull($reverseTransformer->reverseTransform(''));
     }
 
+    public function testReverseTransformWithNullBytes()
+    {
+        $transformer = new DateTimeToStringTransformer();
+
+        $nullByte = chr(0);
+        $value = '2024-03-15 21:11:00'.$nullByte;
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Null bytes not allowed');
+
+        $transformer->reverseTransform($value);
+    }
+
     public function testReverseTransformWithDifferentTimezones()
     {
         $reverseTransformer = new DateTimeToStringTransformer('America/New_York', 'Asia/Hong_Kong', 'Y-m-d H:i:s');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | -  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

On one hand, in PHP 7, DateTime::createFromFormat allows null byte injection, and on the other hand, in PHP 8, it throws a ValueError that is not caught. This PR prevents injection when using version 5.4 under PHP 7 and onwards, throwing a TransformationFailedException.