### PR TITLE
[TwigBundle] Don't register emoji extension on missing `intl` extension

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -32,7 +32,7 @@ class ExtensionPass implements CompilerPassInterface
             $container->removeDefinition('twig.extension.assets');
         }
 
-        if (!class_exists(EmojiTransliterator::class)) {
+        if (!class_exists(\Transliterator::class) || !class_exists(EmojiTransliterator::class)) {
             $container->removeDefinition('twig.extension.emoji');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Appveyor is failing a log because Twig bundle tries to load Emoji transliterator even if ext-intl is not present. Snippet of the error:

```
8) Symfony\Bundle\SecurityBundle\Tests\Functional\CsrfFormLoginTest::testFormLoginRedirectsToProtectedResourceAfterLogin with data set #0 (array('CsrfFormLogin', 'config.yml'))
LogicException: You cannot use the "Symfony\Component\Emoji\EmojiTransliterator" class as the "intl" extension is not installed. See https://php.net/intl.

C:\projects\symfony\src\Symfony\Component\Emoji\EmojiTransliterator.php:17
C:\projects\symfony\src\Symfony\Component\ErrorHandler\DebugClassLoader.php:304
C:\projects\symfony\src\Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\ExtensionPass.php:35
C:\projects\symfony\src\Symfony\Component\DependencyInjection\Compiler\Compiler.php:73
C:\projects\symfony\src\Symfony\Component\DependencyInjection\ContainerBuilder.php:750
C:\projects\symfony\src\Symfony\Component\HttpKernel\Kernel.php:495
C:\projects\symfony\src\Symfony\Component\HttpKernel\Kernel.php:732
C:\projects\symfony\src\Symfony\Component\HttpKernel\Kernel.php:120
C:\projects\symfony\src\Symfony\Bundle\FrameworkBundle\Test\KernelTestCase.php:67
C:\projects\symfony\src\Symfony\Bundle\FrameworkBundle\Test\WebTestCase.php:44
C:\projects\symfony\src\Symfony\Bundle\SecurityBundle\Tests\Functional\CsrfFormLoginTest.php:111
```