### PR TITLE
[TypeInfo] Ease getting base type on nullable types

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Type/BackedEnumTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/BackedEnumTypeTest.php
@@ -29,6 +29,11 @@ class BackedEnumTypeTest extends TestCase
         $this->assertFalse((new BackedEnumType(DummyBackedEnum::class, Type::int()))->isNullable());
     }
 
+    public function testGetBaseType()
+    {
+        $this->assertEquals(new BackedEnumType(DummyBackedEnum::class, Type::int()), (new BackedEnumType(DummyBackedEnum::class, Type::int()))->getBaseType());
+    }
+
     public function testAsNonNullable()
     {
         $type = new BackedEnumType(DummyBackedEnum::class, Type::int());

--- a/src/Symfony/Component/TypeInfo/Tests/Type/BuiltinTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/BuiltinTypeTest.php
@@ -24,6 +24,11 @@ class BuiltinTypeTest extends TestCase
         $this->assertSame('int', (string) new BuiltinType(TypeIdentifier::INT));
     }
 
+    public function testGetBaseType()
+    {
+        $this->assertEquals(new BuiltinType(TypeIdentifier::INT), (new BuiltinType(TypeIdentifier::INT))->getBaseType());
+    }
+
     public function testIsNullable()
     {
         $this->assertFalse((new BuiltinType(TypeIdentifier::INT))->isNullable());

--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -74,6 +74,11 @@ class CollectionTypeTest extends TestCase
         $this->assertEquals('array<string,bool>', (string) $type);
     }
 
+    public function testGetBaseType()
+    {
+        $this->assertEquals(Type::int(), Type::collection(Type::generic(Type::int(), Type::string()))->getBaseType());
+    }
+
     public function testIsNullable()
     {
         $this->assertFalse((new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::int())))->isNullable());

--- a/src/Symfony/Component/TypeInfo/Tests/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/EnumTypeTest.php
@@ -23,6 +23,11 @@ class EnumTypeTest extends TestCase
         $this->assertSame(DummyEnum::class, (string) new EnumType(DummyEnum::class));
     }
 
+    public function testGetBaseType()
+    {
+        $this->assertEquals(new EnumType(DummyEnum::class), (new EnumType(DummyEnum::class))->getBaseType());
+    }
+
     public function testIsNullable()
     {
         $this->assertFalse((new EnumType(DummyEnum::class))->isNullable());

--- a/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
@@ -30,6 +30,11 @@ class GenericTypeTest extends TestCase
         $this->assertEquals(sprintf('%s<bool|string,int,float>', self::class), (string) $type);
     }
 
+    public function testGetBaseType()
+    {
+        $this->assertEquals(Type::object(), Type::generic(Type::object(), Type::int())->getBaseType());
+    }
+
     public function testIsNullable()
     {
         $this->assertFalse((new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::int()))->isNullable());

--- a/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
@@ -56,6 +56,12 @@ class IntersectionTypeTest extends TestCase
         $this->assertFalse($type->everyTypeIs(fn (Type $t) => $t instanceof BuiltinType));
     }
 
+    public function testGetBaseType()
+    {
+        $this->expectException(LogicException::class);
+        (new IntersectionType(Type::string(), Type::int()))->getBaseType();
+    }
+
     public function testToString()
     {
         $type = new IntersectionType(Type::int(), Type::string(), Type::float());

--- a/src/Symfony/Component/TypeInfo/Tests/Type/ObjectTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/ObjectTypeTest.php
@@ -27,6 +27,11 @@ class ObjectTypeTest extends TestCase
         $this->assertFalse((new ObjectType(self::class))->isNullable());
     }
 
+    public function testGetBaseType()
+    {
+        $this->assertEquals(new ObjectType(self::class), (new ObjectType(self::class))->getBaseType());
+    }
+
     public function testIsA()
     {
         $this->assertFalse((new ObjectType(self::class))->isA(TypeIdentifier::ARRAY));

--- a/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\TypeInfo\Tests\Type;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\UnionType;
@@ -64,6 +65,14 @@ class UnionTypeTest extends TestCase
             Type::object(\stdClass::class),
             Type::string(),
         ], $type->asNonNullable()->getTypes());
+    }
+
+    public function testGetBaseType()
+    {
+        $this->assertEquals(Type::string(), (new UnionType(Type::string(), Type::null()))->getBaseType());
+
+        $this->expectException(LogicException::class);
+        (new UnionType(Type::string(), Type::int(), Type::null()))->getBaseType();
     }
 
     public function testAtLeastOneTypeIs()

--- a/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
@@ -57,15 +57,6 @@ class TypeTest extends TestCase
         $this->assertFalse(Type::generic(Type::int(), Type::mixed())->isNullable());
     }
 
-    public function testGetBaseType()
-    {
-        $this->assertEquals(Type::string(), Type::string()->getBaseType());
-        $this->assertEquals(Type::object(self::class), Type::object(self::class)->getBaseType());
-        $this->assertEquals(Type::object(), Type::generic(Type::object(), Type::int())->getBaseType());
-        $this->assertEquals(Type::builtin(TypeIdentifier::ARRAY), Type::list()->getBaseType());
-        $this->assertEquals(Type::int(), Type::collection(Type::generic(Type::int(), Type::string()))->getBaseType());
-    }
-
     public function testCannotGetBaseTypeOnCompoundType()
     {
         $this->expectException(LogicException::class);

--- a/src/Symfony/Component/TypeInfo/Type/CompositeTypeTrait.php
+++ b/src/Symfony/Component/TypeInfo/Type/CompositeTypeTrait.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\TypeInfo\Type;
 
 use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
-use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeIdentifier;
 
@@ -48,11 +47,6 @@ trait CompositeTypeTrait
 
         usort($types, fn (Type $a, Type $b): int => (string) $a <=> (string) $b);
         $this->types = array_values(array_unique($types));
-    }
-
-    public function getBaseType(): BuiltinType|ObjectType
-    {
-        throw new LogicException(sprintf('Cannot get base type on "%s" compound type.', $this));
     }
 
     public function isA(TypeIdentifier $typeIdentifier): bool

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -45,6 +45,17 @@ final class IntersectionType extends Type
         return $string;
     }
 
+    /**
+     * @throws LogicException
+     */
+    public function getBaseType(): BuiltinType|ObjectType
+    {
+        throw new LogicException(sprintf('Cannot get base type on "%s" compound type.', $this));
+    }
+
+    /**
+     * @throws LogicException
+     */
     public function asNonNullable(): self
     {
         if ($this->isNullable()) {

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\TypeInfo\Type;
 
+use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeIdentifier;
 
@@ -30,6 +31,19 @@ final class UnionType extends Type
     public function is(callable $callable): bool
     {
         return $this->atLeastOneTypeIs($callable);
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function getBaseType(): BuiltinType|ObjectType
+    {
+        $nonNullableType = $this->asNonNullable();
+        if (!$nonNullableType instanceof self) {
+            return $nonNullableType->getBaseType();
+        }
+
+        throw new LogicException(sprintf('Cannot get base type on "%s" compound type.', $this));
     }
 
     public function asNonNullable(): Type


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Allow retrieving base type on "nullable union types" (ie: `string|null`) without getting a `LogicException`.