### PR TITLE
Add hint which version of Symfony not longer require proxy manager bridge

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/README.md
+++ b/src/Symfony/Bridge/ProxyManager/README.md
@@ -5,7 +5,8 @@ The ProxyManager bridge provides integration for [ProxyManager][1] with various
 Symfony components.
 
 > [!WARNING]  
-> This bridge is no longer necessary and is thus discontinued; 6.4 is the last version.
+> This bridge is no longer necessary and is thus discontinued; 6.4 is the last version.  
+> The first version of Symfony no longer requiring the ProxyManager bridge for lazy services is 6.2.
 
 Resources
 ---------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Add hint which version of Symfony not longer require proxy manager bridge.

Source: https://github.com/symfony/symfony/pull/53462#issuecomment-2060604946