### PR TITLE
[Cache] Always select database for persistent redis connections

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -74,4 +74,57 @@ class RedisTraitTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * Due to a bug in phpredis, the persistent connection will keep its last selected database. So when re-using
+     * a persistent connection, the database has to be re-selected, too.
+     *
+     * @see https://github.com/phpredis/phpredis/issues/1920
+     *
+     * @group integration
+     */
+    public function testPconnectSelectsCorrectDatabase()
+    {
+        if (!class_exists(\Redis::class)) {
+            throw new SkippedTestSuiteError('The "Redis" class is required.');
+        }
+        if (!getenv('REDIS_HOST')) {
+            throw new SkippedTestSuiteError('REDIS_HOST env var is not defined.');
+        }
+        if (!\ini_get('redis.pconnect.pooling_enabled')) {
+            throw new SkippedTestSuiteError('The bug only occurs when pooling is enabled.');
+        }
+
+        // Limit the connection pool size to 1:
+        if (false === $prevPoolSize = ini_set('redis.pconnect.connection_limit', 1)) {
+            throw new SkippedTestSuiteError('Unable to set pool size');
+        }
+
+        try {
+            $mock = self::getObjectForTrait(RedisTrait::class);
+
+            $dsn = 'redis://'.getenv('REDIS_HOST');
+
+            $cacheKey = 'testPconnectSelectsCorrectDatabase';
+            $cacheValueOnDb1 = 'I should only be on database 1';
+
+            // First connect to database 1 and set a value there so we can identify this database:
+            $db1 = $mock::createConnection($dsn, ['dbindex' => 1, 'persistent' => 1]);
+            self::assertInstanceOf(\Redis::class, $db1);
+            self::assertSame(1, $db1->getDbNum());
+            $db1->set($cacheKey, $cacheValueOnDb1);
+            self::assertSame($cacheValueOnDb1, $db1->get($cacheKey));
+
+            // Unset the connection - do not use `close()` or we will lose the persistent connection:
+            unset($db1);
+
+            // Now connect to database 0 and see that we do not actually ended up on database 1 by checking the value:
+            $db0 = $mock::createConnection($dsn, ['dbindex' => 0, 'persistent' => 1]);
+            self::assertInstanceOf(\Redis::class, $db0);
+            self::assertSame(0, $db0->getDbNum()); // Redis is lying here! We could actually be on any database!
+            self::assertNotSame($cacheValueOnDb1, $db0->get($cacheKey)); // This value should not exist if we are actually on db 0
+        } finally {
+            ini_set('redis.pconnect.connection_limit', $prevPoolSize);
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51578
| License       | MIT

Even though the `dbindex` is supposed to be `0` by default for any new redis connection, when dealing with a persistent connection pool, due to a [bug in phpreds](https://github.com/phpredis/phpredis/issues/1920) you can actually end up on a different database.

This PR will call `select` even for a `dbindex` of `0` under these conditions to assure you are actually on the right database.