### PR TITLE
[ErrorHandler] ErrorHandler - add filename and line number to error message

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -428,7 +428,7 @@ class ErrorHandler
             return false;
         }
 
-        $logMessage = $this->levels[$type].': '.$message;
+        $logMessage = $this->levels[$type].': '.$message. ' at '.$file.' line '.$line;
 
         if (null !== self::$toStringException) {
             $errorAsException = self::$toStringException;

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -428,7 +428,7 @@ class ErrorHandler
             return false;
         }
 
-        $logMessage = $this->levels[$type].': '.$message. ' at '.$file.' line '.$line;
+        $logMessage = $this->levels[$type].': '.$message.' at '.$file.' line '.$line;
 
         if (null !== self::$toStringException) {
             $errorAsException = self::$toStringException;

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -493,7 +493,7 @@ class ErrorHandlerTest extends TestCase
 
         $this->assertSame($loggers, $handler->setLoggers([]));
 
-        $handler->handleError(\E_DEPRECATED, 'Foo message', 'foo.php' , 123, []);
+        $handler->handleError(\E_DEPRECATED, 'Foo message', 'foo.php', 123, []);
 
         $logs = $bootLogger->cleanLogs();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | -
| License       | MIT

Filename and line number are missing from Logged Message

For debugging purpose we need filename and line number.

