### PR TITLE
[Console] Disallow multi-letters option shortcuts

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -92,7 +92,7 @@ class InputOption
 
             foreach ($shortcuts as $shortcut) {
                 if (\strlen($shortcut) > 1) {
-                    throw new InvalidArgumentException("Shortcut of more than 1 letter such as $shortcut are not allowed");
+                    throw new InvalidArgumentException("Shortcut of more than 1 letter such as $shortcut are not allowed.");
                 }
             }
 

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -88,7 +88,14 @@ class InputOption
                 $shortcut = implode('|', $shortcut);
             }
             $shortcuts = preg_split('{(\|)-?}', ltrim($shortcut, '-'));
-            $shortcuts = array_filter($shortcuts, 'strlen');
+            $shortcuts = array_filter($shortcuts, \strlen(...));
+
+            foreach ($shortcuts as $shortcut) {
+                if (\strlen($shortcut) > 1) {
+                    throw new InvalidArgumentException("Shortcut of more than 1 letter such as $shortcut are not allowed");
+                }
+            }
+
             $shortcut = implode('|', $shortcuts);
 
             if ('' === $shortcut) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In command line, `-vn` stands for `-v` and `-n` both enabled, so there is no way AFAIK to have an option with a `'vn'` shortcut.

If there is any context where it's possible I suggest it should throw an exception at the very creation so to make it clear.