### PR TITLE
[HttpClient] Test with guzzle promises v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^2.13.1|^3.0",
         "doctrine/orm": "^2.7.4",
-        "guzzlehttp/promises": "^1.4",
+        "guzzlehttp/promises": "^1.4|^2.0",
         "masterminds/html5": "^2.6",
         "monolog/monolog": "^1.25.1|^2",
         "nyholm/psr7": "^1.0",

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -35,7 +35,7 @@
         "amphp/http-client": "^4.2.1",
         "amphp/http-tunnel": "^1.0",
         "amphp/socket": "^1.1",
-        "guzzlehttp/promises": "^1.4",
+        "guzzlehttp/promises": "^1.4|^2.0",
         "nyholm/psr7": "^1.0",
         "php-http/httplug": "^1.0|^2.0",
         "php-http/message-factory": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

We don't disallow v2 either so let's run our tests with guzzle promises v2. This should fix some PHP 8.4 deprecations also.