### PR TITLE
[Console] Better error handling when misuse of `ArgvInput` with arrays

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -49,6 +49,12 @@ class ArgvInput extends Input
     {
         $argv ??= $_SERVER['argv'] ?? [];
 
+        foreach ($argv as $arg) {
+            if (!\is_scalar($arg) && !$arg instanceof \Stringable) {
+                throw new RuntimeException(sprintf('Argument values expected to be all scalars, got "%s".', get_debug_type($arg)));
+            }
+        }
+
         // strip the application name
         array_shift($argv);
 

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -324,6 +324,11 @@ class ArgvInputTest extends TestCase
                 new InputDefinition([new InputArgument('name', InputArgument::REQUIRED)]),
                 'Too many arguments, expected arguments "name".',
             ],
+            [
+                ['cli.php', ['array']],
+                new InputDefinition(),
+                'Argument values expected to be all scalars, got "array".',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53836
| License       | MIT

### Issue
When we don't use `ArgvInput` correclty, and use array in $argv values, it returns different PHP fatal errors.
See all details and how to reproduce it in the issue https://github.com/symfony/symfony/issues/53836

### Solution
In this PR
 - Add some DX with an exception explaining the problem, to avoid PHP fatal errors
 - Add tests**

_____
Note : Old PR #54147 was targeting 5.4, see [this comment](https://github.com/symfony/symfony/pull/54147#issuecomment-1976483185) for more details