### PR TITLE
[SecurityBundle] Set translator in AccessTokenAuthenticator in Security bundle config

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -42,6 +42,7 @@ return static function (ContainerConfigurator $container) {
                 null,
                 null,
             ])
+        ->call('setTranslator', [service('translator')->ignoreOnInvalid()])
 
         ->set('security.authenticator.access_token.chain_extractor', ChainAccessTokenExtractor::class)
             ->abstract()

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -84,6 +84,9 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
 
         if (null !== $this->translator) {
             $errorMessage = $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security');
+            if (false === mb_check_encoding($errorMessage, 'ASCII')) {
+                $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
+            }
         } else {
             $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -85,11 +85,11 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
         if (null !== $this->translator) {
             $errorMessage = $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security');
             if (preg_match('/[^\x00-\x7F]/', $errorMessage)) {
-               trigger_deprecation(
-                   'symfony/security-http',
-                   '6.4',
-                   'Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.'
-               );
+                trigger_deprecation(
+                    'symfony/security-http',
+                    '6.4',
+                    'Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.'
+                );
             }
         } else {
             $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -84,7 +84,7 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
 
         if (null !== $this->translator) {
             $errorMessage = $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security');
-            if (false === mb_check_encoding($errorMessage, 'ASCII')) {
+            if (0 !== preg_match('/[^\x00-\x7F]/', $errorMessage)) {
                 $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
             }
         } else {

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -84,8 +84,12 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
 
         if (null !== $this->translator) {
             $errorMessage = $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security');
-            if (0 !== preg_match('/[^\x00-\x7F]/', $errorMessage)) {
-                $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
+            if (preg_match('/[^\x00-\x7F]/', $errorMessage)) {
+               trigger_deprecation(
+                   'symfony/security-http',
+                   '6.4',
+                   'Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.'
+               );
             }
         } else {
             $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -85,11 +85,7 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
         if (null !== $this->translator) {
             $errorMessage = $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security');
             if (preg_match('/[^\x00-\x7F]/', $errorMessage)) {
-                trigger_deprecation(
-                    'symfony/security-http',
-                    '6.4',
-                    'Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.'
-                );
+                trigger_deprecation('symfony/security-http', '6.4', 'Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.');
             }
         } else {
             $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -70,10 +70,13 @@ class AccessTokenAuthenticatorTest extends TestCase
             $response = $authenticator->onAuthenticationFailure($request, $e);
         }
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('Bearer error="invalid_token",error_description="Credenciales invalidas."', $response->headers->get('WWW-Authenticate'));
+        $this->assertSame('Bearer error="invalid_token",error_description="Credenciales invalidas."', $response->headers->get('WWW-Authenticate'));
     }
 
-    public function testOnAuthenticationFailureWithTranslatorRevertsTranslationWhenTranslatedMessageContainsNonAscii()
+    /**
+     * @expectedDeprecation Since symfony/security-http 6.4: Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.
+     */
+    public function testOnAuthenticationFailureWithTranslatorThrowsDeprecationWhenTranslatedMessageContainsNonAscii()
     {
         $request = Request::create('/test');
 
@@ -106,7 +109,7 @@ class AccessTokenAuthenticatorTest extends TestCase
             $response = $authenticator->onAuthenticationFailure($request, $e);
         }
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('Bearer error="invalid_token",error_description="Invalid credentials."', $response->headers->get('WWW-Authenticate'));
+        $this->assertSame('Bearer error="invalid_token",error_description="Credenciales inválidas."', $response->headers->get('WWW-Authenticate'));
     }
 
     public function testAuthenticateWithoutAccessToken()

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -74,6 +74,7 @@ class AccessTokenAuthenticatorTest extends TestCase
     }
 
     /**
+     * @group legacy
      * @expectedDeprecation Since symfony/security-http 6.4: Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.
      */
     public function testOnAuthenticationFailureWithTranslatorThrowsDeprecationWhenTranslatedMessageContainsNonAscii()

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -75,7 +75,7 @@ class AccessTokenAuthenticatorTest extends TestCase
 
     /**
      * @group legacy
-     * 
+     *
      * @expectedDeprecation Since symfony/security-http 6.4: Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.
      */
     public function testOnAuthenticationFailureWithTranslatorThrowsDeprecationWhenTranslatedMessageContainsNonAscii()

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -13,6 +13,7 @@ namespace Authenticator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
@@ -22,6 +23,7 @@ use Symfony\Component\Security\Http\AccessToken\HeaderAccessTokenExtractor;
 use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\FallbackUserLoader;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AccessTokenAuthenticatorTest extends TestCase
 {
@@ -34,6 +36,77 @@ class AccessTokenAuthenticatorTest extends TestCase
         $this->accessTokenHandler = $this->createMock(AccessTokenHandlerInterface::class);
         $this->accessTokenExtractor = $this->createMock(AccessTokenExtractorInterface::class);
         $this->userProvider = new InMemoryUserProvider(['test' => ['password' => 's$cr$t']]);
+    }
+
+    public function testOnAuthenticationFailureWithTranslatorTranslatesErrorMessage()
+    {
+        $request = Request::create('/test');
+
+        $this->accessTokenExtractor
+            ->expects($this->once())
+            ->method('extractAccessToken')
+            ->with($request)
+            ->willReturn(null);
+
+        $authenticator = new AccessTokenAuthenticator(
+            $this->accessTokenHandler,
+            $this->accessTokenExtractor,
+            $this->userProvider,
+        );
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Invalid credentials.')
+            ->willReturn('Credenciales invalidas.');
+
+        $authenticator->setTranslator($translator);
+
+        $response = null;
+        try {
+            $authenticator->authenticate($request);
+        } catch (BadCredentialsException $e) {
+            $response = $authenticator->onAuthenticationFailure($request, $e);
+        }
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals('Bearer error="invalid_token",error_description="Credenciales invalidas."', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testOnAuthenticationFailureWithTranslatorRevertsTranslationWhenTranslatedMessageContainsNonAscii()
+    {
+        $request = Request::create('/test');
+
+        $this->accessTokenExtractor
+            ->expects($this->once())
+            ->method('extractAccessToken')
+            ->with($request)
+            ->willReturn(null);
+
+        $authenticator = new AccessTokenAuthenticator(
+            $this->accessTokenHandler,
+            $this->accessTokenExtractor,
+            $this->userProvider,
+        );
+
+        $nonAsciiString = "Credenciales inválidas.";
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Invalid credentials.')
+            ->willReturn($nonAsciiString);
+
+        $authenticator->setTranslator($translator);
+
+        $response = null;
+        try {
+            $authenticator->authenticate($request);
+        } catch (BadCredentialsException $e) {
+            $response = $authenticator->onAuthenticationFailure($request, $e);
+        }
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals('Bearer error="invalid_token",error_description="Invalid credentials."', $response->headers->get('WWW-Authenticate'));
     }
 
     public function testAuthenticateWithoutAccessToken()

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -89,7 +89,7 @@ class AccessTokenAuthenticatorTest extends TestCase
             $this->userProvider,
         );
 
-        $nonAsciiString = "Credenciales inválidas.";
+        $nonAsciiString = 'Credenciales inválidas.';
         $translator = $this->createMock(TranslatorInterface::class);
         $translator
             ->expects($this->once())

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -75,6 +75,7 @@ class AccessTokenAuthenticatorTest extends TestCase
 
     /**
      * @group legacy
+     * 
      * @expectedDeprecation Since symfony/security-http 6.4: Using non-ASCII characters in the error message is deprecated. Use ASCII characters only.
      */
     public function testOnAuthenticationFailureWithTranslatorThrowsDeprecationWhenTranslatedMessageContainsNonAscii()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | 
| License       | MIT

The `AccessTokenAuthenticator` doesn't get configured with the `translator` service. This appears to be a bug, as this class's `setTranslator` is unused and the translator can't be injected anywhere else.