### PR TITLE
[Serializer] Fix: Report Xml warning/error instead of silently returning a wrong xml

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -433,6 +433,12 @@ XML;
         $this->assertEquals($expected, $serializer->serialize(new NormalizableTraversableDummy(), 'xml'));
     }
 
+    public function testEncodeException()
+    {
+        $this->expectException(NotEncodableValueException::class);
+        $this->encoder->encode('Invalid character: '.\chr(7), 'xml');
+    }
+
     public function testDecode()
     {
         $source = $this->getXmlSource();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

When `DomDocument::saveXML` encounter an error/warning, for example
```
DOMDocument::saveXML(): xmlEscapeEntities : char out of range
```
the method will return false or an empty/incomplete XML.

In case of `false`, since symfony doesn't use strict type, it will be cast into `string` (for 6.4+ version with native typehint) so the `encode` method will return an empty string.
In case of empty/incomplete XML, symfony returns it as if, without any notice about the error/warning.

I think Symfony should not silently ignore such XML error when decoding.

Or should it be an option ?