### PR TITLE
Remove unnecessary empty usages

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -116,7 +116,7 @@ class UniqueEntityValidator extends ConstraintValidator
 
         // skip validation if there are no criteria (this can happen when the
         // "ignoreNull" option is enabled and fields to be checked are null
-        if (empty($criteria)) {
+        if (!$criteria) {
             return;
         }
 

--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -100,14 +100,14 @@ final class ConsoleFormatter implements FormatterInterface
     {
         $record = $this->replacePlaceHolder($record);
 
-        if (!$this->options['ignore_empty_context_and_extra'] || !empty($record->context)) {
+        if (!$this->options['ignore_empty_context_and_extra'] || $record->context) {
             $context = $record->context;
             $context = ($this->options['multiline'] ? "\n" : ' ').$this->dumpData($context);
         } else {
             $context = '';
         }
 
-        if (!$this->options['ignore_empty_context_and_extra'] || !empty($record->extra)) {
+        if (!$this->options['ignore_empty_context_and_extra'] || $record->extra) {
             $extra = $record->extra;
             $extra = ($this->options['multiline'] ? "\n" : ' ').$this->dumpData($extra);
         } else {

--- a/src/Symfony/Bridge/PsrHttpMessage/Factory/PsrHttpFactory.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Factory/PsrHttpFactory.php
@@ -178,7 +178,7 @@ class PsrHttpFactory implements HttpMessageFactoryInterface
 
         $headers = $symfonyResponse->headers->all();
         $cookies = $symfonyResponse->headers->getCookies();
-        if (!empty($cookies)) {
+        if ($cookies) {
             $headers['Set-Cookie'] = [];
 
             foreach ($cookies as $cookie) {

--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Fixtures/Uri.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Fixtures/Uri.php
@@ -47,13 +47,13 @@ class Uri implements UriInterface
 
     public function getAuthority(): string
     {
-        if (empty($this->host)) {
+        if (!$this->host) {
             return '';
         }
 
         $authority = $this->host;
 
-        if (!empty($this->userInfo)) {
+        if ($this->userInfo) {
             $authority = $this->userInfo.'@'.$authority;
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -275,7 +275,7 @@ class ProfilerController
             $session->set('_profiler_search_type', $profileType);
         }
 
-        if (!empty($token)) {
+        if ($token) {
             return new RedirectResponse($this->generator->generate('_profiler', ['token' => $token]), 302, ['Content-Type' => 'text/html']);
         }
 

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -531,7 +531,7 @@ abstract class AbstractBrowser
      */
     public function followRedirect(): Crawler
     {
-        if (empty($this->redirect)) {
+        if (!$this->redirect) {
             throw new LogicException('The request was not redirected.');
         }
 

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -71,7 +71,7 @@ class Cookie
             $this->value = $value ?? '';
             $this->rawValue = rawurlencode($this->value);
         }
-        $this->path = empty($path) ? '/' : $path;
+        $this->path = $path ?: '/';
 
         if (null !== $expires) {
             $timestampAsDateTime = \DateTimeImmutable::createFromFormat('U', $expires);

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -71,7 +71,7 @@ class CookieJar
     {
         $path ??= '/';
 
-        if (empty($domain)) {
+        if (!$domain) {
             // an empty domain means any domain
             // this should never happen but it allows for a better BC
             $domains = array_keys($this->cookieJar);

--- a/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
@@ -112,7 +112,7 @@ class CouchbaseBucketAdapter extends AbstractAdapter
 
             unset($options['username'], $options['password']);
             foreach ($options as $option => $value) {
-                if (!empty($value)) {
+                if ($value) {
                     $bucket->$option = $value;
                 }
             }

--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -100,7 +100,7 @@ class ExprBuilder
      */
     public function ifEmpty(): static
     {
-        $this->ifPart = static fn ($v) => empty($v);
+        $this->ifPart = static fn ($v) => !$v;
         $this->allowedTypes = self::TYPE_ANY;
 
         return $this;

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -280,7 +280,7 @@ class XmlReferenceDumper
             return 'null';
         }
 
-        if (empty($value)) {
+        if (!$value) {
             return '';
         }
 

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -112,6 +112,6 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
      */
     protected function isValueEmpty(mixed $value): bool
     {
-        return empty($value);
+        return !$value;
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -239,7 +239,7 @@ class ArrayNodeDefinitionTest extends TestCase
             ->children()
                 ->scalarNode('value')
                     ->beforeNormalization()
-                        ->ifTrue(fn ($value) => empty($value))
+                        ->ifTrue(fn ($value) => !$value)
                         ->thenUnset()
                     ->end()
                 ->end()

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -620,7 +620,7 @@ class Application implements ResetInterface
         $expr = implode('[^:]*:', array_map('preg_quote', explode(':', $namespace))).'[^:]*';
         $namespaces = preg_grep('{^'.$expr.'}', $allNamespaces);
 
-        if (empty($namespaces)) {
+        if (!$namespaces) {
             $message = sprintf('There are no commands defined in the "%s" namespace.', $namespace);
 
             if ($alternatives = $this->findAlternatives($namespace, $allNamespaces)) {
@@ -674,12 +674,12 @@ class Application implements ResetInterface
         $expr = implode('[^:]*:', array_map('preg_quote', explode(':', $name))).'[^:]*';
         $commands = preg_grep('{^'.$expr.'}', $allCommands);
 
-        if (empty($commands)) {
+        if (!$commands) {
             $commands = preg_grep('{^'.$expr.'}i', $allCommands);
         }
 
         // if no commands matched or we just matched namespaces
-        if (empty($commands) || \count(preg_grep('{^'.$expr.'$}i', $commands)) < 1) {
+        if (!$commands || \count(preg_grep('{^'.$expr.'$}i', $commands)) < 1) {
             if (false !== $pos = strrpos($name, ':')) {
                 // check if a namespace exists and contains commands
                 $this->findNamespace(substr($name, 0, $pos));

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -208,7 +208,7 @@ class XmlDescriptor extends Descriptor
             $defaults = \is_array($option->getDefault()) ? $option->getDefault() : (\is_bool($option->getDefault()) ? [var_export($option->getDefault(), true)] : ($option->getDefault() ? [$option->getDefault()] : []));
             $objectXML->appendChild($defaultsXML = $dom->createElement('defaults'));
 
-            if (!empty($defaults)) {
+            if ($defaults) {
                 foreach ($defaults as $default) {
                     $defaultsXML->appendChild($defaultXML = $dom->createElement('default'));
                     $defaultXML->appendChild($dom->createTextNode($default));

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -726,7 +726,7 @@ class Table
             } else {
                 $row = $this->copyRow($rows, $unmergedRowKey - 1);
                 foreach ($unmergedRow as $column => $cell) {
-                    if (!empty($cell)) {
+                    if ($cell) {
                         $row[$column] = $cell;
                     }
                 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -75,7 +75,7 @@ class InputOption
             $name = substr($name, 2);
         }
 
-        if (empty($name)) {
+        if (!$name) {
             throw new InvalidArgumentException('An option name cannot be empty.');
         }
 

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -63,7 +63,7 @@ class ConsoleSectionOutput extends StreamOutput
      */
     public function clear(?int $lines = null): void
     {
-        if (empty($this->content) || !$this->isDecorated()) {
+        if (!$this->content || !$this->isDecorated()) {
             return;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -328,7 +328,7 @@ class Definition
      */
     public function addMethodCall(string $method, array $arguments = [], bool $returnsClone = false): static
     {
-        if (empty($method)) {
+        if (!$method) {
             throw new InvalidArgumentException('Method name cannot be empty.');
         }
         $this->calls[] = $returnsClone ? [$method, $arguments, true] : [$method, $arguments];

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -130,7 +130,7 @@ class Crawler implements \Countable, \IteratorAggregate
      */
     public function addContent(string $content, ?string $type = null): void
     {
-        if (empty($type)) {
+        if (!$type) {
             $type = str_starts_with($content, '<?xml') ? 'application/xml' : 'text/html';
         }
 
@@ -176,7 +176,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $base = $this->filterRelativeXPath('descendant-or-self::base')->extract(['href']);
 
         $baseHref = current($base);
-        if (\count($base) && !empty($baseHref)) {
+        if (\count($base) && $baseHref) {
             if ($this->baseHref) {
                 $linkNode = $dom->createElement('a');
                 $linkNode->setAttribute('href', $baseHref);

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -236,7 +236,7 @@ class ChoiceFormField extends FormField
         $option = [];
 
         $defaultDefaultValue = 'select' === $this->node->nodeName ? '' : 'on';
-        $defaultValue = (isset($node->nodeValue) && !empty($node->nodeValue)) ? $node->nodeValue : $defaultDefaultValue;
+        $defaultValue = (isset($node->nodeValue) && $node->nodeValue) ? $node->nodeValue : $defaultDefaultValue;
         $option['value'] = $node->hasAttribute('value') ? $node->getAttribute('value') : $defaultValue;
         $option['disabled'] = $node->hasAttribute('disabled');
 

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -121,7 +121,7 @@ class Form extends Link implements \ArrayAccess
         $values = [];
         foreach ($this->getValues() as $name => $value) {
             $qs = http_build_query([$name => $value], '', '&');
-            if (!empty($qs)) {
+            if ($qs) {
                 parse_str($qs, $expandedValue);
                 $varName = substr($name, 0, \strlen(key($expandedValue)));
                 $values[] = [$varName => current($expandedValue)];
@@ -146,7 +146,7 @@ class Form extends Link implements \ArrayAccess
         $values = [];
         foreach ($this->getFiles() as $name => $value) {
             $qs = http_build_query([$name => $value], '', '&');
-            if (!empty($qs)) {
+            if ($qs) {
                 parse_str($qs, $expandedValue);
                 $varName = substr($name, 0, \strlen(key($expandedValue)));
 

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -136,7 +136,7 @@ class FormFieldRegistry
     private function walk(array $array, ?string $base = '', array &$output = []): array
     {
         foreach ($array as $k => $v) {
-            $path = empty($base) ? $k : sprintf('%s[%s]', $base, $k);
+            $path = $base ? sprintf('%s[%s]', $base, $k) : $k;
             if (\is_array($v)) {
                 $this->walk($v, $path, $output);
             } else {

--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -351,7 +351,7 @@ final class Path
         }
 
         // No actual extension in path
-        if (empty($actualExtension)) {
+        if (!$actualExtension) {
             return $path.(str_ends_with($path, '.') ? '' : '.').$extension;
         }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -65,7 +65,7 @@ class FilesystemTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        if (!empty($this->longPathNamesWindows)) {
+        if ($this->longPathNamesWindows) {
             foreach ($this->longPathNamesWindows as $path) {
                 exec('DEL '.$path);
             }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -101,7 +101,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
      */
     public function reverseTransform(mixed $value): ?\DateTime
     {
-        if (empty($value)) {
+        if (!$value) {
             return null;
         }
 

--- a/src/Symfony/Component/Form/Extension/Validator/Type/BaseValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/BaseValidatorExtension.php
@@ -32,7 +32,7 @@ abstract class BaseValidatorExtension extends AbstractTypeExtension
                 return [];
             }
 
-            if (empty($groups)) {
+            if (!$groups) {
                 return null;
             }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -120,7 +120,7 @@ class CollectionTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'entry_type' => AuthorType::class,
             'allow_delete' => true,
-            'delete_empty' => fn (?Author $obj = null) => null === $obj || empty($obj->firstName),
+            'delete_empty' => fn (?Author $obj = null) => null === $obj || !$obj->firstName,
         ]);
 
         $form->setData([new Author('Bob'), new Author('Alice')]);

--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -213,7 +213,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             }
         }
 
-        $dataArg = empty($dataArg) ? null : implode(' ', $dataArg);
+        $dataArg = $dataArg ? implode(' ', $dataArg) : null;
 
         foreach (explode("\n", $trace['info']['debug']) as $line) {
             $line = substr($line, 0, -1);

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -101,7 +101,7 @@ class Cookie
             throw new \InvalidArgumentException(sprintf('The cookie name "%s" contains invalid characters.', $name));
         }
 
-        if (empty($name)) {
+        if (!$name) {
             throw new \InvalidArgumentException('The cookie name cannot be empty.');
         }
 
@@ -109,7 +109,7 @@ class Cookie
         $this->value = $value;
         $this->domain = $domain;
         $this->expire = self::expiresTimestamp($expire);
-        $this->path = empty($path) ? '/' : $path;
+        $this->path = $path ?: '/';
         $this->secure = $secure;
         $this->httpOnly = $httpOnly;
         $this->raw = $raw;

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1048,7 +1048,7 @@ class Request
 
         $https = $this->server->get('HTTPS');
 
-        return !empty($https) && 'off' !== strtolower($https);
+        return $https && 'off' !== strtolower($https);
     }
 
     /**
@@ -1528,7 +1528,7 @@ class Request
     {
         $preferredLanguages = $this->getLanguages();
 
-        if (empty($locales)) {
+        if (!$locales) {
             return $preferredLanguages[0] ?? null;
         }
 
@@ -1759,7 +1759,7 @@ class Request
         }
 
         $basename = basename($baseUrl ?? '');
-        if (empty($basename) || !strpos(rawurldecode($truncatedRequestUri), $basename)) {
+        if (!$basename || !strpos(rawurldecode($truncatedRequestUri), $basename)) {
             // no match whatsoever; set it blank
             return '';
         }
@@ -1780,7 +1780,7 @@ class Request
     protected function prepareBasePath(): string
     {
         $baseUrl = $this->getBaseUrl();
-        if (empty($baseUrl)) {
+        if (!$baseUrl) {
             return '';
         }
 

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -180,7 +180,7 @@ class ResponseHeaderBag extends HeaderBag
             }
         }
 
-        if (empty($this->cookies)) {
+        if (!$this->cookies) {
             unset($this->headerNames['set-cookie']);
         }
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -134,7 +134,7 @@ class Session implements FlashBagAwareSessionInterface, \IteratorAggregate, \Cou
             }
         }
         foreach ($this->data as &$data) {
-            if (!empty($data)) {
+            if ($data) {
                 return false;
             }
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -56,7 +56,7 @@ class MockArraySessionStorage implements SessionStorageInterface
             return true;
         }
 
-        if (empty($this->id)) {
+        if (!$this->id) {
             $this->id = $this->generateId();
         }
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -47,7 +47,7 @@ class Esi extends AbstractSurrogate
             $alt ? sprintf(' alt="%s"', $alt) : ''
         );
 
-        if (!empty($comment)) {
+        if ($comment) {
             return sprintf("<esi:comment text=\"%s\" />\n%s", $comment, $html);
         }
 
@@ -57,7 +57,7 @@ class Esi extends AbstractSurrogate
     public function process(Request $request, Response $response): Response
     {
         $type = $response->headers->get('Content-Type');
-        if (empty($type)) {
+        if (!$type) {
             $type = 'text/html';
         }
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -41,7 +41,7 @@ class Ssi extends AbstractSurrogate
     public function process(Request $request, Response $response): Response
     {
         $type = $response->headers->get('Content-Type');
-        if (empty($type)) {
+        if (!$type) {
             $type = 'text/html';
         }
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -278,7 +278,7 @@ class Store implements StoreInterface
      */
     private function requestsMatch(?string $vary, array $env1, array $env2): bool
     {
-        if (empty($vary)) {
+        if (!$vary) {
             return true;
         }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -74,11 +74,11 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
-            if (!empty($start) && $csvTime < $start) {
+            if ($start && $csvTime < $start) {
                 continue;
             }
 
-            if (!empty($end) && $csvTime > $end) {
+            if ($end && $csvTime > $end) {
                 continue;
             }
 

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
@@ -56,10 +56,10 @@ class Adapter implements AdapterInterface
 
         // Per RFC 4514, leading/trailing spaces should be encoded in DNs, as well as carriage returns.
         if ($flags & \LDAP_ESCAPE_DN) {
-            if (!empty($value) && ' ' === $value[0]) {
+            if ($value && ' ' === $value[0]) {
                 $value = '\\20'.substr($value, 1);
             }
-            if (!empty($value) && ' ' === $value[\strlen($value) - 1]) {
+            if ($value && ' ' === $value[\strlen($value) - 1]) {
                 $value = substr($value, 0, -1).'\\20';
             }
             $value = str_replace("\r", '\0d', $value);

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -175,7 +175,7 @@ class Query extends AbstractQuery
         // This is not supported in PHP < 7.2, so these versions will remain broken.
         $ctl = [];
         ldap_get_option($con, \LDAP_OPT_SERVER_CONTROLS, $ctl);
-        if (!empty($ctl)) {
+        if ($ctl) {
             foreach ($ctl as $idx => $info) {
                 if (static::PAGINATION_OID == $info['oid']) {
                     unset($ctl[$idx]);

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
@@ -115,7 +115,7 @@ final class AzureApiTransport extends AbstractApiTransport
             'senderAddress' => $envelope->getSender()->getAddress(),
             'attachments' => $this->getMessageAttachments($email),
             'userEngagementTrackingDisabled' => $this->disableTracking,
-            'headers' => empty($headers = $this->getMessageCustomHeaders($email)) ? null : $headers,
+            'headers' => ($headers = $this->getMessageCustomHeaders($email)) ? $headers : null,
             'importance' => $this->getPriorityLevel($email->getPriority()),
         ];
 
@@ -167,7 +167,7 @@ final class AzureApiTransport extends AbstractApiTransport
      */
     private function getAzureCSEndpoint(): string
     {
-        return !empty($this->host) ? $this->host : sprintf(self::HOST, $this->resourceName);
+        return $this->host ?: sprintf(self::HOST, $this->resourceName);
     }
 
     private function generateContentHash(string $content): string

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -156,7 +156,7 @@ class Connection
         }
 
         $parsedPath = explode('/', ltrim($params['path'] ?? '/', '/'));
-        if (\count($parsedPath) > 0 && !empty($queueName = end($parsedPath))) {
+        if (\count($parsedPath) > 0 && ($queueName = end($parsedPath))) {
             $configuration['queue_name'] = $queueName;
         }
         $configuration['account'] = 2 === \count($parsedPath) ? $parsedPath[0] : $options['account'] ?? self::DEFAULT_OPTIONS['account'];
@@ -202,7 +202,7 @@ class Connection
      */
     private function getPendingMessages(): \Generator
     {
-        while (!empty($this->buffer)) {
+        while ($this->buffer) {
             yield array_shift($this->buffer);
         }
     }

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransportFactory.php
@@ -37,15 +37,15 @@ final class NtfyTransportFactory extends AbstractTransportFactory
         }
 
         $transport = (new NtfyTransport($topic, $secureHttp))->setHost($host);
-        if (!empty($port = $dsn->getPort())) {
+        if ($port = $dsn->getPort()) {
             $transport->setPort($port);
         }
 
-        if (!empty($user = $dsn->getUser())) {
+        if ($user = $dsn->getUser()) {
             $transport->setUser($user);
         }
 
-        if (!empty($password = $dsn->getPassword())) {
+        if ($password = $dsn->getPassword()) {
             $transport->setPassword($password);
         }
 

--- a/src/Symfony/Component/PasswordHasher/Hasher/PlaintextPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PlaintextPasswordHasher.php
@@ -64,7 +64,7 @@ class PlaintextPasswordHasher implements LegacyPasswordHasherInterface
 
     private function mergePasswordAndSalt(#[\SensitiveParameter] string $password, ?string $salt): string
     {
-        if (empty($salt)) {
+        if (!$salt) {
             return $password;
         }
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -82,7 +82,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
         $shortDescription = $docBlock->getSummary();
 
-        if (!empty($shortDescription)) {
+        if ($shortDescription) {
             return $shortDescription;
         }
 
@@ -90,7 +90,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             if ($var && !$var instanceof InvalidTag) {
                 $varDescription = $var->getDescription()->render();
 
-                if (!empty($varDescription)) {
+                if ($varDescription) {
                     return $varDescription;
                 }
             }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
@@ -26,16 +26,16 @@ final class PersistentToken implements PersistentTokenInterface
 
     public function __construct(string $class, string $userIdentifier, string $series, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed)
     {
-        if (empty($class)) {
+        if (!$class) {
             throw new \InvalidArgumentException('$class must not be empty.');
         }
         if ('' === $userIdentifier) {
             throw new \InvalidArgumentException('$userIdentifier must not be empty.');
         }
-        if (empty($series)) {
+        if (!$series) {
             throw new \InvalidArgumentException('$series must not be empty.');
         }
-        if (empty($tokenValue)) {
+        if (!$tokenValue) {
             throw new \InvalidArgumentException('$tokenValue must not be empty.');
         }
 

--- a/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
@@ -74,7 +74,7 @@ final class Cas2Handler implements AccessTokenHandlerInterface
             throw new AuthenticationException('No ticket found in request.');
         }
         unset($query['ticket']);
-        $queryString = empty($query) ? '' : '?'.http_build_query($query);
+        $queryString = $query ? '?'.http_build_query($query) : '';
 
         return sprintf('%s?ticket=%s&service=%s',
             $this->validationUrl,

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -57,7 +57,7 @@ class ContextListener extends AbstractListener
      */
     public function __construct(TokenStorageInterface $tokenStorage, iterable $userProviders, string $contextKey, ?LoggerInterface $logger = null, ?EventDispatcherInterface $dispatcher = null, ?AuthenticationTrustResolverInterface $trustResolver = null, ?callable $sessionTrackerEnabler = null)
     {
-        if (empty($contextKey)) {
+        if (!$contextKey) {
             throw new \InvalidArgumentException('$contextKey must not be empty.');
         }
 

--- a/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
@@ -29,11 +29,11 @@ class DiscriminatorMap
         private readonly string $typeProperty,
         private readonly array $mapping,
     ) {
-        if (empty($typeProperty)) {
+        if (!$typeProperty) {
             throw new InvalidArgumentException(sprintf('Parameter "typeProperty" given to "%s" cannot be empty.', static::class));
         }
 
-        if (empty($mapping)) {
+        if (!$mapping) {
             throw new InvalidArgumentException(sprintf('Parameter "mapping" given to "%s" cannot be empty.', static::class));
         }
     }

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -62,7 +62,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
         if (!is_iterable($data)) {
             $data = [[$data]];
-        } elseif (empty($data)) {
+        } elseif (!$data) {
             $data = [[]];
         } else {
             // Sequential arrays of arrays are considered as collections
@@ -191,7 +191,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
             return $result;
         }
 
-        if (empty($result) || isset($result[1])) {
+        if (!$result || isset($result[1])) {
             return $result;
         }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -160,7 +160,7 @@ class YamlFileLoader extends FileLoader
 
         $classes = $this->yamlParser->parseFile($this->file, Yaml::PARSE_CONSTANT);
 
-        if (empty($classes)) {
+        if (!$classes) {
             return [];
         }
 

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -103,7 +103,7 @@ class StopwatchEvent
      */
     public function isStarted(): bool
     {
-        return !empty($this->started);
+        return (bool) $this->started;
     }
 
     /**

--- a/src/Symfony/Component/Translation/Loader/QtFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/QtFileLoader.php
@@ -57,7 +57,7 @@ class QtFileLoader implements LoaderInterface
             foreach ($translations as $translation) {
                 $translationValue = (string) $translation->getElementsByTagName('translation')->item(0)->nodeValue;
 
-                if (!empty($translationValue)) {
+                if ($translationValue) {
                     $catalogue->set(
                         (string) $translation->getElementsByTagName('source')->item(0)->nodeValue,
                         $translationValue,

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -197,7 +197,7 @@ class XliffFileLoader implements LoaderInterface
      */
     private function utf8ToCharset(string $content, ?string $encoding = null): string
     {
-        if ('UTF-8' !== $encoding && !empty($encoding)) {
+        if ('UTF-8' !== $encoding && $encoding) {
             return mb_convert_encoding($content, $encoding, 'UTF-8');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -52,7 +52,7 @@ class ImageValidator extends FileValidator
 
         $size = @getimagesize($value);
 
-        if (empty($size) || (0 === $size[0]) || (0 === $size[1])) {
+        if (!$size || (0 === $size[0]) || (0 === $size[1])) {
             $this->context->buildViolation($constraint->sizeNotDetectedMessage)
                 ->setCode(Image::SIZE_NOT_DETECTED_ERROR)
                 ->addViolation();

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -35,7 +35,7 @@ class NotBlankValidator extends ConstraintValidator
             $value = ($constraint->normalizer)($value);
         }
 
-        if (false === $value || (empty($value) && '0' != $value)) {
+        if (false === $value || (!$value && '0' != $value)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(NotBlank::IS_BLANK_ERROR)

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -91,9 +91,7 @@ class Regex extends Constraint
     {
         // If htmlPattern is specified, use it
         if (null !== $this->htmlPattern) {
-            return empty($this->htmlPattern)
-                ? null
-                : $this->htmlPattern;
+            return $this->htmlPattern ?: null;
         }
 
         // Quit if delimiters not at very beginning/end (e.g. when options are passed)

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -51,10 +51,10 @@ class Dumper
         $dumpObjectAsInlineMap = true;
 
         if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($input instanceof \ArrayObject || $input instanceof \stdClass)) {
-            $dumpObjectAsInlineMap = empty((array) $input);
+            $dumpObjectAsInlineMap = !(array) $input;
         }
 
-        if ($inline <= 0 || (!\is_array($input) && !$input instanceof TaggedValue && $dumpObjectAsInlineMap) || empty($input)) {
+        if ($inline <= 0 || (!\is_array($input) && !$input instanceof TaggedValue && $dumpObjectAsInlineMap) || !$input) {
             $output .= $prefix.Inline::dump($input, $flags);
         } elseif ($input instanceof TaggedValue) {
             $output .= $this->dumpTaggedValue($input, $inline, $indent, $flags, $prefix);
@@ -121,10 +121,10 @@ class Dumper
                 $dumpObjectAsInlineMap = true;
 
                 if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($value instanceof \ArrayObject || $value instanceof \stdClass)) {
-                    $dumpObjectAsInlineMap = empty((array) $value);
+                    $dumpObjectAsInlineMap = !(array) $value;
                 }
 
-                $willBeInlined = $inline - 1 <= 0 || !\is_array($value) && $dumpObjectAsInlineMap || empty($value);
+                $willBeInlined = $inline - 1 <= 0 || !\is_array($value) && $dumpObjectAsInlineMap || !$value;
 
                 $output .= sprintf('%s%s%s%s',
                     $prefix,

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -494,7 +494,7 @@ class Parser
             $data = $object;
         }
 
-        return empty($data) ? null : $data;
+        return $data ?: null;
     }
 
     private function parseBlock(int $offset, string $yaml, int $flags): mixed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  |no
| Deprecations? |  no
| Issues        | 
| License       | MIT

I've written a rector for this https://github.com/rectorphp/rector-src/pull/5783 and decided to apply it on Symfony src here.

As for motivation for removing empty where possible, in my and several other prominent devs opinions, using `empty()` is a bad practice for several reasons:
- it's misleading. It doesn't work with collection or stringable objects. Its meaning is more like `isset($foo) && (bool) $foo` rather than `count($foo) === 0` or `strlen($foo) === 0`, contrary to name of this function.
- it decreases safety of the code, because it's doing implicit `isset` call, so once you remove variable assignment, `empty()` call that references it continues silently working
- it increases complexity because of having to negate the call in most cases (there is no `nonempty()` function). This is unlike everywhere else where people work with `has()`, here you have to consciously reverse meaning with `hasNot()` in single case
- it's unnecessary in most cases and hence adds extra opcodes and increases length of code for no good reason
- it makes you not being able to use short form of ternaries with `?:`

There were also several articles written on this topic, I know about these 2:
- https://www.contextualcode.com/Blog/php-micro-optimization.-variable-boolean-cast-vs-!empty
- https://www.beberlei.de/2021/02/19/when_to_use_empty_in_php_i_say_never.html (this one is from @beberlei)

However, personally I'm not in a super strict camp. I like that I don't have to explicitly specify `[] === $foo` or `'' === $foo` or `null === $foo` (and so on and on)  and I think Symfony shares the similar opinion.