### PR TITLE
[HttpClient] Let curl handle transfer encoding

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -246,9 +246,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
             if (isset($options['normalized_headers']['content-length'][0])) {
                 $curlopts[\CURLOPT_INFILESIZE] = (int) substr($options['normalized_headers']['content-length'][0], \strlen('Content-Length: '));
-            }
-            if (!isset($options['normalized_headers']['transfer-encoding'])) {
-                $curlopts[\CURLOPT_HTTPHEADER][] = 'Transfer-Encoding:'.(isset($curlopts[\CURLOPT_INFILESIZE]) ? '' : ' chunked');
+            } elseif (!isset($options['normalized_headers']['transfer-encoding'])) {
+                $curlopts[\CURLOPT_INFILESIZE] = -1;
             }
 
             if ('POST' !== $method) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54516, Fix #54491
| License       | MIT

Removes the `Transfer-Encoding: chunked` header that is added for chunked request bodies. This will allow curl to handle the transfer encoding and set appropriate headers based on the HTTP protocol version it negotiated with the server, since HTTP/2 does not support chunked transfer encoding.