### PR TITLE
[Filesystem] Strengthen the check of file permissions in `dumpFile`

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -691,7 +691,7 @@ class Filesystem
                 throw new IOException(sprintf('Failed to write file "%s": ', $filename).self::$lastError, 0, null, $filename);
             }
 
-            self::box('chmod', $tmpFile, file_exists($filename) ? fileperms($filename) : 0666 & ~umask());
+            self::box('chmod', $tmpFile, @fileperms($filename) ?: 0666 & ~umask());
 
             $this->rename($tmpFile, $filename, true);
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54444
| License       | MIT

`fileperms()` can fail and return `false`, I think we should strengthen the checks on its return value when using it to avoid undesirable behavior.