### PR TITLE
[Translation] Fix LocaleSwitcher throws when intl not loaded

### DIFF
--- a/src/Symfony/Component/Translation/LocaleSwitcher.php
+++ b/src/Symfony/Component/Translation/LocaleSwitcher.php
@@ -34,9 +34,14 @@ class LocaleSwitcher implements LocaleAwareInterface
 
     public function setLocale(string $locale): void
     {
-        if (class_exists(\Locale::class)) {
-            \Locale::setDefault($locale);
+        // Silently ignore if the intl extension is not loaded
+        try {
+            if (class_exists(\Locale::class, false)) {
+                \Locale::setDefault($locale);
+            }
+        } catch (\Exception) {
         }
+
         $this->locale = $locale;
         $this->requestContext?->setParameter('_locale', $locale);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix issue [1505](https://github.com/symfony/demo/issues/1505) (from Symfony demo)
| License       | MIT

LocaleSwitcher::setDefault() throw an exception when intl is not installed

> "The Symfony\Polyfill\Intl\Icu\Locale::setDefault() is not implemented. Please install the "intl" extension for full localization capabilities."

Fixed by following @stof suggestion

> Symfony should ignore this in the LocaleSwitcher, as already done in \Symfony\Component\HttpFoundation\Request::setLocale

