### PR TITLE
Add more explicit nullable types for default null values

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ContainerAwareFixture.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ContainerAwareFixture.php
@@ -20,7 +20,7 @@ class ContainerAwareFixture implements FixtureInterface, ContainerAwareInterface
 {
     public $container;
 
-    public function setContainer(ContainerInterface $container = null)
+    public function setContainer(?ContainerInterface $container = null)
     {
         $this->container = $container;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapper.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapper.php
@@ -15,7 +15,7 @@ class StringWrapper
 {
     private $string;
 
-    public function __construct(string $string = null)
+    public function __construct(?string $string = null)
     {
         $this->string = $string;
     }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
@@ -525,7 +525,7 @@ class ConfigurationTest extends TestCase
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessageMatches('/[Ff]ailed to open stream: Permission denied/');
 
-        set_error_handler(static function (int $errno, string $errstr, string $errfile = null, int $errline = null): bool {
+        set_error_handler(static function (int $errno, string $errstr, ?string $errfile = null, ?int $errline = null): bool {
             if ($errno & (E_WARNING | E_WARNING)) {
                 throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
             }

--- a/src/Symfony/Component/Cache/Tests/Fixtures/DriverWrapper.php
+++ b/src/Symfony/Component/Cache/Tests/Fixtures/DriverWrapper.php
@@ -32,7 +32,7 @@ class DriverWrapper implements Driver
         return $this->driver->connect($params, $username, $password, $driverOptions);
     }
 
-    public function getDatabasePlatform(ServerVersionProvider $versionProvider = null): AbstractPlatform
+    public function getDatabasePlatform(?ServerVersionProvider $versionProvider = null): AbstractPlatform
     {
         return $this->driver->getDatabasePlatform($versionProvider);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\FooVariadic;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\MultipleArgumentsOptionalScalarNotReallyOptional;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\OptionalParameter;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -405,6 +406,9 @@ class AutowirePassTest extends TestCase
         $this->assertEquals(Foo::class, $container->getDefinition('bar')->getArgument(0));
     }
 
+    /**
+     * @group legacy
+     */
     public function testOptionalParameter()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Bar.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Bar.php
@@ -15,12 +15,12 @@ class Bar implements BarInterface
 {
     public $quz;
 
-    public function __construct($quz = null, \NonExistent $nonExistent = null, BarInterface $decorated = null, array $foo = [], iterable $baz = [])
+    public function __construct($quz = null, ?\NonExistent $nonExistent = null, ?BarInterface $decorated = null, array $foo = [], iterable $baz = [])
     {
         $this->quz = $quz;
     }
 
-    public static function create(\NonExistent $nonExistent = null, $factory = null)
+    public static function create(?\NonExistent $nonExistent = null, $factory = null)
     {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
@@ -20,7 +20,7 @@ class BarMethodCall
         $this->foo = $foo;
     }
 
-    public function setFoosOptional(Foo $foo, Foo $fooOptional = null)
+    public function setFoosOptional(Foo $foo, ?Foo $fooOptional = null)
     {
         $this->foo = $foo;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarOptionalArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarOptionalArgument.php
@@ -6,7 +6,7 @@ class BarOptionalArgument
 {
     public $foo;
 
-    public function __construct(\stdClass $foo = null)
+    public function __construct(?\stdClass $foo = null)
     {
         $this->foo = $foo;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/Foo.php
@@ -9,7 +9,7 @@ class Foo
         return new Bar(new \stdClass());
     }
 
-    public static function createBarArguments(\stdClass $stdClass, \stdClass $stdClassOptional = null)
+    public static function createBarArguments(\stdClass $stdClass, ?\stdClass $stdClassOptional = null)
     {
         return new Bar($stdClass);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/OptionalParameter.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/OptionalParameter.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Tests\Compiler\A;
+use Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface;
+use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
+
+class OptionalParameter
+{
+    public function __construct(?CollisionInterface $c = null, A $a, ?Foo $f = null)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Attribute\When;
 #[When(env: 'dev')]
 class Foo implements FooInterface, Sub\BarInterface
 {
-    public function __construct($bar = null, iterable $foo = null, object $baz = null)
+    public function __construct($bar = null, ?iterable $foo = null, ?object $baz = null)
     {
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -99,7 +99,7 @@ class D
 
 class E
 {
-    public function __construct(D $d = null)
+    public function __construct(?D $d = null)
     {
     }
 }
@@ -155,13 +155,6 @@ class LesTilleuls
     }
 }
 
-class OptionalParameter
-{
-    public function __construct(CollisionInterface $c = null, A $a, Foo $f = null)
-    {
-    }
-}
-
 class BadTypeHintedArgument
 {
     public function __construct(Dunglas $k, NotARealClass $r)
@@ -195,7 +188,7 @@ class MultipleArguments
 
 class MultipleArgumentsOptionalScalar
 {
-    public function __construct(A $a, $foo = 'default_val', Lille $lille = null)
+    public function __construct(A $a, $foo = 'default_val', ?Lille $lille = null)
     {
     }
 }
@@ -211,7 +204,7 @@ class MultipleArgumentsOptionalScalarLast
  */
 class ClassForResource
 {
-    public function __construct($foo, Bar $bar = null)
+    public function __construct($foo, ?Bar $bar = null)
     {
     }
 
@@ -350,7 +343,7 @@ class NotWireable
     {
     }
 
-    public function setOptionalNotAutowireable(NotARealClass $n = null)
+    public function setOptionalNotAutowireable(?NotARealClass $n = null)
     {
     }
 
@@ -399,7 +392,7 @@ class DecoratorImpl implements DecoratorInterface
 
 class Decorated implements DecoratorInterface
 {
-    public function __construct($quz = null, \NonExistent $nonExistent = null, DecoratorInterface $decorated = null, array $foo = [])
+    public function __construct($quz = null, ?\NonExistent $nonExistent = null, ?DecoratorInterface $decorated = null, array $foo = [])
     {
     }
 }

--- a/src/Symfony/Component/Filesystem/Tests/Fixtures/MockStream/MockStream.php
+++ b/src/Symfony/Component/Filesystem/Tests/Fixtures/MockStream/MockStream.php
@@ -28,7 +28,7 @@ class MockStream
      * @param string|null $opened_path If the path is opened successfully, and STREAM_USE_PATH is set in options,
      *                                 opened_path should be set to the full path of the file/resource that was actually opened
      */
-    public function stream_open(string $path, string $mode, int $options, string &$opened_path = null): bool
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path = null): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/ChoiceList/DeprecatedChoiceListFactory.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/ChoiceList/DeprecatedChoiceListFactory.php
@@ -9,15 +9,15 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
 
 class DeprecatedChoiceListFactory implements ChoiceListFactoryInterface
 {
-    public function createListFromChoices(iterable $choices, callable $value = null): ChoiceListInterface
+    public function createListFromChoices(iterable $choices, ?callable $value = null): ChoiceListInterface
     {
     }
 
-    public function createListFromLoader(ChoiceLoaderInterface $loader, callable $value = null): ChoiceListInterface
+    public function createListFromLoader(ChoiceLoaderInterface $loader, ?callable $value = null): ChoiceListInterface
     {
     }
 
-    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, callable $index = null, callable $groupBy = null, $attr = null): ChoiceListView
+    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, ?callable $index = null, ?callable $groupBy = null, $attr = null): ChoiceListView
     {
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/CustomArrayObject.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/CustomArrayObject.php
@@ -19,7 +19,7 @@ class CustomArrayObject implements \ArrayAccess, \IteratorAggregate, \Countable,
 {
     private $array;
 
-    public function __construct(array $array = null)
+    public function __construct(?array $array = null)
     {
         $this->array = $array ?: [];
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FixedTranslator.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FixedTranslator.php
@@ -22,7 +22,7 @@ class FixedTranslator implements TranslatorInterface
         $this->translations = $translations;
     }
 
-    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
+    public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         return $this->translations[$id] ?? $id;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/CloneVarDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/CloneVarDataCollector.php
@@ -24,7 +24,7 @@ class CloneVarDataCollector extends DataCollector
         $this->varToClone = $varToClone;
     }
 
-    public function collect(Request $request, Response $response, \Throwable $exception = null)
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null)
     {
         $this->data = $this->cloneVar($this->varToClone);
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/NonTraversableArrayObject.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/NonTraversableArrayObject.php
@@ -19,7 +19,7 @@ class NonTraversableArrayObject implements \ArrayAccess, \Countable, \Serializab
 {
     private $array;
 
-    public function __construct(array $array = null)
+    public function __construct(?array $array = null)
     {
         $this->array = $array ?: [];
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TraversableArrayObject.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TraversableArrayObject.php
@@ -19,7 +19,7 @@ class TraversableArrayObject implements \ArrayAccess, \IteratorAggregate, \Count
 {
     private $array;
 
-    public function __construct(array $array = null)
+    public function __construct(?array $array = null)
     {
         $this->array = $array ?: [];
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -194,7 +194,7 @@ class Dummy extends ParentDummy
      *
      * @param ParentDummy|null $parent
      */
-    public function setB(ParentDummy $parent = null)
+    public function setB(?ParentDummy $parent = null)
     {
     }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/RedirectableUrlMatcher.php
@@ -19,7 +19,7 @@ use Symfony\Component\Routing\Matcher\UrlMatcher;
  */
 class RedirectableUrlMatcher extends UrlMatcher implements RedirectableUrlMatcherInterface
 {
-    public function redirect(string $path, string $route, string $scheme = null): array
+    public function redirect(string $path, string $route, ?string $scheme = null): array
     {
         return [
             '_controller' => 'Some controller reference...',

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
@@ -31,14 +31,14 @@ class AbstractNormalizerDummy extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null): bool
+    public function supportsNormalization($data, ?string $format = null): bool
     {
         return true;
     }
@@ -46,14 +46,14 @@ class AbstractNormalizerDummy extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function denormalize($data, string $type, string $format = null, array $context = [])
+    public function denormalize($data, string $type, ?string $format = null, array $context = [])
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null): bool
+    public function supportsDenormalization($data, string $type, ?string $format = null): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DenormalizableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DenormalizableDummy.php
@@ -16,7 +16,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class DenormalizableDummy implements DenormalizableInterface
 {
-    public function denormalize(DenormalizerInterface $denormalizer, $data, string $format = null, array $context = [])
+    public function denormalize(DenormalizerInterface $denormalizer, $data, ?string $format = null, array $context = [])
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Dummy.php
@@ -23,7 +23,7 @@ class Dummy implements NormalizableInterface, DenormalizableInterface
     public $baz;
     public $qux;
 
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, ?string $format = null, array $context = [])
     {
         return [
             'foo' => $this->foo,
@@ -33,7 +33,7 @@ class Dummy implements NormalizableInterface, DenormalizableInterface
         ];
     }
 
-    public function denormalize(DenormalizerInterface $denormalizer, $data, string $format = null, array $context = [])
+    public function denormalize(DenormalizerInterface $denormalizer, $data, ?string $format = null, array $context = [])
     {
         $this->foo = $data['foo'];
         $this->bar = $data['bar'];

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyString.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyString.php
@@ -22,7 +22,7 @@ class DummyString implements DenormalizableInterface
     /** @var string $value */
     public $value;
 
-    public function denormalize(DenormalizerInterface $denormalizer, $data, string $format = null, array $context = [])
+    public function denormalize(DenormalizerInterface $denormalizer, $data, ?string $format = null, array $context = [])
     {
         $this->value = $data;
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
@@ -20,7 +20,7 @@ class EnvelopeNormalizer implements NormalizerInterface
 {
     private $serializer;
 
-    public function normalize($envelope, string $format = null, array $context = []): array
+    public function normalize($envelope, ?string $format = null, array $context = []): array
     {
         $xmlContent = $this->serializer->serialize($envelope->message, 'xml');
 
@@ -31,7 +31,7 @@ class EnvelopeNormalizer implements NormalizerInterface
         ];
     }
 
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof EnvelopeObject;
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
@@ -18,14 +18,14 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class EnvelopedMessageNormalizer implements NormalizerInterface
 {
-    public function normalize($message, string $format = null, array $context = []): array
+    public function normalize($message, ?string $format = null, array $context = []): array
     {
         return [
             'text' => $message->text,
         ];
     }
 
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof EnvelopedMessage;
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NormalizableTraversableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NormalizableTraversableDummy.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class NormalizableTraversableDummy extends TraversableDummy implements NormalizableInterface, DenormalizableInterface
 {
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, ?string $format = null, array $context = [])
     {
         return [
             'foo' => 'normalizedFoo',
@@ -26,7 +26,7 @@ class NormalizableTraversableDummy extends TraversableDummy implements Normaliza
         ];
     }
 
-    public function denormalize(DenormalizerInterface $denormalizer, $data, string $format = null, array $context = [])
+    public function denormalize(DenormalizerInterface $denormalizer, $data, ?string $format = null, array $context = [])
     {
         return [
             'foo' => 'denormalizedFoo',

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NotNormalizableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NotNormalizableDummy.php
@@ -24,7 +24,7 @@ class NotNormalizableDummy implements DenormalizableInterface
     {
     }
 
-    public function denormalize(DenormalizerInterface $denormalizer, $data, string $format = null, array $context = [])
+    public function denormalize(DenormalizerInterface $denormalizer, $data, ?string $format = null, array $context = [])
     {
         throw new NotNormalizableValueException();
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ScalarDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ScalarDummy.php
@@ -21,12 +21,12 @@ class ScalarDummy implements NormalizableInterface, DenormalizableInterface
     public $foo;
     public $xmlFoo;
 
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, ?string $format = null, array $context = [])
     {
         return 'xml' === $format ? $this->xmlFoo : $this->foo;
     }
 
-    public function denormalize(DenormalizerInterface $denormalizer, $data, string $format = null, array $context = [])
+    public function denormalize(DenormalizerInterface $denormalizer, $data, ?string $format = null, array $context = [])
     {
         if ('xml' === $format) {
             $this->xmlFoo = $data;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -559,12 +559,12 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizer = new class() extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;
 
-            protected function extractAttributes(object $object, string $format = null, array $context = []): array
+            protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
             {
                 return array_keys((array) $object);
             }
 
-            protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = [])
+            protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = [])
             {
                 return $object->{$attribute};
             }
@@ -599,12 +599,12 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizer = new class() extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;
 
-            protected function extractAttributes(object $object, string $format = null, array $context = []): array
+            protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
             {
                 return array_keys((array) $object);
             }
 
-            protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = [])
+            protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = [])
             {
                 return $object->{$attribute};
             }
@@ -634,12 +634,12 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizer = new class() extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;
 
-            protected function extractAttributes(object $object, string $format = null, array $context = []): array
+            protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
             {
                 return array_keys((array) $object);
             }
 
-            protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = [])
+            protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = [])
             {
                 return $object->{$attribute};
             }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/CustomArrayObject.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/CustomArrayObject.php
@@ -19,7 +19,7 @@ class CustomArrayObject implements \ArrayAccess, \IteratorAggregate, \Countable,
 {
     private $array;
 
-    public function __construct(array $array = null)
+    public function __construct(?array $array = null)
     {
         $this->array = $array ?: [];
     }

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/FooInterface.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/FooInterface.php
@@ -7,5 +7,5 @@ interface FooInterface
     /**
      * Hello.
      */
-    public function foo(?\stdClass $a, \stdClass $b = null);
+    public function foo(?\stdClass $a, ?\stdClass $b = null);
 }

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/Twig.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/Twig.php
@@ -18,7 +18,7 @@ class __TwigTemplate_VarDumperFixture_u75a09 extends AbstractTwigTemplate
 {
     private $path;
 
-    public function __construct(Twig\Environment $env = null, $path = null)
+    public function __construct(?Twig\Environment $env = null, $path = null)
     {
         if (null !== $env) {
             parent::__construct($env);

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/dumb-var.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/dumb-var.php
@@ -22,7 +22,7 @@ $var = [
     '[]' => [],
     'res' => $g,
     'obj' => $foo,
-    'closure' => function ($a, \PDO &$b = null) {},
+    'closure' => function ($a, ?\PDO &$b = null) {},
     'line' => __LINE__ - 1,
     'nobj' => [(object) []],
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Continuing to bring deprecation-free support for PHP 8.4 (https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

If this gets merged, I'll take care of adding missing ones in upper branches if not done during upmerge 🙂 