### PR TITLE
[TypeInfo] Support `\Stringable` objects in `StringTypeResolver`

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -40,6 +40,23 @@ class StringTypeResolverTest extends TestCase
     }
 
     /**
+     * @dataProvider resolveDataProvider
+     */
+    public function testResolveStringable(Type $expectedType, string $string, ?TypeContext $typeContext = null)
+    {
+        $this->assertEquals($expectedType, $this->resolver->resolve(new class($string) implements \Stringable {
+            public function __construct(private string $value)
+            {
+            }
+
+            public function __toString(): string
+            {
+                return $this->value;
+            }
+        }, $typeContext));
+    }
+
+    /**
      * @return iterable<array{0: Type, 1: string, 2?: TypeContext}>
      */
     public function resolveDataProvider(): iterable

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -71,7 +71,9 @@ final class StringTypeResolver implements TypeResolverInterface
 
     public function resolve(mixed $subject, ?TypeContext $typeContext = null): Type
     {
-        if (!\is_string($subject)) {
+        if ($subject instanceof \Stringable) {
+            $subject = (string) $subject;
+        } elseif (!\is_string($subject)) {
             throw new UnsupportedException(sprintf('Expected subject to be a "string", "%s" given.', get_debug_type($subject)), $subject);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
