### PR TITLE
[Form] Add `csrf_token_lazy` option

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -68,7 +68,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
         if ($options['csrf_protection'] && !$view->parent && $options['compound']) {
             $factory = $form->getConfig()->getFormFactory();
             $tokenId = $options['csrf_token_id'] ?: ($form->getName() ?: $form->getConfig()->getType()->getInnerType()::class);
-            $data = (string) $options['csrf_token_manager']->getToken($tokenId);
+            $data = $options['csrf_token_lazy'] ? '' : (string) $options['csrf_token_manager']->getToken($tokenId);
 
             $csrfForm = $factory->createNamed($options['csrf_field_name'], HiddenType::class, $data, [
                 'block_prefix' => 'csrf_token',
@@ -87,6 +87,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             'csrf_message' => 'The CSRF token is invalid. Please try to resubmit the form.',
             'csrf_token_manager' => $this->defaultTokenManager,
             'csrf_token_id' => null,
+            'csrf_token_lazy' => false,
         ]);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -122,6 +122,26 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->assertEquals('token', $view['csrf']->vars['value']);
     }
 
+    public function testGenerateLazyCsrfToken()
+    {
+        $this->tokenManager->expects($this->once())
+            ->method('getToken')
+            ->with('TOKEN_ID')
+            ->willReturn(new CsrfToken('TOKEN_ID', 'token'));
+
+        $view = $this->factory
+            ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
+                'csrf_field_name' => 'csrf',
+                'csrf_token_manager' => $this->tokenManager,
+                'csrf_token_id' => 'TOKEN_ID',
+                'csrf_token_lazy' => true,
+                'compound' => true,
+            ])
+            ->createView();
+
+        $this->assertEquals('token', '');
+    }
+
     public function testGenerateCsrfTokenUsesFormNameAsIntentionByDefault()
     {
         $this->tokenManager->expects($this->once())

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -76,6 +76,7 @@
                 "csrf_message",
                 "csrf_protection",
                 "csrf_token_id",
+                "csrf_token_lazy",
                 "csrf_token_manager"
             ]
         },

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -11,8 +11,8 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   choice_loader                   data_class           allow_file_upload              csrf_message           
   choice_name                     empty_data           attr                           csrf_protection        
   choice_translation_domain       error_bubbling       attr_translation_parameters    csrf_token_id          
-  choice_translation_parameters   invalid_message      auto_initialize                csrf_token_manager     
-  choice_value                    trim                 block_name                                            
+  choice_translation_parameters   invalid_message      auto_initialize                csrf_token_lazy        
+  choice_value                    trim                 block_name                     csrf_token_manager     
   choices                                              block_prefix                                          
   duplicate_preferred_choices                          by_reference                                          
   expanded                                             data                                                  


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | #40270 , #13464  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

### Description
This pull request introduces `csrf_token_lazy`, a new form option in Symfony. This option allows for deferred CSRF token generation until form submission, aiding in performance optimization and mitigating conflicts with caching mechanisms.

### Motivation
The necessity for this option arises from the default behavior of Symfony's CSRF protection mechanism, which initiates sessions for token generation. However, in scenarios where caching is employed, this behavior can lead to cache misses or bypasses, impacting application performance adversely. By introducing `csrf_token_lazy`, developers gain the ability to generate tokens only when necessary, thus avoiding unnecessary session starts during form rendering.

### Functionality
With `csrf_token_lazy` enabled, token generation occurs exclusively during form submission. This ensures that sessions are not initiated unnecessarily during form rendering, thereby maintaining security while optimizing performance, particularly in environments sensitive to caching concerns.

### Usage
Developers can enable `csrf_token_lazy` in form configurations:
```php
public function formAction(Request $request, CsrfTokenManagerInterface $csrfTokenManager): Response {

    $lazy = !$request->hasPreviousSession();

    if ($lazy && $request->isMethod('POST')
        && $request->isXmlHttpRequest()
        && $request->request->has('token')) {
        $response = new Response($csrfTokenManager->getToken('lazy_form_token')->getValue());
        $response->headers->set('Content-Type', 'text/plain');
        return $response;
    }
    
    $form = $this->createFormBuilder($formData, [
        'csrf_token_id' => 'lazy_form_token', 
        'csrf_token_lazy' => $lazy,
        'block_prefix' => ''
    ])->add('field_name')->getForm();
    
    return $this->render('form.html.twig', ['form' => $form->createView()]);
}
```

```javascript
const field = document.getElementById('field_name');
const token = document.getElementById('_token');

field.addEventListener('change', () => {
    if(token.value === '') {
        fetch('/form', {
            method: 'POST', body: 'token',
            credentials: 'same-origin',
            headers: {
                'X-Requested-With': 'XMLHttpRequest',
                'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
            }
        }).then(response => response.text()).then(tokenVal=> token.value = tokenVal);
    }
});
```