### PR TITLE
[Workflow] Add a way to add more definition validator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -183,6 +183,7 @@ use Symfony\Component\Validator\Validation;
 use Symfony\Component\Webhook\Controller\WebhookController;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Symfony\Component\Workflow;
+use Symfony\Component\Workflow\Validator\ConfiguredDefinitionValidatorInterface;
 use Symfony\Component\Workflow\WorkflowInterface;
 use Symfony\Component\Yaml\Command\LintCommand as BaseYamlLintCommand;
 use Symfony\Component\Yaml\Yaml;
@@ -1010,6 +1011,7 @@ class FrameworkExtension extends Extension
             $definitionDefinition->addArgument($transitions);
             $definitionDefinition->addArgument($initialMarking);
             $definitionDefinition->addArgument(new Reference(sprintf('%s.metadata_store', $workflowId)));
+            $definitionDefinition->addTag('workflow.definition', ['name' => $name]);
 
             // Create MarkingStore
             $markingStoreDefinition = null;
@@ -1104,6 +1106,9 @@ class FrameworkExtension extends Extension
                 $container->setParameter('workflow.has_guard_listeners', true);
             }
         }
+
+        $container->registerForAutoconfiguration(ConfiguredDefinitionValidatorInterface::class)
+            ->addTag('workflow.definition_validator');
     }
 
     private function registerDebugConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -70,6 +70,7 @@ use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 use Symfony\Component\Validator\DependencyInjection\AddValidatorInitializersPass;
 use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\Registry;
+use Symfony\Component\Workflow\DependencyInjection\DefinitionValidatorPass;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowDebugPass;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowGuardListenerPass;
 
@@ -158,6 +159,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new CachePoolPrunerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $this->addCompilerPassIfExists($container, FormPass::class);
         $this->addCompilerPassIfExists($container, WorkflowGuardListenerPass::class);
+        $this->addCompilerPassIfExists($container, DefinitionValidatorPass::class);
         $container->addCompilerPass(new ResettableServicePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
         $container->addCompilerPass(new RegisterLocaleAwareServicesPass());
         $container->addCompilerPass(new TestServiceContainerWeakRefPass(), PassConfig::TYPE_BEFORE_REMOVING, -32);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Workflow\CacheWarmer\DefinitionValidatorCacheWarmer;
 use Symfony\Component\Workflow\EventListener\ExpressionLanguage;
 use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
 use Symfony\Component\Workflow\Registry;
@@ -42,5 +43,10 @@ return static function (ContainerConfigurator $container) {
         ->set('workflow.registry', Registry::class)
         ->alias(Registry::class, 'workflow.registry')
         ->set('workflow.security.expression_language', ExpressionLanguage::class)
+        ->set('workflow.cache_warmer.definition_validator', DefinitionValidatorCacheWarmer::class)
+            ->args([
+                abstract_arg('definition and validators'),
+            ])
+            ->tag('kernel.cache_warmer')
     ;
 };

--- a/src/Symfony/Component/Workflow/CacheWarmer/DefinitionAndValidator.php
+++ b/src/Symfony/Component/Workflow/CacheWarmer/DefinitionAndValidator.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\CacheWarmer;
+
+use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\Validator\DefinitionValidatorInterface;
+
+final class DefinitionAndValidator
+{
+    public function __construct(
+        public readonly DefinitionValidatorInterface $validator,
+        public readonly Definition $definition,
+        public readonly string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Workflow/CacheWarmer/DefinitionValidatorCacheWarmer.php
+++ b/src/Symfony/Component/Workflow/CacheWarmer/DefinitionValidatorCacheWarmer.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\CacheWarmer;
+
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+final class DefinitionValidatorCacheWarmer implements CacheWarmerInterface
+{
+    /**
+     * @param iterable<DefinitionAndValidator> $definitionAndValidators
+     */
+    public function __construct(
+        private readonly iterable $definitionAndValidators,
+    ) {
+    }
+
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
+    {
+        foreach ($this->definitionAndValidators as $definitionAndValidator) {
+            $definitionAndValidator
+                ->validator
+                ->validate($definitionAndValidator->definition, $definitionAndValidator->name)
+            ;
+        }
+
+        return [];
+    }
+}

--- a/src/Symfony/Component/Workflow/DependencyInjection/DefinitionValidatorPass.php
+++ b/src/Symfony/Component/Workflow/DependencyInjection/DefinitionValidatorPass.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Workflow\CacheWarmer\DefinitionAndValidator;
+use Symfony\Component\Workflow\Validator\ConfiguredDefinitionValidatorInterface;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class DefinitionValidatorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('workflow.cache_warmer.definition_validator')) {
+            return;
+        }
+
+        $definitions = [];
+        foreach ($container->findTaggedServiceIds('workflow.definition') as $id => $attributes) {
+            $name = $attributes[0]['name'] ?? throw new InvalidArgumentException(sprintf('The "name" attribute is mandatory for the "workflow.definition" tag. Check the tag for service "%s".', $id));
+            $definitions[$name] = new Reference($id);
+        }
+
+        $definitionAndValidators = [];
+        foreach ($container->findTaggedServiceIds('workflow.definition_validator') as $id => $attributes) {
+            $def = $container->getDefinition($id);
+
+            $class = $def->getClass();
+
+            if (!$r = $container->getReflectionClass($class)) {
+                throw new InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
+            }
+            if (!$r->isSubclassOf(ConfiguredDefinitionValidatorInterface::class)) {
+                throw new InvalidArgumentException(sprintf('Service "%s" must implement interface "%s".', $id, ConfiguredDefinitionValidatorInterface::class));
+            }
+
+            foreach ($class::getSupportedWorkflows() as $name) {
+                if ('*' === $name) {
+                    foreach ($definitions as $definitionName => $definition) {
+                        $definitionAndValidators[] = new Definition(
+                            DefinitionAndValidator::class,
+                            [
+                                new Reference($id),
+                                $definition,
+                                $definitionName,
+                            ]
+                        );
+                    }
+                } elseif (isset($definitions[$name])) {
+                    $definitionAndValidators[] = new Definition(
+                        DefinitionAndValidator::class,
+                        [
+                            new Reference($id),
+                            $definitions[$name],
+                            $name,
+                        ]
+                    );
+                } else {
+                    throw new InvalidArgumentException(sprintf('The workflow "%s" does not exist. Check the "getConfiguration()" method of the service "%s".', $name, $id));
+                }
+            }
+        }
+
+        $container
+            ->getDefinition('workflow.cache_warmer.definition_validator')
+            ->replaceArgument(0, $definitionAndValidators)
+        ;
+    }
+}

--- a/src/Symfony/Component/Workflow/Validator/ConfiguredDefinitionValidatorInterface.php
+++ b/src/Symfony/Component/Workflow/Validator/ConfiguredDefinitionValidatorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Validator;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+interface ConfiguredDefinitionValidatorInterface extends DefinitionValidatorInterface
+{
+    /**
+     * @return list<string> A list of workflow name, or "*" for all workflows
+     */
+    public static function getSupportedWorkflows(): iterable;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54034, Fix #54276 
| License       | MIT


---

As asked by @nicolas-grekas, I tried to use a cache warmer.

It works, but it has a huge drawback in term of DX:
I a throw an exception, or use `dd()` in the validator, on the very fist time I see the exception, or the `dd()`, and If I refresh the page... the cache is hot, I see the homepage. This is not really handy to debug the warmer.

More over, nothing prevent the application to boot 😬 