### PR TITLE
[Validator] Add a `requireTld` option to `Url` constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Possibility to use all `Ip` constraint versions for `Cidr` constraint
  * Add `list` and `associative_array` types to `Type` constraint
  * Add the `Charset` constraint
+ * Add the `requireTld` option to the `Url` constraint
 
 7.0
 ---

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -23,14 +23,18 @@ use Symfony\Component\Validator\Exception\InvalidArgumentException;
 class Url extends Constraint
 {
     public const INVALID_URL_ERROR = '57c2f299-1154-4870-89bb-ef3b1f5ad229';
+    public const MISSING_TLD_ERROR = '8a5d387f-0716-46b4-844b-67367faf435a';
 
     protected const ERROR_NAMES = [
         self::INVALID_URL_ERROR => 'INVALID_URL_ERROR',
+        self::MISSING_TLD_ERROR => 'MISSING_TLD_ERROR',
     ];
 
     public string $message = 'This value is not a valid URL.';
+    public string $tldMessage = 'This URL does not contain a TLD.';
     public array $protocols = ['http', 'https'];
     public bool $relativeProtocol = false;
+    public bool $requireTld = false;
     /** @var callable|null */
     public $normalizer;
 
@@ -39,6 +43,7 @@ class Url extends Constraint
      * @param string[]|null            $protocols        The protocols considered to be valid for the URL (e.g. http, https, ftp, etc.) (defaults to ['http', 'https']
      * @param bool|null                $relativeProtocol Whether to accept URL without the protocol (i.e. //example.com) (defaults to false)
      * @param string[]|null            $groups
+     * @param bool|null                $requireTld       Whether to require the URL to include a top-level domain (defaults to false)
      */
     public function __construct(
         ?array $options = null,
@@ -48,6 +53,7 @@ class Url extends Constraint
         ?callable $normalizer = null,
         ?array $groups = null,
         mixed $payload = null,
+        ?bool $requireTld = null,
     ) {
         parent::__construct($options, $groups, $payload);
 
@@ -55,6 +61,7 @@ class Url extends Constraint
         $this->protocols = $protocols ?? $this->protocols;
         $this->relativeProtocol = $relativeProtocol ?? $this->relativeProtocol;
         $this->normalizer = $normalizer ?? $this->normalizer;
+        $this->requireTld = $requireTld ?? $this->requireTld;
 
         if (null !== $this->normalizer && !\is_callable($this->normalizer)) {
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -79,5 +79,18 @@ class UrlValidator extends ConstraintValidator
 
             return;
         }
+
+        if ($constraint->requireTld) {
+            $urlHost = parse_url($value, \PHP_URL_HOST);
+            // the host of URLs with a TLD must include at least a '.' (but it can't be an IP address like '127.0.0.1')
+            if (!str_contains($urlHost, '.') || filter_var($urlHost, \FILTER_VALIDATE_IP)) {
+                $this->context->buildViolation($constraint->tldMessage)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Url::MISSING_TLD_ERROR)
+                    ->addViolation();
+
+                return;
+            }
+        }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
@@ -52,17 +52,26 @@ class UrlTest extends TestCase
         self::assertSame(['http', 'https'], $aConstraint->protocols);
         self::assertFalse($aConstraint->relativeProtocol);
         self::assertNull($aConstraint->normalizer);
+        self::assertFalse($aConstraint->requireTld);
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();
         self::assertSame(['ftp', 'gopher'], $bConstraint->protocols);
         self::assertSame('trim', $bConstraint->normalizer);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'UrlDummy'], $bConstraint->groups);
+        self::assertFalse($bConstraint->requireTld);
 
         [$cConstraint] = $metadata->properties['c']->getConstraints();
         self::assertTrue($cConstraint->relativeProtocol);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
+        self::assertFalse($cConstraint->requireTld);
+
+        [$dConstraint] = $metadata->properties['d']->getConstraints();
+        self::assertSame(['http', 'https'], $aConstraint->protocols);
+        self::assertFalse($aConstraint->relativeProtocol);
+        self::assertNull($aConstraint->normalizer);
+        self::assertTrue($dConstraint->requireTld);
     }
 }
 
@@ -76,4 +85,7 @@ class UrlDummy
 
     #[Url(relativeProtocol: true, groups: ['my_group'], payload: 'some attached data')]
     private $c;
+
+    #[Url(requireTld: true)]
+    private $d;
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -311,6 +311,45 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ['git://[::1]/'],
         ];
     }
+
+    /**
+     * @dataProvider getUrlsForRequiredTld
+     */
+    public function testRequiredTld(string $url, bool $requireTld, bool $isValid)
+    {
+        $constraint = new Url([
+            'requireTld' => $requireTld,
+        ]);
+
+        $this->validator->validate($url, $constraint);
+
+        if ($isValid) {
+            $this->assertNoViolation();
+        } else {
+            $this->buildViolation($constraint->tldMessage)
+                ->setParameter('{{ value }}', '"'.$url.'"')
+                ->setCode(Url::MISSING_TLD_ERROR)
+                ->assertRaised();
+        }
+    }
+
+    public static function getUrlsForRequiredTld(): iterable
+    {
+        yield ['https://aaa', true, false];
+        yield ['https://aaa', false, true];
+        yield ['https://localhost', true, false];
+        yield ['https://localhost', false, true];
+        yield ['http://127.0.0.1', false, true];
+        yield ['http://127.0.0.1', true, false];
+        yield ['http://user.pass@local', false, true];
+        yield ['http://user.pass@local', true, false];
+        yield ['https://example.com', true, true];
+        yield ['https://example.com', false, true];
+        yield ['http://foo/bar.png', false, true];
+        yield ['http://foo/bar.png', true, false];
+        yield ['https://example.com.org', true, true];
+        yield ['https://example.com.org', false, true];
+    }
 }
 
 class EmailProvider


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #50871
| License       | MIT

This implements the last part of #50871 following the suggestions from Wouter and Christian in
https://github.com/symfony/symfony/issues/50871#issuecomment-1871046803
