### PR TITLE
[Serializer] Fixed BackedEnumNormalizer priority for translatable enum

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -219,6 +219,6 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('serializer.normalizer.backed_enum', BackedEnumNormalizer::class)
-            ->tag('serializer.normalizer', ['priority' => -915])
+            ->tag('serializer.normalizer', ['priority' => -880])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TranslatableBackedEnum.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TranslatableBackedEnum.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum TranslatableBackedEnum: string implements TranslatableInterface
+{
+    case Get = 'GET';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return match ($this) {
+            self::Get => 'custom_get_string',
+        };
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TranslatableBackedEnum;
+
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -66,6 +68,15 @@ class SerializerTest extends AbstractWebTestCase
             ['serializer.encoder.yaml.alias'],
             ['serializer.encoder.csv.alias'],
         ];
+    }
+
+    public function testSerializeTranslatableBackedEnum()
+    {
+        static::bootKernel(['test_case' => 'Serializer']);
+
+        $serializer = static::getContainer()->get('serializer.alias');
+
+        $this->assertEquals('GET', $serializer->serialize(TranslatableBackedEnum::Get, 'yaml'));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | 
| License       | MIT

```php
enum MyEnum: string implements TranslatableInterface
{
    case Get = 'GET';
    case Post = 'POST';
    case Update = 'UPDATE';

    public function trans(TranslatorInterface $translator, ?string $locale = null): string
    {
        return match ($this) {
            self::Get  => 'custom_get',
            self::Post  => 'custom_post',
            self::Update => 'custom_update'
        };
    }
}
```

```php
class MyController {
    public function __invoke(SerializerInterface $serializer) {
        dd($serializer->serialize(MyEnum::Get)); // ""custom_get"" , Expected result: ""GET""
    }
}
```

serialize a BackedEnum that implements `TranslatableInterface` will return the translation value instead of the enum item value. this is because `TranslatableNormalizer` ([ref](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php#L116-L118)) has higher priority than `BackedEnumNormalizer`

this PR changes the `BackedEnumNormalizer` priority higher than  `TranslatableNormalizer` priority