### PR TITLE
[Serializer] explicitly mark nullable parameters as nullable

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -670,17 +670,17 @@ class AbstractObjectNormalizerTest extends TestCase
                 parent::__construct(null, new MetadataAwareNameConverter(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()))));
             }
 
-            protected function extractAttributes(object $object, string $format = null, array $context = []): array
+            protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
             {
                 return [];
             }
 
-            protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = [])
+            protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = [])
             {
                 return null;
             }
 
-            protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = [])
+            protected function setAttributeValue(object $object, string $attribute, $value, ?string $format = null, array $context = [])
             {
                 $object->$attribute = $value;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | refs #54180
| License       | MIT