### PR TITLE
[Serializer] Ignore when using #[Ignore] on a non-accessor

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -138,11 +138,9 @@ class AnnotationLoader implements LoaderInterface
 
                     $attributeMetadata->setSerializedName($annotation->getSerializedName());
                 } elseif ($annotation instanceof Ignore) {
-                    if (!$accessorOrMutator) {
-                        throw new MappingException(sprintf('Ignore on "%s::%s()" cannot be added. Ignore can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
+                    if ($accessorOrMutator) {
+                        $attributeMetadata->setIgnore(true);
                     }
-
-                    $attributeMetadata->setIgnore(true);
                 } elseif ($annotation instanceof Context) {
                     if (!$accessorOrMutator) {
                         throw new MappingException(sprintf('Context on "%s::%s()" cannot be added. Context can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
@@ -141,13 +141,12 @@ abstract class AnnotationLoaderTestCase extends TestCase
     {
         $class = $this->getNamespace().'\Entity45016';
 
-        $this->expectException(MappingException::class);
-        $this->expectExceptionMessage(sprintf('Ignore on "%s::badIgnore()" cannot be added', $class));
-
         $metadata = new ClassMetadata($class);
         $loader = $this->getLoaderForContextMapping();
 
         $loader->loadClassMetadata($metadata);
+
+        $this->assertSame(['id'], array_keys($metadata->getAttributesMetadata()));
     }
 
     public function testIgnoreGetterWirhRequiredParameterIfIgnoreAnnotationIsUsed()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54477
| License       | MIT

Because ignore means ignore so we know what to do with the attribute even when it's on something else than an accessor.