### PR TITLE
[Messenger] Swallow Exception on Rollback

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
@@ -34,7 +34,10 @@ class DoctrineTransactionMiddleware extends AbstractDoctrineMiddleware
 
             return $envelope;
         } catch (\Throwable $exception) {
-            $entityManager->getConnection()->rollBack();
+            try {
+                $entityManager->getConnection()->rollBack();
+            } catch (\Throwable $e) {
+            }
 
             if ($exception instanceof HandlerFailedException) {
                 // Remove all HandledStamp from the envelope so the retry will execute all handlers again.

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineTransactionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineTransactionMiddlewareTest.php
@@ -69,6 +69,22 @@ class DoctrineTransactionMiddlewareTest extends MiddlewareTestCase
         $this->middleware->handle(new Envelope(new \stdClass()), $this->getThrowingStackMock());
     }
 
+    public function testExceptionRollingBackTransactionSwallowed()
+    {
+        $this->connection->expects($this->once())
+            ->method('beginTransaction')
+        ;
+        $this->connection->expects($this->once())
+            ->method('rollBack')
+            ->will($this->throwException(new \Exception('Could not roll back transaction.')))
+        ;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Thrown from next middleware.');
+
+        $this->middleware->handle(new Envelope(new \stdClass()), $this->getThrowingStackMock());
+    }
+
     public function testInvalidEntityManagerThrowsException()
     {
         $managerRegistry = $this->createMock(ManagerRegistry::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

When a database level exception occurs, eg. constraint violations, it may not be possible to rollback the active transaction when handing the exception in the Messenger middleware. In this case an exception is thrown from rollback, and the original exception is lost.

I've added a try/catch to swallow any exception rolling back, so the original exception will be thrown as expected. I don't know if there is better behaviour here, just swallowing the exception seems quite poor. We could create a new exception with the rollback error, adding the original exception to it?

I also tried checking if there was an active transaction before rolling back, but that does not seem to be a reliable method for catching this condition.

I've marked this as neither a bugfix or a feature...  it's a minor improvement, but let me know if I should update the description.