### PR TITLE
[Finder] Also consider .git inside the basedir of in() directory

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
@@ -37,9 +37,9 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
     {
         $this->baseDir = $this->normalizePath($baseDir);
 
-        foreach ($this->parentDirectoriesUpwards($this->baseDir) as $parentDirectory) {
-            if (@is_dir("{$parentDirectory}/.git")) {
-                $this->baseDir = $parentDirectory;
+        foreach ([$this->baseDir, ...$this->parentDirectoriesUpwards($this->baseDir)] as $directory) {
+            if (@is_dir("{$directory}/.git")) {
+                $this->baseDir = $directory;
                 break;
             }
         }

--- a/src/Symfony/Component/Finder/Tests/Iterator/VcsIgnoredFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/VcsIgnoredFilterIteratorTest.php
@@ -34,7 +34,7 @@ class VcsIgnoredFilterIteratorTest extends IteratorTestCase
      *
      * @dataProvider getAcceptData
      */
-    public function testAccept(array $gitIgnoreFiles, array $otherFileNames, array $expectedResult)
+    public function testAccept(array $gitIgnoreFiles, array $otherFileNames, array $expectedResult, string $baseDir = '')
     {
         $otherFileNames = $this->toAbsolute($otherFileNames);
         foreach ($otherFileNames as $path) {
@@ -51,7 +51,8 @@ class VcsIgnoredFilterIteratorTest extends IteratorTestCase
 
         $inner = new InnerNameIterator($otherFileNames);
 
-        $iterator = new VcsIgnoredFilterIterator($inner, $this->tmpDir);
+        $baseDir = $this->tmpDir.('' !== $baseDir ? '/'.$baseDir : '');
+        $iterator = new VcsIgnoredFilterIterator($inner, $baseDir);
 
         $this->assertIterator($this->toAbsolute($expectedResult), $iterator);
     }
@@ -72,6 +73,55 @@ class VcsIgnoredFilterIteratorTest extends IteratorTestCase
                 'b.txt',
                 'dir',
             ],
+        ];
+
+        yield 'simple file - .gitignore and in() from repository root' => [
+            [
+                '.gitignore' => 'a.txt',
+            ],
+            [
+                '.git',
+                'a.txt',
+                'b.txt',
+                'dir/',
+                'dir/a.txt',
+            ],
+            [
+                '.git',
+                'b.txt',
+                'dir',
+            ],
+        ];
+
+        yield 'nested git repositories only consider .gitignore files of the most inner repository' => [
+            [
+                '.gitignore' => "nested/*\na.txt",
+                'nested/.gitignore' => 'c.txt',
+                'nested/dir/.gitignore' => 'f.txt',
+            ],
+            [
+                '.git',
+                'a.txt',
+                'b.txt',
+                'nested/',
+                'nested/.git',
+                'nested/c.txt',
+                'nested/d.txt',
+                'nested/dir/',
+                'nested/dir/e.txt',
+                'nested/dir/f.txt',
+            ],
+            [
+                '.git',
+                'a.txt',
+                'b.txt',
+                'nested',
+                'nested/.git',
+                'nested/d.txt',
+                'nested/dir',
+                'nested/dir/e.txt',
+            ],
+            'nested',
         ];
 
         yield 'simple file at root' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix described below
| License       | MIT


### Bug description
Previously when the `in()` directory was the root of your repository the `.gitignore` was skipped from consideration, which meant potentially all local files are ignored.

E.g. in the Nextcloud community we have the server locally with an `.gitignore` for the `apps/` directory. Now when an app developer develops their own app locally, they put their own git repository inside this ignored `apps/` folder.
The CS Fixer rules we use since a long time are:
```php
(new Finder())
	->ignoreVCSIgnored(true)
	->notPath('l10n')
	->notPath('vendor')
	->notPath('vendor-bin')
	->in(__DIR__);
```

and this worked pretty well with 5.4 and previous versions of the finder. Now that the Nextcloud project finally dropped PHP 8.0 for the latest version and we get the update to Symfony 6.4 the bug become visible locally, but our CI still works as we don't need the "server" repository as a parent when running the CS fixer.

### Locally - nested inside "server" repository
```
~/Nextcloud/server/apps/spreed$ composer run cs:check
> php-cs-fixer fix --dry-run --diff
PHP CS Fixer 3.54.0 15 Keys Accelerate by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.2.18
Loaded config default from "/home/nickv/Nextcloud/30/server/appsbabies/spreed/.php-cs-fixer.dist.php".
Using cache file ".php-cs-fixer.cache".
    0 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]
```

:x:  No files found, all ignored by `server/.gitignore`

### CI without a parent repository
```
Run composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )
 > php-cs-fixer fix --dry-run --diff
PHP CS Fixer 3.54.0 15 Keys Accelerate by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.1.2-1ubuntu2.13
Loaded config default from "/home/runner/actions-runner/_work/spreed/spreed/.php-cs-fixer.dist.php".
   0/502 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
```

:white_check_mark: Correct file list found


### 5.4 
- From my POV this is a regression from https://github.com/symfony/symfony/pull/43239 (so 6.1+ only) and it becomes more "obvious" when backporting the unit test to 5.4 as it passes there without patching `VcsIgnoredFilterIterator.php`.
- Therefore cc-ing @julienfalque as author, to clarify if this was intentional

