### PR TITLE
[Notifier] [Slack] Add button block element and `emoji`/`verbatim` options to section block

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
@@ -30,21 +30,9 @@ final class SlackActionsBlock extends AbstractSlackBlock
             throw new \LogicException('Maximum number of buttons should not exceed 25.');
         }
 
-        $element = [
-            'type' => 'button',
-            'text' => [
-                'type' => 'plain_text',
-                'text' => $text,
-            ],
-            'url' => $url,
-        ];
+        $element = new SlackButtonBlockElement($text, $url, $style);
 
-        if ($style) {
-            // primary or danger
-            $element['style'] = $style;
-        }
-
-        $this->options['elements'][] = $element;
+        $this->options['elements'][] = $element->toArray();
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackButtonBlockElement.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackButtonBlockElement.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Slack\Block;
+
+/**
+ * @author Christophe Vergne <christophe.vergne@gmail.com>
+ */
+final class SlackButtonBlockElement extends AbstractSlackBlockElement
+{
+    public function __construct(string $text, string $url, ?string $style = null)
+    {
+        $this->options = [
+            'type' => 'button',
+            'text' => [
+                'type' => 'plain_text',
+                'text' => $text,
+            ],
+            'url' => $url,
+        ];
+
+        if ($style) {
+            // primary or danger
+            $this->options['style'] = $style;
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
@@ -24,12 +24,19 @@ final class SlackSectionBlock extends AbstractSlackBlock
     /**
      * @return $this
      */
-    public function text(string $text, bool $markdown = true): static
+    public function text(string $text, bool $markdown = true, bool $emoji = true, bool $verbatim = false): static
     {
         $this->options['text'] = [
             'type' => $markdown ? 'mrkdwn' : 'plain_text',
             'text' => $text,
         ];
+
+        // verbatim is only available for markdown
+        if ($markdown) {
+            $this->options['text']['verbatim'] = $verbatim;
+        } else {
+            $this->options['text']['emoji'] = $emoji;
+        }
 
         return $this;
     }
@@ -37,16 +44,25 @@ final class SlackSectionBlock extends AbstractSlackBlock
     /**
      * @return $this
      */
-    public function field(string $text, bool $markdown = true): static
+    public function field(string $text, bool $markdown = true, bool $emoji = true, bool $verbatim = false): static
     {
         if (10 === \count($this->options['fields'] ?? [])) {
             throw new \LogicException('Maximum number of fields should not exceed 10.');
         }
 
-        $this->options['fields'][] = [
+        $field = [
             'type' => $markdown ? 'mrkdwn' : 'plain_text',
             'text' => $text,
         ];
+
+        // verbatim is only available for markdown
+        if ($markdown) {
+            $field['verbatim'] = $verbatim;
+        } else {
+            $field['emoji'] = $emoji;
+        }
+
+        $this->options['fields'][] = $field;
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `SlackButtonBlockElement` to add button as accessory to a section block
+ * Add `emoji` and `verbatim` options to `text` and `field` methods in `SlackSectionBlock`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackSectionBlockTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackSectionBlockTest.php
@@ -22,6 +22,8 @@ final class SlackSectionBlockTest extends TestCase
         $section = new SlackSectionBlock();
         $section->text('section text');
         $section->field('section field');
+        $section->field('section field with verbatim', true, true, false);
+        $section->field('section field in plain text with verbatim', false, true, true);
         $section->accessory(new SlackImageBlockElement('https://example.com/image.jpg', 'an image'));
 
         $this->assertSame([
@@ -29,11 +31,23 @@ final class SlackSectionBlockTest extends TestCase
             'text' => [
                 'type' => 'mrkdwn',
                 'text' => 'section text',
+                'verbatim' => false,
             ],
             'fields' => [
                 [
                     'type' => 'mrkdwn',
                     'text' => 'section field',
+                    'verbatim' => false,
+                ],
+                [
+                    'type' => 'mrkdwn',
+                    'text' => 'section field with verbatim',
+                    'verbatim' => false,
+                ],
+                [
+                    'type' => 'plain_text',
+                    'text' => 'section field in plain text with verbatim',
+                    'emoji' => true,
                 ],
             ],
             'accessory' => [

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
@@ -146,6 +146,7 @@ final class SlackOptionsTest extends TestCase
                         'text' => [
                             'type' => 'mrkdwn',
                             'text' => $subject,
+                            'verbatim' => false,
                         ],
                     ],
                 ],
@@ -162,6 +163,7 @@ final class SlackOptionsTest extends TestCase
                         'text' => [
                             'type' => 'mrkdwn',
                             'text' => $subject,
+                            'verbatim' => false,
                         ],
                     ],
                     [
@@ -169,6 +171,7 @@ final class SlackOptionsTest extends TestCase
                         'text' => [
                             'type' => 'mrkdwn',
                             'text' => $content,
+                            'verbatim' => false,
                         ],
                     ],
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Hi,

When using the Slack Notifier bridge, I've noticed it wasn't possible to add a button as accessory to a section because button is only managed in the SlackActionsBlock, which is not allowed as an accessory in a Section block.
So the first purpose of this PR is add a SlackButtonBlockElement we can use as `accessory` into a section block (and use that block into SlackActionsBlock as it follows the same structure).

Then, I noticed `verbatim` (for markdown) and `emoji` (for plain text) options were not available in SectionBlock (but available in ContextBlock), so I've added them.
Note that originally, I was going to add them as optional arguments (`?bool $verbatim = null`) to avoid adding them if not explicitly given and keep the Slack default value, but the ContextBlock adds a default value (the same as Slack) for them, so I kept the same argument signature.

You can see an example of both use of button as accessory and verbatim param with the following link on [Slack Block Kit Builder](https://app.slack.com/block-kit-builder/#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22Example%20with%20URL%20:%20Symfony.com%22,%22verbatim%22:true%7D,%22accessory%22:%7B%22type%22:%22button%22,%22text%22:%7B%22type%22:%22plain_text%22,%22emoji%22:true,%22text%22:%22Button%20as%20accessory%22%7D,%22value%22:%22https://symfony.com%22%7D%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22from%20*Symfony.com*%22,%22verbatim%22:true%7D%5D%7D%5D%7D) (_must be logged in to a Slack Account_).

_These minor additions are in the same PR, but tell me if I should split them into two PRs._

Thanks :)