### PR TITLE
[Console] Allow to return all tokens after the command name

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -348,11 +348,30 @@ class ArgvInput extends Input
     /**
      * Returns un-parsed and not validated tokens.
      *
+     * @param bool $strip Whether to return the raw parameters (false) or the values after the command name (true)
+     *
      * @return list<string>
      */
-    public function getRawTokens(): array
+    public function getRawTokens(bool $strip = false): array
     {
-        return $this->tokens;
+        if (!$strip) {
+            return $this->tokens;
+        }
+
+        $parameters = [];
+        $keep = false;
+        foreach ($this->tokens as $value) {
+            if (!$keep && $value === $this->getFirstArgument()) {
+                $keep = true;
+
+                continue;
+            }
+            if ($keep) {
+                $parameters[] = $value;
+            }
+        }
+
+        return $parameters;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -562,4 +562,31 @@ class ArgvInputTest extends TestCase
         $this->assertEquals(['foo' => '0'], $input->getOptions(), '->parse() parses optional options with empty value as null');
         $this->assertEquals(['name' => 'bar'], $input->getArguments(), '->parse() parses optional arguments');
     }
+
+    public function testGetRawTokensFalse()
+    {
+        $input = new ArgvInput(['cli.php', '--foo', 'bar']);
+        $this->assertSame(['--foo', 'bar'], $input->getRawTokens());
+    }
+
+    /**
+     * @dataProvider provideGetRawTokensTrueTests
+     */
+    public function testGetRawTokensTrue(array $argv, array $expected)
+    {
+        $input = new ArgvInput($argv);
+        $this->assertSame($expected, $input->getRawTokens(true));
+    }
+
+    public static function provideGetRawTokensTrueTests(): iterable
+    {
+        yield [['app/console', 'foo:bar'], []];
+        yield [['app/console', 'foo:bar', '--env=prod'], ['--env=prod']];
+        yield [['app/console', 'foo:bar', '--env', 'prod'], ['--env', 'prod']];
+        yield [['app/console', '--no-ansi', 'foo:bar', '--env', 'prod'], ['--env', 'prod']];
+        yield [['app/console', '--no-ansi', 'foo:bar', '--env', 'prod'], ['--env', 'prod']];
+        yield [['app/console', '--no-ansi', 'foo:bar', 'argument'], ['argument']];
+        yield [['app/console', '--no-ansi', 'foo:bar', 'foo:bar'], ['foo:bar']];
+        yield [['app/console', '--no-ansi', 'foo:bar', '--', 'argument'], ['--', 'argument']];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

follows #54238

Now, we can make it works at the command level (previous PR was at the application level)

```php
#!/usr/bin/env php
<?php

use Symfony\Component\Console\Application;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Process\Process;

require __DIR__ . '/vendor/autoload.php';

$command = new Command('ls');
$command->ignoreValidationErrors();
$command->setCode(function ($input) {
    $p = new Process(['ls', ...$input->getRawTokens(true)]);
    $p->setTty(true);
    $p->mustRun();
});
$app = new Application();
$app->add($command);
$app->run();
```


![image](https://github.com/symfony/symfony/assets/408368/39b47b14-c2bb-4df6-ad79-26a2fe888523)