### PR TITLE
[FrameworkBundle] Add support for setting `headers` with `TemplateController`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add support for setting `headers` with `Symfony\Bundle\FrameworkBundle\Controller\TemplateController`
+
 7.1
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -37,8 +37,9 @@ class TemplateController
      * @param bool|null $private    Whether or not caching should apply for client caches only
      * @param array     $context    The context (arguments) of the template
      * @param int       $statusCode The HTTP status code to return with the response (200 "OK" by default)
+     * @param array     $headers    The HTTP headers to add to the response
      */
-    public function templateAction(string $template, ?int $maxAge = null, ?int $sharedAge = null, ?bool $private = null, array $context = [], int $statusCode = 200): Response
+    public function templateAction(string $template, ?int $maxAge = null, ?int $sharedAge = null, ?bool $private = null, array $context = [], int $statusCode = 200, array $headers = []): Response
     {
         if (null === $this->twig) {
             throw new \LogicException('You cannot use the TemplateController if the Twig Bundle is not available. Try running "composer require symfony/twig-bundle".');
@@ -58,6 +59,10 @@ class TemplateController
             $response->setPrivate();
         } elseif (false === $private || (null === $private && (null !== $maxAge || null !== $sharedAge))) {
             $response->setPublic();
+        }
+
+        foreach ($headers as $key => $value) {
+            $response->headers->set($key, $value);
         }
 
         return $response;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -84,4 +84,18 @@ class TemplateControllerTest extends TestCase
         $this->assertSame(201, $controller->templateAction($templateName, null, null, null, [], $statusCode)->getStatusCode());
         $this->assertSame(200, $controller->templateAction($templateName)->getStatusCode());
     }
+
+    public function testHeaders()
+    {
+        $templateName = 'image.svg.twig';
+
+        $loader = new ArrayLoader();
+        $loader->setTemplate($templateName, '<svg></svg>');
+
+        $twig = new Environment($loader);
+        $controller = new TemplateController($twig);
+
+        $this->assertSame('image/svg+xml', $controller->templateAction($templateName, headers: ['Content-Type' => 'image/svg+xml'])->headers->get('Content-Type'));
+        $this->assertNull($controller->templateAction($templateName)->headers->get('Content-Type'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

It would be nice to be able to set some additional headers such as `Content-Type` when using the `TemplateController`.