### PR TITLE
[WebProfilerBundle] add extra data to logs panel

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -40,6 +40,7 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
             'priority' => $record->level->value,
             'priorityName' => $record->level->getName(),
             'context' => $record->context,
+            'extra' => $record->extra,
             'channel' => $record->channel ?? '',
         ];
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -540,6 +540,7 @@
 {% macro render_log_message(category, log_index, log) %}
     {% set has_context = log.context is defined and log.context is not empty %}
     {% set has_trace = log.context.exception.trace is defined %}
+    {% set has_extra = log.extra is defined and log.extra is not empty %}
 
     {% if not has_context %}
         {{ profiler_dump_log(log.message) }}
@@ -566,6 +567,11 @@
             <span><button type="button" class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ trace_id }}" data-toggle-alt-content="Hide trace">Show trace</button></span>
         {% endif %}
 
+        {% if has_extra %}
+            {% set extra_id = 'extra-data-' ~ category ~ '-' ~ log_index %}
+            <span><button type="button" class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ extra_id }}" data-toggle-alt-content="Hide extra data">Show extra data</button></span>
+        {% endif %}
+
         {% if has_context %}
             <div id="{{ context_id }}" class="context sf-toggle-content sf-toggle-hidden">
                 {{ profiler_dump(log.context, maxDepth=1) }}
@@ -575,6 +581,12 @@
         {% if has_trace %}
             <div id="{{ trace_id }}" class="context sf-toggle-content sf-toggle-hidden">
                 {{ profiler_dump(log.context.exception.trace, maxDepth=1) }}
+            </div>
+        {% endif %}
+
+        {% if has_extra %}
+            <div id="{{ extra_id }}" class="context sf-toggle-content sf-toggle-hidden">
+                {{ profiler_dump(log.extra, maxDepth=1) }}
             </div>
         {% endif %}
     </div>

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -96,6 +96,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
                 'channel' => $rawLogData['channel']->getValue(),
                 'message' => $rawLogData['message'],
                 'context' => $rawLogData['context'],
+                'extra' => $rawLogData['extra'],
             ];
         }
 

--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerConfigurator.php
@@ -30,7 +30,16 @@ class DebugLoggerConfigurator
     public function pushDebugLogger(Logger $logger): void
     {
         if ($this->processor) {
+            $processors = $logger->getProcessors();
+            while ([] !== $logger->getProcessors()) {
+                $logger->popProcessor();
+            }
+
+            // Ensure the DebugLogger is the first processor as Monolog add processors in reverse order
             $logger->pushProcessor($this->processor);
+            foreach ($processors as $processor) {
+                $logger->pushProcessor($processor);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This is an attempt to add `extra` data to `Logs` panel in profiler.

I'm not convinced by this approch but I couldn't find another way to put `DebugProcessor` as last item. Doing so ensure that when logs are collected, `extra` property contains all data from previous processors.

I think this PR could help: ~~https://github.com/symfony/monolog-bundle/pull/455~~ https://github.com/symfony/monolog-bundle/pull/485

Here's an example with `Symfony\Bridge\Monolog\Processor\WebProcessor` and `Monolog\Processor\MemoryUsageProcessor` enabled

![image](https://github.com/symfony/symfony/assets/17051512/727c884f-40df-4f8b-a996-942ed792de23)

## TODO

- [ ] Tests
- [ ] Update changelogs