### PR TITLE
[Cache] Allow to use namespace delimiter in cache key

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -37,7 +37,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).static::NS_SEPARATOR;
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::NS_SEPARATOR).static::NS_SEPARATOR;
         $this->defaultLifetime = $defaultLifetime;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s").', $this->maxIdLength - 24, \strlen($namespace), $namespace));

--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -42,7 +42,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        if (static::$reservedChars === null) {
+        if (null === static::$reservedChars) {
             static::$reservedChars = str_replace(self::NS_SEPARATOR, '', CacheItem::RESERVED_CHARACTERS);
         }
         $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::$reservedChars).static::NS_SEPARATOR;

--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -33,11 +33,19 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
      */
     protected const NS_SEPARATOR = ':';
 
+    /**
+     * @internal
+     */
+    protected static ?string $reservedChars = null;
+
     private static bool $apcuSupported;
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::NS_SEPARATOR).static::NS_SEPARATOR;
+        if (static::$reservedChars === null) {
+            static::$reservedChars = str_replace(self::NS_SEPARATOR, '', CacheItem::RESERVED_CHARACTERS);
+        }
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::$reservedChars).static::NS_SEPARATOR;
         $this->defaultLifetime = $defaultLifetime;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s").', $this->maxIdLength - 24, \strlen($namespace), $namespace));

--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -37,9 +37,14 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
 
     private const TAGS_PREFIX = "\1tags\1";
 
+    /**
+     * @internal
+     */
+    protected const NS_SEPARATOR = ':';
+
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).':';
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::NS_SEPARATOR).static::NS_SEPARATOR;
         $this->defaultLifetime = $defaultLifetime;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s").', $this->maxIdLength - 24, \strlen($namespace), $namespace));

--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -42,9 +42,17 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
      */
     protected const NS_SEPARATOR = ':';
 
+    /**
+     * @internal
+     */
+    protected static ?string $reservedChars = null;
+
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::NS_SEPARATOR).static::NS_SEPARATOR;
+        if (static::$reservedChars === null) {
+            static::$reservedChars = str_replace(self::NS_SEPARATOR, '', CacheItem::RESERVED_CHARACTERS);
+        }
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::$reservedChars).static::NS_SEPARATOR;
         $this->defaultLifetime = $defaultLifetime;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s").', $this->maxIdLength - 24, \strlen($namespace), $namespace));

--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -49,7 +49,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        if (static::$reservedChars === null) {
+        if (null === static::$reservedChars) {
             static::$reservedChars = str_replace(self::NS_SEPARATOR, '', CacheItem::RESERVED_CHARACTERS);
         }
         $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace, static::$reservedChars).static::NS_SEPARATOR;

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -30,6 +30,12 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
 {
     use LoggerAwareTrait;
 
+    /**
+     * @internal
+     */
+    protected const NS_SEPARATOR = ':';
+
+    private bool $storeSerialized;
     private array $values = [];
     private array $tags = [];
     private array $expiries = [];
@@ -104,7 +110,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
 
             return true;
         }
-        \assert('' !== CacheItem::validateKey($key));
+        \assert('' !== CacheItem::validateKey($key, static::NS_SEPARATOR));
 
         return isset($this->expiries[$key]) && !$this->deleteItem($key);
     }
@@ -134,7 +140,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
 
     public function deleteItem(mixed $key): bool
     {
-        \assert('' !== CacheItem::validateKey($key));
+        \assert('' !== CacheItem::validateKey($key, static::NS_SEPARATOR));
         unset($this->values[$key], $this->tags[$key], $this->expiries[$key]);
 
         return true;
@@ -350,7 +356,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
     {
         foreach ($keys as $key) {
             if (!\is_string($key) || !isset($this->expiries[$key])) {
-                CacheItem::validateKey($key);
+                CacheItem::validateKey($key, static::NS_SEPARATOR);
             }
         }
 

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -55,7 +55,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
         private float $maxLifetime = 0,
         private int $maxItems = 0,
     ) {
-        if (static::$reservedChars === null) {
+        if (null === static::$reservedChars) {
             static::$reservedChars = str_replace(self::NS_SEPARATOR, '', CacheItem::RESERVED_CHARACTERS);
         }
 

--- a/src/Symfony/Component/Cache/Adapter/Psr16Adapter.php
+++ b/src/Symfony/Component/Cache/Adapter/Psr16Adapter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Adapter;
 
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
 use Symfony\Component\Cache\Traits\ProxyTrait;
@@ -40,6 +41,20 @@ class Psr16Adapter extends AbstractAdapter implements PruneableInterface, Resett
         $this->miss = new \stdClass();
     }
 
+    public function getItem(mixed $key): CacheItem
+    {
+        CacheItem::validateKey($key);
+
+        return parent::getItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        CacheItem::validateKeys($keys);
+
+        return parent::getItems($keys);
+    }
+
     protected function doFetch(array $ids): iterable
     {
         foreach ($this->pool->getMultiple($ids, $this->miss) as $key => $value) {
@@ -62,6 +77,13 @@ class Psr16Adapter extends AbstractAdapter implements PruneableInterface, Resett
     protected function doDelete(array $ids): bool
     {
         return $this->pool->deleteMultiple($ids);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        CacheItem::validateKeys($keys);
+
+        return parent::deleteItems($keys);
     }
 
     protected function doSave(array $values, int $lifetime): array|bool

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -127,7 +127,7 @@ final class CacheItem implements ItemInterface
      *
      * @throws InvalidArgumentException When $key is not valid
      */
-    public static function validateKey($key): string
+    public static function validateKey($key, string $allowChars = null): string
     {
         if (!\is_string($key)) {
             throw new InvalidArgumentException(sprintf('Cache key must be string, "%s" given.', get_debug_type($key)));
@@ -135,8 +135,9 @@ final class CacheItem implements ItemInterface
         if ('' === $key) {
             throw new InvalidArgumentException('Cache key length must be greater than zero.');
         }
-        if (false !== strpbrk($key, self::RESERVED_CHARACTERS)) {
-            throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters "%s".', $key, self::RESERVED_CHARACTERS));
+        $reservedChars = null === $allowChars ? self::RESERVED_CHARACTERS : str_replace(str_split($allowChars), '', self::RESERVED_CHARACTERS);
+        if ('' !== $reservedChars && false !== strpbrk($key, $reservedChars)) {
+            throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters "%s".', $key, $reservedChars));
         }
 
         return $key;

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -123,7 +123,7 @@ final class CacheItem implements ItemInterface
     /**
      * Validates a cache key according to PSR-6.
      *
-     * @param mixed $key The key to validate
+     * @param mixed  $key           The key to validate
      * @param string $reservedChars Can be used to override the list of reserved characters
      *
      * @throws InvalidArgumentException When $key is not valid

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -124,10 +124,11 @@ final class CacheItem implements ItemInterface
      * Validates a cache key according to PSR-6.
      *
      * @param mixed $key The key to validate
+     * @param string $reservedChars Can be used to override the list of reserved characters
      *
      * @throws InvalidArgumentException When $key is not valid
      */
-    public static function validateKey($key, string $allowChars = null): string
+    public static function validateKey($key, string $reservedChars = self::RESERVED_CHARACTERS): string
     {
         if (!\is_string($key)) {
             throw new InvalidArgumentException(sprintf('Cache key must be string, "%s" given.', get_debug_type($key)));
@@ -135,7 +136,6 @@ final class CacheItem implements ItemInterface
         if ('' === $key) {
             throw new InvalidArgumentException('Cache key length must be greater than zero.');
         }
-        $reservedChars = null === $allowChars ? self::RESERVED_CHARACTERS : str_replace(str_split($allowChars), '', self::RESERVED_CHARACTERS);
         if ('' !== $reservedChars && false !== strpbrk($key, $reservedChars)) {
             throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters "%s".', $key, $reservedChars));
         }

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -144,6 +144,16 @@ final class CacheItem implements ItemInterface
     }
 
     /**
+     * @param mixed[] $keys The keys to validate
+     */
+    public static function validateKeys(array $keys): void
+    {
+        foreach ($keys as $key) {
+            self::validateKey($key);
+        }
+    }
+
+    /**
      * Internal logging helper.
      *
      * @internal

--- a/src/Symfony/Component/Cache/Psr16Cache.php
+++ b/src/Symfony/Component/Cache/Psr16Cache.php
@@ -47,7 +47,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
                 if ($allowInt && \is_int($key)) {
                     $item->key = (string) $key;
                 } else {
-                    \assert('' !== CacheItem::validateKey($key));
+                    CacheItem::validateKey($key);
                     $item->key = $key;
                 }
                 $item->value = $value;
@@ -79,6 +79,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
 
     public function get($key, $default = null): mixed
     {
+        CacheItem::validateKey($key);
         try {
             $item = $this->pool->getItem($key);
         } catch (SimpleCacheException $e) {
@@ -96,6 +97,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
 
     public function set($key, $value, $ttl = null): bool
     {
+        CacheItem::validateKey($key);
         try {
             if (null !== $f = $this->createCacheItem) {
                 $item = $f($key, $value);
@@ -117,6 +119,8 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
     public function delete($key): bool
     {
         try {
+            CacheItem::validateKey($key);
+
             return $this->pool->deleteItem($key);
         } catch (SimpleCacheException $e) {
             throw $e;
@@ -139,6 +143,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
         }
 
         try {
+            CacheItem::validateKeys($keys);
             $items = $this->pool->getItems($keys);
         } catch (SimpleCacheException $e) {
             throw $e;
@@ -179,7 +184,9 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
             } elseif ($valuesIsArray) {
                 $items = [];
                 foreach ($values as $key => $value) {
-                    $items[] = (string) $key;
+                    $key = (string) $key;
+                    CacheItem::validateKey($key);
+                    $items[] = $key;
                 }
                 $items = $this->pool->getItems($items);
             } else {
@@ -187,6 +194,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
                     if (\is_int($key)) {
                         $key = (string) $key;
                     }
+                    CacheItem::validateKey($key);
                     $items[$key] = $this->pool->getItem($key)->set($value);
                 }
             }
@@ -198,6 +206,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
         $ok = true;
 
         foreach ($items as $key => $item) {
+            CacheItem::validateKey((string) $key);
             if ($valuesIsArray) {
                 $item->set($values[$key]);
             }
@@ -219,6 +228,8 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
         }
 
         try {
+            CacheItem::validateKeys($keys);
+
             return $this->pool->deleteItems($keys);
         } catch (SimpleCacheException $e) {
             throw $e;
@@ -230,6 +241,8 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
     public function has($key): bool
     {
         try {
+            CacheItem::validateKey($key);
+
             return $this->pool->hasItem($key);
         } catch (SimpleCacheException $e) {
             throw $e;

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -21,6 +21,8 @@ use Symfony\Contracts\Cache\CallbackInterface;
 
 abstract class AdapterTestCase extends CachePoolTest
 {
+    protected static ?string $allowPsr6Keys = ':';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -38,6 +40,16 @@ abstract class AdapterTestCase extends CachePoolTest
             $this->skippedTests['testDeleteItemsInvalidKeys'] = 'Keys are checked only when assert() is enabled.';
         } catch (\Exception $e) {
         }
+    }
+
+    public static function invalidKeys(): array
+    {
+        $keys = parent::invalidKeys();
+        if (null !== static::$allowPsr6Keys) {
+            $keys = array_filter($keys, fn ($key) => !\is_string($key[0] ?? null) || false === strpbrk($key[0], static::$allowPsr6Keys));
+        }
+
+        return $keys;
     }
 
     public function testGet()

--- a/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\Cache\Psr16Cache;
  */
 class Psr16AdapterTest extends AdapterTestCase
 {
+    protected static ?string $allowPsr6Keys = null;
+
     protected $skippedTests = [
         'testPrune' => 'Psr16adapter just proxies',
         'testClearPrefix' => 'SimpleCache cannot clear by prefix',

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -57,7 +57,7 @@ class Psr16CacheTest extends SimpleCacheTest
 
     public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
-        return new Psr16Cache(new FilesystemAdapter('', $defaultLifetime));
+        return new Psr16Cache(new FilesystemTestAdapter('', $defaultLifetime));
     }
 
     public static function validKeys(): array
@@ -180,4 +180,9 @@ class NotUnserializable
     {
         throw new \Exception(__CLASS__);
     }
+}
+
+class FilesystemTestAdapter extends FilesystemAdapter
+{
+    protected const NS_SEPARATOR = '_';
 }

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -343,7 +343,7 @@ trait AbstractAdapterTrait
         if (\is_string($key) && isset($this->ids[$key])) {
             return $this->namespace.$this->namespaceVersion.$this->ids[$key];
         }
-        \assert('' !== CacheItem::validateKey($key));
+        \assert('' !== CacheItem::validateKey($key, static::NS_SEPARATOR));
         $this->ids[$key] = $key;
 
         if (\count($this->ids) > 1000) {

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -343,7 +343,7 @@ trait AbstractAdapterTrait
         if (\is_string($key) && isset($this->ids[$key])) {
             return $this->namespace.$this->namespaceVersion.$this->ids[$key];
         }
-        \assert('' !== CacheItem::validateKey($key, static::NS_SEPARATOR));
+        \assert('' !== CacheItem::validateKey($key, static::$reservedChars));
         $this->ids[$key] = $key;
 
         if (\count($this->ids) > 1000) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/45599
| License       | MIT

Replaces https://github.com/symfony/symfony/pull/51603

This PR allow colon char `:` in cache key. It may be useful for redis grouping keys by pattern without creating a many pools for each namespace.

Difference between implementation https://github.com/symfony/symfony/pull/47561

- colon is only allowed for Symfony contracts cache, the PSR-6/16 adapters keeps this validation as before.
- Allow colon in namespace name too

--------------------------------------------

@nicolas-grekas I have taken a look at some approaches to how to optimize this, but it looks like:
```php
$reservedChars = null === $allowChars 
    ? self::RESERVED_CHARACTERS
    : str_replace(str_split($allowChars), '', self::RESERVED_CHARACTERS);
```
is pretty well optimized and is marginally faster than `preg_replace` and a lot faster than some other `for` based approaches I tried. I think the main problem is that this code would need to get executed for each validation, of which there can be many in single http request. So I thought that maybe a different approach would could work - simply allowing override of RESERVED_CHARACTERS via the parameter. Here is a simple test for performance comparison.

```php
<?php

class CacheItem {
    private const RESERVED_CHARACTERS = '{}()/\@:';

    /**
     * Validates a cache key according to PSR-6.
     *
     * @param mixed $key The key to validate
     *
     * @throws InvalidArgumentException When $key is not valid
     */
    public static function validateKey($key, string $allowChars = null): string
    {
        if (!\is_string($key)) {
            throw new InvalidArgumentException(sprintf('Cache key must be string, "%s" given.', get_debug_type($key)));
        }
        if ('' === $key) {
            throw new InvalidArgumentException('Cache key length must be greater than zero.');
        }
        $reservedChars = null === $allowChars ? self::RESERVED_CHARACTERS : str_replace(str_split($allowChars), '', self::RESERVED_CHARACTERS);
        if ('' !== $reservedChars && false !== strpbrk($key, $reservedChars)) {
            throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters "%s".', $key, $reservedChars));
        }

        return $key;
    }

    /**
     * Validates a cache key according to PSR-6.
     *
     * @param mixed $key The key to validate
     *
     * @throws InvalidArgumentException When $key is not valid
     */
    public static function validateKeyByOverride($key, string $reservedChars = self::RESERVED_CHARACTERS): string
    {
        if (!\is_string($key)) {
            throw new InvalidArgumentException(sprintf('Cache key must be string, "%s" given.', get_debug_type($key)));
        }
        if ('' === $key) {
            throw new InvalidArgumentException('Cache key length must be greater than zero.');
        }
        if ('' !== $reservedChars && false !== strpbrk($key, $reservedChars)) {
            throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters "%s".', $key, $reservedChars));
        }

        return $key;
    }
}

$key = "product:123456:discount";
$iterations = 1000000;

// Testing the original approach
$start_time = microtime(true);
for ($i = 0; $i < $iterations; $i++) {
    CacheItem::validateKey($key, ':');
}
$end_time = microtime(true);
$time_original = $end_time - $start_time;
echo "Original Method Time: " . $time_original . " seconds\n";

// Testing the optimized approach
$start_time = microtime(true);
for ($i = 0; $i < $iterations; $i++) {
    CacheItem::validateKeyByOverride($key, '{}()/\@X');
}
$end_time = microtime(true);
$time_optimized = $end_time - $start_time;
echo "Optimized Method Time: " . $time_optimized . " seconds\n";
```

Here are the results from 5 executions, 1000000 iterations each:

| Original in seconds | Optimized in seconds |
|-----------------|-----------------|
| 1.8678679466248 | 0.62751603126526 |
| 1.4007370471954 | 0.61563205718994 |
| 0.89250898361206 | 0.48939108848572 |
| 0.85805201530457 | 0.41882705688477 |
| 0.86538910865784 | 0.47265005111694 |

Looks like getting rid of the `str_replace` an `str_split` makes the method about 2x faster.

The downside seems relatively small, the logic is moved to the cache adapters. Or we could get rid of the logic completely and just let each adapter define their list of reserved characters..

I am still working on the tests & to ensure that PSR 6 / PSR 16 validation is kept intact.