### PR TITLE
[WebProfilerBundle] Add settings to have the profiler follow the browser

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+* Follow the browser from the profiler to quickly find the profiler token
+
 7.1
 ---
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/settings-follow-all.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/settings-follow-all.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-arrows-down-up" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <line x1="17" y1="3" x2="17" y2="21"></line>
+    <path d="M10 18l-3 3l-3 -3"></path>
+    <line x1="7" y1="21" x2="7" y2="3"></line>
+    <path d="M20 6l-3 -3l-3 3"></path>
+</svg>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/settings-follow-main.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/settings-follow-main.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-browser" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <rect x="4" y="4" width="16" height="16" rx="1"></rect>
+    <line x1="4" y1="8" x2="20" y2="8"></line>
+    <line x1="8" y1="4" x2="8" y2="8"></line>
+</svg>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/settings-follow-nothing.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/settings-follow-nothing.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <line x1="18" y1="6" x2="6" y2="18"></line>
+    <line x1="6" y1="6" x2="18" y2="18"></line>
+</svg>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/browser_tracker.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/browser_tracker.html.twig
@@ -1,0 +1,77 @@
+<div class="status status-compact" id="status-browser-tracking" hidden>
+    <span class="icon">{{ source('@WebProfiler/Icon/settings-follow-main.svg') }}</span>
+
+    Browser is now at token <a href="#" id="status-browser-tracking-link"></a> (<span class="help" id="status-browser-tracking-help"></span>).
+    - <a href="#" id="status-browser-tracking-enable-link">Follow the browser automatically</a>
+</div>
+
+<div class="status status-compact status-warning" id="status-browser-tracking-automatic" hidden>
+    <span class="icon">{{ source('@WebProfiler/Icon/settings-follow-main.svg') }}</span>
+    <span id="status-browser-tracking-reloaded" hidden>This tab was reloaded to follow the browser - <a href="javascript:history.back();">Go back</a></span>
+    <span id="status-browser-tracking-following" hidden>This tab is following the browser</span>
+
+    - <a href="#" id="status-browser-tracking-disable-link">Stop following the browser automatically</a>
+</div>
+
+<script>
+    (function () {
+        if (sessionStorage.getItem('symfony/profiler/follow-without-prompt') === 'on' && localStorage.getItem('symfony/profiler/follow') !== 'follow-nothing') {
+            const automaticReloadPanel = document.getElementById('status-browser-tracking-automatic');
+            const followBrowserDisableLink = document.getElementById('status-browser-tracking-disable-link');
+            const reloadedBrowserMessage = document.getElementById('status-browser-tracking-reloaded');
+            const followingBrowserMessage = document.getElementById('status-browser-tracking-following');
+
+            automaticReloadPanel.hidden = false;
+
+            if (sessionStorage.getItem('symfony/profiler/followed-without-prompt') === 'yes') {
+                sessionStorage.setItem('symfony/profiler/followed-without-prompt', 'no');
+                reloadedBrowserMessage.hidden = false;
+            } else {
+                followingBrowserMessage.hidden = false;
+            }
+
+            followBrowserDisableLink.addEventListener('click', function () {
+                sessionStorage.setItem('symfony/profiler/follow-without-prompt', 'off');
+                automaticReloadPanel.hidden = true;
+            });
+        }
+
+        const followBrowserPanel = document.getElementById('status-browser-tracking');
+        const followBrowserHelp = document.getElementById('status-browser-tracking-help');
+        const followBrowserLink = document.getElementById('status-browser-tracking-link');
+        const followBrowserEnableLink = document.getElementById('status-browser-tracking-enable-link');
+        followBrowserEnableLink.addEventListener('click', function () {
+            sessionStorage.setItem('symfony/profiler/follow-without-prompt', 'on');
+            document.location.href = followBrowserLink.href;
+        });
+
+        (new BroadcastChannel('symfony_profiler')).addEventListener('message', function ({data}) {
+            let types = [];
+            switch (localStorage.getItem('symfony/profiler/follow') || 'follow-main') {
+                case 'follow-nothing':
+                    return;
+                case 'follow-main':
+                    types = ['main'];
+                    break;
+                case 'follow-all':
+                    types = ['main', 'ajax'];
+                    break;
+            }
+            if (types.includes(data.type)) {
+                if (sessionStorage.getItem('symfony/profiler/follow-without-prompt') === 'on') {
+                    sessionStorage.setItem('symfony/profiler/followed-without-prompt', 'yes');
+                    document.location.href = '{{ url('_profiler_home')|escape('js') }}' + data.token + document.location.search;
+                    return;
+                }
+
+                followBrowserPanel.hidden = false;
+                followBrowserLink.href = '{{ url('_profiler_home')|escape('js') }}' + data.token + document.location.search;
+                followBrowserLink.innerText = data.token;
+                followBrowserHelp.innerText = data.help;
+
+
+                setTimeout(() => followBrowserLink.focus(), 30);
+            }
+        });
+    })();
+</script>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -18,6 +18,8 @@
                 }, with_context=false) }}
             {% endif %}
         {% endblock %}
+
+        {{ include('@WebProfiler/Profiler/browser_tracker.html.twig') }}
     </div>
 
         <div id="content">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/settings.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/settings.html.twig
@@ -250,6 +250,34 @@
                     </p>
                 </label>
             </div>
+
+            <h4>Follow Browser</h4>
+
+            <div class="settings-group">
+                <label for="settings-follow-nothing">
+                    <input class="config-option" type="radio" name="follow" value="nothing" id="settings-follow-nothing">
+                    <p>
+                        {{ source('@WebProfiler/Icon/settings-follow-nothing.svg') }}
+                        <span>Don't follow</span>
+                    </p>
+                </label>
+
+                <label for="settings-follow-main">
+                    <input class="config-option" type="radio" name="follow" value="main" id="settings-follow-main">
+                    <p>
+                        {{ source('@WebProfiler/Icon/settings-follow-main.svg') }}
+                        <span>Follow main pages</span>
+                    </p>
+                </label>
+
+                <label for="settings-follow-all">
+                    <input class="config-option" type="radio" name="follow" value="all" id="settings-follow-all">
+                    <p>
+                        {{ source('@WebProfiler/Icon/settings-follow-all.svg') }}
+                        <span>Follow main pages and ajax</span>
+                    </p>
+                </label>
+            </div>
         </div>
     </div>
 </div>
@@ -295,6 +323,7 @@
     openModalButton.addEventListener('click', function(event) {
         document.getElementById('settings-' + (localStorage.getItem('symfony/profiler/theme') || 'theme-auto')).checked = 'checked';
         document.getElementById('settings-' + (localStorage.getItem('symfony/profiler/width') || 'width-normal')).checked = 'checked';
+        document.getElementById('settings-' + (localStorage.getItem('symfony/profiler/follow') || 'follow-main')).checked = 'checked';
 
         modalWindow.classList.toggle('visible');
         setTimeout(() => closeModalButton.focus(), 30);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -248,6 +248,9 @@
                         }
                     }
                 }
+                else if(request.profile) {
+                    broadCastToken(request.profile, "ajax", request.url);
+                }
 
                 pendingRequests--;
                 var row = request.DOMNode;
@@ -396,6 +399,16 @@
             }
             {% endif %}
 
+            function broadCastToken(token, type, help) {
+                if (!window.hasOwnProperty('BroadcastChannel')) return;
+
+                (new BroadcastChannel('symfony_profiler')).postMessage({
+                    token: token,
+                    type: type,
+                    help: help
+                });
+            }
+
             return {
                 hasClass: hasClass,
 
@@ -510,6 +523,7 @@
 
                         setPreference('toolbar/displayState', 'block');
                     });
+                    broadCastToken(token, 'main', (document.getElementById('sfToolbarMainContent-' + token).querySelector(".sf-toolbar-block-request .sf-toolbar-label")?.innerText ?? "") + (document.getElementById('sfToolbarMainContent-' + token).querySelector(".sf-toolbar-block-request .sf-toolbar-info-piece-additional")?.innerText ?? ""));
                 },
 
                 loadToolbar: function(token, newToken) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Often during development, we load a page, check some informations in the profiler, see something wrong, fix, reload the page, reload the profiler. That mean that we often reload the profiler page.
If we can use the 'latest' token it's ok, but if there is another controller called (for example a webmanifest), we either need to search for it or close the tab, then reopen a new tab.

This change use the BroadcastChannel javascript api to broadcast to other tabs that a toolbar have loaded or that an ajax request have finished. The profiler page listen to this broadcast and load the new profiler page based on the token broadcasted. A new setting allow to choose if :
- We don't want this behavior
- We want to follow only the main requests where a toolbar is shown (default)
- We also want to follow ajax call captured by the toolbar

The settings section look like that :
![image](https://github.com/symfony/symfony/assets/602252/1f58faab-fe51-4417-a820-9090627894f0)

I didn't submit a PR to the doc side, as it seem that there is no section related to the settings.

