### PR TITLE
[PropertyInfo] Fix PHPStan properties type in trait

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -233,6 +233,14 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
             return null;
         }
 
+        $reflector = $reflectionProperty->getDeclaringClass();
+
+        foreach ($reflector->getTraits() as $trait) {
+            if ($trait->hasProperty($property)) {
+                return $this->getDocBlockFromProperty($trait->getName(), $property);
+            }
+        }
+
         if (null === $rawDocNode = $reflectionProperty->getDocComment() ?: null) {
             return null;
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy\RootDummyItem;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\AnotherNamespace\DummyInAnotherNamespace;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type;
@@ -311,6 +312,7 @@ class PhpStanExtractorTest extends TestCase
             ['propertyInTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
             ['propertyInTraitObjectSameNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyUsedInTrait::class)],
             ['propertyInTraitObjectDifferentNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)],
+            ['dummyInAnotherNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyInAnotherNamespace::class)],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/AnotherNamespace/DummyInAnotherNamespace.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/AnotherNamespace/DummyInAnotherNamespace.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\AnotherNamespace;
+
+class DummyInAnotherNamespace
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/AnotherNamespace/DummyTraitInAnotherNamespace.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/AnotherNamespace/DummyTraitInAnotherNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\AnotherNamespace;
+
+trait DummyTraitInAnotherNamespace
+{
+    /**
+     * @var DummyInAnotherNamespace
+     */
+    public $dummyInAnotherNamespace;
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyUsingTrait.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyUsingTrait.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage;
 
+use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\AnotherNamespace\DummyTraitInAnotherNamespace;
+
 class DummyUsingTrait
 {
     use DummyTrait;
+    use DummyTraitInAnotherNamespace;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54569
| License       | MIT

Handle traits properly in `PhpStanExtractor`.