### PR TITLE
[DependencyInjection] Apply attribute configurator to child classes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -699,9 +699,9 @@ class FrameworkExtension extends Extension
                 $taskAttributeClass,
                 static function (ChildDefinition $definition, AsPeriodicTask|AsCronTask $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
                     $tagAttributes = get_object_vars($attribute) + [
-                        'trigger' => match ($attribute::class) {
-                            AsPeriodicTask::class => 'every',
-                            AsCronTask::class => 'cron',
+                        'trigger' => match (true) {
+                            $attribute instanceof AsPeriodicTask => 'every',
+                            $attribute instanceof AsCronTask => 'cron',
                         },
                     ];
                     if ($reflector instanceof \ReflectionMethod) {

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Have `ServiceLocator` implement `ServiceCollectionInterface`
  * Add `#[Lazy]` attribute as shortcut for `#[Autowire(lazy: [bool|string])]` and `#[Autoconfigure(lazy: [bool|string])]`
  * Add `#[AutowireMethodOf]` attribute to autowire a method of a service as a callable
+ * Make `ContainerBuilder::registerAttributeForAutoconfiguration()` propagate to attribute classes that extend the registered class
 
 7.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -57,6 +57,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService2;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService3;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService3Configurator;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService4;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService5;
 use Symfony\Contracts\Service\Attribute\SubscribedService;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
@@ -993,6 +994,10 @@ class IntegrationTest extends TestCase
             ->setPublic(true)
             ->setAutoconfigured(true);
 
+        $container->register(TaggedService5::class)
+            ->setPublic(true)
+            ->setAutoconfigured(true);
+
         $container->register('failing_factory', \stdClass::class);
         $container->register('ccc', TaggedService4::class)
             ->setFactory([new Reference('failing_factory'), 'create'])
@@ -1017,6 +1022,12 @@ class IntegrationTest extends TestCase
                 ['someAttribute' => 'on barAction', 'priority' => 0, 'method' => 'barAction'],
                 ['property' => 'name'],
                 ['someAttribute' => 'on name', 'priority' => 0, 'property' => 'name'],
+            ],
+            TaggedService5::class => [
+                ['class' => TaggedService5::class],
+                ['parameter' => 'param1'],
+                ['method' => 'fooAction'],
+                ['property' => 'name'],
             ],
             'ccc' => [
                 ['class' => TaggedService4::class],

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Attribute/CustomChildAttribute.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Attribute/CustomChildAttribute.php
@@ -12,6 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
-class CustomAnyAttribute
+class CustomChildAttribute extends CustomAnyAttribute
 {
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService5.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService5.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomChildAttribute;
+
+#[CustomChildAttribute]
+final class TaggedService5
+{
+    #[CustomChildAttribute]
+    public string $name;
+
+    public function __construct(
+        #[CustomChildAttribute]
+        private string $param1,
+    ) {}
+
+    #[CustomChildAttribute]
+    public function fooAction(
+        #[CustomChildAttribute]
+        string $param1
+    ) {}
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52898 
| License       | MIT

This allows extending attribute classes registered for autoconfiguration.

Use-case: Share configuration between several classes with pre-configured attribute classes. As described in #52898 (bus name for `AsMessageHandler`, schedule name for `AsCronTask` and `AsPeriodicTask`)

The child-class attribute is handled by the same function as it's parent class that is registered for autoconfiguration. This means any additional property will be ignored (unless supported, which could be new feature for the `AsTaggedItem` attribute configurator).

If there is a configurator for the child class, the configurator for the parent class is not called.