### PR TITLE
[TypeInfo] rework isA to handle class names and improve isNullable

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Type/BackedEnumTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/BackedEnumTypeTest.php
@@ -45,5 +45,9 @@ class BackedEnumTypeTest extends TestCase
     {
         $this->assertFalse((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isA(TypeIdentifier::ARRAY));
         $this->assertTrue((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isA(TypeIdentifier::OBJECT));
+        $this->assertFalse((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isA(self::class));
+        $this->assertTrue((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isA(DummyBackedEnum::class));
+        $this->assertTrue((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isA(\BackedEnum::class));
+        $this->assertTrue((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isA(\UnitEnum::class));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/BuiltinTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/BuiltinTypeTest.php
@@ -66,5 +66,8 @@ class BuiltinTypeTest extends TestCase
     {
         $this->assertFalse((new BuiltinType(TypeIdentifier::INT))->isA(TypeIdentifier::ARRAY));
         $this->assertTrue((new BuiltinType(TypeIdentifier::INT))->isA(TypeIdentifier::INT));
+        $this->assertFalse((new BuiltinType(TypeIdentifier::INT))->isA('array'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::INT))->isA('int'));
+        $this->assertFalse((new BuiltinType(TypeIdentifier::INT))->isA(self::class));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -100,5 +100,12 @@ class CollectionTypeTest extends TestCase
         $this->assertTrue($type->isA(TypeIdentifier::ARRAY));
         $this->assertFalse($type->isA(TypeIdentifier::STRING));
         $this->assertFalse($type->isA(TypeIdentifier::INT));
+        $this->assertFalse($type->isA(self::class));
+
+        $type = new CollectionType(new GenericType(Type::object(self::class), Type::string(), Type::bool()));
+
+        $this->assertFalse($type->isA(TypeIdentifier::ARRAY));
+        $this->assertTrue($type->isA(TypeIdentifier::OBJECT));
+        $this->assertTrue($type->isA(self::class));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/EnumTypeTest.php
@@ -44,5 +44,8 @@ class EnumTypeTest extends TestCase
     {
         $this->assertFalse((new EnumType(DummyEnum::class))->isA(TypeIdentifier::ARRAY));
         $this->assertTrue((new EnumType(DummyEnum::class))->isA(TypeIdentifier::OBJECT));
+        $this->assertTrue((new EnumType(DummyEnum::class))->isA(DummyEnum::class));
+        $this->assertTrue((new EnumType(DummyEnum::class))->isA(\UnitEnum::class));
+        $this->assertFalse((new EnumType(DummyEnum::class))->isA(\BackedEnum::class));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
@@ -54,10 +54,12 @@ class GenericTypeTest extends TestCase
         $type = new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool());
         $this->assertTrue($type->isA(TypeIdentifier::ARRAY));
         $this->assertFalse($type->isA(TypeIdentifier::STRING));
+        $this->assertFalse($type->isA(self::class));
 
         $type = new GenericType(Type::object(self::class), Type::union(Type::bool(), Type::string()), Type::int(), Type::float());
         $this->assertTrue($type->isA(TypeIdentifier::OBJECT));
         $this->assertFalse($type->isA(TypeIdentifier::INT));
         $this->assertFalse($type->isA(TypeIdentifier::STRING));
+        $this->assertTrue($type->isA(self::class));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/ObjectTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/ObjectTypeTest.php
@@ -36,5 +36,7 @@ class ObjectTypeTest extends TestCase
     {
         $this->assertFalse((new ObjectType(self::class))->isA(TypeIdentifier::ARRAY));
         $this->assertTrue((new ObjectType(self::class))->isA(TypeIdentifier::OBJECT));
+        $this->assertTrue((new ObjectType(self::class))->isA(self::class));
+        $this->assertFalse((new ObjectType(self::class))->isA(\stdClass::class));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
@@ -31,17 +31,6 @@ class TypeTest extends TestCase
         $this->assertFalse(Type::generic(Type::string(), Type::int())->is($isInt));
     }
 
-    public function testIsA()
-    {
-        $this->assertTrue(Type::int()->isA(TypeIdentifier::INT));
-        $this->assertTrue(Type::union(Type::string(), Type::int())->isA(TypeIdentifier::INT));
-        $this->assertTrue(Type::generic(Type::int(), Type::string())->isA(TypeIdentifier::INT));
-
-        $this->assertFalse(Type::string()->isA(TypeIdentifier::INT));
-        $this->assertFalse(Type::union(Type::string(), Type::float())->isA(TypeIdentifier::INT));
-        $this->assertFalse(Type::generic(Type::string(), Type::int())->isA(TypeIdentifier::INT));
-    }
-
     public function testIsNullable()
     {
         $this->assertTrue(Type::null()->isNullable());

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -27,6 +27,13 @@ abstract class Type implements \Stringable
     abstract public function getBaseType(): BuiltinType|ObjectType;
 
     /**
+     * @param TypeIdentifier|class-string $subject
+     */
+    abstract public function isA(TypeIdentifier|string $subject): bool;
+
+    abstract public function asNonNullable(): self;
+
+    /**
      * @param callable(Type): bool $callable
      */
     public function is(callable $callable): bool
@@ -34,15 +41,8 @@ abstract class Type implements \Stringable
         return $callable($this);
     }
 
-    public function isA(TypeIdentifier $typeIdentifier): bool
-    {
-        return $this->getBaseType()->getTypeIdentifier() === $typeIdentifier;
-    }
-
     public function isNullable(): bool
     {
-        return \in_array($this->getBaseType()->getTypeIdentifier(), [TypeIdentifier::NULL, TypeIdentifier::MIXED], true);
+        return $this->is(fn (Type $t): bool => $t->isA(TypeIdentifier::NULL) || $t->isA(TypeIdentifier::MIXED));
     }
-
-    abstract public function asNonNullable(): self;
 }

--- a/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
@@ -46,6 +46,19 @@ final class BuiltinType extends Type
         return $this->typeIdentifier;
     }
 
+    public function isA(TypeIdentifier|string $subject): bool
+    {
+        if ($subject instanceof TypeIdentifier) {
+            return $this->getTypeIdentifier() === $subject;
+        }
+
+        try {
+            return TypeIdentifier::from($subject) === $this->getTypeIdentifier();
+        } catch (\ValueError) {
+            return false;
+        }
+    }
+
     /**
      * @return self|UnionType<BuiltinType<TypeIdentifier::OBJECT>|BuiltinType<TypeIdentifier::RESOURCE>|BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::STRING>|BuiltinType<TypeIdentifier::FLOAT>|BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::BOOL>>
      */

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -58,6 +58,11 @@ final class CollectionType extends Type
         return $this->type;
     }
 
+    public function isA(TypeIdentifier|string $subject): bool
+    {
+        return $this->getType()->isA($subject);
+    }
+
     public function isList(): bool
     {
         return $this->isList;

--- a/src/Symfony/Component/TypeInfo/Type/CompositeTypeTrait.php
+++ b/src/Symfony/Component/TypeInfo/Type/CompositeTypeTrait.php
@@ -49,14 +49,9 @@ trait CompositeTypeTrait
         $this->types = array_values(array_unique($types));
     }
 
-    public function isA(TypeIdentifier $typeIdentifier): bool
+    public function isA(TypeIdentifier|string $subject): bool
     {
-        return $this->is(fn (Type $type) => $type->isA($typeIdentifier));
-    }
-
-    public function isNullable(): bool
-    {
-        return $this->is(fn (Type $type) => $type->isNullable());
+        return $this->is(fn (Type $type) => $type->isA($subject));
     }
 
     /**

--- a/src/Symfony/Component/TypeInfo/Type/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/Type/GenericType.php
@@ -56,6 +56,11 @@ final class GenericType extends Type
         return $this->type;
     }
 
+    public function isA(TypeIdentifier|string $subject): bool
+    {
+        return $this->getType()->isA($subject);
+    }
+
     public function asNonNullable(): self
     {
         return $this;

--- a/src/Symfony/Component/TypeInfo/Type/ObjectType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectType.php
@@ -42,6 +42,15 @@ class ObjectType extends Type
         return TypeIdentifier::OBJECT;
     }
 
+    public function isA(TypeIdentifier|string $subject): bool
+    {
+        if ($subject instanceof TypeIdentifier) {
+            return $this->getTypeIdentifier() === $subject;
+        }
+
+        return is_a($this->getClassName(), $subject, allow_string: true);
+    }
+
     /**
      * @return T
      */

--- a/src/Symfony/Component/TypeInfo/Type/TemplateType.php
+++ b/src/Symfony/Component/TypeInfo/Type/TemplateType.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\TypeInfo\Type;
 
 use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 /**
  * Represents a template placeholder, such as "T" in "Collection<T>".
@@ -33,6 +34,11 @@ final class TemplateType extends Type
     public function getBaseType(): BuiltinType|ObjectType
     {
         throw new LogicException(sprintf('Cannot get base type on "%s" template type.', $this));
+    }
+
+    public function isA(TypeIdentifier|string $subject): bool
+    {
+        return false;
     }
 
     public function getName(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

https://github.com/symfony/symfony/pull/54659 introduces a better design that allows us to easily handle class names in `isA` and to simplify `isNullable`