### PR TITLE
[Validator] Update the "no TLD" error message

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -31,7 +31,7 @@ class Url extends Constraint
     ];
 
     public string $message = 'This value is not a valid URL.';
-    public string $tldMessage = 'This URL does not contain a TLD.';
+    public string $tldMessage = 'This URL is missing a top-level domain.';
     public array $protocols = ['http', 'https'];
     public bool $relativeProtocol = false;
     public bool $requireTld = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Could this message be easier to understand?

```diff
-    public string $tldMessage = 'This URL does not contain a TLD.';
+    public string $tldMessage = 'This URL is missing a top-level domain.';
```

/cc @javiereguiluz 