### PR TITLE
[Console] return null when message with name is not set

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -169,9 +169,12 @@ final class ProgressBar
         $this->messages[$name] = $message;
     }
 
+    /**
+     * @return string|null
+     */
     public function getMessage(string $name = 'message')
     {
-        return $this->messages[$name];
+        return $this->messages[$name] ?? null;
     }
 
     public function getStartTime(): int

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -1173,4 +1173,11 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
             stream_get_contents($output->getStream())
         );
     }
+
+    public function testGetNotSetMessage()
+    {
+        $progressBar = new ProgressBar($this->getOutputStream());
+
+        $this->assertNull($progressBar->getMessage());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

same as #54419 but for the `5.4` branch