### PR TITLE
[Form] Replace array_merge by spread operator in FormFactoryBuilder.php

### DIFF
--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -63,7 +63,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
 
     public function addExtensions(array $extensions): static
     {
-        $this->extensions = array_merge($this->extensions, $extensions);
+        $this->extensions = [...$this->extensions, ...$extensions];
 
         return $this;
     }
@@ -111,7 +111,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
 
     public function addTypeGuessers(array $typeGuessers): static
     {
-        $this->typeGuessers = array_merge($this->typeGuessers, $typeGuessers);
+        $this->typeGuessers = [...$this->typeGuessers, ...$typeGuessers];
 
         return $this;
     }


### PR DESCRIPTION
Just a little refactoring: replace array_merge function by spread operator (...).  It's a little bit shorter and faster.

| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
