### PR TITLE
[Security] Add support for dynamic CSRF id with Expression in `#[IsCsrfTokenValid]`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterCsrfFeaturesPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterCsrfFeaturesPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
 use Symfony\Component\Security\Http\EventListener\CsrfProtectionListener;
@@ -35,6 +36,10 @@ class RegisterCsrfFeaturesPass implements CompilerPassInterface
 
     private function registerCsrfProtectionListener(ContainerBuilder $container): void
     {
+        if (!$container->hasDefinition('cache.system')) {
+            $container->removeDefinition('cache.security_is_csrf_token_valid_attribute_expression_language');
+        }
+
         if (!$container->has('security.authenticator.manager') || !$container->has('security.csrf.token_manager')) {
             return;
         }
@@ -45,6 +50,7 @@ class RegisterCsrfFeaturesPass implements CompilerPassInterface
 
         $container->register('controller.is_csrf_token_valid_attribute_listener', IsCsrfTokenValidAttributeListener::class)
             ->addArgument(new Reference('security.csrf.token_manager'))
+            ->addArgument(new Reference('security.is_csrf_token_valid_attribute_expression_language', ContainerInterface::NULL_ON_INVALID_REFERENCE))
             ->addTag('kernel.event_subscriber');
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -123,6 +123,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             $container->removeDefinition('security.expression_language');
             $container->removeDefinition('security.access.expression_voter');
             $container->removeDefinition('security.is_granted_attribute_expression_language');
+            $container->removeDefinition('security.is_csrf_token_valid_attribute_expression_language');
         }
 
         if (!class_exists(PasswordHasherExtension::class)) {

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -303,5 +303,12 @@ return static function (ContainerConfigurator $container) {
         ->set('cache.security_is_granted_attribute_expression_language')
             ->parent('cache.system')
             ->tag('cache.pool')
+
+        ->set('security.is_csrf_token_valid_attribute_expression_language', BaseExpressionLanguage::class)
+            ->args([service('cache.security_is_csrf_token_valid_attribute_expression_language')->nullOnInvalid()])
+
+        ->set('cache.security_is_csrf_token_valid_attribute_expression_language')
+            ->parent('cache.system')
+            ->tag('cache.pool')
     ;
 };

--- a/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
@@ -11,14 +11,16 @@
 
 namespace Symfony\Component\Security\Http\Attribute;
 
+use Symfony\Component\ExpressionLanguage\Expression;
+
 #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
 final class IsCsrfTokenValid
 {
     public function __construct(
         /**
-         * Sets the id used when generating the token.
+         * Sets the id, or an Expression evaluated to the id, used when generating the token.
          */
-        public string $id,
+        public string|Expression $id,
 
         /**
          * Sets the key of the request that contains the actual token value that should be validated.

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsCsrfTokenValidAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsCsrfTokenValidAttributeMethodsController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Tests\Fixtures;
 
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 
 class IsCsrfTokenValidAttributeMethodsController
@@ -21,6 +22,16 @@ class IsCsrfTokenValidAttributeMethodsController
 
     #[IsCsrfTokenValid('foo')]
     public function withDefaultTokenKey()
+    {
+    }
+
+    #[IsCsrfTokenValid(new Expression('"foo_" ~ args.id'))]
+    public function withCustomExpressionId(string $id)
+    {
+    }
+
+    #[IsCsrfTokenValid(new Expression('"foo_" ~ args.slug'))]
+    public function withInvalidExpressionId(string $id)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | continuation of #52961 from Hackday
| License       | MIT

Use case is for example on a list page with delete action per item, and you want a CSRF token per item, so in the template you have something like the following:

```twig
{# in a loop over multiple posts #}
<form action="{{ path('post_delete', {post: post.id}) }}" method="POST">
    <input type="hidden" name="_token" value="{{ csrf_token('delete-post-' ~ post.id) }}">
    ...
</form>
```

The new feature will allow:
```php
#[IsCsrfTokenValid(new Expression('"delete-post-" ~ args["post"].id'))]
public function delete(Request $request, Post $post): Response
{
    // ... delete the post
}
```

Maybe this need more tests but need help identify which test cases are useful.
Hope this can pass before the feature freeze