### PR TITLE
[HtmlSanitizer] Ignore Processing Instructions

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -309,6 +309,12 @@ class HtmlSanitizerAllTest extends TestCase
                 'Lorem ipsum  ',
             ],
 
+            // Processing instructions
+            [
+                'Lorem ipsum<?div x?>foo',
+                'Lorem ipsumfoo',
+            ],
+
             // Normal tags
             [
                 '<abbr>Lorem ipsum</abbr>',

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
@@ -134,9 +134,10 @@ final class DomVisitor
             if ('#text' === $child->nodeName) {
                 // Add text directly for performance
                 $cursor->node->addChild(new TextNode($cursor->node, $child->nodeValue));
-            } elseif (!$child instanceof \DOMText) {
+            } elseif (!$child instanceof \DOMText && !$child instanceof \DOMProcessingInstruction) {
                 // Otherwise continue the visit recursively
                 // Ignore comments for security reasons (interpreted differently by browsers)
+                // Ignore processing instructions (treated as comments)
                 $this->visitNode($child, $cursor);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #54492
| License       | MIT

Ignore Processing Instructions (as comments) to avoid mixing them with standard DOM nodes (see #54492)

(targetting 6.4 as the component was released  in 6.1))