### PR TITLE
[Clock] Add a polyfill for DateTimeImmutable::createFromTimestamp()

### DIFF
--- a/src/Symfony/Component/Clock/DatePoint.php
+++ b/src/Symfony/Component/Clock/DatePoint.php
@@ -66,6 +66,27 @@ final class DatePoint extends \DateTimeImmutable
         return parent::createFromMutable($object);
     }
 
+    public static function createFromTimestamp(int|float $timestamp): static
+    {
+        if (\PHP_VERSION_ID >= 80400) {
+            return parent::createFromTimestamp($timestamp);
+        }
+
+        if (\is_int($timestamp) || !$ms = (int) $timestamp - $timestamp) {
+            return static::createFromFormat('U', (string) $timestamp);
+        }
+
+        if (!is_finite($timestamp) || \PHP_INT_MAX + 1.0 <= $timestamp || \PHP_INT_MIN > $timestamp) {
+            throw new \DateRangeError(sprintf('DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %s and %s.999999, %s given', \PHP_INT_MIN, \PHP_INT_MAX, $timestamp));
+        }
+
+        if ($timestamp < 0) {
+            $timestamp = (int) $timestamp - 2.0 + $ms;
+        }
+
+        return static::createFromFormat('U.u', sprintf('%.6F', $timestamp));
+    }
+
     public function add(\DateInterval $interval): static
     {
         return parent::add($interval);

--- a/src/Symfony/Component/Clock/Tests/DatePointTest.php
+++ b/src/Symfony/Component/Clock/Tests/DatePointTest.php
@@ -45,6 +45,47 @@ class DatePointTest extends TestCase
         DatePoint::createFromFormat('Y-m-d H:i:s', 'Bad Date');
     }
 
+    /**
+     * @dataProvider provideValidTimestamps
+     */
+    public function testCreateFromTimestamp(int|float $timestamp, string $expected)
+    {
+        $date = DatePoint::createFromTimestamp($timestamp);
+
+        $this->assertInstanceOf(DatePoint::class, $date);
+        $this->assertSame($expected, $date->format('Y-m-d\TH:i:s.uP'));
+    }
+
+    public static function provideValidTimestamps(): iterable
+    {
+        yield 'positive integer' => [1359188516, '2013-01-26T08:21:56.000000+00:00'];
+        yield 'positive float' => [1359188516.123456, '2013-01-26T08:21:56.123456+00:00'];
+        yield 'positive integer-ish float' => [1359188516.0, '2013-01-26T08:21:56.000000+00:00'];
+        yield 'zero as integer' => [0, '1970-01-01T00:00:00.000000+00:00'];
+        yield 'zero as float' => [0.0, '1970-01-01T00:00:00.000000+00:00'];
+        yield 'negative integer' => [-100, '1969-12-31T23:58:20.000000+00:00'];
+        yield 'negative float' => [-100.123456, '1969-12-31T23:58:19.876544+00:00'];
+        yield 'negative integer-ish float' => [-100.0, '1969-12-31T23:58:20.000000+00:00'];
+    }
+
+    /**
+     * @dataProvider provideOutOfRangeFloatTimestamps
+     */
+    public function testCreateFromTimestampWithFloatOutOfRange(float $timestamp)
+    {
+        $this->expectException(\DateRangeError::class);
+        $this->expectExceptionMessage('DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between');
+        DatePoint::createFromTimestamp($timestamp);
+    }
+
+    public static function provideOutOfRangeFloatTimestamps(): iterable
+    {
+        yield 'too large (positive)' => [1e20];
+        yield 'too large (negative)' => [-1e20];
+        yield 'NaN' => [\NAN];
+        yield 'infinity' => [\INF];
+    }
+
     public function testModify()
     {
         $date = new DatePoint('2010-01-28 15:00:00');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR adds the new `createFromTimestamp()` method introduced in php/php-src#12413 to our `DatePoint` class. It comes with a polyfill implementation for PHP 8.2/8.3.