### PR TITLE
[Ldap] Improve error reporting during LDAP bind

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -78,7 +78,8 @@ class Connection extends AbstractConnection
                 case self::LDAP_ALREADY_EXISTS:
                     throw new AlreadyExistsException($error);
             }
-            throw new ConnectionException($error);
+            ldap_get_option($this->connection, LDAP_OPT_DIAGNOSTIC_MESSAGE, $diagnostic_message);
+            throw new ConnectionException($error.' '.$diagnostic_message);
         }
 
         $this->bound = true;

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+ * Improve error reporting during LDAP bind
+
 7.0
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

In some rare edge-case where there are issue binding to the LDAP server, for example where the error code doesn't match known error codes in `\Symfony\Component\Ldap\Adapter\ExtLdap\Connection::bind()` it would be very useful to get any additional information available.