### PR TITLE
[Security] Track first token usage even if firewall is lazy

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/GetUserBundle/Controller/RootController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/GetUserBundle/Controller/RootController.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\GetUserBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class RootController
+{
+    public function __invoke(?UserInterface $user): Response
+    {
+        return new Response();
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/GetUserBundle/GetUserBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/GetUserBundle/GetUserBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\GetUserBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class GetUserBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LazyFirewallTokenStorageUsageTrackingTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LazyFirewallTokenStorageUsageTrackingTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+class LazyFirewallTokenStorageUsageTrackingTest extends AbstractWebTestCase
+{
+    public function testTokenStorageUsageIsTracked()
+    {
+        $client = $this->createClient(['test_case' => 'LazyFirewallTokenStorageUsageTracking']);
+        $client->request('GET', '/');
+
+        $this->assertSame(1, $client->getRequest()->getSession()->getUsageIndex());
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LazyFirewallTokenStorageUsageTracking/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LazyFirewallTokenStorageUsageTracking/bundles.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\SecuredPageBundle\SecuredPageBundle;
+use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new SecurityBundle(),
+    new SecuredPageBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LazyFirewallTokenStorageUsageTracking/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LazyFirewallTokenStorageUsageTracking/config.yml
@@ -1,0 +1,12 @@
+imports:
+  - { resource: ./../config/framework.yml }
+
+security:
+  providers:
+    in_memory:
+      memory:
+        users:
+
+  firewalls:
+    default:
+      lazy: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LazyFirewallTokenStorageUsageTracking/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LazyFirewallTokenStorageUsageTracking/routing.yml
@@ -1,0 +1,3 @@
+root:
+  path: /
+  defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\GetUserBundle\Controller\RootController::__invoke }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
@@ -78,6 +78,6 @@ final class UsageTrackingTokenStorage implements TokenStorageInterface, ServiceS
 
     private function shouldTrackUsage(): bool
     {
-        return $this->enableUsageTracking && $this->container->get('request_stack')->getMainRequest();
+        return null !== $this->container->get('request_stack')->getMainRequest();
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
@@ -37,20 +37,14 @@ class UsageTrackingTokenStorageTest extends TestCase
         $trackingStorage = new UsageTrackingTokenStorage($tokenStorage, $sessionLocator);
 
         $this->assertNull($trackingStorage->getToken());
+        $this->assertSame(1, $session->getUsageIndex());
         $token = new NullToken();
 
         $trackingStorage->setToken($token);
-        $this->assertSame($token, $trackingStorage->getToken());
+        $this->assertSame(2, $session->getUsageIndex());
         $this->assertSame($token, $tokenStorage->getToken());
-        $this->assertSame(0, $session->getUsageIndex());
-
-        $trackingStorage->enableUsageTracking();
         $this->assertSame($token, $trackingStorage->getToken());
-        $this->assertSame(1, $session->getUsageIndex());
-
-        $trackingStorage->disableUsageTracking();
-        $this->assertSame($token, $trackingStorage->getToken());
-        $this->assertSame(1, $session->getUsageIndex());
+        $this->assertSame(3, $session->getUsageIndex());
     }
 
     public function testWithoutMainRequest()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #54475 
| License       | MIT

This PR adds a test case for what I think to be #54475’s cause.

For now I’m just checking if always considering the tracking to be enabled makes tests fail.