### PR TITLE
[PropertyInfo] Update DoctrineExtractor for new DBAL 4 BIGINT type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\PropertyInfo;
 
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\BigIntType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
@@ -142,6 +143,15 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             }
 
             $nullable = $metadata instanceof ClassMetadata && $metadata->isNullable($property);
+
+            // DBAL 4 has a special fallback strategy for BINGINT (int -> string)
+            if (Types::BIGINT === $typeOfField && !method_exists(BigIntType::class, 'getName')) {
+                return [
+                    new Type(Type::BUILTIN_TYPE_INT, $nullable),
+                    new Type(Type::BUILTIN_TYPE_STRING, $nullable),
+                ];
+            }
+
             $enumType = null;
             if (null !== $enumClass = self::getMappingValue($metadata->getFieldMapping($property), 'enumType') ?? null) {
                 $enumType = new Type(Type::BUILTIN_TYPE_OBJECT, $nullable, $enumClass);

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Types\BigIntType;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Column;
@@ -162,10 +163,17 @@ class DoctrineExtractorTest extends TestCase
 
     public static function typesProvider(): array
     {
+        // DBAL 4 has a special fallback strategy for BINGINT (int -> string)
+        if (!method_exists(BigIntType::class, 'getName')) {
+            $expectedBingIntType = [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)];
+        } else {
+            $expectedBingIntType = [new Type(Type::BUILTIN_TYPE_STRING)];
+        }
+
         return [
             ['id', [new Type(Type::BUILTIN_TYPE_INT)]],
             ['guid', [new Type(Type::BUILTIN_TYPE_STRING)]],
-            ['bigint', [new Type(Type::BUILTIN_TYPE_STRING)]],
+            ['bigint', $expectedBingIntType],
             ['time', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')]],
             ['timeImmutable', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTimeImmutable')]],
             ['dateInterval', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateInterval')]],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | not sure
| Deprecations? | no
| Issues        | Fix #54418 
| License       | MIT

## Additional Considerations

This issue looks pretty straight forward, but it has had me running in circles not being sure how to exactly interpret it. The new return type to make it work with DBAL 4 is _fine_, but it is neither an intersection nor a union type, which **will** cause trouble for other libs if they do not explicitly check each. 

There is not easy way to get which DBAL version is the extractor is running against, so trying to optimize the flow is _tricky_. I am opening this PR to have a starting point in the hopes that maintainers of this package have more historical context than me. 

I have tried to document as much as possible about this in the issue linked above. 🍻 
