### PR TITLE
[PasswordHasher] Skip test assertions that are no longer valid with PHP >= 8.2.18/8.3.5

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
@@ -103,7 +103,11 @@ class NativePasswordHasherTest extends TestCase
         $hasher = new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT);
         $plainPassword = "a\0b";
 
-        $this->assertFalse($hasher->verify(password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]), $plainPassword));
+        if (\PHP_VERSION_ID < 80218 || \PHP_VERSION_ID >= 80300 && \PHP_VERSION_ID < 80305) {
+            // password_hash() does not accept passwords containing NUL bytes since PHP 8.2.18 and 8.3.5
+            $this->assertFalse($hasher->verify(password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]), $plainPassword));
+        }
+
         $this->assertTrue($hasher->verify($hasher->hash($plainPassword), $plainPassword));
     }
 

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
@@ -78,7 +78,11 @@ class SodiumPasswordHasherTest extends TestCase
         $hasher = new SodiumPasswordHasher(null, null);
         $plainPassword = "a\0b";
 
-        $this->assertFalse($hasher->verify(password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]), $plainPassword));
+        if (\PHP_VERSION_ID < 80218 || \PHP_VERSION_ID >= 80300 && \PHP_VERSION_ID < 80305) {
+            // password_hash() does not accept passwords containing NUL bytes since PHP 8.2.18 and 8.3.5
+            $this->assertFalse($hasher->verify(password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]), $plainPassword));
+        }
+
         $this->assertTrue($hasher->verify((new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT))->hash($plainPassword), $plainPassword));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see php/php-src@0ba5229a3f7572846e91c8f5382e87785f543826 and https://3v4l.org/9QigI