### PR TITLE
[Validator] Deprecate `Bic::INVALID_BANK_CODE_ERROR`

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -57,6 +57,11 @@ TwigBundle
 
  * Mark class `TemplateCacheWarmer` as `final`
 
+Validator
+---------
+
+ * Deprecate `Bic::INVALID_BANK_CODE_ERROR`
+
 Workflow
 --------
 

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `list` and `associative_array` types to `Type` constraint
  * Add the `Charset` constraint
  * Add the `requireTld` option to the `Url` constraint
+ * Deprecate `Bic::INVALID_BANK_CODE_ERROR`
 
 7.0
 ---

--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -29,6 +29,9 @@ class Bic extends Constraint
 {
     public const INVALID_LENGTH_ERROR = '66dad313-af0b-4214-8566-6c799be9789c';
     public const INVALID_CHARACTERS_ERROR = 'f424c529-7add-4417-8f2d-4b656e4833e2';
+    /**
+     * @deprecated since Symfony 7.1, to be removed in 8.0
+     */
     public const INVALID_BANK_CODE_ERROR = '00559357-6170-4f29-aebd-d19330aa19cf';
     public const INVALID_COUNTRY_CODE_ERROR = '1ce76f8d-3c1f-451c-9e62-fe9c3ed486ae';
     public const INVALID_CASE_ERROR = '11884038-3312-4ae5-9d04-699f782130c7';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

Follow-up of #54219: now that `Bic::INVALID_BANK_CODE_ERROR` is no longer referenced, it should be deprecated then removed.