### PR TITLE
[DependencyInjection] Update an error message

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -42,7 +42,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
                 }
             }
             if (!preg_match('/^(?:[-.\w\\\\]*+:)*+\w*+$/', $env)) {
-                throw new InvalidArgumentException(sprintf('Invalid %s name: only "word" characters are allowed.', $name));
+                throw new InvalidArgumentException(sprintf('The given env var name "%s" contains invalid characters (allowed characters: letters, digits, hyphens, backslashes and colons).', $name));
             }
             if ($this->has($name) && null !== ($defaultValue = parent::get($name)) && !\is_string($defaultValue)) {
                 throw new RuntimeException(sprintf('The default value of an env() parameter must be a string or null, but "%s" given to "%s".', get_debug_type($defaultValue), $name));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

In a Symfony app I had the following:

```php
#[Autowire('%env(kernel.project_dir)%')] private string $projectDir,
```

This should be instead:

```php
#[Autowire('%kernel.project_dir%')] private string $projectDir,
```

In the console I saw this error message:

<img width="822" alt="" src="https://github.com/symfony/symfony/assets/73419/c0303757-36bd-41ab-9ba1-ef912c9740df">

In my opinion, the error is not perfectly clear. That's why in this PR I propose some changes for your consideration. Thanks!
