### PR TITLE
[Translation] Skip state=needs-translation entries only when source == target

### DIFF
--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -111,16 +111,20 @@ class XliffFileLoader implements LoaderInterface
                     continue;
                 }
 
-                if (isset($translation->target) && 'needs-translation' === (string) $translation->target->attributes()['state']) {
+                $source = (string) (isset($attributes['resname']) && $attributes['resname'] ? $attributes['resname'] : $translation->source);
+
+                if (isset($translation->target)
+                    && 'needs-translation' === (string) $translation->target->attributes()['state']
+                    && \in_array((string) $translation->target, [$source, (string) $translation->source], true)
+                ) {
                     continue;
                 }
 
-                $source = isset($attributes['resname']) && $attributes['resname'] ? $attributes['resname'] : $translation->source;
                 // If the xlf file has another encoding specified, try to convert it because
                 // simple_xml will always return utf-8 encoded values
                 $target = $this->utf8ToCharset((string) ($translation->target ?? $translation->source), $encoding);
 
-                $catalogue->set((string) $source, $target, $domain);
+                $catalogue->set($source, $target, $domain);
 
                 $metadata = [
                     'source' => (string) $translation->source,
@@ -143,7 +147,7 @@ class XliffFileLoader implements LoaderInterface
                     $metadata['id'] = (string) $attributes['id'];
                 }
 
-                $catalogue->setMetadata((string) $source, $metadata, $domain);
+                $catalogue->setMetadata($source, $metadata, $domain);
             }
         }
     }

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -52,8 +52,16 @@ class XliffFileLoaderTest extends TestCase
       </trans-unit>
       <trans-unit id="4">
         <source>test</source>
-        <target>with</target>
+        <target state="needs-translation">with</target>
         <note>note</note>
+      </trans-unit>
+      <trans-unit id="5">
+        <source>baz</source>
+        <target state="needs-translation">baz</target>
+      </trans-unit>
+      <trans-unit id="6" resname="buz">
+        <source>baz</source>
+        <target state="needs-translation">buz</target>
       </trans-unit>
     </body>
   </file>
@@ -65,6 +73,7 @@ XLIFF;
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertSame([], libxml_get_errors());
         $this->assertContainsOnly('string', $catalogue->all('domain1'));
+        $this->assertSame(['foo', 'extra', 'key', 'test'], array_keys($catalogue->all('domain1')));
     }
 
     public function testLoadWithInternalErrorsEnabled()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54541
| License       | MIT

