### PR TITLE
[HttpFoundation] Allow array style callable setting for Request setFactory method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -382,7 +382,7 @@ class Request
      */
     public static function setFactory(?callable $callable): void
     {
-        self::$requestFactory = $callable;
+        self::$requestFactory = null === $callable ? null : $callable(...);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2197,6 +2197,23 @@ class RequestTest extends TestCase
         Request::setFactory(null);
     }
 
+    public function testFactoryCallable()
+    {
+        $requestFactory = new class {
+            public function createRequest(): Request
+            {
+                return new NewRequest();
+            }
+        };
+
+        Request::setFactory([$requestFactory, 'createRequest']);
+
+        $this->assertEquals('foo', Request::create('/')->getFoo());
+
+        Request::setFactory(null);
+
+    }
+
     /**
      * @dataProvider getLongHostNames
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch? | 7.0
| Bug fix? | yes
| New feature? | no
| Deprecations? | no
| Issues | Fix #54321
| License | MIT

Allowing to use the array notation for callback for the setFactory static method of the request.

Unit test added to confirm bug/fixing the bug.
