### PR TITLE
[Validator] Missing translations for Hungarian (hu)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
@@ -440,7 +440,7 @@
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target state="needs-review-translation">Ennek az URL-nek hiányzik a legfelső szintű domain.</target>
+                <target>Az URL-ből hiányzik a legfelső szintű tartomány (top-level domain).</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54556
| License       | MIT

Translation of TLD changed based on relevant wikipedia page:
https://hu.wikipedia.org/wiki/Legfels%C5%91_szint%C5%B1_tartom%C3%A1ny

If the Wikipedia article authors accept it as a valid translation of top-level domain, I'm fine with it.