### PR TITLE
Fix TypeError on ProgressBar

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -183,9 +183,9 @@ final class ProgressBar
         $this->messages[$name] = $message;
     }
 
-    public function getMessage(string $name = 'message'): string
+    public function getMessage(string $name = 'message'): ?string
     {
-        return $this->messages[$name];
+        return $this->messages[$name] ?? null;
     }
 
     public function getStartTime(): int


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #54386 
| License       | MIT

`ProgressBar->getMessage()` returns null if the message is not defined