### PR TITLE
[Serializer] Add `XmlEncoder::CDATA_WRAPPING_PATTERN` context option

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `AbstractNormalizer::FILTER_BOOL` context option
  * Add `CamelCaseToSnakeCaseNameConverter::REQUIRE_SNAKE_CASE_PROPERTIES` context option
  * Deprecate `AbstractNormalizerContextBuilder::withDefaultContructorArguments(?array $defaultContructorArguments)`, use `withDefaultConstructorArguments(?array $defaultConstructorArguments)` instead (note the missing `s` character in Contructor word in deprecated method)
+ * Add `XmlEncoder::CDATA_WRAPPING_PATTERN` context option
 
 7.0
 ---

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -152,4 +152,12 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     {
         return $this->with(XmlEncoder::CDATA_WRAPPING, $cdataWrapping);
     }
+
+    /**
+     * Configures the pattern used to evaluate if a CDATA section should be added.
+     */
+    public function withCdataWrappingPattern(?string $cdataWrappingPattern): static
+    {
+        return $this->with(XmlEncoder::CDATA_WRAPPING_PATTERN, $cdataWrappingPattern);
+    }
 }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -59,6 +59,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     public const TYPE_CAST_ATTRIBUTES = 'xml_type_cast_attributes';
     public const VERSION = 'xml_version';
     public const CDATA_WRAPPING = 'cdata_wrapping';
+    public const CDATA_WRAPPING_PATTERN = 'cdata_wrapping_pattern';
 
     private array $defaultContext = [
         self::AS_COLLECTION => false,
@@ -70,6 +71,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::ROOT_NODE_NAME => 'response',
         self::TYPE_CAST_ATTRIBUTES => true,
         self::CDATA_WRAPPING => true,
+        self::CDATA_WRAPPING_PATTERN => '/[<>&]/',
     ];
 
     public function __construct(array $defaultContext = [])
@@ -433,7 +435,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
      */
     private function needsCdataWrapping(string $val, array $context): bool
     {
-        return ($context[self::CDATA_WRAPPING] ?? $this->defaultContext[self::CDATA_WRAPPING]) && preg_match('/[<>&]/', $val);
+        return ($context[self::CDATA_WRAPPING] ?? $this->defaultContext[self::CDATA_WRAPPING]) && preg_match($context[self::CDATA_WRAPPING_PATTERN] ?? $this->defaultContext[self::CDATA_WRAPPING_PATTERN], $val);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
@@ -46,6 +46,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             ->withTypeCastAttributes($values[XmlEncoder::TYPE_CAST_ATTRIBUTES])
             ->withVersion($values[XmlEncoder::VERSION])
             ->withCdataWrapping($values[XmlEncoder::CDATA_WRAPPING])
+            ->withCdataWrappingPattern($values[XmlEncoder::CDATA_WRAPPING_PATTERN])
             ->toArray();
 
         $this->assertSame($values, $context);
@@ -67,6 +68,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::TYPE_CAST_ATTRIBUTES => true,
             XmlEncoder::VERSION => '1.0',
             XmlEncoder::CDATA_WRAPPING => false,
+            XmlEncoder::CDATA_WRAPPING_PATTERN => '/[<>&"\']/',
         ]];
 
         yield 'With null values' => [[
@@ -83,6 +85,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::TYPE_CAST_ATTRIBUTES => null,
             XmlEncoder::VERSION => null,
             XmlEncoder::CDATA_WRAPPING => null,
+            XmlEncoder::CDATA_WRAPPING_PATTERN => null,
         ]];
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -231,16 +231,56 @@ XML;
         $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
     }
 
-    public function testEncodeCdataWrapping()
+    /**
+     * @dataProvider encodeCdataWrappingWithDefaultPattern
+     */
+    public function testEncodeCdataWrappingWithDefaultPattern($input, $expected)
     {
-        $array = [
-            'firstname' => 'Paul & Martha <or Me>',
+        $this->assertEquals($expected, $this->encoder->encode($input, 'xml'));
+    }
+
+    public static function encodeCdataWrappingWithDefaultPattern()
+    {
+        return [
+            [
+                ['firstname' => 'Paul and Martha'],
+                '<?xml version="1.0"?>'."\n".'<response><firstname>Paul and Martha</firstname></response>'."\n",
+            ],
+            [
+                ['lastname' => 'O\'Donnel'],
+                '<?xml version="1.0"?>'."\n".'<response><lastname>O\'Donnel</lastname></response>'."\n",
+            ],
+            [
+                ['firstname' => 'Paul & Martha <or Me>'],
+                '<?xml version="1.0"?>'."\n".'<response><firstname><![CDATA[Paul & Martha <or Me>]]></firstname></response>'."\n",
+            ],
         ];
+    }
 
-        $expected = '<?xml version="1.0"?>'."\n".
-            '<response><firstname><![CDATA[Paul & Martha <or Me>]]></firstname></response>'."\n";
+    /**
+     * @dataProvider encodeCdataWrappingWithCustomPattern
+     */
+    public function testEncodeCdataWrappingWithCustomPattern($input, $expected)
+    {
+        $this->assertEquals($expected, $this->encoder->encode($input, 'xml', ['cdata_wrapping_pattern' => '/[<>&"\']/']));
+    }
 
-        $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
+    public static function encodeCdataWrappingWithCustomPattern()
+    {
+        return [
+            [
+                ['firstname' => 'Paul and Martha'],
+                '<?xml version="1.0"?>'."\n".'<response><firstname>Paul and Martha</firstname></response>'."\n",
+            ],
+            [
+                ['lastname' => 'O\'Donnel'],
+                '<?xml version="1.0"?>'."\n".'<response><lastname><![CDATA[O\'Donnel]]></lastname></response>'."\n",
+            ],
+            [
+                ['firstname' => 'Paul & Martha <or Me>'],
+                '<?xml version="1.0"?>'."\n".'<response><firstname><![CDATA[Paul & Martha <or Me>]]></firstname></response>'."\n",
+            ],
+        ];
     }
 
     public function testEnableCdataWrapping()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54155
| License       | MIT

First of all thank you for all your hard work!

This PR adds the ability to configure the CDATA wrapping pattern to give more flexibility on when to wrap values in a CDATA section.
For example, XML validators are not allowing double and single quotes outside of a CDATA section, with this change we could be able to change the pattern from `/[<>&]/` to `/[<>&"\']/` and solve that issue without the need of writing a custom XMLEncoder.
