### PR TITLE
[DependencyInjection] Resolve container parameter used in index attribute of service tags

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add a `ContainerBuilder::registerChild()` shortcut method for registering child definitions
  * Add support for `key-type` in `XmlFileLoader`
  * Enable non-empty parameters with `ParameterBag::cannotBeEmpty()` and `ContainerBuilder::parameterCannotBeEmpty()` methods
+ * Resolve parameters found in index attribute of service tags
 
 7.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -50,6 +50,7 @@ trait PriorityTaggedServiceTrait
             $tagName = $tagName->getTag();
         }
 
+        $parameterBag = $container->getParameterBag();
         $i = 0;
         $services = [];
 
@@ -81,8 +82,9 @@ trait PriorityTaggedServiceTrait
                 }
 
                 if (null !== $indexAttribute && isset($attribute[$indexAttribute])) {
-                    $index = $attribute[$indexAttribute];
-                } elseif (null === $defaultIndex && $defaultPriorityMethod && $class) {
+                    $index = $parameterBag->resolveValue($attribute[$indexAttribute]);
+                }
+                if (null === $index && null === $defaultIndex && $defaultPriorityMethod && $class) {
                     $defaultIndex = PriorityTaggedServiceUtil::getDefault($container, $serviceId, $class, $defaultIndexMethod ?? 'getDefaultName', $tagName, $indexAttribute, $checkTaggedItem);
                 }
                 $decorated = $definition->getTag('container.decorator')[0]['id'] ?? null;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -233,6 +233,34 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertSame(array_keys($expected), array_keys($services));
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
     }
+
+    public function testResolveIndexedTags()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('custom_param_service1', 'bar');
+        $container->setParameter('custom_param_service2', 'baz');
+        $container->setParameter('custom_param_service2_empty', '');
+        $container->setParameter('custom_param_service2_null', null);
+        $container->register('service1')->addTag('my_custom_tag', ['foo' => '%custom_param_service1%']);
+
+        $definition = $container->register('service2', BarTagClass::class);
+        $definition->addTag('my_custom_tag', ['foo' => '%custom_param_service2%', 'priority' => 100]);
+        $definition->addTag('my_custom_tag', ['foo' => '%custom_param_service2_empty%']);
+        $definition->addTag('my_custom_tag', ['foo' => '%custom_param_service2_null%']);
+
+        $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
+
+        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar');
+        $expected = [
+            'baz' => new TypedReference('service2', BarTagClass::class),
+            'bar' => new Reference('service1'),
+            '' => new TypedReference('service2', BarTagClass::class),
+            'bar_tab_class_with_defaultmethod' => new TypedReference('service2', BarTagClass::class),
+        ];
+        $services = $priorityTaggedServiceTraitImplementation->test($tag, $container);
+        $this->assertSame(array_keys($expected), array_keys($services));
+        $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
+    }
 }
 
 class PriorityTaggedServiceTraitImplementation


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Resolve tags' index attribute to allow the use of container parameters.

YAML config example:
```yaml
parameters:
    foo.bar_reference1: !php/const:App\Service\Foo::EXAMPLE_REFERENCE1
    foo.bar_reference2: !php/const:App\Service\Foo::EXAMPLE_REFERENCE2

services:
    App\Service\Foo:
        tags:
            - { name: 'bar.reference', key: '%foo.bar_reference1%' }
            - { name: 'bar.reference', key: '%foo.bar_reference2%' }

    App\Service\Bar:
        arguments:
            - !tagged_locator { tag: 'bar.reference', index_by: 'key' }
```

XML config example:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<container [...]>
    <parameters>
        <parameter key="foo.bar_reference1" type="constant">App\Service\Foo::EXAMPLE_REFERENCE1</parameter>
        <parameter key="foo.bar_reference2" type="constant">App\Service\Foo::EXAMPLE_REFERENCE2</parameter>
    </parameters>

    <services>
        <service id="App\Service\Foo">
            <tag name="bar.reference" key="%foo.bar_reference1%" />
            <tag name="bar.reference" key="%foo.bar_reference2%" />
        </service>

        <service id="App\Service\Bar">
            <argument type="tagged_locator" tag="bar.reference" index-by="key" />
        </service>
    </services>
</container>
```