### PR TITLE
[TypeInfo] Proxies methods to non-nullable and fail gracefully

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -108,4 +108,10 @@ class CollectionTypeTest extends TestCase
         $this->assertTrue($type->isA(TypeIdentifier::OBJECT));
         $this->assertTrue($type->isA(self::class));
     }
+
+    public function testProxiesMethodsToBaseType()
+    {
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
+        $this->assertEquals([Type::string(), Type::bool()], $type->getVariableTypes());
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
@@ -62,4 +62,10 @@ class GenericTypeTest extends TestCase
         $this->assertFalse($type->isA(TypeIdentifier::STRING));
         $this->assertTrue($type->isA(self::class));
     }
+
+    public function testProxiesMethodsToBaseType()
+    {
+        $type = new GenericType(Type::object(self::class), Type::float());
+        $this->assertSame(self::class, $type->getClassName());
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
@@ -123,4 +123,23 @@ class UnionTypeTest extends TestCase
         $type = new UnionType(Type::string(), Type::intersection(Type::int(), Type::int()));
         $this->assertTrue($type->isA(TypeIdentifier::INT));
     }
+
+    public function testProxiesMethodsToNonNullableType()
+    {
+        $this->assertEquals(Type::string(), (new UnionType(Type::list(Type::string()), Type::null()))->getCollectionValueType());
+
+        try {
+            (new UnionType(Type::int(), Type::null()))->getCollectionValueType();
+            $this->fail();
+        } catch (LogicException) {
+            $this->addToAssertionCount(1);
+        }
+
+        try {
+            (new UnionType(Type::list(Type::string()), Type::string()))->getCollectionValueType();
+            $this->fail();
+        } catch (LogicException) {
+            $this->addToAssertionCount(1);
+        }
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
@@ -51,4 +51,10 @@ class TypeTest extends TestCase
         $this->expectException(LogicException::class);
         Type::union(Type::int(), Type::string())->getBaseType();
     }
+
+    public function testThrowsOnUnexistingMethod()
+    {
+        $this->expectException(LogicException::class);
+        Type::int()->unexistingMethod();
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\TypeInfo;
 
+use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
@@ -44,5 +45,15 @@ abstract class Type implements \Stringable
     public function isNullable(): bool
     {
         return $this->is(fn (Type $t): bool => $t->isA(TypeIdentifier::NULL) || $t->isA(TypeIdentifier::MIXED));
+    }
+
+    /**
+     * Graceful fallback for unexisting methods.
+     *
+     * @param list<mixed> $arguments
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        throw new LogicException(sprintf('Cannot call "%s" on "%s" type.', $method, $this));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -78,4 +78,24 @@ final class UnionType extends Type
 
         return $string;
     }
+
+    /**
+     * Proxies all method calls to the original non-nullable type.
+     *
+     * @param list<mixed> $arguments
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        $nonNullableType = $this->asNonNullable();
+
+        if (!$nonNullableType instanceof self) {
+            if (!method_exists($nonNullableType, $method)) {
+                throw new LogicException(sprintf('Method "%s" doesn\'t exist on "%s" type.', $method, $nonNullableType));
+            }
+
+            return $nonNullableType->{$method}(...$arguments);
+        }
+
+        throw new LogicException(sprintf('Cannot call "%s" on "%s" compound type.', $method, $this));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

- Proxies methods of "nullable union types" (ie: string|null) on non-nullable related type.
- Gracefully fail with a `LogicException` on invalid method call. This allows for example to call `getClassName` on every `Type` within a try/catch block, without having to retrieve the very precise type holding the class name.
