### PR TITLE
Make PasswordStrenghtValidator::estimateStrength public

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
@@ -56,7 +56,7 @@ final class PasswordStrengthValidator extends ConstraintValidator
      *
      * @return PasswordStrength::STRENGTH_*
      */
-    private static function estimateStrength(#[\SensitiveParameter] string $password): int
+    public static function estimateStrength(#[\SensitiveParameter] string $password): int
     {
         if (!$length = \strlen($password)) {
             return PasswordStrength::STRENGTH_VERY_WEAK;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Issues        |
| License       | MIT

When implementing a password strength check in the frontend off an application duplicate code has to be made. By making the estimateStrength method public we can utilize the same logic/implementation as the backend validation.
