### PR TITLE
[HttpKernel] Add `MapSessionParameter` to map session parameters to controllers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeVal
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ServiceValueResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionParameterValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\UidValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\VariadicValueResolver;
@@ -100,6 +101,9 @@ return static function (ContainerConfigurator $container) {
 
         ->set('argument_resolver.query_parameter_value_resolver', QueryParameterValueResolver::class)
             ->tag('controller.targeted_value_resolver', ['name' => QueryParameterValueResolver::class])
+
+        ->set('argument_resolver.session_parameter_value_resolver', SessionParameterValueResolver::class)
+            ->tag('controller.targeted_value_resolver', ['name' => SessionParameterValueResolver::class])
 
         ->set('response_listener', ResponseListener::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/error-handler": "^7.3",
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-foundation": "^7.3",
-        "symfony/http-kernel": "^7.2",
+        "symfony/http-kernel": "^7.3",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "^7.1",
         "symfony/finder": "^6.4|^7.0",

--- a/src/Symfony/Component/HttpKernel/Attribute/MapSessionParameter.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapSessionParameter.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionParameterValueResolver;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+
+/**
+ * Can be used to pass a session parameter to a controller argument.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class MapSessionParameter extends ValueResolver
+{
+    /**
+     * @param string|null                                 $name     The name of the session parameter; if null, the name of the argument in the controller will be used
+     * @param class-string<ValueResolverInterface>|string $resolver The name of the resolver to use
+     */
+    public function __construct(
+        public ?string $name = null,
+        string $resolver = SessionParameterValueResolver::class,
+    ) {
+        parent::__construct($resolver);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,7 +8,8 @@ CHANGELOG
  * Support `Uid` in `#[MapQueryParameter]`
  * Add `ServicesResetterInterface`, implemented by `ServicesResetter`
  * Allow configuring the logging channel per type of exceptions in ErrorListener
- 
+ * Add `#[MapSessionParameter]` to pass a session parameter to a controller argument
+
 7.2
 ---
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionParameterValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionParameterValueResolver.php
@@ -29,7 +29,13 @@ final class SessionParameterValueResolver implements ValueResolverInterface
         }
 
         if ((!$type = $argument->getType()) || (!class_exists($type) && !interface_exists($type, false))) {
-            throw new \LogicException(\sprintf('#[MapSessionParameter] cannot be used on controller argument "$%s": "%s" is not a class or interface name.', $argument->getName(), $type));
+            if ($type && (str_contains($type, '|') || str_contains($type, '&'))) {
+                if (!$argument->hasDefaultValue() && !$argument->isNullable()) {
+                    throw new \LogicException(\sprintf('#[MapSessionParameter] cannot be used on controller argument "$%s": "%s" is an union or intersection type, you need to make the parameter nullable or provide a default value..', $argument->getName(), $type));
+                }
+            } else {
+                throw new \LogicException(\sprintf('#[MapSessionParameter] cannot be used on controller argument "$%s": "%s" is not a class or interface name.', $argument->getName(), $type));
+            }
         }
 
         if (interface_exists($type, false) && !$argument->hasDefaultValue() && !$argument->isNullable()) {
@@ -39,14 +45,21 @@ final class SessionParameterValueResolver implements ValueResolverInterface
         $name = $attribute->name ?? $argument->getName();
         if ($request->getSession()->has($name)) {
             $value = $request->getSession()->get($name);
-            if (!$value instanceof $type) {
+            if (!$value instanceof $type && !str_contains($type, '|') && !str_contains($type, '&')) {
                 throw new \LogicException(\sprintf('#[MapSessionParameter] cannot be used to map controller argument "$%s": the session contains a value of type "%s" which is not an instance of "%s".', $argument->getName(), get_debug_type($value), $type));
             }
 
             return [$value];
         }
 
-        if (\is_object($value = $argument->hasDefaultValue() ? $argument->getDefaultValue() : new $type())) {
+        if ($argument->hasDefaultValue()) {
+            $value = $argument->getDefaultValue();
+        } else {
+            // handle the type SessionInterface|null $param, which doesn't have a default value and can't be instantiated.
+            $value = class_exists($type, false) ? new $type() : null;
+        }
+
+        if (\is_object($value)) {
             $request->getSession()->set($name, $value);
         }
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionParameterValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionParameterValueResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapSessionParameter;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+final class SessionParameterValueResolver implements ValueResolverInterface
+{
+    public function resolve(Request $request, ArgumentMetadata $argument): array
+    {
+        if (!$attribute = $argument->getAttributesOfType(MapSessionParameter::class, ArgumentMetadata::IS_INSTANCEOF)[0] ?? null) {
+            return [];
+        }
+
+        if (!$request->hasSession()) {
+            return [];
+        }
+
+        if ((!$type = $argument->getType()) || (!class_exists($type) && !interface_exists($type, false))) {
+            throw new \LogicException(\sprintf('#[MapSessionParameter] cannot be used on controller argument "$%s": "%s" is not a class or interface name.', $argument->getName(), $type));
+        }
+
+        if (interface_exists($type, false) && !$argument->hasDefaultValue() && !$argument->isNullable()) {
+            throw new \LogicException(\sprintf('#[MapSessionParameter] cannot be used on controller argument "$%s": "%s" is an interface, you need to make the parameter nullable or provide a default value.', $argument->getName(), $type));
+        }
+
+        $name = $attribute->name ?? $argument->getName();
+        if ($request->getSession()->has($name)) {
+            $value = $request->getSession()->get($name);
+            if (!$value instanceof $type) {
+                throw new \LogicException(\sprintf('#[MapSessionParameter] cannot be used to map controller argument "$%s": the session contains a value of type "%s" which is not an instance of "%s".', $argument->getName(), get_debug_type($value), $type));
+            }
+
+            return [$value];
+        }
+
+        if (\is_object($value = $argument->hasDefaultValue() ? $argument->getDefaultValue() : new $type())) {
+            $request->getSession()->set($name, $value);
+        }
+
+        return [$value];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/SessionParameterValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/SessionParameterValueResolverTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Attribute\MapSessionParameter;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionParameterValueResolver;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+class SessionParameterValueResolverTest extends TestCase
+{
+    private ValueResolverInterface $resolver;
+
+    private Request $request;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new SessionParameterValueResolver();
+
+        $session = new Session(new MockArraySessionStorage());
+        $this->request = Request::create('/');
+        $this->request->setSession($session);
+    }
+
+    public function testSkipWhenNoAttribute()
+    {
+        $metadata = new ArgumentMetadata('browsingContext', 'string', false, true, false);
+
+        $this->assertSame([], $this->resolver->resolve($this->request, $metadata));
+    }
+
+    public function testSkipWhenNoSession()
+    {
+        $metadata = new ArgumentMetadata('MySessionObject', BasicSessionParameter::class, false, false, false, attributes: [new MapSessionParameter()]);
+
+        $this->assertSame([], $this->resolver->resolve(Request::create('/'), $metadata));
+    }
+
+    /**
+     * @dataProvider invalidArgumentTypeProvider
+     */
+    public function testResolvingWithInvalidArgumentType(ArgumentMetadata $metadata, string $exceptionMessage)
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($exceptionMessage);
+
+        $this->resolver->resolve($this->request, $metadata);
+    }
+
+    /**
+     * @return iterable<string, array{ArgumentMetadata,string}>
+     */
+    public static function invalidArgumentTypeProvider(): iterable
+    {
+        yield 'untyped parameter' => [
+            new ArgumentMetadata('MySessionObject', null, false, false, false, attributes: [new MapSessionParameter()]),
+            '#[MapSessionParameter] cannot be used on controller argument "$MySessionObject": "" is not a class or interface name.',
+        ];
+
+        yield 'scalar parameter' => [
+            new ArgumentMetadata('MySessionObject', 'string', false, false, false, attributes: [new MapSessionParameter()]),
+            '#[MapSessionParameter] cannot be used on controller argument "$MySessionObject": "string" is not a class or interface name.',
+        ];
+
+        yield 'variadic scalar parameter' => [
+            new ArgumentMetadata('MySessionObject', 'string', true, false, false, true, attributes: [new MapSessionParameter()]),
+            '#[MapSessionParameter] cannot be used on controller argument "$MySessionObject": "string" is not a class or interface name.',
+        ];
+
+        yield 'interface without default value and not nullable' => [
+            new ArgumentMetadata('MySessionObject', SessionParameterInterface::class, false, false, false, attributes: [new MapSessionParameter()]),
+            '#[MapSessionParameter] cannot be used on controller argument "$MySessionObject": "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\SessionParameterInterface" is an interface, you need to make the parameter nullable or provide a default value.',
+        ];
+    }
+
+    /**
+     * @dataProvider validDataProvider
+     */
+    public function testResolvingSuccessfully(ArgumentMetadata $metadata, ?string $expectedType)
+    {
+        $result = $this->resolver->resolve($this->request, $metadata);
+        $this->assertCount(1, $result);
+
+        if (null === $expectedType) {
+            $this->assertNull($result[0]);
+        } else {
+            $this->assertInstanceOf($expectedType, $result[0]);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{ArgumentMetadata,string|null}>
+     */
+    public static function validDataProvider(): iterable
+    {
+        yield 'typed parameter with properties' => [
+            new ArgumentMetadata('MySessionObject', BasicSessionParameter::class, false, false, false, attributes: [new MapSessionParameter()]),
+            BasicSessionParameter::class,
+        ];
+        yield 'typed parameter without properties' => [
+            new ArgumentMetadata('MySessionObject', EmptySessionParameter::class, false, false, false, attributes: [new MapSessionParameter()]),
+            EmptySessionParameter::class,
+        ];
+        yield 'stdClass parameter' => [
+            new ArgumentMetadata('MySessionObject', \stdClass::class, false, false, false, attributes: [new MapSessionParameter()]),
+            \stdClass::class,
+        ];
+        yield 'variadic parameter' => [
+            new ArgumentMetadata('MySessionObject', BasicSessionParameter::class, true, false, false, attributes: [new MapSessionParameter()]),
+            BasicSessionParameter::class,
+        ];
+        yield 'nullable parameter' => [
+            new ArgumentMetadata('MySessionObject', BasicSessionParameter::class, false, false, false, true, attributes: [new MapSessionParameter()]),
+            BasicSessionParameter::class,
+        ];
+        yield 'default to null parameter' => [
+            new ArgumentMetadata('MySessionObject', BasicSessionParameter::class, false, true, null, true, attributes: [new MapSessionParameter()]),
+            null,
+        ];
+        yield 'nullable interface without default value' => [
+            new ArgumentMetadata('MySessionObject', SessionParameterInterface::class, false, true, null, true, attributes: [new MapSessionParameter()]),
+            null,
+        ];
+        yield 'interface with default value' => [
+            new ArgumentMetadata('MySessionObject', SessionParameterInterface::class, false, true, new BasicSessionParameter(), false, attributes: [new MapSessionParameter()]),
+            BasicSessionParameter::class,
+        ];
+    }
+
+    public function testWithoutNameParameter()
+    {
+        $metadata = new ArgumentMetadata('MySessionObject', BasicSessionParameter::class, false, false, false, attributes: [new MapSessionParameter()]);
+        $this->resolver->resolve($this->request, $metadata);
+        $this->assertEquals(['MySessionObject'], array_keys($this->request->getSession()->all()));
+    }
+
+    /**
+     * @dataProvider sessionNameProvider
+     */
+    public function testNameParameter(?string $name, string $sessionKey)
+    {
+        $metadata = new ArgumentMetadata('MySessionObject', BasicSessionParameter::class, false, false, false, attributes: [
+            new MapSessionParameter($name),
+        ]);
+        $this->resolver->resolve($this->request, $metadata);
+        $this->assertEquals([$sessionKey], array_keys($this->request->getSession()->all()));
+    }
+
+    /**
+     * @return iterable<?string, string>
+     */
+    public static function sessionNameProvider(): iterable
+    {
+        yield 'no value' => [null, 'MySessionObject'];
+        yield 'same as class' => ['MySessionObject', 'MySessionObject'];
+        yield 'empty' => ['', ''];
+        yield 'other' => ['other', 'other'];
+    }
+
+    public function testResolvingCorrectTypeSuccessfully()
+    {
+        $this->request->getSession()->set('MySessionObject', new ExtendingEmptySessionParameter());
+        $result = $this->resolver->resolve($this->request, new ArgumentMetadata('MySessionObject', EmptySessionParameter::class, false, false, false, attributes: [new MapSessionParameter()]));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(EmptySessionParameter::class, $result[0]);
+    }
+
+    public function testResolvingCorrectInterfaceSuccessfully()
+    {
+        $this->request->getSession()->set('MySessionObject', new BasicSessionParameter());
+        $result = $this->resolver->resolve($this->request, new ArgumentMetadata('MySessionObject', SessionParameterInterface::class, false, false, false, isNullable: true, attributes: [new MapSessionParameter()]));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(SessionParameterInterface::class, $result[0]);
+    }
+
+    public function testResolvingIncorrectTypeFailure()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('#[MapSessionParameter] cannot be used to map controller argument "$MySessionObject": the session contains a value of type "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\BasicSessionParameter" which is not an instance of "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\EmptySessionParameter".');
+
+        $this->request->getSession()->set('MySessionObject', new BasicSessionParameter());
+        $this->resolver->resolve($this->request, new ArgumentMetadata('MySessionObject', EmptySessionParameter::class, false, false, false, attributes: [new MapSessionParameter()]));
+    }
+
+    public function testResolvingIncorrectInterfaceFailure()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('#[MapSessionParameter] cannot be used to map controller argument "$MySessionObject": the session contains a value of type "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\EmptySessionParameter" which is not an instance of "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\SessionParameterInterface".');
+
+        $this->request->getSession()->set('MySessionObject', new EmptySessionParameter());
+        $this->resolver->resolve($this->request, new ArgumentMetadata('MySessionObject', SessionParameterInterface::class, false, false, false, isNullable: true, attributes: [new MapSessionParameter()]));
+    }
+}
+
+class BasicSessionParameter implements SessionParameterInterface
+{
+    public $locale;
+}
+
+class EmptySessionParameter
+{
+}
+
+class ExtendingEmptySessionParameter extends EmptySessionParameter
+{
+}
+
+interface SessionParameterInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR | symfony/symfony-docs#19728

This attribute allow to map an object from/to the session. The read/write to the public properties are proxied to the session using the property name as a key, or the value defined by the attribute SessionKey. There is no prefix, so if two class use the same property, they will read/write to the same session entry, which is intended to have variable shared between context if needed.

This allow to type property and have ide autocompletion, static validation and runtime validation of type. The default value from the property is also used as a default value when reading from session.

Using this method reduce the errors related to a wrong key used or inconsistent default value. It also help seing which key are currently used and avoid conflicts

Calling isset will return if the property is defined in session but will not check if the value is null. Calling unset remove the entry from the session

For example, we can create a class like this :
```
class BrowsingSessionContext
{
    public string $locale = "en";

    public bool $preferDarkTheme = false;
}
```

and use it in a controller :
```
#[Route("/", name: "home")]
class DefaultController extends AbstractController
{
    public function __invoke(
        Request $request,
        #[MapSessionContext] BrowsingSessionContext $browsingSessionContext,
    ) {
        $localeSelector                 = $this
            ->createFormBuilder($browsingSessionContext)
            ->add("locale", TextType::class)
            ->add("preferDarkTheme", CheckboxType::class)
            ->add("submit", SubmitType::class)
            ->getForm()
        ;
        $localeSelector->handleRequest($request);
        if ($localeSelector->isSubmitted() && $localeSelector->isValid()) {
            return $this->redirectToRoute("home");
        }

        return $this->render("index.html.twig", [
            "value"          => $browsingSessionContext->locale,
            "localeSelector" => $localeSelector,
        ]);
    }
}
```

The term session context come from the idea that we get a lot of information that are often together. I avoided to use something too close of Object to avoid confusion with the SessionInterface object.

This pull request is based in HttpKernel to be close to `SessionValueResolver` but i'm not confident if the namespaces used are the right ones.

I'm not fond of the eval to create the anonymous class, but didn't managed to create an anonymous class without that. Also, i'm not sure if it's possible to create a proxy during container build in this context.
