### PR TITLE
[FrameworkBundle] Add more shortcuts to throw additional 4xx exceptions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -30,7 +30,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -295,6 +300,66 @@ abstract class AbstractController implements ServiceSubscriberInterface
     protected function createNotFoundException(string $message = 'Not Found', ?\Throwable $previous = null): NotFoundHttpException
     {
         return new NotFoundHttpException($message, $previous);
+    }
+
+    /**
+     * Returns a BadRequestHttpException.
+     *
+     * This will result in a 400 response code. Usage example:
+     *
+     *     throw $this->createBadRequestException('Bad request!');
+     */
+    protected function createBadRequestException(string $message = 'Bad request', ?\Throwable $previous = null): BadRequestHttpException
+    {
+        return new BadRequestHttpException($message, $previous);
+    }
+
+    /**
+     * Returns an UnauthorizedHttpException.
+     *
+     * This will result in a 401 response code. Usage example:
+     *
+     *     throw $this->createUnauthorizedException('Unauthorized!');
+     */
+    protected function createUnauthorizedException(string $message = 'Unauthorized', ?\Throwable $previous = null): UnauthorizedHttpException
+    {
+        return new UnauthorizedHttpException($message, $previous);
+    }
+
+    /**
+     * Returns an ConflictHttpException.
+     *
+     * This will result in a 409 response code. Usage example:
+     *
+     *     throw $this->createConflictException('Conflict!');
+     */
+    protected function createConflictException(string $message = 'Conflict', ?\Throwable $previous = null): ConflictHttpException
+    {
+        return new ConflictHttpException($message, $previous);
+    }
+
+    /**
+     * Returns an GoneHttpException.
+     *
+     * This will result in a 410 response code. Usage example:
+     *
+     *     throw $this->createConflictException('Gone!');
+     */
+    protected function createGoneException(string $message = 'Gone', ?\Throwable $previous = null): GoneHttpException
+    {
+        return new GoneHttpException($message, $previous);
+    }
+
+    /**
+     * Returns an UnprocessableEntityHttpException.
+     *
+     * This will result in a 422 response code. Usage example:
+     *
+     *     throw $this->createUnprocessableEntityException('Unprocessable entity!');
+     */
+    protected function createUnprocessableEntityException(string $message = 'Unprocessable entity', ?\Throwable $previous = null): UnprocessableEntityHttpException
+    {
+        return new UnprocessableEntityHttpException($message, $previous);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -321,9 +321,9 @@ abstract class AbstractController implements ServiceSubscriberInterface
      *
      *     throw $this->createUnauthorizedException('Unauthorized!');
      */
-    protected function createUnauthorizedException(string $message = 'Unauthorized', ?\Throwable $previous = null): UnauthorizedHttpException
+    protected function createUnauthorizedException(string $challenge = '', string $message = 'Unauthorized', ?\Throwable $previous = null): UnauthorizedHttpException
     {
-        return new UnauthorizedHttpException($message, $previous);
+        return new UnauthorizedHttpException($challenge, $message, $previous);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -35,7 +35,12 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
@@ -576,6 +581,41 @@ class AbstractControllerTest extends TestCase
         $controller = $this->createController();
 
         $this->assertInstanceOf(NotFoundHttpException::class, $controller->createNotFoundException());
+    }
+
+    public function testBadRequestException()
+    {
+        $controller = $this->createController();
+
+        $this->assertInstanceOf(BadRequestHttpException::class, $controller->createBadRequestException());
+    }
+
+    public function testUnauthorizedException()
+    {
+        $controller = $this->createController();
+
+        $this->assertInstanceOf(UnauthorizedHttpException::class, $controller->createUnauthorizedException());
+    }
+
+    public function testConflictException()
+    {
+        $controller = $this->createController();
+
+        $this->assertInstanceOf(ConflictHttpException::class, $controller->createConflictException());
+    }
+
+    public function testGoneException()
+    {
+        $controller = $this->createController();
+
+        $this->assertInstanceOf(GoneHttpException::class, $controller->createGoneException());
+    }
+
+    public function testUnprocessableEntityException()
+    {
+        $controller = $this->createController();
+
+        $this->assertInstanceOf(UnprocessableEntityHttpException::class, $controller->createUnprocessableEntityException());
     }
 
     public function testCreateForm()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

This PR aims to enhance the AbstractController base class by adding additional shortcuts for throwing 4xx exceptions. The goal is to ensure consistency across controllers that extend AbstractController by providing a unified approach for throwing 4xx exceptions. Currently, there are only two exceptions accessible via shortcuts in AbstractController, leading to inconsistency as other 4xx exceptions must be referenced directly through use-statements from the HttpKernel component. 

This PR comes with the following shortcuts to additional common 4xx exceptions:

- createBadRequestException();
- createUnauthorizedException();
- createConflictException();
- createGoneException();
- createUnprocessableEntityException();

