### PR TITLE
[FrameworkBundle] Increase `RequestValueResolver` and `SessionValueResolver` priority

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -80,10 +80,10 @@ return static function (ContainerConfigurator $container) {
             ->tag('controller.argument_value_resolver', ['priority' => 100, 'name' => RequestAttributeValueResolver::class])
 
         ->set('argument_resolver.request', RequestValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 50, 'name' => RequestValueResolver::class])
+            ->tag('controller.argument_value_resolver', ['priority' => 120, 'name' => RequestValueResolver::class])
 
         ->set('argument_resolver.session', SessionValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 50, 'name' => SessionValueResolver::class])
+            ->tag('controller.argument_value_resolver', ['priority' => 120, 'name' => SessionValueResolver::class])
 
         ->set('argument_resolver.service', ServiceValueResolver::class)
             ->args([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #54337
| License       | MIT

The `RequestValueResolver` and `SessionValueResolver` are simple and fast, so it may make sense to run them before the `EntityValueResolver`. That way arguments type-hinted with `Request` or `Session` won’t have to wait for entity managers to be initialized and looped over. The linked issue says it can take 40–50ms; I wasn’t able to reproduce such numbers locally but it still seems worth it.