### PR TITLE
[HttpKernel] Map a list of items with `MapRequestPayload` attribute

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
@@ -32,6 +32,7 @@ class MapRequestPayload extends ValueResolver
      * @param string|GroupSequence|array<string>|null $validationGroups           The validation groups to use when validating the query string mapping
      * @param class-string                            $resolver                   The class name of the resolver to use
      * @param int                                     $validationFailedStatusCode The HTTP code to return if the validation fails
+     * @param class-string|string|null                $type                       The element type for array deserialization
      */
     public function __construct(
         public readonly array|string|null $acceptFormat = null,
@@ -39,6 +40,7 @@ class MapRequestPayload extends ValueResolver
         public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
         public readonly int $validationFailedStatusCode = Response::HTTP_UNPROCESSABLE_ENTITY,
+        public readonly ?string $type = null,
     ) {
         parent::__construct($resolver);
     }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `HttpException::fromStatusCode()`
  * Add `$validationFailedStatusCode` argument to `#[MapQueryParameter]` that allows setting a custom HTTP status code when validation fails
  * Add `NearMissValueResolverException` to let value resolvers report when an argument could be under their watch but failed to be resolved
+ * Add `$type` argument to `#[MapRequestPayload]` that allows mapping a list of items
 
 7.0
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

**Request:**
```json
Content-Type: application/json
[
    {"price": 50},
    {"price": 23}
]
```
**Controller:**
```php
class MyController
{
    public function __invoke(
        #[MapRequestPayload(type: Price::class)] array $prices,
    ): Response {
        // do something with $prices -> array<Price>
    }
}
```
Cheers!