### PR TITLE
[TwigBridge] Remove whitespaces from block form_help output

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -361,12 +361,12 @@
 {# Help #}
 
 {%- block form_help -%}
-    {% set row_class = row_attr.class|default('') %}
-    {% set help_class = ' form-text' %}
-    {% if 'input-group' in row_class %}
+    {%- set row_class = row_attr.class|default('') -%}
+    {%- set help_class = ' form-text' -%}
+    {%- if 'input-group' in row_class -%}
         {#- Hack to properly display help with input group -#}
-        {% set help_class = ' input-group-text' %}
-    {% endif %}
+        {%- set help_class = ' input-group-text' -%}
+    {%- endif -%}
     {%- if help is not empty -%}
         {%- set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ help_class ~ ' mb-0')|trim}) -%}
     {%- endif -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The block form_help adds unnecessary whitespaces to the output

This is inconsistent with the rest of the output
