### PR TITLE
[Intl] Remove resources data from classmap generation

### DIFF
--- a/src/Symfony/Component/Intl/composer.json
+++ b/src/Symfony/Component/Intl/composer.json
@@ -37,7 +37,8 @@
         "classmap": [ "Resources/stubs" ],
         "files": [ "Resources/functions.php" ],
         "exclude-from-classmap": [
-            "/Tests/"
+            "/Tests/",
+            "/Resources/data/"
         ]
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I was annoyed why my `composer install` takes 5 seconds to complete, so I debugged and the most time-consuming was optimized autoloader generation. Looking more deep into, I figured out that Composer looks into any of the "Data PHP" files of Intl. Removed it and it make it much faster for me. It has no negativ effect to Intl component removing them from classmap, as they don't contain something autoloadable.

`composer dumpautoload -o` on my project with 137 packages

Before: 4.662s
After: 1.833s