### PR TITLE
[Form] Fix merging POST params and files when collection entries have mismatched indices

### DIFF
--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -343,7 +343,56 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
         $this->assertFalse($itemsForm->has('1'));
 
         $this->assertEquals('test', $itemsForm->get('0')->get('item')->getData());
-        $this->assertNotNull($itemsForm->get('0')->get('file'));
+        $this->assertNotNull($itemsForm->get('0')->get('file')->getData());
+    }
+
+    public function testMergePartialDataFromCollection()
+    {
+        $form = $this->createForm('root', 'POST', true);
+        $form->add('items', CollectionType::class, [
+            'entry_type' => ItemFileType::class,
+            'allow_add' => true,
+        ]);
+
+        $file = $this->getUploadedFile();
+        $file2 = $this->getUploadedFile();
+
+        $this->setRequestData('POST', [
+            'root' => [
+                'items' => [
+                    1 => [
+                        'item' => 'test',
+                    ],
+                ],
+            ],
+        ], [
+            'root' => [
+                'items' => [
+                    0 => [
+                        'file' => $file,
+                    ],
+                    1 => [
+                        'file' => $file2,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $itemsForm = $form->get('items');
+        $data = $itemsForm->getData();
+        $this->assertTrue($form->isSubmitted());
+        $this->assertTrue($form->isValid());
+
+        $this->assertCount(2, $data);
+        $this->assertArrayHasKey(0, $data);
+        $this->assertArrayHasKey(1, $data);
+
+        $this->assertNull($itemsForm->get('0')->get('item')->getData());
+        $this->assertNotNull($itemsForm->get('0')->get('file')->getData());
+        $this->assertEquals('test', $itemsForm->get('1')->get('item')->getData());
+        $this->assertNotNull($itemsForm->get('1')->get('file')->getData());
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
@@ -11,8 +11,13 @@
 
 namespace Symfony\Component\Form\Tests\Extension\HttpFoundation;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
+use Symfony\Component\Form\Extension\HttpFoundation\Type\FormTypeHttpFoundationExtension;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\Tests\AbstractRequestHandlerTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
@@ -46,7 +51,7 @@ class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTestCase
 
     protected function getUploadedFile($suffix = '')
     {
-        return new UploadedFile(__DIR__.'/../../Fixtures/foo'.$suffix, 'foo'.$suffix);
+        return new UploadedFile(__DIR__.'/../../Fixtures/foo'.$suffix, 'foo'.$suffix, null, null, true);
     }
 
     protected function getInvalidFile()
@@ -63,5 +68,21 @@ class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTestCase
         }
 
         return new UploadedFile(__DIR__.'/../../Fixtures/foo', 'foo', null, null, $errorCode, true);
+    }
+
+    protected function createBuilder($name, $compound = false, array $options = [])
+    {
+        $factory = Forms::createFormFactoryBuilder()
+            ->addTypeExtension(new FormTypeHttpFoundationExtension($this->requestHandler))
+            ->getFormFactory();
+
+        $builder = new FormBuilder($name, null, new EventDispatcher(), $factory, $options);
+        $builder->setCompound($compound);
+
+        if ($compound) {
+            $builder->setDataMapper(new DataMapper());
+        }
+
+        return $builder;
     }
 }

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Util;
 
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
@@ -39,30 +41,84 @@ class FormUtil
     }
 
     /**
-     * Recursively replaces or appends elements of the first array with elements
-     * of second array. If the key is an integer, the values will be appended to
-     * the new array; otherwise, the value from the second array will replace
-     * the one from the first array.
+     * Merges query string or post parameters with uploaded files.
      */
     public static function mergeParamsAndFiles(array $params, array $files): array
     {
-        $isFilesList = array_is_list($files);
+        return self::merge($params, $files);
+    }
 
-        foreach ($params as $key => $value) {
-            if (\is_array($value) && \is_array($files[$key] ?? null)) {
-                $params[$key] = self::mergeParamsAndFiles($value, $files[$key]);
-                unset($files[$key]);
+    private static function merge(mixed $params, mixed $files): mixed
+    {
+        if (null === $params) {
+            return $files;
+        }
+
+        if (\is_array($params) && self::isFileUpload($files)) {
+            return $files; // if the array is a file upload field, it has the precedence
+        }
+
+        if (\is_array($params) && \is_array($files)) {
+            // if both are lists and both do not contain arrays, then merge them and return
+            if (array_is_list($params) && self::doesNotContainNonFileUploadArray($params) && array_is_list($files) && self::doesNotContainNonFileUploadArray($files)) {
+                return array_merge($params, $files);
             }
+
+            // heuristics to preserve order, the bigger array wins
+            if (\count($files) > \count($params)) {
+                $keys = array_unique(array_merge(array_keys($files), array_keys($params)));
+            } else {
+                $keys = array_unique(array_merge(array_keys($params), array_keys($files)));
+            }
+
+            $result = [];
+
+            foreach ($keys as $key) {
+                $result[$key] = self::merge($params[$key] ?? null, $files[$key] ?? null);
+            }
+
+            return $result;
         }
 
-        if (!$isFilesList) {
-            return array_replace($params, $files);
+        if (\is_array($params)) {
+            return $params; // params has the precedence
         }
 
-        foreach ($files as $value) {
-            $params[] = $value;
+        if (self::isFileUpload($files)) {
+            return $files; // if the array is a file upload field, it has the precedence
         }
 
         return $params;
+    }
+
+    private static function isFileUpload(mixed $value): bool
+    {
+        if ($value instanceof UploadedFile) {
+            return true;
+        }
+
+        if (!\is_array($value) || !\in_array(\count($value), [5, 6], true)) {
+            return false;
+        }
+
+        if (\array_key_exists('full_path', $value)) {
+            unset($value['full_path']);
+        }
+
+        $keys = array_keys($value);
+        sort($keys);
+
+        return ['error', 'name', 'size', 'tmp_name', 'type'] === $keys;
+    }
+
+    private static function doesNotContainNonFileUploadArray(array $array): bool
+    {
+        foreach ($array as $value) {
+            if (\is_array($value) && !self::isFileUpload($value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/53359
| License       | MIT

This is an update to the PR https://github.com/symfony/symfony/pull/53353

This fixes another value-files merging bug involving collections of a form containing a file upload field and a checkbox.