### PR TITLE
[WebProfilerBundle] Update the search links in the profiler layout

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -195,7 +195,6 @@ class ProfilerController
                 'end' => $request->query->get('end', $session?->get('_profiler_search_end')),
                 'limit' => $request->query->get('limit', $session?->get('_profiler_search_limit')),
                 'request' => $request,
-                'render_hidden_by_default' => false,
                 'profile_type' => $request->query->get('type', $session?->get('_profiler_search_type', 'request')),
             ]),
             200,

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -28,16 +28,10 @@
                             <div id="sidebar-shortcuts">
                                 {% block sidebar_shortcuts_links %}
                                     <div class="shortcuts">
-                                        <a class="btn btn-link" href="{{ path('_profiler_search', { limit: 10, type: profile_type }) }}">Last 10</a>
+                                        <a class="btn btn-link" href="{{ path('_profiler_search', { limit: 10, type: profile_type }) }}">{{ source('@WebProfiler/Icon/search.svg') }} Search profiles</a>
                                         <a class="btn btn-link" href="{{ path('_profiler', { token: 'latest', type: profile_type }|merge(request.query.all)) }}">Latest</a>
-
-                                        <a class="sf-toggle btn btn-link" data-toggle-selector="#sidebar-search" {% if tokens is defined or about is defined %}data-toggle-initial="display"{% endif %}>
-                                            {{ source('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
-                                        </a>
                                     </div>
                                 {% endblock sidebar_shortcuts_links %}
-
-                                {{ render(controller('web_profiler.controller.profiler::searchBarAction', query={type: profile_type }|merge(request.query.all))) }}
                             </div>
 
                             {% if templates is defined %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -1416,7 +1416,7 @@ tr.status-warning td {
    ------------------------------------------------------------------------- #}
 #sidebar #sidebar-shortcuts {
     color: var(--gray-500);
-    padding: 10px 15px;
+    padding: 5px 8px;
 }
 #sidebar #sidebar-shortcuts .sf-tabs .tab-navigation {
     margin: 5px 0 15px;
@@ -1431,14 +1431,20 @@ tr.status-warning td {
     display: flex;
     align-items: center;
     font-size: 13px;
+    padding: 5px 7px;
 }
-#sidebar #sidebar-shortcuts:hover .btn-link {
-    color: var(--menu-color);
+#sidebar #sidebar-shortcuts .btn-link:hover {
+    background: var(--menu-active-background);
+    color: var(--menu-active-color);
+    text-decoration: none;
 }
 #sidebar-shortcuts .shortcuts svg {
     height: 16px;
     width: 16px;
     margin-right: 4px;
+}
+#sidebar #sidebar-shortcuts form {
+    padding: 5px 7px;
 }
 
 {# Sidebar Search (the colors of this element don't change based on the selected theme)

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -35,7 +35,9 @@
 {% endblock %}
 
 {% block sidebar_search_css_class %}{% endblock %}
-{% block sidebar_shortcuts_links %}{% endblock %}
+{% block sidebar_shortcuts_links %}
+    {{ render(controller('web_profiler.controller.profiler::searchBarAction', query={type: profile_type }|merge(request.query.all))) }}
+{% endblock %}
 
 {% block panel %}
     <div class="sf-tabs" data-processed="true">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -1,4 +1,4 @@
-<div id="sidebar-search" class="{{ (render_hidden_by_default ?? true) ? 'hidden' }}">
+<div id="sidebar-search">
     <form action="{{ path('_profiler_search') }}" method="get">
         <div class="form-group">
             <label for="ip">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

While working on #54421, I noticed that the page jump is mostly caused by the "profile search form" that we embed in the page via Ajax. This is how it looks expanded:

![image](https://github.com/symfony/symfony/assets/73419/090febc8-65e6-4ede-8c21-8b3fb0d738d2)

However, thew workflow is as follows:

1. Click on `Search` link
2. The embedded search form expands
3. Input the search criteria
4. Click on `Search` button
5. You are redirected to the Search page to see the results

-----

In this PR, I propose to NOT embed the search form in any pages and change the workflow as follows:

1. Click on `Search` link
2. You are redirected to the Search page to see the results
3. Input the search criteria (in the already expanded search form)
4. Click on `Search` button to see the results

This fixes some of the perceived performance slowdown and looks like a better workflow to me.

-----

Also, the current sidebar shows these shortcut links:

![image](https://github.com/symfony/symfony/assets/73419/1ef165fe-1ac1-42ff-8d01-1514c2b2320f)

* "Last 10" shows the 10 most recent profiles
* "Latest" shows the most recent profile available
* "Search" expands the search form

This PR changes it to only show 2 shortcuts:

* "Search profiles" shows the last 10 profiles and also the search form expanded
* "Latest" shows the most recent profile aaailable

It looks like this:

![search-links](https://github.com/symfony/symfony/assets/73419/8f2ba944-c9a3-4f56-9a12-4818c79bfdcb)
