### PR TITLE
[Messenger] Fix reading pending messages with Redis

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -304,7 +304,7 @@ class Connection
         try {
             // This could soon be optimized with https://github.com/antirez/redis/issues/5212 or
             // https://github.com/antirez/redis/issues/6256
-            $pendingMessages = $this->connection->xpending($this->stream, $this->group, '-', '+', 1);
+            $pendingMessages = $this->connection->xpending($this->stream, $this->group, '-', '+', 1) ?: [];
         } catch (\RedisException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As seen sometimes on appveyor, `Redis::xpending()` can return false.