### PR TITLE
[Security] Do not try to clear CSRF on stateless request

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterCsrfFeaturesPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterCsrfFeaturesPass.php
@@ -58,6 +58,7 @@ class RegisterCsrfFeaturesPass implements CompilerPassInterface
 
         $container->register('security.logout.listener.csrf_token_clearing', CsrfTokenClearingLogoutListener::class)
             ->addArgument(new Reference('security.csrf.token_storage'))
+            ->addArgument(new Reference('security.firewall.map'))
             ->addTag('kernel.event_subscriber');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -21,4 +21,3 @@ security:
                 secret: secret
             logout:
                 invalidate_session: false
-            stateless: true

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CsrfTokenClearingLogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CsrfTokenClearingLogoutListenerTest.php
@@ -12,23 +12,64 @@
 namespace Symfony\Component\Security\Http\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\EventListener\CsrfTokenClearingLogoutListener;
 
 class CsrfTokenClearingLogoutListenerTest extends TestCase
 {
-    public function testSkipsClearingSessionTokenStorageOnStatelessRequest()
+    public function testSkipsClearingSessionTokenStorageOnRequestWithoutSession()
     {
+        $map = $this->createMock(FirewallMap::class);
+        $map
+            ->expects($this->once())
+            ->method('getFirewallConfig')
+            ->willReturn(new FirewallConfig('firewall', 'user_checker'))
+        ;
+
         try {
             (new CsrfTokenClearingLogoutListener(
-                new SessionTokenStorage(new RequestStack())
+                new SessionTokenStorage(new RequestStack()),
+                $map
             ))->onLogout(new LogoutEvent(new Request(), null));
         } catch (SessionNotFoundException) {
             $this->fail('clear() must not be called if the request is not associated with a session instance');
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testSkipsClearingSessionTokenStorageOnStatelessRequest()
+    {
+        $session = new Session();
+
+        // Create a stateless request with a previous session
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set($session->getName(), 'previous_session');
+        $request->attributes->set('_stateless', true);
+
+        $map = $this->createMock(FirewallMap::class);
+        $map
+            ->expects($this->once())
+            ->method('getFirewallConfig')
+            ->with($this->equalTo($request))
+            ->willReturn(new FirewallConfig('stateless_firewall', 'user_checker', stateless: true))
+        ;
+
+        try {
+            (new CsrfTokenClearingLogoutListener(
+                new SessionTokenStorage(new RequestStack()),
+                $map
+            ))->onLogout(new LogoutEvent($request, null));
+        } catch (SessionNotFoundException) {
+            $this->fail('clear() must not be called if the request is stateless');
         }
 
         $this->addToAssertionCount(1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In my application, I am getting many logs `Session was used while the request was declared stateless.` triggered by users logout on our API.

We should not try to clear CSRF on stateless sessions.
Similar to https://github.com/symfony/symfony/pull/51350