### PR TITLE
[Filesystem] Change the picture used in a flaky tests

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -170,7 +170,7 @@ class FilesystemTest extends FilesystemTestCase
         if (!\in_array('https', stream_get_wrappers())) {
             $this->markTestSkipped('"https" stream wrapper is not enabled.');
         }
-        $sourceFilePath = 'https://symfony.com/images/common/logo/logo_symfony_header.png';
+        $sourceFilePath = 'https://symfony.com/logos/symfony_black_02.png';
         $targetFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_target_file';
 
         file_put_contents($targetFilePath, 'TARGET FILE');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

There's a [flaky test](https://github.com/symfony/symfony/actions/runs/8534031916/job/23377714887#step:7:342) in the CI for a while now because of an image file.

I tried comparing pictures with https://www.robots.ox.ac.uk and found the following intriguing result:

<img width="262" alt="Capture d’écran 2024-04-03 à 13 44 05" src="https://github.com/symfony/symfony/assets/2144837/449aed71-6693-422d-8490-83275e9f99c8">

I tried to compare the IDAT section of each PNG. They differ a bit, but nothing huge. But they differ, which cause the test to fail. After having a look for some time, I genuinely can't tell why is that. What I know for sure is that I've been able to reproduce it **once**, then I ran the test again and I couldn't reproduce it anymore. There's something with this logo that I can't understand. Or maybe some cache/CDN is involved?

I suggest using another picture (from https://symfony.com/logo) to avoid what happens with this precise picture. This will correct the flakiness of the test. The new picture is 8KB, the current one is 1.6KB which seems reasonable to me.