### PR TITLE
[PhpUnitBridge] Introduce AssertDeprecationTrait

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/AssertDeprecationTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/AssertDeprecationTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+use PHPUnit\Framework\Assert;
+
+trait AssertDeprecationTrait
+{
+    /**
+     * @param callable(): TReturn $callable
+     * @return TReturn
+     * @template TReturn
+     */
+    private static function assertDeprecation(string $expectedMessage, callable $callable): mixed
+    {
+        $matched = false;
+        $observed = [];
+        $previousErrorHandler = null;
+        $previousErrorHandler = set_error_handler(static function (int $type, string $message) use (&$previousErrorHandler, &$matched, &$observed, $expectedMessage) {
+            if (($type === E_USER_DEPRECATED || $type === E_DEPRECATED)) {
+                if (str_contains($message, $expectedMessage)) {
+                    return $matched = true;
+                }
+
+                $observed[] = $message;
+            }
+
+            return $previousErrorHandler(...func_get_args());
+        }) ?? static function () {
+            return false;
+        };
+        try {
+            $result = $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        if ([] === $observed) {
+            Assert::assertTrue($matched, implode(PHP_EOL, [
+                'The following deprecation has not been raised: ' . $expectedMessage,
+                'No other deprecations have been observed.',
+            ]));
+        } else {
+            Assert::assertTrue($matched, implode(PHP_EOL, array_merge(
+                [
+                    'The following deprecation has not been raised: ' . $expectedMessage,
+                    'Instead, the following deprecations have been observed:',
+                ],
+                array_map(static function (string $message) {
+                    return " - $message";
+                }, $observed),
+            )));
+        }
+
+        return $result;
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/AssertDeprecationTraitTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/AssertDeprecationTraitTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
+
+final class AssertDeprecationTraitTest extends TestCase
+{
+    public function testExpectedDeprecationHasBeenRaised()
+    {
+        $test = new class() {
+            use AssertDeprecationTrait;
+
+            public function run(): string
+            {
+                return self::assertDeprecation(
+                    'Since foo/bar 47.11: Stop using this.',
+                    static function (): string {
+                        trigger_deprecation('foo/bar', '47.11', 'Stop using this.');
+
+                        return 'foo';
+                    }
+                );
+            }
+        };
+
+        self::assertSame('foo', $test->run());
+    }
+
+    public function testExpectedDeprecationHasBeenRaisedAmongOthers()
+    {
+        $test = new class() {
+            use AssertDeprecationTrait;
+
+            public function run(): string
+            {
+                return self::assertDeprecation(
+                    'Since foo/bar 47.11: Stop using this.',
+                    static function (): string {
+                        trigger_deprecation('fuz/baz', '0.8.15', 'Ignore me.');
+                        trigger_deprecation('foo/bar', '47.11', 'Stop using this.');
+
+                        return 'foo';
+                    }
+                );
+            }
+        };
+
+        $loggedDeprecations = [];
+        $previous = null;
+        $previous = set_error_handler(static function ($errno, $errstr) use (&$loggedDeprecations, &$previous) {
+            if ($errno === E_USER_DEPRECATED) {
+                $loggedDeprecations[] = $errstr;
+
+                return true;
+            }
+
+            return $previous(...func_get_args());
+        }) ?? static function () {
+            return false;
+        };
+
+        try {
+            self::assertSame('foo', $test->run());
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame(['Since fuz/baz 0.8.15: Ignore me.'], $loggedDeprecations);
+    }
+
+    public function testNoDeprecationHasBeenRaised()
+    {
+        $test = new class() {
+            use AssertDeprecationTrait;
+
+            public function run(): string
+            {
+                return self::assertDeprecation(
+                    'Since foo/bar 47.11: Stop using this.',
+                    static function (): void {
+                    }
+                );
+            }
+        };
+
+        $e = null;
+        try {
+            $test->run();
+        } catch (ExpectationFailedException $e) {
+        }
+
+        self::assertNotNull($e);
+        self::assertSame(
+            "The following deprecation has not been raised: Since foo/bar 47.11: Stop using this.\nNo other deprecations have been observed.\nFailed asserting that false is true.",
+            $e->getMessage()
+        );
+    }
+
+    public function testOtherDeprecationsHaveBeenRaised()
+    {
+        $test = new class() {
+            use AssertDeprecationTrait;
+
+            public function run(): string
+            {
+                return self::assertDeprecation(
+                    'Since foo/bar 47.11: Stop using this.',
+                    static function (): void {
+                        trigger_deprecation('fuz/baz', '0.8.15', 'Ignore me.');
+                        trigger_deprecation('fiz/buz', '0.8.16', 'And me as well.');
+                    }
+                );
+            }
+        };
+
+        $e = null;
+        $loggedDeprecations = [];
+        $previous = null;
+        $previous = set_error_handler(static function ($errno, $errstr) use (&$loggedDeprecations, &$previous) {
+            if ($errno === E_USER_DEPRECATED) {
+                $loggedDeprecations[] = $errstr;
+
+                return true;
+            }
+
+            return $previous(...func_get_args());
+        }) ?? static function () {
+            return false;
+        };
+        try {
+            $test->run();
+        } catch (ExpectationFailedException $e) {
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNotNull($e);
+        self::assertSame(
+            "The following deprecation has not been raised: Since foo/bar 47.11: Stop using this.\nInstead, the following deprecations have been observed:\n - Since fuz/baz 0.8.15: Ignore me.\n - Since fiz/buz 0.8.16: And me as well.\nFailed asserting that false is true.",
+            $e->getMessage()
+        );
+        self::assertSame([
+            'Since fuz/baz 0.8.15: Ignore me.',
+            'Since fiz/buz 0.8.16: And me as well.',
+        ], $loggedDeprecations);
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\AssetMapper\Tests\ImportMap;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntries;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
@@ -22,7 +22,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class ImportMapConfigReaderTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     private Filesystem $filesystem;
 
@@ -171,7 +171,9 @@ EOF;
      */
     public function testDeprecatedMethodTriggerDeprecation()
     {
-        $this->expectDeprecation('Since symfony/asset-mapper 7.1: The method "Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader::splitPackageNameAndFilePath()" is deprecated and will be removed in 8.0. Use ImportMapEntry::splitPackageNameAndFilePath() instead.');
-        ImportMapConfigReader::splitPackageNameAndFilePath('foo');
+        self::assertDeprecation(
+            'Since symfony/asset-mapper 7.1: The method "Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader::splitPackageNameAndFilePath()" is deprecated and will be removed in 8.0. Use ImportMapEntry::splitPackageNameAndFilePath() instead.',
+            static fn () => ImportMapConfigReader::splitPackageNameAndFilePath('foo'),
+        );
     }
 }

--- a/src/Symfony/Component/AssetMapper/composer.json
+++ b/src/Symfony/Component/AssetMapper/composer.json
@@ -31,6 +31,7 @@
         "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^7.1",
         "symfony/web-link": "^6.4|^7.0"
     },
     "conflict": {

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
 
@@ -26,7 +26,7 @@ use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
  */
 class CouchbaseBucketAdapterTest extends AdapterTestCase
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     protected $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
@@ -36,11 +36,16 @@ class CouchbaseBucketAdapterTest extends AdapterTestCase
 
     protected function setUp(): void
     {
-        $this->expectDeprecation('Since symfony/cache 7.1: The "Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter" class is deprecated, use "Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter" instead.');
-
         $this->client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
             ['username' => getenv('COUCHBASE_USER'), 'password' => getenv('COUCHBASE_PASS')]
         );
+
+        if (!class_exists(CouchbaseBucketAdapter::class, false)) {
+            self::assertDeprecation(
+                'Since symfony/cache 7.1: The "Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter" class is deprecated, use "Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter" instead.',
+                static fn () => class_exists(CouchbaseBucketAdapter::class),
+            );
+        }
     }
 
     public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
 
@@ -20,22 +19,18 @@ use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
  * @requires extension couchbase <4.0.0
  * @requires extension couchbase >=3.0.5
  *
- * @group legacy integration
+ * @group integration
  *
  * @author Antonio Jose Cerezo Aranda <aj.cerezo@gmail.com>
  */
 class CouchbaseCollectionAdapterTest extends AdapterTestCase
 {
-    use ExpectDeprecationTrait;
-
     protected $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
     ];
 
     public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
-        $this->expectDeprecation('Since symfony/cache 7.1: The "Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter" class is deprecated, use "Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter" instead.');
-
         $client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
             ['username' => getenv('COUCHBASE_USER'), 'password' => getenv('COUCHBASE_PASS')]
         );

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -39,6 +39,7 @@
         "symfony/filesystem": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/messenger": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^7.1",
         "symfony/var-dumper": "^6.4|^7.0"
     },
     "conflict": {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\ResolveReferencesToAliasesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ResolveReferencesToAliasesPassTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     public function testProcess()
     {
@@ -92,7 +92,6 @@ class ResolveReferencesToAliasesPassTest extends TestCase
      */
     public function testDeprecationNoticeWhenReferencedByAlias()
     {
-        $this->expectDeprecation('Since foobar 1.2.3.4: The "deprecated_foo_alias" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "alias" alias.');
         $container = new ContainerBuilder();
 
         $container->register('foo', 'stdClass');
@@ -104,7 +103,10 @@ class ResolveReferencesToAliasesPassTest extends TestCase
         $alias = new Alias('deprecated_foo_alias');
         $container->setAlias('alias', $alias);
 
-        $this->process($container);
+        self::assertDeprecation(
+            'Since foobar 1.2.3.4: The "deprecated_foo_alias" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "alias" alias.',
+            fn () => $this->process($container),
+        );
     }
 
     /**
@@ -114,7 +116,6 @@ class ResolveReferencesToAliasesPassTest extends TestCase
      */
     public function testDeprecationNoticeWhenReferencedByDefinition()
     {
-        $this->expectDeprecation('Since foobar 1.2.3.4: The "foo_aliased" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "definition" service.');
         $container = new ContainerBuilder();
 
         $container->register('foo', 'stdClass');
@@ -128,7 +129,10 @@ class ResolveReferencesToAliasesPassTest extends TestCase
             ->setArguments([new Reference('foo_aliased')])
         ;
 
-        $this->process($container);
+        self::assertDeprecation(
+            'Since foobar 1.2.3.4: The "foo_aliased" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "definition" service.',
+            fn () => $this->process($container),
+        );
     }
 
     public function testNoDeprecationNoticeWhenReferencedByDeprecatedAlias()

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -16,7 +16,7 @@ require_once __DIR__.'/Fixtures/includes/classes.php';
 require_once __DIR__.'/Fixtures/includes/ProjectExtension.php';
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
@@ -62,7 +62,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 class ContainerBuilderTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     public function testDefaultRegisteredDefinitions()
     {
@@ -116,9 +116,10 @@ class ContainerBuilderTest extends TestCase
 
         $builder->deprecateParameter('foo', 'symfony/test', '6.3');
 
-        $this->expectDeprecation('Since symfony/test 6.3: The parameter "foo" is deprecated.');
-
-        $builder->getParameter('foo');
+        self::assertDeprecation(
+            'Since symfony/test 6.3: The parameter "foo" is deprecated.',
+            static fn () => $builder->getParameter('foo'),
+        );
     }
 
     /**
@@ -134,9 +135,10 @@ class ContainerBuilderTest extends TestCase
 
         $builder->deprecateParameter('bar', 'symfony/test', '6.3');
 
-        $this->expectDeprecation('Since symfony/test 6.3: The parameter "bar" is deprecated.');
-
-        $builder->compile();
+        self::assertDeprecation(
+            'Since symfony/test 6.3: The parameter "bar" is deprecated.',
+            $builder->compile(...),
+        );
     }
 
     public function testDeprecateParameterThrowsWhenParameterIsUndefined()
@@ -1918,8 +1920,6 @@ class ContainerBuilderTest extends TestCase
      */
     public function testDirectlyAccessingDeprecatedPublicService()
     {
-        $this->expectDeprecation('Since foo/bar 3.8: Accessing the "Symfony\Component\DependencyInjection\Tests\A" service directly from the container is deprecated, use dependency injection instead.');
-
         $container = new ContainerBuilder();
         $container
             ->register(A::class)
@@ -1928,7 +1928,10 @@ class ContainerBuilderTest extends TestCase
 
         $container->compile();
 
-        $container->get(A::class);
+        self::assertDeprecation(
+            'Since foo/bar 3.8: Accessing the "Symfony\Component\DependencyInjection\Tests\A" service directly from the container is deprecated, use dependency injection instead.',
+            static fn () => $container->get(A::class),
+        );
     }
 
     public function testReferencingDeprecatedPublicService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
@@ -73,7 +73,7 @@ require_once __DIR__.'/../Fixtures/includes/foo_lazy.php';
 
 class PhpDumperTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     protected static string $fixturesPath;
 
@@ -482,8 +482,10 @@ class PhpDumperTest extends TestCase
     {
         $container = include self::$fixturesPath.'/containers/container_deprecated_parameters.php';
 
-        $this->expectDeprecation('Since symfony/test 6.3: The parameter "foo_class" is deprecated.');
-        $container->compile();
+        self::assertDeprecation(
+            'Since symfony/test 6.3: The parameter "foo_class" is deprecated.',
+            static fn () => $container->compile(),
+        );
 
         $dumper = new PhpDumper($container);
 
@@ -499,8 +501,10 @@ class PhpDumperTest extends TestCase
     {
         $container = include self::$fixturesPath.'/containers/container_deprecated_parameters.php';
 
-        $this->expectDeprecation('Since symfony/test 6.3: The parameter "foo_class" is deprecated.');
-        $container->compile();
+        self::assertDeprecation(
+            'Since symfony/test 6.3: The parameter "foo_class" is deprecated.',
+            static fn () => $container->compile(),
+        );
 
         $dumper = new PhpDumper($container);
         $dump = print_r($dumper->dump(['as_files' => true, 'file' => __DIR__, 'inline_factories_parameter' => false, 'inline_class_loader_parameter' => false]), true);
@@ -1699,8 +1703,6 @@ PHP
      */
     public function testDirectlyAccessingDeprecatedPublicService()
     {
-        $this->expectDeprecation('Since foo/bar 3.8: Accessing the "bar" service directly from the container is deprecated, use dependency injection instead.');
-
         $container = new ContainerBuilder();
         $container
             ->register('bar', \BarClass::class)
@@ -1714,7 +1716,10 @@ PHP
 
         $container = new \Symfony_DI_PhpDumper_Test_Directly_Accessing_Deprecated_Public_Service();
 
-        $container->get('bar');
+        self::assertDeprecation(
+            'Since foo/bar 3.8: Accessing the "bar" service directly from the container is deprecated, use dependency injection instead.',
+            static fn() => $container->get('bar')
+        );
     }
 
     public function testReferencingDeprecatedPublicService()

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\DependencyInjection\Tests\ParameterBag;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 class FrozenParameterBagTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     public function testConstructor()
     {
@@ -76,8 +76,9 @@ class FrozenParameterBagTest extends TestCase
             ['foo' => ['symfony/test', '6.3', 'The parameter "%s" is deprecated.', 'foo']]
         );
 
-        $this->expectDeprecation('Since symfony/test 6.3: The parameter "foo" is deprecated.');
-
-        $bag->get('foo');
+        self::assertDeprecation(
+            'Since symfony/test 6.3: The parameter "foo" is deprecated.',
+            static fn () => $bag->get('foo'),
+        );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\ParameterBag;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class ParameterBagTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     public function testConstructor()
     {
@@ -138,52 +138,40 @@ class ParameterBagTest extends TestCase
         ];
     }
 
-    /**
-     * The test should be kept in the group as it always expects a deprecation.
-     *
-     * @group legacy
-     */
     public function testDeprecate()
     {
         $bag = new ParameterBag(['foo' => 'bar']);
 
         $bag->deprecate('foo', 'symfony/test', '6.3');
 
-        $this->expectDeprecation('Since symfony/test 6.3: The parameter "foo" is deprecated.');
-
-        $bag->get('foo');
+        self::assertDeprecation(
+            'Since symfony/test 6.3: The parameter "foo" is deprecated.',
+            static fn () => $bag->get('foo'),
+        );
     }
 
-    /**
-     * The test should be kept in the group as it always expects a deprecation.
-     *
-     * @group legacy
-     */
     public function testDeprecateWithMessage()
     {
         $bag = new ParameterBag(['foo' => 'bar']);
 
         $bag->deprecate('foo', 'symfony/test', '6.3', 'The parameter "%s" is deprecated, use "new_foo" instead.');
 
-        $this->expectDeprecation('Since symfony/test 6.3: The parameter "foo" is deprecated, use "new_foo" instead.');
-
-        $bag->get('foo');
+        self::assertDeprecation(
+            'Since symfony/test 6.3: The parameter "foo" is deprecated, use "new_foo" instead.',
+            static fn () => $bag->get('foo'),
+        );
     }
 
-    /**
-     * The test should be kept in the group as it always expects a deprecation.
-     *
-     * @group legacy
-     */
     public function testDeprecationIsTriggeredWhenResolved()
     {
         $bag = new ParameterBag(['foo' => '%bar%', 'bar' => 'baz']);
 
         $bag->deprecate('bar', 'symfony/test', '6.3');
 
-        $this->expectDeprecation('Since symfony/test 6.3: The parameter "bar" is deprecated.');
-
-        $bag->resolve();
+        self::assertDeprecation(
+            'Since symfony/test 6.3: The parameter "bar" is deprecated.',
+            $bag->resolve(...)
+        );
     }
 
     public function testDeprecateThrowsWhenParameterIsUndefined()

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -25,7 +25,8 @@
     "require-dev": {
         "symfony/yaml": "^6.4|^7.0",
         "symfony/config": "^6.4|^7.0",
-        "symfony/expression-language": "^6.4|^7.0"
+        "symfony/expression-language": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^7.1"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class UrlTypeTest extends TextTypeTest
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\UrlType';
 
@@ -25,8 +26,10 @@ class UrlTypeTest extends TextTypeTest
      */
     public function testSubmitAddsDefaultProtocolIfNoneIsIncluded()
     {
-        $this->expectDeprecation('Since symfony/form 7.1: Not configuring the "default_protocol" option when using the UrlType is deprecated. It will default to "null" in 8.0.');
-        $form = $this->factory->create(static::TESTED_TYPE, 'name');
+        $form = self::assertDeprecation(
+            'Since symfony/form 7.1: Not configuring the "default_protocol" option when using the UrlType is deprecated. It will default to "null" in 8.0.',
+            fn (): FormInterface => $this->factory->create(static::TESTED_TYPE, 'name'),
+        );
 
         $form->submit('www.domain.com');
 

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -37,6 +37,7 @@
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/intl": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^7.1",
         "symfony/security-core": "^6.4|^7.0",
         "symfony/security-csrf": "^6.4|^7.0",
         "symfony/translation": "^6.4.3|^7.0.3",

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Routing\Tests\Generator;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\AssertDeprecationTrait;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\RouteCircularReferenceException;
@@ -26,7 +26,7 @@ use Symfony\Component\Routing\RouteCollection;
 
 class UrlGeneratorTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use AssertDeprecationTrait;
 
     public function testAbsoluteUrlWithPort80()
     {
@@ -806,50 +806,44 @@ class UrlGeneratorTest extends TestCase
         $this->getGenerator($routes)->generate('d');
     }
 
-    /**
-     * @group legacy
-     */
     public function testDeprecatedAlias()
     {
-        $this->expectDeprecation('Since foo/bar 1.0.0: The "b" route alias is deprecated. You should stop using it, as it will be removed in the future.');
-
         $routes = new RouteCollection();
         $routes->add('a', new Route('/foo'));
         $routes->addAlias('b', 'a')
             ->setDeprecated('foo/bar', '1.0.0', '');
 
-        $this->getGenerator($routes)->generate('b');
+        $this->assertDeprecation(
+            'Since foo/bar 1.0.0: The "b" route alias is deprecated. You should stop using it, as it will be removed in the future.',
+            fn () => $this->getGenerator($routes)->generate('b'),
+        );
     }
 
-    /**
-     * @group legacy
-     */
     public function testDeprecatedAliasWithCustomMessage()
     {
-        $this->expectDeprecation('Since foo/bar 1.0.0: foo b.');
-
         $routes = new RouteCollection();
         $routes->add('a', new Route('/foo'));
         $routes->addAlias('b', 'a')
             ->setDeprecated('foo/bar', '1.0.0', 'foo %alias_id%.');
 
-        $this->getGenerator($routes)->generate('b');
+        self::assertDeprecation(
+            'Since foo/bar 1.0.0: foo b.',
+            fn () => $this->getGenerator($routes)->generate('b'),
+        );
     }
 
-    /**
-     * @group legacy
-     */
     public function testTargettingADeprecatedAliasShouldTriggerDeprecation()
     {
-        $this->expectDeprecation('Since foo/bar 1.0.0: foo b.');
-
         $routes = new RouteCollection();
         $routes->add('a', new Route('/foo'));
         $routes->addAlias('b', 'a')
             ->setDeprecated('foo/bar', '1.0.0', 'foo %alias_id%.');
         $routes->addAlias('c', 'b');
 
-        $this->getGenerator($routes)->generate('c');
+        self::assertDeprecation(
+            'Since foo/bar 1.0.0: foo b.',
+            fn () => $this->getGenerator($routes)->generate('c'),
+        );
     }
 
     public function testCircularReferenceShouldThrowAnException()

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -25,6 +25,7 @@
         "symfony/yaml": "^6.4|^7.0",
         "symfony/expression-language": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^7.1",
         "psr/log": "^1|^2|^3"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Part of #49069
| License       | MIT

PHPUnit made some progress with regards to error handling which renders our current way of dealing with deprecations incompatible. I'd like to leverage PHPUnit's error handler instead of having our error handler collect deprecations.

As a first step, I'd like to propose a lightweight replacement for `ExpectDeprecationTrait`. It comed with a method `assertDeprecation()` that takes an expected deprecation message and a callable that is supposed to trigger that deprecation. I'm registering a temporary error handler that filters out the expected deprecation while letting everything else bubble up.

An interesting side effect is that tests which only trigger expected deprecations don't have to be added to the `legacy` group anymore. This is especially useful for testing tooling around deprecations in the Config and DependencyInjection components.

With this new trait, I was able to execute the affected tests with PHPUnit 11.1 locally.

```php
public function testDeprecatedMethod()
{
    $someObject = new SomeClass();

    $returnValue = self::assertDeprecation(
        'Since symfony/some-component 7.1: This is deprecated, do something else instead.',
        static fn () => $someObject->someDeprecatedMethod(47, 11),
    );

    self::assertSame('foo', $returnValue);
}
```