### PR TITLE
[HttpClient] Implemented LoggerAwareInterface in HttpClientInterface decorators

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,7 +33,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class CachingHttpClient implements HttpClientInterface, ResetInterface
+class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use HttpClientTrait;
 
@@ -140,6 +142,13 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
     {
         if ($this->client instanceof ResetInterface) {
             $this->client->reset();
+        }
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        if ($this->client instanceof LoggerAwareInterface) {
+            $this->client->setLogger($logger);
         }
     }
 }

--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\Exception\EventSourceException;
 use Symfony\Component\HttpClient\Response\AsyncContext;
@@ -25,7 +27,7 @@ use Symfony\Contracts\Service\ResetInterface;
  * @author Antoine Bluchet <soyuka@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
+final class EventSourceHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use AsyncDecoratorTrait, HttpClientTrait {
         AsyncDecoratorTrait::withOptions insteadof HttpClientTrait;
@@ -155,5 +157,12 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
                 yield $chunk;
             }
         });
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        if ($this->client instanceof LoggerAwareInterface) {
+            $this->client->setLogger($logger);
+        }
     }
 }

--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
@@ -27,7 +28,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class RetryableHttpClient implements HttpClientInterface, ResetInterface
+class RetryableHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use AsyncDecoratorTrait;
 
@@ -161,6 +162,14 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
                 $context->passthru();
             }
         });
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+        if ($this->client instanceof LoggerAwareInterface) {
+            $this->client->setLogger($logger);
+        }
     }
 
     private function getDelayFromHeader(array $headers): ?int

--- a/src/Symfony/Component/HttpClient/ThrottlingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/ThrottlingHttpClient.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -19,7 +21,7 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * Limits the number of requests within a certain period.
  */
-class ThrottlingHttpClient implements HttpClientInterface, ResetInterface
+class ThrottlingHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use DecoratorTrait {
         reset as private traitReset;
@@ -47,5 +49,12 @@ class ThrottlingHttpClient implements HttpClientInterface, ResetInterface
     {
         $this->traitReset();
         $this->rateLimiter->reset();
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        if ($this->client instanceof LoggerAwareInterface) {
+            $this->client->setLogger($logger);
+        }
     }
 }

--- a/src/Symfony/Component/HttpClient/UriTemplateHttpClient.php
+++ b/src/Symfony/Component/HttpClient/UriTemplateHttpClient.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
-class UriTemplateHttpClient implements HttpClientInterface, ResetInterface
+class UriTemplateHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use DecoratorTrait;
 
@@ -60,6 +62,13 @@ class UriTemplateHttpClient implements HttpClientInterface, ResetInterface
         $clone->client = $this->client->withOptions($options);
 
         return $clone;
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        if ($this->client instanceof LoggerAwareInterface) {
+            $this->client->setLogger($logger);
+        }
     }
 
     /**


### PR DESCRIPTION
Implement `Psr\Log\LoggerAwareInterface` in `Symfony\Component\HttpClient\UriTemplateHttpClient`.

| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I was on a journey to enhance our logs on a project that highly depend on `HttpClient`.
I started to separate logs per feature, and I wanted to include `HttpClient` logs to the logger of the currently running the feature.

I figured out that most implementations of `HttpClientInterface` are implementing `LoggerAwareInterface`, so I decided to just call `$client->setLogger(...)` on my side.
And **nothing changed**.

Nothing changed because my logger is decorated by the `UriTemplateHttpClient` that is not implementing `LoggerAwareInterface`.
Althought `UriTemplateHttpClient` has no need of a logger, as a decorator it should be able to act like it, so the underlying client can be reached.
This is what is done for instance in `Symfony\Component\HttpClient\TraceableHttpClient`.