### PR TITLE
[Messenger] Add asynchronous message handling support to `HandlerTrait`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `--all` option to the `messenger:consume` command
  * Add parameter `$jitter` to `MultiplierRetryStrategy` in order to randomize delay and prevent the thundering herd effect
  * Add `SIGQUIT` signal among list of signals that gracefully shut down `messenger:consume` and `messenger:failed:retry` commands
+ * Add asynchronous message handling support to `HandlerTrait`
 
 7.0
 ---

--- a/src/Symfony/Component/Messenger/Exception/MultipleHandlersForMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/MultipleHandlersForMessageException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+class MultipleHandlersForMessageException extends LogicException
+{
+}

--- a/src/Symfony/Component/Messenger/HandleTrait.php
+++ b/src/Symfony/Component/Messenger/HandleTrait.php
@@ -12,21 +12,27 @@
 namespace Symfony\Component\Messenger;
 
 use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Exception\MultipleHandlersForMessageException;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
 
 /**
- * Leverages a message bus to expect a single, synchronous message handling and return its result.
+ * Leverages a message bus to expect a single, synchronous message handling
+ * and return its result; or return null if asynchronous handling.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
 trait HandleTrait
 {
     private MessageBusInterface $messageBus;
+    private bool $allowAsyncHandling = false;
 
     /**
      * Dispatches the given message, expecting to be handled by a single handler
-     * and returns the result from the handler returned value.
-     * This behavior is useful for both synchronous command & query buses,
+     * and returns the result from the handler returned value. If the message was
+     * handled asynchronously, this method returns null.
+     * This behavior is useful for both command & query buses,
      * the last one usually returning the handler result.
      *
      * @param object|Envelope $message The message or the message pre-wrapped in an envelope
@@ -42,13 +48,18 @@ trait HandleTrait
         $handledStamps = $envelope->all(HandledStamp::class);
 
         if (!$handledStamps) {
-            throw new LogicException(sprintf('Message of type "%s" was handled zero times. Exactly one handler is expected when using "%s::%s()".', get_debug_type($envelope->getMessage()), static::class, __FUNCTION__));
+            if ($this->allowAsyncHandling && $envelope->all(SentStamp::class)) {
+                // it went through an asynchronous transport
+                return null;
+            }
+
+            throw new NoHandlerForMessageException(sprintf('Message of type "%s" was handled zero times. Exactly one handler is expected when using "%s::%s()".', get_debug_type($envelope->getMessage()), static::class, __FUNCTION__));
         }
 
         if (\count($handledStamps) > 1) {
             $handlers = implode(', ', array_map(fn (HandledStamp $stamp): string => sprintf('"%s"', $stamp->getHandlerName()), $handledStamps));
 
-            throw new LogicException(sprintf('Message of type "%s" was handled multiple times. Only one handler is expected when using "%s::%s()", got %d: %s.', get_debug_type($envelope->getMessage()), static::class, __FUNCTION__, \count($handledStamps), $handlers));
+            throw new MultipleHandlersForMessageException(sprintf('Message of type "%s" was handled multiple times. Only one handler is expected when using "%s::%s()", got %d: %s.', get_debug_type($envelope->getMessage()), static::class, __FUNCTION__, \count($handledStamps), $handlers));
         }
 
         return $handledStamps[0]->getResult();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This `HandlerTrait` was initially designed to handle synchronous messages only, so a message handler is immediately required. However, it's conceptually correct and sometimes necessary that a command bus dispatches commands asynchronously, which is not currently possible with this trait. Otherwise, you'll face this error (if `allow_no_handlers` is true):
```
Message of type "FooCommand" was handled zero times. Exactly one handler is expected...
```
which is expected, because in this case the envelope will be marked as handled (`HandledStamp`) only when it's processed in the background by `HandleMessageMiddleware`. However, the envelope will contain at least a `SentStamp` which we can track.

So this PR proposes to unlock that capability in `HandlerTrait` by adding a new *flag* property `$allowAsyncHandling`, checking for `SentStamp`, and returning `null` if no handler is found.

The goal of this new *flag* `$allowAsyncHandling` is to force you to manually enable this capability for those buses allowed to handle both approaches at the same time (e.i. CommandBus).