### PR TITLE
[HttpFoundation] Set content-type header in RedirectResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -103,6 +103,7 @@ class RedirectResponse extends Response
 </html>', htmlspecialchars($url, \ENT_QUOTES, 'UTF-8')));
 
         $this->headers->set('Location', $url);
+        $this->headers->set('Content-Type', 'text/html; charset=utf-8');
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -44,6 +44,13 @@ class RedirectResponseTest extends TestCase
         $this->assertEquals('foo.bar', $response->headers->get('Location'));
     }
 
+    public function testGenerateContentTypeHeader()
+    {
+        $response = new RedirectResponse('foo.bar');
+
+        $this->assertSame('text/html; charset=utf-8', $response->headers->get('Content-Type'));
+    }
+
     public function testGetTargetUrl()
     {
         $response = new RedirectResponse('foo.bar');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54434
| License       | MIT

The RedirectResponse has no content-type set, leading to the response using the "current" one (see issue #54434)

As `setTargetUrl` set response body with HTML/UTF-8 content, it seems fair to add the matching header at this moment.

(not sure if really a _bug_ or not so i'm targetting 7.1 for now)