### PR TITLE
[FrameworkBundle] Add console command option to control clock time

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Console;
 
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\ListCommand;
@@ -42,6 +44,10 @@ class Application extends BaseApplication
         $inputDefinition->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', $kernel->getEnvironment()));
         $inputDefinition->addOption(new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switch off debug mode.'));
         $inputDefinition->addOption(new InputOption('--profile', null, InputOption::VALUE_NONE, 'Enables profiling (requires debug).'));
+
+        if (class_exists(Clock::class)) {
+            $inputDefinition->addOption(new InputOption('--set-time', null, InputOption::VALUE_OPTIONAL, 'Define a custom clock'));
+        }
     }
 
     /**
@@ -88,6 +94,10 @@ class Application extends BaseApplication
                 $this->registrationErrors = [];
                 $renderRegistrationErrors = false;
             }
+        }
+
+        if (class_exists(Clock::class) && $time = $input->getParameterOption('--set-time')) {
+            Clock::set(new MockClock($time));
         }
 
         if ($input->hasParameterOption('--profile')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

I would like to propose a new option for console command to control the clock. This option allows users to define the time when the command runs:

```shell
$ php bin/console app:test --set-time="2024-01-01 00:00:00"
```

```php
<?php

namespace App\Command;

use Symfony\Component\Clock\ClockInterface;
use Symfony\Component\Console\Attribute\AsCommand;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Console\Style\SymfonyStyle;

#[AsCommand(name: 'app:test')]
class TestCommand extends Command
{
    public function __construct(
        private ClockInterface $clock,
    ) {
        parent::__construct();
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $io = new SymfonyStyle($input, $output);
        // Will display "Current date: 2024-01-01 00:00:00"
	$io->writeln('Current date: '.$this->clock->now()->format('Y-m-d H:i:s'));

        return Command::SUCCESS;
    }
}
```