### PR TITLE
[Clock] initialize the current time with midnight before modifying the date

### DIFF
--- a/src/Symfony/Component/Clock/DatePoint.php
+++ b/src/Symfony/Component/Clock/DatePoint.php
@@ -32,15 +32,21 @@ final class DatePoint extends \DateTimeImmutable
 
             if (\PHP_VERSION_ID < 80300) {
                 try {
-                    $timezone = (new parent($datetime, $timezone ?? $now->getTimezone()))->getTimezone();
+                    $builtInDate = new parent($datetime, $timezone ?? $now->getTimezone());
+                    $timezone = $builtInDate->getTimezone();
                 } catch (\Exception $e) {
                     throw new \DateMalformedStringException($e->getMessage(), $e->getCode(), $e);
                 }
             } else {
-                $timezone = (new parent($datetime, $timezone ?? $now->getTimezone()))->getTimezone();
+                $builtInDate = new parent($datetime, $timezone ?? $now->getTimezone());
+                $timezone = $builtInDate->getTimezone();
             }
 
             $now = $now->setTimezone($timezone)->modify($datetime);
+
+            if ('00:00:00.000000' === $builtInDate->format('H:i:s.u')) {
+                $now = $now->setTime(0, 0);
+            }
         } elseif (null !== $timezone) {
             $now = $now->setTimezone($timezone);
         }

--- a/src/Symfony/Component/Clock/Tests/DatePointTest.php
+++ b/src/Symfony/Component/Clock/Tests/DatePointTest.php
@@ -57,4 +57,19 @@ class DatePointTest extends TestCase
         $this->expectExceptionMessage('Failed to parse time string (Bad Date)');
         $date->modify('Bad Date');
     }
+
+    /**
+     * @testWith ["2024-04-01 00:00:00.000000", "2024-04"]
+     *           ["2024-04-09 00:00:00.000000", "2024-04-09"]
+     *           ["2024-04-09 03:00:00.000000", "2024-04-09 03:00"]
+     *           ["2024-04-09 00:00:00.123456", "2024-04-09 00:00:00.123456"]
+     */
+    public function testTimeDefaultsToMidnight(string $expected, string $datetime)
+    {
+        $date = new \DateTimeImmutable($datetime);
+        $this->assertSame($expected, $date->format('Y-m-d H:i:s.u'));
+
+        $date = new DatePoint($datetime);
+        $this->assertSame($expected, $date->format('Y-m-d H:i:s.u'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54497
| License       | MIT