### PR TITLE
Add test for AccessTokenHeaderRegex and adjust regex

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/HeaderAccessTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/HeaderAccessTokenExtractor.php
@@ -29,7 +29,7 @@ final class HeaderAccessTokenExtractor implements AccessTokenExtractorInterface
         private readonly string $tokenType = 'Bearer'
     ) {
         $this->regex = sprintf(
-            '/^%s([a-zA-Z0-9\-_\+~\/\.]+)$/',
+            '/^%s([a-zA-Z0-9\-_\+~\/\.]+=*)$/',
             '' === $this->tokenType ? '' : preg_quote($this->tokenType).'\s+'
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #54660
| License       | MIT

The regular expression was tweaked to support a wider range of tokens, especially those ending with an equals sign and fulfil with the [RFC6750](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1).
A new test was added to AccessTokenAuthenticatorTest to ensure that the regular expression in HeaderAccessTokenExtractor works correctly. 
