### PR TITLE
[DoctrineBridge] Add argument to `EntityValueResolver` to set type aliases

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -35,6 +35,8 @@ final class EntityValueResolver implements ValueResolverInterface
         private ManagerRegistry $registry,
         private ?ExpressionLanguage $expressionLanguage = null,
         private MapEntity $defaults = new MapEntity(),
+        /** @var array<class-string, class-string> */
+        private readonly array $typeAliases = [],
     ) {
     }
 
@@ -50,6 +52,9 @@ final class EntityValueResolver implements ValueResolverInterface
         if (!$options->class || $options->disabled) {
             return [];
         }
+
+        $options->class = $this->typeAliases[$options->class] ?? $options->class;
+
         if (!$manager = $this->getManager($options->objectManager, $options->class)) {
             return [];
         }

--- a/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
@@ -53,7 +53,7 @@ class MapEntity extends ValueResolver
     public function withDefaults(self $defaults, ?string $class): static
     {
         $clone = clone $this;
-        $clone->class ??= class_exists($class ?? '') ? $class : null;
+        $clone->class ??= class_exists($class ?? '') || interface_exists($class ?? '', false) ? $class : null;
         $clone->objectManager ??= $defaults->objectManager;
         $clone->expr ??= $defaults->expr;
         $clone->mapping ??= $defaults->mapping;

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Accept `ReadableCollection` in `CollectionToArrayTransformer`
+ * Add type aliases support to `EntityValueResolver`
 
 7.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #51765
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This allows for fixing https://github.com/symfony/symfony/issues/51765; with a consequential Doctrine bundle update, the resolve_target_entities configuration can be injected similarly to ResolveTargetEntityListener in the Doctrine codebase.

Alternatively the config and ValueResolver can be injected using a compiler pass in the Symfony core code, however the value resolver seems to be configured in the Doctrine bundle already.
