### PR TITLE
Make ServiceSubscriberTrait compatible with AbstractController for Symfony 7 with strong types

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -23,8 +23,7 @@ use Symfony\Contracts\Service\Attribute\SubscribedService;
  */
 trait ServiceSubscriberTrait
 {
-    /** @var ContainerInterface */
-    protected $container;
+    protected ContainerInterface $container;
 
     public static function getSubscribedServices(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | 🤔 
| License       | MIT

If you have a class like this: 

You get the following error in Symfony 7 with symfony/contracts 3.4.2: 
```php
<?php

namespace App\Controller;

use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Contracts\Service\ServiceSubscriberTrait;

abstract class DemoController extends AbstractController
{
    use ServiceSubscriberTrait;
    // ...
}
```

> Compile Error: Symfony\Bundle\FrameworkBundle\Controller\AbstractController and Symfony\Contracts\Service\ServiceSubscriberTrait define the same property ($container) in the composition of App\Controller\DemoController. However, the definition differs and is considered incompatible. Class was composed

`ServiceSubscriberTrait::$container` is defined as: 
```php
    /** @var ContainerInterface */
    protected $container;
```

While `AbstractController::$container` is: 
```php
    protected ContainerInterface $container;
```

This leads to the incompatible composition.

This PR would fix that, but I'm not sure which versions of symfony/framework-bundle and symfony/contracts to target. Maybe we should add a conflict against symfony/framework-bundle < 7.0 to symfony/contract's `composer.json`. 