### PR TITLE
[Config] Fix `YamlReferenceDumper` handling of array examples

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -18,7 +18,6 @@ use Symfony\Component\Config\Definition\EnumNode;
 use Symfony\Component\Config\Definition\NodeInterface;
 use Symfony\Component\Config\Definition\PrototypedArrayNode;
 use Symfony\Component\Config\Definition\ScalarNode;
-use Symfony\Component\Config\Definition\VariableNode;
 use Symfony\Component\Yaml\Inline;
 
 /**
@@ -90,19 +89,12 @@ class YamlReferenceDumper
                 $children = $this->getPrototypeChildren($node);
             }
 
-            if (!$children) {
-                if ($node->hasDefaultValue() && \count($defaultArray = $node->getDefaultValue())) {
-                    $default = '';
-                } elseif (!\is_array($example)) {
-                    $default = '[]';
-                }
+            if (!$children && !($node->hasDefaultValue() && \count($defaultArray = $node->getDefaultValue()))) {
+                $default = '[]';
             }
         } elseif ($node instanceof EnumNode) {
             $comments[] = 'One of '.implode('; ', array_map('json_encode', $node->getValues()));
             $default = $node->hasDefaultValue() ? Inline::dump($node->getDefaultValue()) : '~';
-        } elseif (VariableNode::class === \get_class($node) && \is_array($example)) {
-            // If there is an array example, we are sure we dont need to print a default value
-            $default = '';
         } else {
             $default = '~';
 
@@ -170,7 +162,7 @@ class YamlReferenceDumper
 
             $this->writeLine('# '.$message.':', $depth * 4 + 4);
 
-            $this->writeArray(array_map([Inline::class, 'dump'], $example), $depth + 1);
+            $this->writeArray(array_map([Inline::class, 'dump'], $example), $depth + 1, true);
         }
 
         if ($children) {
@@ -191,7 +183,7 @@ class YamlReferenceDumper
         $this->reference .= sprintf($format, $text)."\n";
     }
 
-    private function writeArray(array $array, int $depth)
+    private function writeArray(array $array, int $depth, bool $asComment = false)
     {
         $isIndexed = array_values($array) === $array;
 
@@ -202,14 +194,16 @@ class YamlReferenceDumper
                 $val = $value;
             }
 
+            $prefix = $asComment ? '# ' : '';
+
             if ($isIndexed) {
-                $this->writeLine('- '.$val, $depth * 4);
+                $this->writeLine($prefix.'- '.$val, $depth * 4);
             } else {
-                $this->writeLine(sprintf('%-20s %s', $key.':', $val), $depth * 4);
+                $this->writeLine(sprintf('%s%-20s %s', $prefix, $key.':', $val), $depth * 4);
             }
 
             if (\is_array($value)) {
-                $this->writeArray($value, $depth + 1);
+                $this->writeArray($value, $depth + 1, $asComment);
             }
         }
     }

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
@@ -109,6 +109,8 @@ class XmlReferenceDumperTest extends TestCase
 
     </pipou>
 
+    <array-with-array-example-and-no-default-value />
+
 </config>
 
 EOL

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -114,11 +114,11 @@ acme_root:
         # which should be indented
         child3:               ~ # Example: 'example setting'
     scalar_prototyped:    []
-    variable:
+    variable:             ~
 
         # Examples:
-        - foo
-        - bar
+        # - foo
+        # - bar
     parameters:
 
         # Prototype: Parameter name
@@ -142,6 +142,11 @@ acme_root:
 
         # Prototype
         name:                 []
+    array_with_array_example_and_no_default_value: []
+
+        # Examples:
+        # - foo
+        # - bar
     custom_node:          true
 
 EOL;

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
@@ -96,6 +96,9 @@ class ExampleConfiguration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('array_with_array_example_and_no_default_value')
+                    ->example(['foo', 'bar'])
+                ->end()
                 ->append(new CustomNodeDefinition('acme'))
             ->end()
         ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54326
| License       | MIT

#54326 was based on a wrong branch.

It seems example arrays were considered as default values in some cases. Now that they are displayed as comments, this PR ensures the default value makes sense.