### PR TITLE
[Messenger] Allow extending attribute class `AsMessageHandler`

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -22,11 +22,6 @@ FrameworkBundle
 
  * Mark classes `ConfigBuilderCacheWarmer`, `Router`, `SerializerCacheWarmer`, `TranslationsCacheWarmer`, `Translator` and `ValidatorCacheWarmer` as `final`
 
-Messenger
----------
-
- * Make `#[AsMessageHandler]` final
-
 SecurityBundle
 --------------
 

--- a/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Messenger\Attribute;
 /**
  * Service tag to autoconfigure message handlers.
  *
- * @final since Symfony 7.1
- *
  * @author Alireza Mirsepassi <alirezamirsepassi@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,7 +6,6 @@ CHANGELOG
 
  * Add option `redis_sentinel` as an alias for `sentinel_master`
  * Add `--all` option to the `messenger:consume` command
- * Make `#[AsMessageHandler]` final
  * Add parameter `$jitter` to `MultiplierRetryStrategy` in order to randomize delay and prevent the thundering herd effect
 
 7.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Revert #52971 which made `AsMessageHandler` final.

Discussed in https://github.com/symfony/symfony/pull/54365#issuecomment-2014668287