### PR TITLE
[Form] add isSubmittedRequestValid function

### DIFF
--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -307,6 +307,16 @@ class Button implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * Unsupported method.
+     *
+     * @throws BadMethodCallException
+     */
+    public function isSubmittedRequestValid(mixed $request = null): bool
+    {
+        throw new BadMethodCallException('Buttons cannot handle requests. Call isSubmittedRequestValid() on the root form instead.');
+    }
+
+    /**
      * Submits data to the button.
      *
      * @return $this

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -312,7 +312,7 @@ class Button implements \IteratorAggregate, FormInterface
      *
      * @throws BadMethodCallException
      */
-    public function isSubmittedRequestValid(Request $request): bool
+    public function isSubmittedRequestValid(?Request $request = null): bool
     {
         throw new BadMethodCallException('Buttons cannot handle requests. Call isSubmittedRequestValid() on the root form instead.');
     }

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form;
 use Symfony\Component\Form\Exception\AlreadySubmittedException;
 use Symfony\Component\Form\Exception\BadMethodCallException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
 
 /**
@@ -311,7 +312,7 @@ class Button implements \IteratorAggregate, FormInterface
      *
      * @throws BadMethodCallException
      */
-    public function isSubmittedRequestValid(mixed $request = null): bool
+    public function isSubmittedRequestValid(Request $request): bool
     {
         throw new BadMethodCallException('Buttons cannot handle requests. Call isSubmittedRequestValid() on the root form instead.');
     }

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate not configuring the `default_protocol` option of the `UrlType`, it will default to `null` in 8.0 (the current default is `'http'`)
  * Add a `keep_as_list` option to `CollectionType`
  * Add a new `model_type` option to `MoneyType`, to be able to cast the transformed value to `integer`
+ * Add new `isSubmittedRequestValid` method to `Form/FormInterface` make a shortcut of the three functions `handleRequest()`, `isSubmitted()` and `isValid()`
 
 7.0
 ---

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -302,7 +302,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
             if (null !== $dataClass && !$viewData instanceof $dataClass) {
                 $actualType = get_debug_type($viewData);
 
-                throw new LogicException('The form\'s view data is expected to be a ".'.$dataClass.'", but it is a "'.$actualType.'". You can avoid this error by setting the "data_class" option to null or by adding a view transformer that transforms "'.$actualType.'" to an instance of "'.$dataClass.'".');
+                throw new LogicException('The form\'s view data is expected to be a "'.$dataClass.'", but it is a "'.$actualType.'". You can avoid this error by setting the "data_class" option to null or by adding a view transformer that transforms "'.$actualType.'" to an instance of "'.$dataClass.'".');
             }
         }
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -416,6 +416,13 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
         return $this;
     }
 
+    public function isSubmittedRequestValid(mixed $request = null): bool
+    {
+        $this->handleRequest($request);
+
+        return $this->isSubmitted() && $this->isValid();
+    }
+
     public function submit(mixed $submittedData, bool $clearMissing = true): static
     {
         if ($this->submitted) {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -417,7 +417,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
         return $this;
     }
 
-    public function isSubmittedRequestValid(Request $request): bool
+    public function isSubmittedRequestValid(?Request $request = null): bool
     {
         $this->handleRequest($request);
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -302,7 +302,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
             if (null !== $dataClass && !$viewData instanceof $dataClass) {
                 $actualType = get_debug_type($viewData);
 
-                throw new LogicException('The form\'s view data is expected to be a "'.$dataClass.'", but it is a "'.$actualType.'". You can avoid this error by setting the "data_class" option to null or by adding a view transformer that transforms "'.$actualType.'" to an instance of "'.$dataClass.'".');
+                throw new LogicException('The form\'s view data is expected to be a ".'.$dataClass.'", but it is a "'.$actualType.'". You can avoid this error by setting the "data_class" option to null or by adding a view transformer that transforms "'.$actualType.'" to an instance of "'.$dataClass.'".');
             }
         }
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -25,6 +25,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\Util\InheritDataAwareIterator;
 use Symfony\Component\Form\Util\OrderedHashMap;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
 
@@ -416,7 +417,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
         return $this;
     }
 
-    public function isSubmittedRequestValid(mixed $request = null): bool
+    public function isSubmittedRequestValid(Request $request): bool
     {
         $this->handleRequest($request);
 

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -16,7 +16,6 @@ namespace Symfony\Component\Form;
  *
  * @extends \Traversable<string, FormBuilderInterface>
  * 
- * @method bool isSubmittedRequestValid(Request $request) Call {@link handleRequest()} and return the result of the condition {@link isSubmitted()} and {@link isValid()}
  */
 interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuilderInterface
 {

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Form;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @extends \Traversable<string, FormBuilderInterface>
+ * 
+ * @method bool isSubmittedRequestValid(Request $request) Call {@link handleRequest()} and return the result of the condition {@link isSubmitted()} and {@link isValid()}
  */
 interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuilderInterface
 {

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -15,7 +15,6 @@ namespace Symfony\Component\Form;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @extends \Traversable<string, FormBuilderInterface>
- * 
  */
 interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuilderInterface
 {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -261,11 +261,6 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function handleRequest(mixed $request = null): static;
 
     /**
-     * Call {@link handleRequest()} and return the result of the condition {@link isSubmitted()} and {@link isValid()}
-     */
-    public function isSubmittedRequestValid(mixed $request = null): bool;
-
-    /**
      * Submits data to the form.
      *
      * @param string|array|null $submittedData The submitted data

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -21,7 +21,7 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  * @extends \ArrayAccess<string, FormInterface>
  * @extends \Traversable<string, FormInterface>
  * 
- * @method bool isSubmittedRequestValid(Request $request) Call {@link handleRequest()} and return the result of the condition {@link isSubmitted()} and {@link isValid()}
+ * @method bool isSubmittedRequestValid(?Request $request = null) Call {@link handleRequest()} and return the result of the condition {@link isSubmitted()} and {@link isValid()}
  */
 interface FormInterface extends \ArrayAccess, \Traversable, \Countable
 {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -261,6 +261,11 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function handleRequest(mixed $request = null): static;
 
     /**
+     * Call {@link handleRequest()} and return the result of the condition {@link isSubmitted()} and {@link isValid()}
+     */
+    public function isSubmittedRequestValid(mixed $request = null): bool;
+
+    /**
      * Submits data to the form.
      *
      * @param string|array|null $submittedData The submitted data

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -20,6 +20,8 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  *
  * @extends \ArrayAccess<string, FormInterface>
  * @extends \Traversable<string, FormInterface>
+ * 
+ * @method bool isSubmittedRequestValid(Request $request) Call {@link handleRequest()} and return the result of the condition {@link isSubmitted()} and {@link isValid()}
  */
 interface FormInterface extends \ArrayAccess, \Traversable, \Countable
 {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -20,7 +20,7 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  *
  * @extends \ArrayAccess<string, FormInterface>
  * @extends \Traversable<string, FormInterface>
- * 
+ *
  * @method bool isSubmittedRequestValid(?Request $request = null) Call {@link handleRequest()} and return the result of the condition {@link isSubmitted()} and {@link isValid()}
  */
 interface FormInterface extends \ArrayAccess, \Traversable, \Countable

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -1103,6 +1103,49 @@ class CompoundFormTest extends TestCase
         $this->assertEquals(['date' => new \DateTime('2022-08-04', new \DateTimeZone('UTC'))], $form->getData());
     }
 
+    public function testIsSubmittedRequestValid()
+    {
+        $form = $this->getBuilder('author')
+            ->setMethod(Request::METHOD_POST)
+            ->setCompound(true)
+            ->setDataMapper(new DataMapper())
+            ->setRequestHandler(new HttpFoundationRequestHandler())
+            ->getForm();
+
+        $form->add($this->getBuilder('firstName')->getForm());
+        $form->add($this->getBuilder('lastName')->getForm());
+
+        $values = [
+            'author' => [
+                'firstName' => 'Loïc',
+                'lastName' => 'Ovigne',
+            ],
+        ];
+
+        $request = new Request([], $values, [], [], [], [
+            'REQUEST_METHOD' => Request::METHOD_POST,
+        ]);
+
+        $this->assertTrue($form->isSubmittedRequestValid($request));
+    }
+
+    public function testIsSubmittedRequestUnvalid()
+    {
+        $form = $this->getBuilder('author')
+            ->setMethod(Request::METHOD_POST)
+            ->setCompound(true)
+            ->setDataMapper(new DataMapper())
+            ->setRequestHandler(new HttpFoundationRequestHandler())
+            ->getForm();
+
+        $form->add($this->getBuilder('firstName')->getForm());
+        $form->add($this->getBuilder('lastName')->getForm());
+
+        $request = new Request();
+
+        $this->assertFalse($form->isSubmittedRequestValid($request));
+    }
+
     private function createForm(string $name = 'name', bool $compound = true): FormInterface
     {
         $builder = $this->getBuilder($name);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
In controllers, we often have to call three functions to validate a form: `handleRequest`, ìsSubmitted`and `isValid`. I wrote a new method that calls `handlerequest` and return the result of the condition `isSubmitted() && isValid()`
