### PR TITLE
[Notifier] [Slack] Add support for `conversations.open` method

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -201,15 +201,10 @@ class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
-    public function getConversationIds(): ?array
-    {
-        return $this->options['conversation_ids'] ?? null;
-    }
-
     /**
      * @return $this
      */
-    public function conversation(array $ids): static
+    public function conversations(array $ids): static
     {
         $this->options['conversation_ids'] = array_unique(array_filter($ids));
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -200,4 +200,19 @@ class SlackOptions implements MessageOptionsInterface
 
         return $this;
     }
+
+    public function getConversationsId(): ?string
+    {
+        return $this->options['conversations_id'] ?? null;
+    }
+
+    /**
+     * @return $this
+     */
+    public function conversations(string|array|callable $id): static
+    {
+        $this->options['conversations_id'] = $id;
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -201,17 +201,17 @@ class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
-    public function getConversationsId(): ?string
+    public function getConversationIds(): ?array
     {
-        return $this->options['conversations_id'] ?? null;
+        return $this->options['conversation_ids'] ?? null;
     }
 
     /**
      * @return $this
      */
-    public function conversations(string|array|callable $id): static
+    public function conversation(array $ids): static
     {
-        $this->options['conversations_id'] = $id;
+        $this->options['conversation_ids'] = array_unique(array_filter($ids));
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -202,6 +202,7 @@ class SlackOptions implements MessageOptionsInterface
     }
 
     /**
+     * @param list<string> $ids
      * @return $this
      */
     public function conversations(array $ids): static

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -69,6 +69,46 @@ final class SlackTransport extends AbstractTransport
         }
 
         $options = $options?->toArray() ?? [];
+
+        if (isset($options['conversations_id'])) {
+            $conversationsId = $options['conversations_id'];
+            if (is_callable($conversationsId )) {
+                $conversationsId  = $conversationsId($this, $message);
+            }
+            if (is_array($conversationsId )) {
+                $conversationsId  = implode(',', array_unique(array_filter($conversationsId)));
+            }
+            if (is_string($conversationsId) && !empty($conversationsId)) {
+                $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/conversations.open', [
+                    'json' => ['users' => $conversationsId],
+                    'auth_bearer' => $this->accessToken,
+                    'headers' => [
+                        'Content-Type' => 'application/json; charset=utf-8',
+                    ],
+                ]);
+                
+                try {
+                    $statusCode = $response->getStatusCode();
+                } catch (TransportExceptionInterface $e) {
+                    throw new TransportException('Could not reach the remote Slack server.', $response, 0, $e);
+                }
+
+                if (200 !== $statusCode) {
+                    throw new TransportException(sprintf('Unable to post the Slack message: "%s".', $response->getContent(false)), $response);
+                }
+
+                $result = $response->toArray(false);
+                if (!$result['ok']) {
+                    $errors = isset($result['errors']) ? ' ('.implode('|', $result['errors']).')' : '';
+        
+                    throw new TransportException(sprintf('Unable to post the Slack message: "%s"%s.', $result['error'], $errors), $response);
+                }
+        
+                $options['channel'] = $result['channel']['id'] ?? null;
+            }
+        }
+        unset($options['conversations_id']);
+
         $options['channel'] ??= $message->getRecipientId() ?: $this->channel;
         $options['text'] = $message->getSubject();
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -70,10 +70,7 @@ final class SlackTransport extends AbstractTransport
 
         $options = $options?->toArray() ?? [];
 
-        if (isset($options['conversation_ids']) 
-            && is_array($options['conversation_ids']) 
-            && count($options['conversation_ids']) > 1
-        ) {
+        if ($options['conversation_ids'] ?? false) {
             $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/conversations.open', [
                 'json' => ['users' => implode(',', $options['conversation_ids'])],
                 'auth_bearer' => $this->accessToken,
@@ -89,7 +86,7 @@ final class SlackTransport extends AbstractTransport
             }
 
             if (200 !== $statusCode) {
-                throw new TransportException(sprintf('Unable to post the Slack message: "%s".', $response->getContent(false)), $response);
+                throw new TransportException('Unable to post the Slack message: '.$response->getContent(false), $response);
             }
 
             $result = $response->toArray(false);
@@ -100,8 +97,8 @@ final class SlackTransport extends AbstractTransport
             }
     
             $options['channel'] = $result['channel']['id'] ?? null;
+            unset($options['conversation_ids']);
         }
-        unset($options['conversation_ids']);
 
         $options['channel'] ??= $message->getRecipientId() ?: $this->channel;
         $options['text'] = $message->getSubject();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54518 
| License       | MIT

### Description

Suppose you have slackIDs of your users in your database and you need to send a message to several of them BUT simultaneously to one channel (no matter if it is created or not), instead of sending a direct message to each of them separately. 
We can implement a special ```conversations``` method that will return the name of an existing channel using the Slack API or create it automatically with the set of users passed as a parameter to this method.
Inside the [SlackTransport::doSend ](https://github.com/symfony/symfony/blob/e928051bcac0c78227f3fe5f9a21df6599b472cd/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php#L64) method, if this option was set earlier, an additional request to the Slack API will be executed in the response, which will contain the name of the target channel, which will be stored in the array of options by the ```recipient_id``` key.

API Details: https://api.slack.com/methods/conversations.open

#### Request
```
curl --location 'https://slack.com/api/conversations.open' \ 
   --header 'Content-Type: application/json; charset=utf-8' \
   --header 'Authorization: Bearer xoxb-XXXXXXXXXXXXX-YYYYYYYYYYYYY-ZZZZZZZZZZZZZZZZZZZZZZZZ' \
   --data '{
      "users": "U0XXXXXXXX1,U0XXXXXXXX2",
   }'
```
#### Response
```json
{"ok":true,"no_op":true,"already_open":true,"channel":{"id":"D0XXXXXXXX1"}}
```

### Example

```php
use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
use Symfony\Component\Notifier\Bridge\Slack\SlackTransport;
use Symfony\Component\Notifier\Message\ChatMessage;
use Symfony\Component\Notifier\Message\MessageInterface;

$chatMessage = new ChatMessage('New Symfony Feature');

$options = (new SlackOptions())
// use string parameter directly in conversation.open API call
    ->conversations('U0XXXXXXXX1,U0XXXXXXXX2') 
// OR allow to specify array
// !!! Implementor MUST perform array_filter and array_unique calls !!!
    ->conversations(['U0XXXXXXXX1', 'U0XXXXXXXX2', null, false, 'U0XXXXXXXX1'])
// OR even allow to specify recipients dynamically
    ->conversations(function(
        SlackTransport $transport,
        MessageInterface $message
    ): array {
        return ['U0XXXXXXXX1', 'U0XXXXXXXX2'];
    })
;
$chatMessage->options($options);

$chatter->send($chatMessage);
```
