### PR TITLE
[TwigBridge] Customizing the id and name attributes of form fields using attr.

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -458,7 +458,8 @@
 {%- endblock form_rows -%}
 
 {%- block widget_attributes -%}
-    id="{{ id }}" name="{{ full_name }}"
+    id="{{ attr.id is defined ? attr.id : id }}"
+    name=" {{ attr.name is defined ? attr.name : full_name }} "
     {%- if disabled %} disabled="disabled"{% endif -%}
     {%- if required %} required="required"{% endif -%}
     {{ block('attributes') }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | none
| License       | MIT

Currently, it is not supported to customize the id and name attributes of form fields via attr. However, for specific scenarios, such as no-code or low-code systems, it is necessary to grant developers the ability to customize these attributes to achieve a higher degree of freedom in form systems. Therefore, I have modified the restriction on the basic id and name attributes and now support customization of these attributes using attr parameters.

Here is an example code snippet demonstrating how to customize the id and name attributes of form fields using the attr parameter:
```php
    $formBuilder = $this->createFormBuilder();
    $formBuilder
    ->add('fieldComment', TextType::class, [
      'attr' => ['id' => 'custom_field_id', 'name' => 'custom_field_name']
    ])
    ->add('fieldName', TextType::class)
    ->add('fieldType', ChoiceType::class, [
      'choices' => [
        'Text' => 'text',
        'Webpage' => 'link',
        'Choices' => 'options',
        'Staff' => 'user'
      ]
    ]);
```
In this example, the `fieldComment` form field will have its id set to custom_field_id and its name set to custom_field_name. You can adjust these values according to your requirements.


```twig
{{ form_widget(formView.fieldComment, {'attr': {'id': 'custom_field_id', 'name': 'custom_field_name'}}) }}
```