### PR TITLE
[Lock] Missing throws for BlockingStoreInterface

### DIFF
--- a/src/Symfony/Component/Lock/BlockingStoreInterface.php
+++ b/src/Symfony/Component/Lock/BlockingStoreInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock;
 
 use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockStorageException;
 
 /**
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
@@ -22,6 +23,7 @@ interface BlockingStoreInterface extends PersistingStoreInterface
      * Waits until a key becomes free, then stores the resource.
      *
      * @throws LockConflictedException
+     * @throws LockStorageException
      */
     public function waitAndSave(Key $key): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Hello,

waitAndSave of the FlockStore will raise an exception not indicate in the interface

https://github.com/symfony/lock/blob/7.0/Store/FlockStore.php#L109

Maybe it could be great just in case of , like handle this exception for a collection of instance which implements this interface to know that it could be throw ?

I think about the LSP of the solid principle describe here about interface and exception declaration : 

https://symfonycasts.com/screencast/solid/liskov-exception#exceptions-are-a-soft-part-of-an-interface

Thanks :)
