### PR TITLE
Avoid bc break for AssciiSlugger::withEmoji in 7.1

### DIFF
--- a/src/Symfony/Component/String/composer.json
+++ b/src/Symfony/Component/String/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/emoji": "^7.1",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-grapheme": "~1.0",
         "symfony/polyfill-intl-normalizer": "~1.0",
@@ -24,7 +25,6 @@
     },
     "require-dev": {
         "symfony/error-handler": "^6.4|^7.0",
-        "symfony/emoji": "^7.1",
         "symfony/http-client": "^6.4|^7.0",
         "symfony/intl": "^6.4|^7.0",
         "symfony/translation-contracts": "^2.5|^3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Related PR: https://github.com/symfony/symfony/pull/53096
| License       | MIT

Avoid bc break for AssciiSlugger::withEmoji in 7.1.

Without a update from 7.0 -> 7.1 can crash application which are build with the `withEmoji` method.

Requirement could be removed again in Symfony 8.0.