### PR TITLE
[Validator] Document `Compound::getConstraints` options

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -121,6 +121,9 @@ abstract class Constraint
         }
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function normalizeOptions(mixed $options): array
     {
         $normalizedOptions = [];

--- a/src/Symfony/Component/Validator/Constraints/Compound.php
+++ b/src/Symfony/Component/Validator/Constraints/Compound.php
@@ -46,6 +46,8 @@ abstract class Compound extends Composite
     }
 
     /**
+     * @param array<string, mixed> $options
+     *
      * @return Constraint[]
      */
     abstract protected function getConstraints(array $options): array;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

The array options is not documented in `Compoung::getConstraints`.

Looking at the usage
```
$this->getConstraints($this->normalizeOptions($options));
```
I think it should be `array<string, mixed>`.