### PR TITLE
[HttpKernel] Fix default locale ignored when Accept-Language has no enabled-locale match

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -41,7 +41,7 @@ class LocaleListener implements EventSubscriberInterface
         $this->requestStack = $requestStack;
         $this->router = $router;
         $this->useAcceptLanguageHeader = $useAcceptLanguageHeader;
-        $this->enabledLocales = $enabledLocales;
+        $this->enabledLocales = $enabledLocales ? array_values(array_unique(array_merge([$defaultLocale], $enabledLocales))) : [];
     }
 
     public function setDefaultLocale(KernelEvent $event): void

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -192,6 +192,20 @@ class LocaleListenerTest extends TestCase
         $this->assertEquals('de', $request->getLocale());
     }
 
+    public function testDefaultLocaleReturnedWhenNoAcceptLanguageMatchAndDefaultLocaleIsNotFirstEnabledLocale()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', 'es;q=0.9,ja;q=0.8');
+
+        // 'de' is the default locale but is NOT first in enabled_locales
+        $listener = new LocaleListener($this->requestStack, 'de', null, true, ['it', 'fr', 'de']);
+        $event = $this->getEvent($request);
+
+        $listener->setDefaultLocale($event);
+        $listener->onKernelRequest($event);
+        $this->assertEquals('de', $request->getLocale());
+    }
+
     public function testRequestNoLocaleFromAcceptLanguageHeader()
     {
         $request = Request::create('/');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 6.4
| Bug fix      | yes
| New feature  | no
| Deprecations | no
| License       | MIT


When the `Accept-Language` header is used to set the locale, if it's value is not within the list of `enabled_locales`, the value for `default_locale` is overwritten by the first value of the list of `enabled_locales`.
