### PR TITLE
[DoctrineBridge] Deprecate auto-mapping of entities in favor of mapped route parameters

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
@@ -47,6 +47,7 @@ class MapEntity extends ValueResolver
         public ?string $message = null,
     ) {
         parent::__construct($resolver, $disabled);
+        $this->selfValidate();
     }
 
     public function withDefaults(self $defaults, ?string $class): static
@@ -62,6 +63,22 @@ class MapEntity extends ValueResolver
         $clone->evictCache ??= $defaults->evictCache ?? false;
         $clone->message ??= $defaults->message;
 
+        $clone->selfValidate();
+
         return $clone;
+    }
+
+    private function selfValidate(): void
+    {
+        if (!$this->id) {
+            return;
+        }
+        if ($this->mapping) {
+            throw new \LogicException('The "id" and "mapping" options cannot be used together on #[MapEntity] attributes.');
+        }
+        if ($this->exclude) {
+            throw new \LogicException('The "id" and "exclude" options cannot be used together on #[MapEntity] attributes.');
+        }
+        $this->mapping = [];
     }
 }

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow `EntityValueResolver` to return a list of entities
  * Add support for auto-closing idle connections
  * Allow validating every class against `UniqueEntity` constraint
+ * Deprecate auto-mapping of entities in favor of mapped route parameters
 
 7.0
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -60,7 +60,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
                     if ($attribute->disabled) {
                         $disabledResolvers[$attribute->resolver] = true;
                     } elseif ($resolverName) {
-                        throw new \LogicException(sprintf('You can only pin one resolver per argument, but argument "$%s" of "%s()" has more.', $metadata->getName(), $this->getPrettyName($controller)));
+                        throw new \LogicException(sprintf('You can only pin one resolver per argument, but argument "$%s" of "%s()" has more.', $metadata->getName(), $metadata->getControllerName()));
                     } else {
                         $resolverName = $attribute->resolver;
                     }
@@ -118,7 +118,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
                 }
             }
 
-            throw new \RuntimeException(sprintf('Controller "%s" requires the "$%s" argument that could not be resolved. '.($reasonCounter > 1 ? 'Possible reasons: ' : '').'%s', $this->getPrettyName($controller), $metadata->getName(), implode(' ', $reasons)));
+            throw new \RuntimeException(sprintf('Controller "%s" requires the "$%s" argument that could not be resolved. '.($reasonCounter > 1 ? 'Possible reasons: ' : '').'%s', $metadata->getControllerName(), $metadata->getName(), implode(' ', $reasons)));
         }
 
         return $arguments;
@@ -136,22 +136,5 @@ final class ArgumentResolver implements ArgumentResolverInterface
             new DefaultValueResolver(),
             new VariadicValueResolver(),
         ];
-    }
-
-    private function getPrettyName($controller): string
-    {
-        if (\is_array($controller)) {
-            if (\is_object($controller[0])) {
-                $controller[0] = get_debug_type($controller[0]);
-            }
-
-            return $controller[0].'::'.$controller[1];
-        }
-
-        if (\is_object($controller)) {
-            return get_debug_type($controller);
-        }
-
-        return $controller;
     }
 }

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -31,6 +31,7 @@ class ArgumentMetadata
         private mixed $defaultValue,
         private bool $isNullable = false,
         private array $attributes = [],
+        private string $controllerName = 'n/a',
     ) {
         $this->isNullable = $isNullable || null === $type || ($hasDefaultValue && null === $defaultValue);
     }
@@ -134,5 +135,10 @@ class ArgumentMetadata
         }
 
         return $attributes;
+    }
+
+    public function getControllerName(): string
+    {
+        return $this->controllerName;
     }
 }

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -22,6 +22,7 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
     {
         $arguments = [];
         $reflector ??= new \ReflectionFunction($controller(...));
+        $controllerName = $this->getPrettyName($reflector);
 
         foreach ($reflector->getParameters() as $param) {
             $attributes = [];
@@ -31,7 +32,7 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
                 }
             }
 
-            $arguments[] = new ArgumentMetadata($param->getName(), $this->getType($param), $param->isVariadic(), $param->isDefaultValueAvailable(), $param->isDefaultValueAvailable() ? $param->getDefaultValue() : null, $param->allowsNull(), $attributes);
+            $arguments[] = new ArgumentMetadata($param->getName(), $this->getType($param), $param->isVariadic(), $param->isDefaultValueAvailable(), $param->isDefaultValueAvailable() ? $param->getDefaultValue() : null, $param->allowsNull(), $attributes, $controllerName);
         }
 
         return $arguments;
@@ -52,5 +53,20 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
             'parent' => get_parent_class($parameter->getDeclaringClass()?->name ?? '') ?: null,
             default => $name,
         };
+    }
+
+    private function getPrettyName(\ReflectionFunctionAbstract $r): string
+    {
+        $name = $r->name;
+
+        if ($r instanceof \ReflectionMethod) {
+            return $r->class.'::'.$name;
+        }
+
+        if ($r->isAnonymous() || !$class = $r->getClosureCalledClass()) {
+            return $name;
+        }
+
+        return $class->name.'::'.$name;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -184,7 +184,7 @@ class ArgumentResolverTest extends TestCase
         $controller = (new ArgumentResolverTestController())->controllerWithFoo(...);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Controller "Closure" requires the "$foo" argument that could not be resolved. Either the argument is nullable and no null value has been provided, no default value has been provided or there is a non-optional argument after this one.');
+        $this->expectExceptionMessage('Controller "'.ArgumentResolverTestController::class.'::controllerWithFoo" requires the "$foo" argument that could not be resolved. Either the argument is nullable and no null value has been provided, no default value has been provided or there is a non-optional argument after this one.');
         self::getResolver()->getArguments($request, $controller);
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -32,12 +32,12 @@ class ArgumentMetadataFactoryTest extends TestCase
 
     public function testSignature1()
     {
-        $arguments = $this->factory->createArgumentMetadata($this->signature1(...));
+        $arguments = $this->factory->createArgumentMetadata([$this, 'signature1']);
 
         $this->assertEquals([
-            new ArgumentMetadata('foo', self::class, false, false, null),
-            new ArgumentMetadata('bar', 'array', false, false, null),
-            new ArgumentMetadata('baz', 'callable', false, false, null),
+            new ArgumentMetadata('foo', self::class, false, false, null, controllerName: $this::class.'::signature1'),
+            new ArgumentMetadata('bar', 'array', false, false, null, controllerName: $this::class.'::signature1'),
+            new ArgumentMetadata('baz', 'callable', false, false, null, controllerName: $this::class.'::signature1'),
         ], $arguments);
     }
 
@@ -46,9 +46,9 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata($this->signature2(...));
 
         $this->assertEquals([
-            new ArgumentMetadata('foo', self::class, false, true, null, true),
-            new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, true, null, true),
-            new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, true, null, true),
+            new ArgumentMetadata('foo', self::class, false, true, null, true, controllerName: $this::class.'::signature2'),
+            new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, true, null, true, controllerName: $this::class.'::signature2'),
+            new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, true, null, true, controllerName: $this::class.'::signature2'),
         ], $arguments);
     }
 
@@ -57,8 +57,8 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata($this->signature3(...));
 
         $this->assertEquals([
-            new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, false, null),
-            new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, false, null),
+            new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, false, null, controllerName: $this::class.'::signature3'),
+            new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, false, null, controllerName: $this::class.'::signature3'),
         ], $arguments);
     }
 
@@ -67,9 +67,9 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata($this->signature4(...));
 
         $this->assertEquals([
-            new ArgumentMetadata('foo', null, false, true, 'default'),
-            new ArgumentMetadata('bar', null, false, true, 500),
-            new ArgumentMetadata('baz', null, false, true, []),
+            new ArgumentMetadata('foo', null, false, true, 'default', controllerName: $this::class.'::signature4'),
+            new ArgumentMetadata('bar', null, false, true, 500, controllerName: $this::class.'::signature4'),
+            new ArgumentMetadata('baz', null, false, true, [], controllerName: $this::class.'::signature4'),
         ], $arguments);
     }
 
@@ -78,8 +78,8 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata($this->signature5(...));
 
         $this->assertEquals([
-            new ArgumentMetadata('foo', 'array', false, true, null, true),
-            new ArgumentMetadata('bar', null, false, true, null, true),
+            new ArgumentMetadata('foo', 'array', false, true, null, true, controllerName: $this::class.'::signature5'),
+            new ArgumentMetadata('bar', null, false, true, null, true, controllerName: $this::class.'::signature5'),
         ], $arguments);
     }
 
@@ -88,8 +88,8 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata([new VariadicController(), 'action']);
 
         $this->assertEquals([
-            new ArgumentMetadata('foo', null, false, false, null),
-            new ArgumentMetadata('bar', null, true, false, null),
+            new ArgumentMetadata('foo', null, false, false, null, controllerName: VariadicController::class.'::action'),
+            new ArgumentMetadata('bar', null, true, false, null, controllerName: VariadicController::class.'::action'),
         ], $arguments);
     }
 
@@ -98,9 +98,9 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata([new BasicTypesController(), 'action']);
 
         $this->assertEquals([
-            new ArgumentMetadata('foo', 'string', false, false, null),
-            new ArgumentMetadata('bar', 'int', false, false, null),
-            new ArgumentMetadata('baz', 'float', false, false, null),
+            new ArgumentMetadata('foo', 'string', false, false, null, controllerName: BasicTypesController::class.'::action'),
+            new ArgumentMetadata('bar', 'int', false, false, null, controllerName: BasicTypesController::class.'::action'),
+            new ArgumentMetadata('baz', 'float', false, false, null, controllerName: BasicTypesController::class.'::action'),
         ], $arguments);
     }
 
@@ -109,9 +109,9 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata($this->signature1(...));
 
         $this->assertEquals([
-            new ArgumentMetadata('foo', self::class, false, false, null),
-            new ArgumentMetadata('bar', 'array', false, false, null),
-            new ArgumentMetadata('baz', 'callable', false, false, null),
+            new ArgumentMetadata('foo', self::class, false, false, null, controllerName: $this::class.'::signature1'),
+            new ArgumentMetadata('bar', 'array', false, false, null, controllerName: $this::class.'::signature1'),
+            new ArgumentMetadata('baz', 'callable', false, false, null, controllerName: $this::class.'::signature1'),
         ], $arguments);
     }
 
@@ -120,10 +120,10 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata([new NullableController(), 'action']);
 
         $this->assertEquals([
-            new ArgumentMetadata('foo', 'string', false, false, null, true),
-            new ArgumentMetadata('bar', \stdClass::class, false, false, null, true),
-            new ArgumentMetadata('baz', 'string', false, true, 'value', true),
-            new ArgumentMetadata('last', 'string', false, true, '', false),
+            new ArgumentMetadata('foo', 'string', false, false, null, true, controllerName: NullableController::class.'::action'),
+            new ArgumentMetadata('bar', \stdClass::class, false, false, null, true, controllerName: NullableController::class.'::action'),
+            new ArgumentMetadata('baz', 'string', false, true, 'value', true, controllerName: NullableController::class.'::action'),
+            new ArgumentMetadata('last', 'string', false, true, '', false, controllerName: NullableController::class.'::action'),
         ], $arguments);
     }
 
@@ -132,7 +132,7 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata([new AttributeController(), 'action']);
 
         $this->assertEquals([
-            new ArgumentMetadata('baz', 'string', false, false, null, false, [new Foo('bar')]),
+            new ArgumentMetadata('baz', 'string', false, false, null, false, [new Foo('bar')], controllerName: AttributeController::class.'::action'),
         ], $arguments);
     }
 
@@ -146,8 +146,8 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([new AttributeController(), 'issue41478']);
         $this->assertEquals([
-            new ArgumentMetadata('baz', 'string', false, false, null, false, [new Foo('bar')]),
-            new ArgumentMetadata('bat', 'string', false, false, null, false, []),
+            new ArgumentMetadata('baz', 'string', false, false, null, false, [new Foo('bar')], controllerName: AttributeController::class.'::issue41478'),
+            new ArgumentMetadata('bat', 'string', false, false, null, false, [], controllerName: AttributeController::class.'::issue41478'),
         ], $arguments);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | 
| Issues        | Fix #50739
| License       | MIT

Auto-mapping of entities on controllers is a foot-gun when multiple entities are listed on the signature of the controller.
This is described extensively by e.g. @stof in the linked issue and in a few others.

The issue is that we try to use all request attributes to call a `findOneBy`, but when there are many entities, there can be an overlap in the naming of the field/associations of both entities.

In this PR, I propose to deprecate auto-mapping and to replace it with mapped route parameters, as introduced in #54720.

If we go this way, people that use auto-mapping to e.g. load a `$conference` based on its `{slug}` will have to declare the mapping by using `{slug:conference}` instead. That makes everything explicit and keeps a nice DX IMHO, by not forcing a `#[MapEntity]` attribute for simple cases.