### PR TITLE
[Serializer] add $class, $format and $context arguments to NameConverterInterface methods

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.1
 ---
 
+ * Add arguments `$class`, `$format` and `$context` to `NameConverterInterface::normalize()` and `NameConverterInterface::denormalize()`
  * Add `DateTimeNormalizer::CAST_KEY` context option
  * Add `Default` and "class name" default groups
  * Add `AbstractNormalizer::FILTER_BOOL` context option

--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedPropertyException;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Aurélien Pillevesse <aurelienpillevesse@hotmail.fr>
  */
-class CamelCaseToSnakeCaseNameConverter implements AdvancedNameConverterInterface
+class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
 {
     /**
      * Require all properties to be written in snake_case.
@@ -36,7 +36,7 @@ class CamelCaseToSnakeCaseNameConverter implements AdvancedNameConverterInterfac
     ) {
     }
 
-    public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+    public function normalize(string $propertyName/* , ?string $class = null, ?string $format = null, array $context = [] */): string
     {
         if (null === $this->attributes || \in_array($propertyName, $this->attributes, true)) {
             return strtolower(preg_replace('/[A-Z]/', '_\\0', lcfirst($propertyName)));
@@ -45,8 +45,12 @@ class CamelCaseToSnakeCaseNameConverter implements AdvancedNameConverterInterfac
         return $propertyName;
     }
 
-    public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+    public function denormalize(string $propertyName/* , ?string $class = null, ?string $format = null, array $context = [] */): string
     {
+        $class = 1 < \func_num_args() ? func_get_arg(1) : null;
+        $format = 2 < \func_num_args() ? func_get_arg(2) : null;
+        $context = 3 < \func_num_args() ? func_get_arg(3) : [];
+
         if (($context[self::REQUIRE_SNAKE_CASE_PROPERTIES] ?? false) && $propertyName !== $this->normalize($propertyName, $class, $format, $context)) {
             throw new UnexpectedPropertyException($propertyName);
         }

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 /**
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  */
-final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
+final class MetadataAwareNameConverter implements NameConverterInterface
 {
     /**
      * @var array<string, array<string, string|null>>
@@ -41,8 +41,12 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
     ) {
     }
 
-    public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+    public function normalize(string $propertyName/* , ?string $class = null, ?string $format = null, array $context = [] */): string
     {
+        $class = 1 < \func_num_args() ? func_get_arg(1) : null;
+        $format = 2 < \func_num_args() ? func_get_arg(2) : null;
+        $context = 3 < \func_num_args() ? func_get_arg(3) : [];
+
         if (null === $class) {
             return $this->normalizeFallback($propertyName, $class, $format, $context);
         }
@@ -54,8 +58,12 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         return self::$normalizeCache[$class][$propertyName] ?? $this->normalizeFallback($propertyName, $class, $format, $context);
     }
 
-    public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+    public function denormalize(string $propertyName/* , ?string $class = null, ?string $format = null, array $context = [] */): string
     {
+        $class = 1 < \func_num_args() ? func_get_arg(1) : null;
+        $format = 2 < \func_num_args() ? func_get_arg(2) : null;
+        $context = 3 < \func_num_args() ? func_get_arg(3) : [];
+
         if (null === $class) {
             return $this->denormalizeFallback($propertyName, $class, $format, $context);
         }

--- a/src/Symfony/Component/Serializer/NameConverter/NameConverterInterface.php
+++ b/src/Symfony/Component/Serializer/NameConverter/NameConverterInterface.php
@@ -20,11 +20,19 @@ interface NameConverterInterface
 {
     /**
      * Converts a property name to its normalized value.
+     *
+     * @param class-string|null    $class
+     * @param string|null          $format
+     * @param array<string, mixed> $context
      */
-    public function normalize(string $propertyName): string;
+    public function normalize(string $propertyName/* , ?string $class = null, ?string $format = null, array $context = [] */): string;
 
     /**
      * Converts a property name to its denormalized value.
+     *
+     * @param class-string|null    $class
+     * @param string|null          $format
+     * @param array<string, mixed> $context
      */
-    public function denormalize(string $propertyName): string;
+    public function denormalize(string $propertyName/* , ?string $class = null, ?string $format = null, array $context = [] */): string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/53898#issuecomment-2011821491
| License       | MIT