### PR TITLE
[WebProfilerBundle] Improve performance

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
@@ -4,6 +4,7 @@
         <meta charset="{{ _charset }}" />
         <meta name="robots" content="noindex,nofollow" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="view-transition" content="same-origin">
         <title>{% block title %}Symfony Profiler{% endblock %}</title>
 
         {% set request_collector = profile is defined ? profile.collectors.request|default(null) : null %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -11,30 +11,11 @@
 
     class SymfonyProfiler {
         constructor() {
-            this.#reorderMainMenuItems();
             this.#createTabs();
             this.#createTableSearchFields();
             this.#createToggles();
             this.#createCopyToClipboard();
             this.#convertDateTimesToUserTimezone();
-        }
-
-        #reorderMainMenuItems() {
-            /* reorder the main menu items to always display first the non-disabled items */
-            const mainMenuElement = document.querySelector('#menu-profiler');
-            const firstDisabledMenuItem = mainMenuElement.querySelector('li a > span.disabled')?.parentNode?.parentNode;
-
-            if (!firstDisabledMenuItem) {
-                return;
-            }
-
-            const mainMenuItems = mainMenuElement.querySelectorAll('li');
-            mainMenuItems.forEach(menuItem => {
-                const isDisabled = null !== menuItem.querySelector('a > span.disabled');
-                if (!isDisabled) {
-                    mainMenuElement.insertBefore(menuItem, firstDisabledMenuItem);
-                }
-            });
         }
 
         #createTabs() {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -1499,10 +1499,15 @@ tr.status-warning td {
     list-style-type: none;
     margin: 0;
     padding: 7px;
+    display: flex;
+    flex-direction: column;
 }
 #menu-profiler li {
     margin-bottom: 0;
     position: relative;
+}
+#menu-profiler li:has(span.disabled) {
+    order: 1;
 }
 #menu-profiler li + li {
     margin-top: 4px;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR tries to solve the following problem:

When clicking on panels like `Logs` or `Doctrine`, the page contents take some time to be ready ... and the JavaScript code that runs to change/Add things to UI, produces visible jumps:

https://github.com/symfony/symfony/assets/73419/5c980dc3-796b-4230-af9a-d63dfacb5240

-----

I debugged this behavior and the browser shows a "Long Task" warning message but not many other details:

![image](https://github.com/symfony/symfony/assets/73419/ba1cd26e-1984-4893-96a6-f90340b0ef0d)

I followed Google's recommendations: https://web.dev/articles/optimize-long-tasks and split the `SymfonyProfiler` tasks in two group: critical (menu and tabs) and normal (the rest of features).

That change in addition to `<meta name="view-transition" content="same-origin">` improves the situation, but it's still not perfect.

So, this PR is mostly **a call for help to JavaScript experts**. Please help us make the UI as fast as possible. Thanks!

