### PR TITLE
[Validator] Accept `Stringable` in `ExecutionContext::build/addViolation()`

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -139,7 +139,7 @@ class ExecutionContext implements ExecutionContextInterface
         $this->constraint = $constraint;
     }
 
-    public function addViolation(string $message, array $parameters = []): void
+    public function addViolation(string|\Stringable $message, array $parameters = []): void
     {
         $this->violations->add(new ConstraintViolation(
             $this->translator->trans($message, $parameters, $this->translationDomain),
@@ -154,7 +154,7 @@ class ExecutionContext implements ExecutionContextInterface
         ));
     }
 
-    public function buildViolation(string $message, array $parameters = []): ConstraintViolationBuilderInterface
+    public function buildViolation(string|\Stringable $message, array $parameters = []): ConstraintViolationBuilderInterface
     {
         return new ConstraintViolationBuilder(
             $this->violations,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony-docs/issues/19704
| License       | MIT

`ConstraintViolationBuilder` accepts any stringable. We mentioned this [in the doc](https://symfony.com/doc/6.4/validation/translations.html) but it doesn't work as explained in the issue. I think `buildViolation()` could accept stringable, also given that `ExecutionContextInterface` defines the type as `string|Stringable` in the PHPDoc.

Same for `addViolation()`.