### PR TITLE
[Console] respect multi-byte characters when rendering vertical-style tables

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -371,8 +371,9 @@ class Table
                         if ($headers && !$containsColspan) {
                             if (0 === $idx) {
                                 $rows[] = [sprintf(
-                                    '<comment>%s</>: %s',
-                                    str_pad($headers[$i] ?? '', $maxHeaderLength, ' ', \STR_PAD_LEFT),
+                                    '<comment>%s%s</>: %s',
+                                    str_repeat(' ', $maxHeaderLength - Helper::width(Helper::removeDecoration($formatter, $headers[$i] ?? ''))),
+                                    $headers[$i] ?? '',
                                     $part
                                 )];
                             } else {

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -1649,6 +1649,28 @@ EOTXT
             $books,
         ];
 
+        yield 'With multibyte characters in some headers (the "í" in "Títle") and cells (the "í" in "Dívíne")' => [
+            <<<EOTXT
++-------------------------+
+|   ISBN: 99921-58-10-7   |
+|  Títle: Dívíne Comedy   |
+| Author: Dante Alighieri |
+|  Price: 9.95            |
++-------------------------+
+
+EOTXT
+            ,
+            ['ISBN', 'Títle', 'Author', 'Price'],
+            [
+                [
+                    '99921-58-10-7',
+                    'Dívíne Comedy',
+                    'Dante Alighieri',
+                    '9.95',
+                ],
+            ],
+        ];
+
         yield 'With header for some' => [
             <<<EOTXT
 +------------------------------+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54433
| License       | MIT