### PR TITLE
[RemoteEvent] Fix date parsing remote event payload converter

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/RemoteEvent/MailerSendPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/RemoteEvent/MailerSendPayloadConverter.php
@@ -43,7 +43,7 @@ final class MailerSendPayloadConverter implements PayloadConverterInterface
             $event = new MailerEngagementEvent($name, $this->getMessageId($payload), $payload);
         }
 
-        if (!$date = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', $payload['created_at'])) {
+        if (!$date = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $payload['created_at'])) {
             throw new ParseException(sprintf('Invalid date "%s".', $payload['created_at']));
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/clicked.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/clicked.php
@@ -9,6 +9,6 @@ $wh->setMetadata([
     'ip' => '127.0.0.1',
     'url' => 'https://www.mailersend.com'
 ]);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/clicked_unique.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/clicked_unique.php
@@ -9,6 +9,6 @@ $wh->setMetadata([
     'ip' => '127.0.0.1',
     'url' => 'https://www.mailersend.com'
 ]);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/delivered.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/delivered.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('test@example.com');
 $wh->setTags(["test-tag"]);
 $wh->setMetadata([]);
 $wh->setReason('');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/hard_bounced.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/hard_bounced.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('test@example.com');
 $wh->setTags(["test-tag"]);
 $wh->setMetadata([]);
 $wh->setReason('Host or domain name not found');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/opened.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/opened.php
@@ -8,6 +8,6 @@ $wh->setTags(["test-tag"]);
 $wh->setMetadata([
     'ip' => '127.0.0.1'
 ]);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/opened_unique.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/opened_unique.php
@@ -8,6 +8,6 @@ $wh->setTags(["test-tag"]);
 $wh->setMetadata([
     'ip' => '127.0.0.1'
 ]);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/sent.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/sent.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('test@example.com');
 $wh->setTags(["test-tag"]);
 $wh->setMetadata([]);
 $wh->setReason('');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/soft_bounced.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/soft_bounced.php
@@ -7,6 +7,6 @@ $wh->setRecipientEmail('test@example.com');
 $wh->setTags(["test-tag"]);
 $wh->setMetadata([]);
 $wh->setReason('Unknown reason');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/spam_complaint.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/spam_complaint.php
@@ -6,6 +6,6 @@ $wh = new MailerEngagementEvent(MailerEngagementEvent::SPAM, '62fb66bef54a112e92
 $wh->setRecipientEmail('test@example.com');
 $wh->setTags(["test-tag"]);
 $wh->setMetadata([]);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/unsubscribed.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/Fixtures/unsubscribed.php
@@ -9,6 +9,6 @@ $wh->setMetadata([
     'reason' => 'NO_LONGER_WANT',
     'readable_reason' => 'I no longer want to receive these emails'
 ]);
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-01-01T12:00:00.000000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-01-01T12:00:00.000000Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/Fixtures/sent.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/Fixtures/sent.php
@@ -21,6 +21,6 @@ $wh->setMetadata([
     ],
 ]);
 $wh->setReason('');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', '2024-04-08T09:43:09.500000Z'));
+$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2024-04-08T09:43:09.500000Z'));
 
 return $wh;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

[AppVeyor fails](https://ci.appveyor.com/project/fabpot/symfony/builds/49679328) on some date expectation:

```diff
There was 1 failure:
1) Symfony\Component\Mailer\Bridge\Resend\Tests\Webhook\ResendRequestParserTest::testParse with data set "C:\projects\symfony\src\Symfony\Component\Mailer\Bridge\Resend\Tests\Webhook/Fixtures\sent.json" ('{\n    "created_at": "2024-04..."\n}\n', Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent Object (...))
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
     'name' => 'received'
     'id' => '172c41ce-ba6d-4281-8a7a-541faa725748'
     'payload' => Array (...)
-    'date' => 2024-04-08T09:43:09.500000-0700
+    'date' => 2024-04-08T09:43:09.500000+0000
     'email' => 'test@example.com'
     'metadata' => Array (...)
     'tags' => Array ()
     'reason' => ''
 )
C:\projects\symfony\src\Symfony\Component\Webhook\Test\AbstractRequestParserTestCase.php:32
```

Indeed, this can happen depending on your configuration because the timezone is not set when creating fixtures, which leads to a difference, as shown here: https://3v4l.org/iFBMq.

Defining the timezone in the parsing should solve this flaky test.