### PR TITLE
[Validator] deprecate the use of option arrays to configure validation constraints

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityTest.php
@@ -61,6 +61,9 @@ class UniqueEntityTest extends TestCase
         self::assertSame(['some_group'], $constraint->groups);
     }
 
+    /**
+     * @group legacy
+     */
     public function testValueOptionConfiguresFields()
     {
         $constraint = new UniqueEntity(['value' => 'email']);

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -165,11 +165,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * This is a functional test as there is a large integration necessary to get the validator working.
-     *
-     * @dataProvider provideUniquenessConstraints
      */
-    public function testValidateUniqueness(UniqueEntity $constraint)
+    public function testValidateUniqueness()
     {
+        $constraint = new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo');
+
         $entity1 = new SingleIntIdEntity(1, 'Foo');
         $entity2 = new SingleIntIdEntity(2, 'Foo');
 
@@ -217,6 +217,28 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         // this will load a proxy object
         $entity = $this->em->getReference(SingleIntIdWithPrivateNameEntity::class, 1);
 
+        $this->validator->validate($entity, new UniqueEntity(
+            fields: ['name'],
+            em: self::EM_NAME,
+        ));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testValidateEntityWithPrivatePropertyAndProxyObjectDoctrineStyle()
+    {
+        $entity = new SingleIntIdWithPrivateNameEntity(1, 'Foo');
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $this->em->clear();
+
+        // this will load a proxy object
+        $entity = $this->em->getReference(SingleIntIdWithPrivateNameEntity::class, 1);
+
         $this->validator->validate($entity, new UniqueEntity([
             'fields' => ['name'],
             'em' => self::EM_NAME,
@@ -225,10 +247,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @dataProvider provideConstraintsWithCustomErrorPath
-     */
-    public function testValidateCustomErrorPath(UniqueEntity $constraint)
+    public function testValidateCustomErrorPath()
     {
         $entity1 = new SingleIntIdEntity(1, 'Foo');
         $entity2 = new SingleIntIdEntity(2, 'Foo');
@@ -236,7 +255,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($entity1);
         $this->em->flush();
 
-        $this->validator->validate($entity2, $constraint);
+        $this->validator->validate($entity2, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', errorPath: 'bar'));
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.bar')
@@ -247,22 +266,34 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideConstraintsWithCustomErrorPath(): iterable
+    /**
+     * @group legacy
+     */
+    public function testValidateCustomErrorPathDoctrineStyle()
     {
-        yield 'Doctrine style' => [new UniqueEntity([
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $entity2 = new SingleIntIdEntity(2, 'Foo');
+
+        $this->em->persist($entity1);
+        $this->em->flush();
+
+        $this->validator->validate($entity2, new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
-            'em' => self::EM_NAME,
+            'em' => 'foo',
             'errorPath' => 'bar',
-        ])];
+        ]));
 
-        yield 'Named arguments' => [new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', errorPath: 'bar')];
+        $this->buildViolation('myMessage')
+            ->atPath('property.path.bar')
+            ->setParameter('{{ value }}', '"Foo"')
+            ->setInvalidValue($entity2)
+            ->setCause([$entity1])
+            ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideUniquenessConstraints
-     */
-    public function testValidateUniquenessWithNull(UniqueEntity $constraint)
+    public function testValidateUniquenessWithNull()
     {
         $entity1 = new SingleIntIdEntity(1, null);
         $entity2 = new SingleIntIdEntity(2, null);
@@ -271,7 +302,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($entity2);
         $this->em->flush();
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validator->validate($entity1, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo'));
 
         $this->assertNoViolation();
     }
@@ -309,13 +340,6 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public static function provideConstraintsWithIgnoreNullDisabled(): iterable
     {
-        yield 'Doctrine style' => [new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name', 'name2'],
-            'em' => self::EM_NAME,
-            'ignoreNull' => false,
-        ])];
-
         yield 'Named arguments' => [new UniqueEntity(message: 'myMessage', fields: ['name', 'name2'], em: 'foo', ignoreNull: false)];
     }
 
@@ -357,36 +381,22 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public static function provideConstraintsWithIgnoreNullEnabled(): iterable
     {
-        yield 'Doctrine style' => [new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name', 'name2'],
-            'em' => self::EM_NAME,
-            'ignoreNull' => true,
-        ])];
-
         yield 'Named arguments' => [new UniqueEntity(message: 'myMessage', fields: ['name', 'name2'], em: 'foo', ignoreNull: true)];
     }
 
     public static function provideConstraintsWithIgnoreNullEnabledOnFirstField(): iterable
     {
-        yield 'Doctrine style (name field)' => [new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name', 'name2'],
-            'em' => self::EM_NAME,
-            'ignoreNull' => 'name',
-        ])];
-
         yield 'Named arguments (name field)' => [new UniqueEntity(message: 'myMessage', fields: ['name', 'name2'], em: 'foo', ignoreNull: 'name')];
     }
 
     public function testValidateUniquenessWithValidCustomErrorPath()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name', 'name2'],
-            'em' => self::EM_NAME,
-            'errorPath' => 'name2',
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name', 'name2'],
+            em: self::EM_NAME,
+            errorPath: 'name2',
+        );
 
         $entity1 = new DoubleNameEntity(1, 'Foo', 'Bar');
         $entity2 = new DoubleNameEntity(2, 'Foo', 'Bar');
@@ -413,10 +423,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideConstraintsWithCustomRepositoryMethod
-     */
-    public function testValidateUniquenessUsingCustomRepositoryMethod(UniqueEntity $constraint)
+    public function testValidateUniquenessUsingCustomRepositoryMethod()
     {
         $repository = $this->createRepositoryMock(SingleIntIdEntity::class);
         $repository->expects($this->once())
@@ -430,15 +437,12 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $entity1 = new SingleIntIdEntity(1, 'foo');
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validator->validate($entity1, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', repositoryMethod: 'findByCustom'));
 
         $this->assertNoViolation();
     }
 
-    /**
-     * @dataProvider provideConstraintsWithCustomRepositoryMethod
-     */
-    public function testValidateUniquenessWithUnrewoundArray(UniqueEntity $constraint)
+    public function testValidateUniquenessWithUnrewoundArray()
     {
         $entity = new SingleIntIdEntity(1, 'foo');
 
@@ -461,21 +465,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator = $this->createValidator();
         $this->validator->initialize($this->context);
 
-        $this->validator->validate($entity, $constraint);
+        $this->validator->validate($entity, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', repositoryMethod: 'findByCustom'));
 
         $this->assertNoViolation();
-    }
-
-    public static function provideConstraintsWithCustomRepositoryMethod(): iterable
-    {
-        yield 'Doctrine style' => [new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-            'repositoryMethod' => 'findByCustom',
-        ])];
-
-        yield 'Named arguments' => [new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', repositoryMethod: 'findByCustom')];
     }
 
     /**
@@ -483,12 +475,12 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidateResultTypes($entity1, $result)
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-            'repositoryMethod' => 'findByCustom',
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+            repositoryMethod: 'findByCustom',
+        );
 
         $repository = $this->createRepositoryMock($entity1::class);
         $repository->expects($this->once())
@@ -518,11 +510,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testAssociatedEntity()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['single'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['single'],
+            em: self::EM_NAME,
+        );
 
         $entity1 = new SingleIntIdEntity(1, 'foo');
         $associated = new AssociationEntity();
@@ -554,11 +546,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidateUniquenessNotToStringEntityWithAssociatedEntity()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['single'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['single'],
+            em: self::EM_NAME,
+        );
 
         $entity1 = new SingleIntIdNoToStringEntity(1, 'foo');
         $associated = new AssociationEntity2();
@@ -592,12 +584,12 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testAssociatedEntityWithNull()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['single'],
-            'em' => self::EM_NAME,
-            'ignoreNull' => false,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['single'],
+            em: self::EM_NAME,
+            ignoreNull: false,
+        );
 
         $associated = new AssociationEntity();
         $associated->single = null;
@@ -649,12 +641,12 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $repository = $this->createRepositoryMock(SingleIntIdEntity::class);
         $this->repositoryFactory->setRepository($this->em, SingleIntIdEntity::class, $repository);
 
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['phoneNumbers'],
-            'em' => self::EM_NAME,
-            'repositoryMethod' => 'findByCustom',
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['phoneNumbers'],
+            em: self::EM_NAME,
+            repositoryMethod: 'findByCustom',
+        );
 
         $entity1 = new SingleIntIdEntity(1, 'foo');
         $entity1->phoneNumbers[] = 123;
@@ -685,11 +677,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testDedicatedEntityManagerNullObject()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+        );
 
         $this->em = null;
         $this->registry = $this->createRegistryMock($this->em);
@@ -706,11 +698,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testEntityManagerNullObject()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
             // no "em" option set
-        ]);
+        );
 
         $this->em = null;
         $this->registry = $this->createRegistryMock($this->em);
@@ -738,11 +730,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator = $this->createValidator();
         $this->validator->initialize($this->context);
 
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+        );
 
         $entity = new SingleIntIdEntity(1, null);
 
@@ -755,12 +747,12 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidateInheritanceUniqueness()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-            'entityClass' => Person::class,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+            entityClass: Person::class,
+        );
 
         $entity1 = new Person(1, 'Foo');
         $entity2 = new Employee(2, 'Foo');
@@ -789,12 +781,12 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidateRepositoryForInheritance()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-            'entityClass' => SingleStringIdEntity::class,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+            entityClass: SingleStringIdEntity::class,
+        );
 
         $entity = new Person(1, 'Foo');
 
@@ -806,11 +798,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidateUniquenessWithCompositeObjectNoToStringIdEntity()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['objectOne', 'objectTwo'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['objectOne', 'objectTwo'],
+            em: self::EM_NAME,
+        );
 
         $objectOne = new SingleIntIdNoToStringEntity(1, 'foo');
         $objectTwo = new SingleIntIdNoToStringEntity(2, 'bar');
@@ -841,11 +833,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidateUniquenessWithCustomDoctrineTypeValue()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+        );
 
         $existingEntity = new SingleIntIdStringWrapperNameEntity(1, new StringWrapper('foo'));
 
@@ -872,11 +864,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidateUniquenessCause()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+        );
 
         $entity1 = new SingleIntIdEntity(1, 'Foo');
         $entity2 = new SingleIntIdEntity(2, 'Foo');
@@ -908,12 +900,12 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidateUniquenessWithEmptyIterator($entity, $result)
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-            'repositoryMethod' => 'findByCustom',
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+            repositoryMethod: 'findByCustom',
+        );
 
         $repository = $this->createRepositoryMock($entity::class);
         $repository->expects($this->once())
@@ -932,11 +924,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testValueMustBeObject()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+        );
 
         $this->expectException(UnexpectedValueException::class);
 
@@ -945,11 +937,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testValueCanBeNull()
     {
-        $constraint = new UniqueEntity([
-            'message' => 'myMessage',
-            'fields' => ['name'],
-            'em' => self::EM_NAME,
-        ]);
+        $constraint = new UniqueEntity(
+            message: 'myMessage',
+            fields: ['name'],
+            em: self::EM_NAME,
+        );
 
         $this->validator->validate(null, $constraint);
 
@@ -1046,6 +1038,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    /**
+     * @group legacy
+     */
     public function testValidateDTOUniquenessDoctrineStyle()
     {
         $constraint = new UniqueEntity([
@@ -1106,6 +1101,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    /**
+     * @group legacy
+     */
     public function testValidateMappingOfFieldNamesDoctrineStyle()
     {
         $constraint = new UniqueEntity([
@@ -1147,6 +1145,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($dto, $constraint);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidateDTOFieldNameDoctrineStyle()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -1177,6 +1178,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($dto, $constraint);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidateEntityFieldNameDoctrineStyle()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -1222,6 +1226,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    /**
+     * @group legacy
+     */
     public function testValidateDTOUniquenessWhenUpdatingEntityDoctrineStyle()
     {
         $constraint = new UniqueEntity([
@@ -1274,6 +1281,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     */
     public function testValidateDTOUniquenessWhenUpdatingEntityWithTheSameValueDoctrineStyle()
     {
         $constraint = new UniqueEntity([
@@ -1325,6 +1335,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     */
     public function testValidateIdentifierMappingOfFieldNamesDoctrineStyle()
     {
         $constraint = new UniqueEntity([
@@ -1382,6 +1395,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($dto, $constraint);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidateMissingIdentifierFieldNameDoctrineStyle()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -1429,6 +1445,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($dto, $constraint);
     }
 
+    /**
+     * @group legacy
+     */
     public function testUninitializedValueThrowExceptionDoctrineStyle()
     {
         $this->expectExceptionMessage('Typed property Symfony\Bridge\Doctrine\Tests\Fixtures\Dto::$foo must not be accessed before initialization');
@@ -1469,6 +1488,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($dto, $constraint);
     }
 
+    /**
+     * @group legacy
+     */
     public function testEntityManagerNullObjectWhenDTODoctrineStyle()
     {
         $this->expectException(ConstraintDefinitionException::class);

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -46,6 +47,7 @@ class UniqueEntity extends Constraint
      *                                               a fieldName => value associative array according to the fields option configuration
      * @param string|null          $errorPath        Bind the constraint violation to this field instead of the first one in the fields option configuration
      */
+    #[HasNamedArguments]
     public function __construct(
         array|string $fields,
         ?string $message = null,
@@ -58,11 +60,19 @@ class UniqueEntity extends Constraint
         ?array $identifierFieldNames = null,
         ?array $groups = null,
         $payload = null,
-        array $options = [],
+        ?array $options = null,
     ) {
         if (\is_array($fields) && \is_string(key($fields)) && [] === array_diff(array_keys($fields), array_merge(array_keys(get_class_vars(static::class)), ['value']))) {
-            $options = array_merge($fields, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($fields, $options ?? []);
         } else {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['fields'] = $fields;
         }
 

--- a/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
@@ -90,7 +90,7 @@ final class DoctrineLoader implements LoaderInterface
             }
 
             if (true === (self::getFieldMappingValue($mapping, 'unique') ?? false) && !isset($existingUniqueFields[self::getFieldMappingValue($mapping, 'fieldName')])) {
-                $metadata->addConstraint(new UniqueEntity(['fields' => self::getFieldMappingValue($mapping, 'fieldName')]));
+                $metadata->addConstraint(new UniqueEntity(fields: self::getFieldMappingValue($mapping, 'fieldName')));
                 $loaded = true;
             }
 
@@ -103,7 +103,7 @@ final class DoctrineLoader implements LoaderInterface
                     $metadata->addPropertyConstraint(self::getFieldMappingValue($mapping, 'declaredField'), new Valid());
                     $loaded = true;
                 } elseif (property_exists($className, self::getFieldMappingValue($mapping, 'fieldName')) && (!$doctrineMetadata->isMappedSuperclass || $metadata->getReflectionClass()->getProperty(self::getFieldMappingValue($mapping, 'fieldName'))->isPrivate())) {
-                    $metadata->addPropertyConstraint(self::getFieldMappingValue($mapping, 'fieldName'), new Length(['max' => self::getFieldMappingValue($mapping, 'length')]));
+                    $metadata->addPropertyConstraint(self::getFieldMappingValue($mapping, 'fieldName'), new Length(max: self::getFieldMappingValue($mapping, 'length')));
                     $loaded = true;
                 }
             } elseif (null === $lengthConstraint->max) {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
@@ -88,7 +88,7 @@ class FormValidatorFunctionalTest extends TestCase
     public function testNonCompositeConstraintValidatedOnce()
     {
         $form = $this->formFactory->create(TextType::class, null, [
-            'constraints' => [new NotBlank(['groups' => ['foo', 'bar']])],
+            'constraints' => [new NotBlank(groups: ['foo', 'bar'])],
             'validation_groups' => ['foo', 'bar'],
         ]);
         $form->submit('');
@@ -105,12 +105,8 @@ class FormValidatorFunctionalTest extends TestCase
         $form = $this->formFactory->create(FormType::class, null, [
             'constraints' => [
                 new Collection([
-                    'field1' => new NotBlank([
-                        'groups' => ['field1'],
-                    ]),
-                    'field2' => new NotBlank([
-                        'groups' => ['field2'],
-                    ]),
+                    'field1' => new NotBlank(groups: ['field1']),
+                    'field2' => new NotBlank(groups: ['field2']),
                 ]),
             ],
             'validation_groups' => ['field1', 'field2'],
@@ -136,12 +132,8 @@ class FormValidatorFunctionalTest extends TestCase
         $form = $this->formFactory->create(FormType::class, null, [
             'constraints' => [
                 new Collection([
-                    'field1' => new NotBlank([
-                        'groups' => ['field1'],
-                    ]),
-                    'field2' => new NotBlank([
-                        'groups' => ['field2'],
-                    ]),
+                    'field1' => new NotBlank(groups: ['field1']),
+                    'field2' => new NotBlank(groups: ['field2']),
                 ]),
             ],
             'validation_groups' => new GroupSequence(['field1', 'field2']),
@@ -167,10 +159,10 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence(['group1', 'group2']),
         ])
             ->add('foo', TextType::class, [
-                'constraints' => [new Length(['min' => 10, 'groups' => ['group1']])],
+                'constraints' => [new Length(min: 10, groups: ['group1'])],
             ])
             ->add('bar', TextType::class, [
-                'constraints' => [new NotBlank(['groups' => ['group2']])],
+                'constraints' => [new NotBlank(groups: ['group2'])],
             ])
         ;
 
@@ -188,13 +180,13 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence([['group1', 'group2'], 'group3']),
         ])
             ->add('foo', TextType::class, [
-                'constraints' => [new Length(['min' => 10, 'groups' => ['group1']])],
+                'constraints' => [new Length(min: 10, groups: ['group1'])],
             ])
             ->add('bar', TextType::class, [
-                'constraints' => [new Length(['min' => 10, 'groups' => ['group2']])],
+                'constraints' => [new Length(min: 10, groups: ['group2'])],
             ])
             ->add('baz', TextType::class, [
-                'constraints' => [new NotBlank(['groups' => ['group3']])],
+                'constraints' => [new NotBlank(groups: ['group3'])],
             ])
         ;
 
@@ -214,13 +206,11 @@ class FormValidatorFunctionalTest extends TestCase
         ])
             ->add('foo', TextType::class, [
                 'constraints' => [
-                    new NotBlank([
-                        'groups' => ['group1'],
-                    ]),
-                    new Length([
-                        'groups' => ['group2'],
-                        'max' => 3,
-                    ]),
+                    new NotBlank(groups: ['group1']),
+                    new Length(
+                        groups: ['group2'],
+                        max: 3,
+                    ),
                 ],
             ]);
         $form->submit([
@@ -242,13 +232,11 @@ class FormValidatorFunctionalTest extends TestCase
             ->add('bar')
             ->add('foo', TextType::class, [
                 'constraints' => [
-                    new NotBlank([
-                        'groups' => ['group1'],
-                    ]),
-                    new Length([
-                        'groups' => ['group2'],
-                        'max' => 3,
-                    ]),
+                    new NotBlank(groups: ['group1']),
+                    new Length(
+                        groups: ['group2'],
+                        max: 3,
+                    ),
                 ],
             ]);
         $form->submit([
@@ -268,11 +256,11 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => ['group1', 'group2'],
         ])
             ->add('field1', null, [
-                'constraints' => [new NotBlank(['groups' => 'group1'])],
+                'constraints' => [new NotBlank(groups: ['group1'])],
                 'property_path' => '[foo]',
             ])
             ->add('field2', null, [
-                'constraints' => [new NotBlank(['groups' => 'group2'])],
+                'constraints' => [new NotBlank(groups: ['group2'])],
                 'property_path' => '[bar]',
             ])
         ;
@@ -359,11 +347,11 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence(['group1', 'group2']),
         ])
             ->add('field1', null, [
-                'constraints' => [new NotBlank(['groups' => 'group1'])],
+                'constraints' => [new NotBlank(groups: ['group1'])],
                 'property_path' => '[foo]',
             ])
             ->add('field2', null, [
-                'constraints' => [new NotBlank(['groups' => 'group2'])],
+                'constraints' => [new NotBlank(groups: ['group2'])],
                 'property_path' => '[bar]',
             ])
         ;
@@ -384,9 +372,7 @@ class FormValidatorFunctionalTest extends TestCase
     {
         $form = $this->formFactory->create(FormType::class)
             ->add('field1', null, [
-                'constraints' => [new Expression([
-                    'expression' => '!this.getParent().get("field2").getData()',
-                ])],
+                'constraints' => [new Expression(expression: '!this.getParent().get("field2").getData()')],
             ])
             ->add('field2')
         ;
@@ -407,10 +393,10 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence(['group1']),
         ])
             ->add('field1', null, [
-                'constraints' => [new Expression([
-                    'expression' => '!this.getParent().get("field2").getData()',
-                    'groups' => ['group1'],
-                ])],
+                'constraints' => [new Expression(
+                    expression: '!this.getParent().get("field2").getData()',
+                    groups: ['group1'],
+                )],
             ])
             ->add('field2')
         ;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -70,9 +70,9 @@ class FormValidatorTest extends ConstraintValidatorTestCase
     public function testValidateConstraints()
     {
         $object = new \stdClass();
-        $constraint1 = new NotNull(['groups' => ['group1', 'group2']]);
-        $constraint2 = new NotBlank(['groups' => 'group2']);
-        $constraint3 = new Length(['groups' => 'group2', 'min' => 3]);
+        $constraint1 = new NotNull(groups: ['group1', 'group2']);
+        $constraint2 = new NotBlank(groups: ['group2']);
+        $constraint3 = new Length(groups: ['group2'], min: 3);
 
         $options = [
             'validation_groups' => ['group1', 'group2'],
@@ -156,8 +156,8 @@ class FormValidatorTest extends ConstraintValidatorTestCase
     public function testValidateConstraintsOptionEvenIfNoValidConstraint()
     {
         $object = new \stdClass();
-        $constraint1 = new NotNull(['groups' => ['group1', 'group2']]);
-        $constraint2 = new NotBlank(['groups' => 'group2']);
+        $constraint1 = new NotNull(groups: ['group1', 'group2']);
+        $constraint2 = new NotBlank(groups: ['group2']);
 
         $parent = $this->getBuilder('parent', null)
             ->setCompound(true)
@@ -684,7 +684,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
     public function testCauseForNotAllowedExtraFieldsIsTheFormConstraint()
     {
         $form = $this
-            ->getBuilder('form', null, ['constraints' => [new NotBlank(['groups' => ['foo']])]])
+            ->getBuilder('form', null, ['constraints' => [new NotBlank(groups: ['foo'])]])
             ->setCompound(true)
             ->setDataMapper(new DataMapper())
             ->getForm();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -84,8 +84,8 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
             ->create(FormTypeTest::TESTED_TYPE, null, ['validation_groups' => new GroupSequence(['First', 'Second'])])
             ->add('field', TextTypeTest::TESTED_TYPE, [
                 'constraints' => [
-                    new Length(['min' => 10, 'groups' => ['First']]),
-                    new NotBlank(['groups' => ['Second']]),
+                    new Length(min: 10, groups: ['First']),
+                    new NotBlank(groups: ['Second']),
                 ],
             ])
         ;
@@ -102,7 +102,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
     {
         $formMetadata = new ClassMetadata(Form::class);
         $authorMetadata = (new ClassMetadata(Author::class))
-            ->addPropertyConstraint('firstName', new NotBlank(['groups' => 'Second']))
+            ->addPropertyConstraint('firstName', new NotBlank(groups: ['Second']))
         ;
         $metadataFactory = $this->createMock(MetadataFactoryInterface::class);
         $metadataFactory->expects($this->any())
@@ -131,12 +131,12 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
             ->add('firstName', TextTypeTest::TESTED_TYPE)
             ->add('lastName', TextTypeTest::TESTED_TYPE, [
                 'constraints' => [
-                    new Length(['min' => 10, 'groups' => ['First']]),
+                    new Length(min: 10, groups: ['First']),
                 ],
             ])
             ->add('australian', TextTypeTest::TESTED_TYPE, [
                 'constraints' => [
-                    new NotBlank(['groups' => ['Second']]),
+                    new NotBlank(groups: ['Second']),
                 ],
             ])
         ;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -96,8 +96,8 @@ class ValidatorTypeGuesserTest extends TestCase
             [new NotNull(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)],
             [new NotBlank(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)],
             [new IsTrue(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)],
-            [new Length(['min' => 10, 'max' => 10]), new ValueGuess(false, Guess::LOW_CONFIDENCE)],
-            [new Range(['min' => 1, 'max' => 20]), new ValueGuess(false, Guess::LOW_CONFIDENCE)],
+            [new Length(min: 10, max: 10), new ValueGuess(false, Guess::LOW_CONFIDENCE)],
+            [new Range(min: 1, max: 20), new ValueGuess(false, Guess::LOW_CONFIDENCE)],
         ];
     }
 
@@ -122,7 +122,7 @@ class ValidatorTypeGuesserTest extends TestCase
 
     public function testGuessMaxLengthForConstraintWithMaxValue()
     {
-        $constraint = new Length(['max' => '2']);
+        $constraint = new Length(max: '2');
 
         $result = $this->guesser->guessMaxLengthForConstraint($constraint);
         $this->assertInstanceOf(ValueGuess::class, $result);
@@ -132,7 +132,7 @@ class ValidatorTypeGuesserTest extends TestCase
 
     public function testGuessMaxLengthForConstraintWithMinValue()
     {
-        $constraint = new Length(['min' => '2']);
+        $constraint = new Length(min: '2');
 
         $result = $this->guesser->guessMaxLengthForConstraint($constraint);
         $this->assertNull($result);
@@ -141,7 +141,7 @@ class ValidatorTypeGuesserTest extends TestCase
     public function testGuessMimeTypesForConstraintWithMimeTypesValue()
     {
         $mimeTypes = ['image/png', 'image/jpeg'];
-        $constraint = new File(['mimeTypes' => $mimeTypes]);
+        $constraint = new File(mimeTypes: $mimeTypes);
         $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
         $this->assertInstanceOf(TypeGuess::class, $typeGuess);
         $this->assertArrayHasKey('attr', $typeGuess->getOptions());
@@ -159,7 +159,7 @@ class ValidatorTypeGuesserTest extends TestCase
 
     public function testGuessMimeTypesForConstraintWithMimeTypesStringValue()
     {
-        $constraint = new File(['mimeTypes' => 'image/*']);
+        $constraint = new File(mimeTypes: 'image/*');
         $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
         $this->assertInstanceOf(TypeGuess::class, $typeGuess);
         $this->assertArrayHasKey('attr', $typeGuess->getOptions());
@@ -169,7 +169,7 @@ class ValidatorTypeGuesserTest extends TestCase
 
     public function testGuessMimeTypesForConstraintWithMimeTypesEmptyStringValue()
     {
-        $constraint = new File(['mimeTypes' => '']);
+        $constraint = new File(mimeTypes: '');
         $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
         $this->assertInstanceOf(TypeGuess::class, $typeGuess);
         $this->assertArrayNotHasKey('attr', $typeGuess->getOptions());

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\LogicException;
@@ -28,11 +29,20 @@ abstract class AbstractComparison extends Constraint
     public mixed $value = null;
     public ?string $propertyPath = null;
 
-    public function __construct(mixed $value = null, ?string $propertyPath = null, ?string $message = null, ?array $groups = null, mixed $payload = null, array $options = [])
+    #[HasNamedArguments]
+    public function __construct(mixed $value = null, ?string $propertyPath = null, ?string $message = null, ?array $groups = null, mixed $payload = null, ?array $options = null)
     {
         if (\is_array($value)) {
-            $options = array_merge($value, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($value, $options ?? []);
         } elseif (null !== $value) {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['value'] = $value;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/All.php
+++ b/src/Symfony/Component/Validator/Constraints/All.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -28,8 +29,13 @@ class All extends Composite
      * @param array<Constraint>|array<string,mixed>|null $constraints
      * @param string[]|null                              $groups
      */
+    #[HasNamedArguments]
     public function __construct(mixed $constraints = null, ?array $groups = null, mixed $payload = null)
     {
+        if (\is_array($constraints) && !array_is_list($constraints)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($constraints ?? [], $groups, $payload);
     }
 

--- a/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php
+++ b/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php
@@ -41,6 +41,10 @@ class AtLeastOneOf extends Composite
      */
     public function __construct(mixed $constraints = null, ?array $groups = null, mixed $payload = null, ?string $message = null, ?string $messageCollection = null, ?bool $includeInternalMessages = null)
     {
+        if (\is_array($constraints) && !array_is_list($constraints)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($constraints ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
@@ -70,6 +71,7 @@ class Bic extends Constraint
      * @param string[]|null                $groups
      * @param self::VALIDATION_MODE_*|null $mode             The mode used to validate the BIC; pass null to use the default mode (strict)
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -88,6 +90,10 @@ class Bic extends Constraint
         }
         if (null !== $mode && !\in_array($mode, self::VALIDATION_MODES, true)) {
             throw new InvalidArgumentException('The "mode" parameter value is not valid.');
+        }
+
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/Blank.php
+++ b/src/Symfony/Component/Validator/Constraints/Blank.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -33,8 +34,13 @@ class Blank extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Callback.php
+++ b/src/Symfony/Component/Validator/Constraints/Callback.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -30,17 +31,28 @@ class Callback extends Constraint
      * @param string|string[]|callable|array<string,mixed>|null $callback The callback definition
      * @param string[]|null                                     $groups
      */
-    public function __construct(array|string|callable|null $callback = null, ?array $groups = null, mixed $payload = null, array $options = [])
+    #[HasNamedArguments]
+    public function __construct(array|string|callable|null $callback = null, ?array $groups = null, mixed $payload = null, ?array $options = null)
     {
         // Invocation through attributes with an array parameter only
         if (\is_array($callback) && 1 === \count($callback) && isset($callback['value'])) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
             $callback = $callback['value'];
         }
 
         if (!\is_array($callback) || (!isset($callback['callback']) && !isset($callback['groups']) && !isset($callback['payload']))) {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['callback'] = $callback;
         } else {
-            $options = array_merge($callback, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($callback, $options ?? []);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/CardScheme.php
+++ b/src/Symfony/Component/Validator/Constraints/CardScheme.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -49,13 +50,22 @@ class CardScheme extends Constraint
     /**
      * @param non-empty-string|non-empty-string[]|array<string,mixed>|null $schemes Name(s) of the number scheme(s) used to validate the credit card number
      * @param string[]|null                                                $groups
-     * @param array<string,mixed>                                          $options
+     * @param array<string,mixed>|null                                     $options
      */
-    public function __construct(array|string|null $schemes, ?string $message = null, ?array $groups = null, mixed $payload = null, array $options = [])
+    #[HasNamedArguments]
+    public function __construct(array|string|null $schemes, ?string $message = null, ?array $groups = null, mixed $payload = null, ?array $options = null)
     {
         if (\is_array($schemes) && \is_string(key($schemes))) {
-            $options = array_merge($schemes, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($schemes, $options ?? []);
         } else {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['value'] = $schemes;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/Cascade.php
+++ b/src/Symfony/Component/Validator/Constraints/Cascade.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -28,11 +29,18 @@ class Cascade extends Constraint
      * @param non-empty-string[]|non-empty-string|array<string,mixed>|null $exclude Properties excluded from validation
      * @param array<string,mixed>|null                                     $options
      */
+    #[HasNamedArguments]
     public function __construct(array|string|null $exclude = null, ?array $options = null)
     {
         if (\is_array($exclude) && !array_is_list($exclude)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
             $options = array_merge($exclude, $options ?? []);
         } else {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            }
+
             $this->exclude = array_flip((array) $exclude);
         }
 

--- a/src/Symfony/Component/Validator/Constraints/Choice.php
+++ b/src/Symfony/Component/Validator/Constraints/Choice.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -59,6 +60,7 @@ class Choice extends Constraint
      * @param string[]|null        $groups
      * @param bool|null            $match    Whether to validate the values are part of the choices or not (defaults to true)
      */
+    #[HasNamedArguments]
     public function __construct(
         string|array $options = [],
         ?array $choices = null,
@@ -78,7 +80,10 @@ class Choice extends Constraint
         if (\is_array($options) && $options && array_is_list($options)) {
             $choices ??= $options;
             $options = [];
+        } elseif (\is_array($options) && [] !== $options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
+
         if (null !== $choices) {
             $options['value'] = $choices;
         }

--- a/src/Symfony/Component/Validator/Constraints/Cidr.php
+++ b/src/Symfony/Component/Validator/Constraints/Cidr.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
@@ -74,6 +75,7 @@ class Cidr extends Constraint
     /** @var callable|null */
     public $normalizer;
 
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $version = null,
@@ -84,6 +86,10 @@ class Cidr extends Constraint
         $payload = null,
         ?callable $normalizer = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         $this->version = $version ?? $options['version'] ?? $this->version;
 
         if (!\array_key_exists($this->version, self::NET_MAXES)) {

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -41,10 +42,13 @@ class Collection extends Composite
      * @param bool|null                                         $allowExtraFields   Whether to allow additional keys not declared in the configured fields (defaults to false)
      * @param bool|null                                         $allowMissingFields Whether to allow the collection to lack some fields declared in the configured fields (defaults to false)
      */
+    #[HasNamedArguments]
     public function __construct(mixed $fields = null, ?array $groups = null, mixed $payload = null, ?bool $allowExtraFields = null, ?bool $allowMissingFields = null, ?string $extraFieldsMessage = null, ?string $missingFieldsMessage = null)
     {
         if (self::isFieldsOption($fields)) {
             $fields = ['fields' => $fields];
+        } else {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($fields, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
@@ -48,8 +49,9 @@ class Count extends Constraint
      * @param int<0, max>|null                     $max         Maximum expected number of elements
      * @param positive-int|null                    $divisibleBy The number the collection count should be divisible by
      * @param string[]|null                        $groups
-     * @param array<mixed,string>                  $options
+     * @param array<mixed,string>|null             $options
      */
+    #[HasNamedArguments]
     public function __construct(
         int|array|null $exactly = null,
         ?int $min = null,
@@ -61,11 +63,17 @@ class Count extends Constraint
         ?string $divisibleByMessage = null,
         ?array $groups = null,
         mixed $payload = null,
-        array $options = [],
+        ?array $options = null,
     ) {
         if (\is_array($exactly)) {
-            $options = array_merge($exactly, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($exactly, $options ?? []);
             $exactly = $options['value'] ?? null;
+        } elseif (\is_array($options)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        } else {
+            $options = [];
         }
 
         $min ??= $options['min'] ?? null;

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -70,10 +70,10 @@ class CountValidator extends ConstraintValidator
                 ->getValidator()
                 ->inContext($this->context)
                 ->validate($count, [
-                    new DivisibleBy([
-                        'value' => $constraint->divisibleBy,
-                        'message' => $constraint->divisibleByMessage,
-                    ]),
+                    new DivisibleBy(
+                        value: $constraint->divisibleBy,
+                        message: $constraint->divisibleByMessage,
+                    ),
                 ], $this->context->getGroup());
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/Country.php
+++ b/src/Symfony/Component/Validator/Constraints/Country.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Countries;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
@@ -41,6 +42,7 @@ class Country extends Constraint
      *
      * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#Current_codes
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -50,6 +52,10 @@ class Country extends Constraint
     ) {
         if (!class_exists(Countries::class)) {
             throw new LogicException('The Intl component is required to use the Country constraint. Try running "composer require symfony/intl".');
+        }
+
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/CssColor.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColor.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 
@@ -66,6 +67,7 @@ class CssColor extends Constraint
      * @param string[]|null                                           $groups
      * @param array<string,mixed>|null                                $options
      */
+    #[HasNamedArguments]
     public function __construct(array|string $formats = [], ?string $message = null, ?array $groups = null, $payload = null, ?array $options = null)
     {
         $validationModesAsString = implode(', ', self::$validationModes);
@@ -73,6 +75,8 @@ class CssColor extends Constraint
         if (!$formats) {
             $options['value'] = self::$validationModes;
         } elseif (\is_array($formats) && \is_string(key($formats))) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
             $options = array_merge($formats, $options ?? []);
         } elseif (\is_array($formats)) {
             if ([] === array_intersect(self::$validationModes, $formats)) {

--- a/src/Symfony/Component/Validator/Constraints/Currency.php
+++ b/src/Symfony/Component/Validator/Constraints/Currency.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Currencies;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
@@ -38,10 +39,15 @@ class Currency extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
         if (!class_exists(Currencies::class)) {
             throw new LogicException('The Intl component is required to use the Currency constraint. Try running "composer require symfony/intl".');
+        }
+
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -37,8 +38,13 @@ class Date extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -39,13 +40,22 @@ class DateTime extends Constraint
     /**
      * @param non-empty-string|array<string,mixed>|null $format  The datetime format to match (defaults to 'Y-m-d H:i:s')
      * @param string[]|null                             $groups
-     * @param array<string,mixed>                       $options
+     * @param array<string,mixed>|null                  $options
      */
-    public function __construct(string|array|null $format = null, ?string $message = null, ?array $groups = null, mixed $payload = null, array $options = [])
+    #[HasNamedArguments]
+    public function __construct(string|array|null $format = null, ?string $message = null, ?array $groups = null, mixed $payload = null, ?array $options = null)
     {
         if (\is_array($format)) {
-            $options = array_merge($format, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($format, $options ?? []);
         } elseif (null !== $format) {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['value'] = $format;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/DisableAutoMapping.php
+++ b/src/Symfony/Component/Validator/Constraints/DisableAutoMapping.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -28,13 +29,18 @@ class DisableAutoMapping extends Constraint
     /**
      * @param array<string,mixed>|null $options
      */
-    public function __construct(?array $options = null)
+    #[HasNamedArguments]
+    public function __construct(?array $options = null, mixed $payload = null)
     {
+        if (\is_array($options)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         if (\is_array($options) && \array_key_exists('groups', $options)) {
             throw new ConstraintDefinitionException(\sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
         }
 
-        parent::__construct($options);
+        parent::__construct($options, null, $payload);
     }
 
     public function getTargets(): string|array

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Egulias\EmailValidator\EmailValidator as StrictEmailValidator;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\LogicException;
@@ -50,6 +51,7 @@ class Email extends Constraint
      * @param self::VALIDATION_MODE_*|null $mode    The pattern used to validate the email address; pass null to use the default mode configured for the EmailValidator
      * @param string[]|null                $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -64,6 +66,10 @@ class Email extends Constraint
 
         if (null !== $mode && !\in_array($mode, self::VALIDATION_MODES, true)) {
             throw new InvalidArgumentException('The "mode" parameter value is not valid.');
+        }
+
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/EnableAutoMapping.php
+++ b/src/Symfony/Component/Validator/Constraints/EnableAutoMapping.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -28,13 +29,18 @@ class EnableAutoMapping extends Constraint
     /**
      * @param array<string,mixed>|null $options
      */
-    public function __construct(?array $options = null)
+    #[HasNamedArguments]
+    public function __construct(?array $options = null, mixed $payload = null)
     {
+        if (\is_array($options)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         if (\is_array($options) && \array_key_exists('groups', $options)) {
             throw new ConstraintDefinitionException(\sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
         }
 
-        parent::__construct($options);
+        parent::__construct($options, null, $payload);
     }
 
     public function getTargets(): string|array

--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\ExpressionLanguage\Expression as ExpressionObject;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
@@ -42,16 +43,17 @@ class Expression extends Constraint
      * @param string|ExpressionObject|array<string,mixed>|null $expression The expression to evaluate
      * @param array<string,mixed>|null                         $values     The values of the custom variables used in the expression (defaults to an empty array)
      * @param string[]|null                                    $groups
-     * @param array<string,mixed>                              $options
+     * @param array<string,mixed>|null                         $options
      * @param bool|null                                        $negate     Whether to fail if the expression evaluates to true (defaults to false)
      */
+    #[HasNamedArguments]
     public function __construct(
         string|ExpressionObject|array|null $expression,
         ?string $message = null,
         ?array $values = null,
         ?array $groups = null,
         mixed $payload = null,
-        array $options = [],
+        ?array $options = null,
         ?bool $negate = null,
     ) {
         if (!class_exists(ExpressionLanguage::class)) {
@@ -59,8 +61,16 @@ class Expression extends Constraint
         }
 
         if (\is_array($expression)) {
-            $options = array_merge($expression, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($expression, $options ?? []);
         } else {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['value'] = $expression;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/ExpressionSyntax.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionSyntax.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -37,8 +38,13 @@ class ExpressionSyntax extends Constraint
      * @param string[]|null            $allowedVariables Restrict the available variables in the expression to these values (defaults to null that allows any variable)
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?string $service = null, ?array $allowedVariables = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -89,6 +90,7 @@ class File extends Constraint
      *
      * @see https://www.iana.org/assignments/media-types/media-types.xhtml Existing media types
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         int|string|null $maxSize = null,
@@ -116,6 +118,10 @@ class File extends Constraint
         array|string|null $extensions = null,
         ?string $extensionsMessage = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->maxSize = $maxSize ?? $this->maxSize;

--- a/src/Symfony/Component/Validator/Constraints/Hostname.php
+++ b/src/Symfony/Component/Validator/Constraints/Hostname.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -35,6 +36,7 @@ class Hostname extends Constraint
      * @param bool|null                $requireTld Whether to require the hostname to include its top-level domain (defaults to true)
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -42,6 +44,10 @@ class Hostname extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Iban.php
+++ b/src/Symfony/Component/Validator/Constraints/Iban.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -45,8 +46,13 @@ class Iban extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
@@ -111,6 +112,7 @@ class Ip extends Constraint
      * @param self::V4*|self::V6*|self::ALL*|null $version The IP version to validate (defaults to {@see self::V4})
      * @param string[]|null                       $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $version = null,
@@ -119,6 +121,10 @@ class Ip extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->version = $version ?? $this->version;

--- a/src/Symfony/Component/Validator/Constraints/IsFalse.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalse.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -33,8 +34,13 @@ class IsFalse extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/IsNull.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNull.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -33,8 +34,13 @@ class IsNull extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/IsTrue.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrue.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -33,8 +34,13 @@ class IsTrue extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Isbn.php
+++ b/src/Symfony/Component/Validator/Constraints/Isbn.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -52,8 +53,9 @@ class Isbn extends Constraint
      * @param self::ISBN_*|array<string,mixed>|null $type    The type of ISBN to validate (i.e. {@see Isbn::ISBN_10}, {@see Isbn::ISBN_13} or null to accept both, defaults to null)
      * @param string|null                           $message If defined, this message has priority over the others
      * @param string[]|null                         $groups
-     * @param array<string,mixed>                   $options
+     * @param array<string,mixed>|null              $options
      */
+    #[HasNamedArguments]
     public function __construct(
         string|array|null $type = null,
         ?string $message = null,
@@ -62,11 +64,19 @@ class Isbn extends Constraint
         ?string $bothIsbnMessage = null,
         ?array $groups = null,
         mixed $payload = null,
-        array $options = [],
+        ?array $options = null,
     ) {
         if (\is_array($type)) {
-            $options = array_merge($type, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($type, $options ?? []);
         } elseif (null !== $type) {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['value'] = $type;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/Isin.php
+++ b/src/Symfony/Component/Validator/Constraints/Isin.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -42,8 +43,13 @@ class Isin extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Issn.php
+++ b/src/Symfony/Component/Validator/Constraints/Issn.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -50,6 +51,7 @@ class Issn extends Constraint
      * @param bool|null                $requireHyphen Whether to require a hyphenated ISSN value (defaults to false)
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -58,6 +60,10 @@ class Issn extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Json.php
+++ b/src/Symfony/Component/Validator/Constraints/Json.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -33,8 +34,13 @@ class Json extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Language.php
+++ b/src/Symfony/Component/Validator/Constraints/Language.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Languages;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
@@ -39,6 +40,7 @@ class Language extends Constraint
      * @param bool|null                $alpha3  Pass true to validate the language with three-letter code (ISO 639-2 (2T)) or false with two-letter code (ISO 639-1) (defaults to false)
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -48,6 +50,10 @@ class Language extends Constraint
     ) {
         if (!class_exists(Languages::class)) {
             throw new LogicException('The Intl component is required to use the Language constraint. Try running "composer require symfony/intl".');
+        }
+
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
@@ -65,8 +66,9 @@ class Length extends Constraint
      * @param callable|null                         $normalizer A callable to normalize value before it is validated
      * @param self::COUNT_*|null                    $countUnit  The character count unit for the length check (defaults to {@see Length::COUNT_CODEPOINTS})
      * @param string[]|null                         $groups
-     * @param array<string,mixed>                   $options
+     * @param array<string,mixed>|null              $options
      */
+    #[HasNamedArguments]
     public function __construct(
         int|array|null $exactly = null,
         ?int $min = null,
@@ -80,11 +82,17 @@ class Length extends Constraint
         ?string $charsetMessage = null,
         ?array $groups = null,
         mixed $payload = null,
-        array $options = [],
+        ?array $options = null,
     ) {
         if (\is_array($exactly)) {
-            $options = array_merge($exactly, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($exactly, $options ?? []);
             $exactly = $options['value'] ?? null;
+        } elseif (\is_array($options)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        } else {
+            $options = [];
         }
 
         $min ??= $options['min'] ?? null;

--- a/src/Symfony/Component/Validator/Constraints/Locale.php
+++ b/src/Symfony/Component/Validator/Constraints/Locale.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Locales;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
@@ -39,6 +40,7 @@ class Locale extends Constraint
      * @param bool|null                $canonicalize Whether to canonicalize the value before validation (defaults to true) (see {@see https://www.php.net/manual/en/locale.canonicalize.php})
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -48,6 +50,10 @@ class Locale extends Constraint
     ) {
         if (!class_exists(Locales::class)) {
             throw new LogicException('The Intl component is required to use the Locale constraint. Try running "composer require symfony/intl".');
+        }
+
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/Luhn.php
+++ b/src/Symfony/Component/Validator/Constraints/Luhn.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -39,12 +40,17 @@ class Luhn extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharacters.php
+++ b/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharacters.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
@@ -89,6 +90,7 @@ class NoSuspiciousCharacters extends Constraint
      * @param string[]|null                               $locales          Restrict the string's characters to those normally used with these locales. Pass null to use the default locales configured for the NoSuspiciousCharactersValidator. (defaults to null)
      * @param string[]|null                               $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $restrictionLevelMessage = null,
@@ -103,6 +105,10 @@ class NoSuspiciousCharacters extends Constraint
     ) {
         if (!class_exists(\Spoofchecker::class)) {
             throw new LogicException('The intl extension is required to use the NoSuspiciousCharacters constraint.');
+        }
+
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/NotBlank.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlank.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 
@@ -39,8 +40,13 @@ class NotBlank extends Constraint
      * @param bool|null                $allowNull Whether to allow null values (defaults to false)
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?bool $allowNull = null, ?callable $normalizer = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/NotCompromisedPassword.php
+++ b/src/Symfony/Component/Validator/Constraints/NotCompromisedPassword.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -37,6 +38,7 @@ class NotCompromisedPassword extends Constraint
      * @param bool|null                $skipOnError Whether to ignore HTTP errors while requesting the API and thus consider the password valid (defaults to false)
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -45,6 +47,10 @@ class NotCompromisedPassword extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/NotNull.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNull.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -33,8 +34,13 @@ class NotNull extends Constraint
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -43,8 +44,13 @@ final class PasswordStrength extends Constraint
      * @param self::STRENGTH_*|null    $minScore The minimum required strength of the password (defaults to {@see PasswordStrength::STRENGTH_MEDIUM})
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?int $minScore = null, ?array $groups = null, mixed $payload = null, ?string $message = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         $options['minScore'] ??= self::STRENGTH_MEDIUM;
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\LogicException;
@@ -57,6 +58,7 @@ class Range extends Constraint
      * @param non-empty-string|null           $maxPropertyPath        Property path to the max value
      * @param string[]|null                   $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $notInRangeMessage = null,
@@ -71,6 +73,10 @@ class Range extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->notInRangeMessage = $notInRangeMessage ?? $this->notInRangeMessage;

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 
@@ -40,8 +41,9 @@ class Regex extends Constraint
      * @param string|null                     $htmlPattern The pattern to use in the HTML5 pattern attribute
      * @param bool|null                       $match       Whether to validate the value matches the configured pattern or not (defaults to false)
      * @param string[]|null                   $groups
-     * @param array<string,mixed>             $options
+     * @param array<string,mixed>|null        $options
      */
+    #[HasNamedArguments]
     public function __construct(
         string|array|null $pattern,
         ?string $message = null,
@@ -50,11 +52,19 @@ class Regex extends Constraint
         ?callable $normalizer = null,
         ?array $groups = null,
         mixed $payload = null,
-        array $options = [],
+        ?array $options = null,
     ) {
         if (\is_array($pattern)) {
-            $options = array_merge($pattern, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($pattern, $options ?? []);
         } elseif (null !== $pattern) {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['value'] = $pattern;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/Sequentially.php
+++ b/src/Symfony/Component/Validator/Constraints/Sequentially.php
@@ -30,6 +30,10 @@ class Sequentially extends Composite
      */
     public function __construct(mixed $constraints = null, ?array $groups = null, mixed $payload = null)
     {
+        if (is_array($constraints) && !array_is_list($constraints)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($constraints ?? [], $groups, $payload);
     }
 

--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -37,6 +38,7 @@ class Time extends Constraint
      * @param string[]|null            $groups
      * @param bool|null                $withSeconds Whether to allow seconds in the given value (defaults to true)
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -44,6 +46,10 @@ class Time extends Constraint
         mixed $payload = null,
         ?bool $withSeconds = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->withSeconds = $withSeconds ?? $this->withSeconds;

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -45,10 +46,11 @@ class Timezone extends Constraint
      * @param string|null                  $countryCode    Restrict the valid timezones to this country if the zone option is {@see \DateTimeZone::PER_COUNTRY}
      * @param bool|null                    $intlCompatible Whether to restrict valid timezones to ones available in PHP's intl (defaults to false)
      * @param string[]|null                $groups
-     * @param array<string,mixed>          $options
+     * @param array<string,mixed>|null     $options
      *
      * @see \DateTimeZone
      */
+    #[HasNamedArguments]
     public function __construct(
         int|array|null $zone = null,
         ?string $message = null,
@@ -56,11 +58,19 @@ class Timezone extends Constraint
         ?bool $intlCompatible = null,
         ?array $groups = null,
         mixed $payload = null,
-        array $options = [],
+        ?array $options = null,
     ) {
         if (\is_array($zone)) {
-            $options = array_merge($zone, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($zone, $options ?? []);
         } elseif (null !== $zone) {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['value'] = $zone;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/Traverse.php
+++ b/src/Symfony/Component/Validator/Constraints/Traverse.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -27,13 +28,18 @@ class Traverse extends Constraint
     /**
      * @param bool|array<string,mixed>|null $traverse Whether to traverse the given object or not (defaults to true). Pass an associative array to configure the constraint's options (e.g. payload).
      */
-    public function __construct(bool|array|null $traverse = null)
+    #[HasNamedArguments]
+    public function __construct(bool|array|null $traverse = null, mixed $payload = null)
     {
         if (\is_array($traverse) && \array_key_exists('groups', $traverse)) {
             throw new ConstraintDefinitionException(\sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
         }
 
-        parent::__construct($traverse);
+        if (\is_array($traverse)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
+        parent::__construct($traverse, null, $payload);
     }
 
     public function getDefaultOption(): ?string

--- a/src/Symfony/Component/Validator/Constraints/Type.php
+++ b/src/Symfony/Component/Validator/Constraints/Type.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -33,14 +34,25 @@ class Type extends Constraint
     /**
      * @param string|string[]|array<string,mixed>|null $type    The type(s) to enforce on the value
      * @param string[]|null                            $groups
-     * @param array<string,mixed>                      $options
+     * @param array<string,mixed>|null                 $options
      */
-    public function __construct(string|array|null $type, ?string $message = null, ?array $groups = null, mixed $payload = null, array $options = [])
+    #[HasNamedArguments]
+    public function __construct(string|array|null $type, ?string $message = null, ?array $groups = null, mixed $payload = null, ?array $options = null)
     {
         if (\is_array($type) && \is_string(key($type))) {
-            $options = array_merge($type, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($type, $options ?? []);
         } elseif (null !== $type) {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['value'] = $type;
+        } elseif (\is_array($options)) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/Ulid.php
+++ b/src/Symfony/Component/Validator/Constraints/Ulid.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -50,6 +51,7 @@ class Ulid extends Constraint
      * @param string[]|null            $groups
      * @param self::FORMAT_*|null      $format
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -57,6 +59,10 @@ class Ulid extends Constraint
         mixed $payload = null,
         ?string $format = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 
@@ -40,6 +41,7 @@ class Unique extends Constraint
      * @param string[]|null            $groups
      * @param string[]|string|null     $fields  Defines the key or keys in the collection that should be checked for uniqueness (defaults to null, which ensure uniqueness for all keys)
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -49,6 +51,10 @@ class Unique extends Constraint
         array|string|null $fields = null,
         ?string $errorPath = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 
@@ -45,6 +46,7 @@ class Url extends Constraint
      * @param string[]|null            $groups
      * @param bool|null                $requireTld       Whether to require the URL to include a top-level domain (defaults to false)
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -56,6 +58,10 @@ class Url extends Constraint
         ?bool $requireTld = null,
         ?string $tldMessage = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         if (null === ($options['requireTld'] ?? $requireTld)) {

--- a/src/Symfony/Component/Validator/Constraints/Uuid.php
+++ b/src/Symfony/Component/Validator/Constraints/Uuid.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 
@@ -100,6 +101,7 @@ class Uuid extends Constraint
      * @param bool|null                $strict   Whether to force the value to follow the RFC's input format rules; pass false to allow alternate formats (defaults to true)
      * @param string[]|null            $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
@@ -109,6 +111,10 @@ class Uuid extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Constraints/Valid.php
+++ b/src/Symfony/Component/Validator/Constraints/Valid.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -28,8 +29,13 @@ class Valid extends Constraint
      * @param string[]|null            $groups
      * @param bool|null                $traverse Whether to validate {@see \Traversable} objects (defaults to true)
      */
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?array $groups = null, $payload = null, ?bool $traverse = null)
     {
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
+
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->traverse = $traverse ?? $this->traverse;

--- a/src/Symfony/Component/Validator/Constraints/When.php
+++ b/src/Symfony/Component/Validator/Constraints/When.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
@@ -33,17 +34,26 @@ class When extends Composite
      * @param Constraint[]|Constraint|null          $constraints One or multiple constraints that are applied if the expression returns true
      * @param array<string,mixed>|null              $values      The values of the custom variables used in the expression (defaults to [])
      * @param string[]|null                         $groups
-     * @param array<string,mixed>                   $options
+     * @param array<string,mixed>|null              $options
      */
-    public function __construct(string|Expression|array $expression, array|Constraint|null $constraints = null, ?array $values = null, ?array $groups = null, $payload = null, array $options = [])
+    #[HasNamedArguments]
+    public function __construct(string|Expression|array $expression, array|Constraint|null $constraints = null, ?array $values = null, ?array $groups = null, $payload = null, ?array $options = null)
     {
         if (!class_exists(ExpressionLanguage::class)) {
             throw new LogicException(\sprintf('The "symfony/expression-language" component is required to use the "%s" constraint. Try running "composer require symfony/expression-language".', __CLASS__));
         }
 
         if (\is_array($expression)) {
-            $options = array_merge($expression, $options);
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+
+            $options = array_merge($expression, $options ?? []);
         } else {
+            if (\is_array($options)) {
+                trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+            } else {
+                $options = [];
+            }
+
             $options['expression'] = $expression;
             $options['constraints'] = $constraints;
         }

--- a/src/Symfony/Component/Validator/Constraints/ZeroComparisonConstraintTrait.php
+++ b/src/Symfony/Component/Validator/Constraints/ZeroComparisonConstraintTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
@@ -21,15 +22,18 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 trait ZeroComparisonConstraintTrait
 {
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
     {
-        $options ??= [];
+        if (null !== $options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
+        }
 
-        if (isset($options['propertyPath'])) {
+        if (is_array($options) && isset($options['propertyPath'])) {
             throw new ConstraintDefinitionException(\sprintf('The "propertyPath" option of the "%s" constraint cannot be set.', static::class));
         }
 
-        if (isset($options['value'])) {
+        if (is_array($options) && isset($options['value'])) {
             throw new ConstraintDefinitionException(\sprintf('The "value" option of the "%s" constraint cannot be set.', static::class));
         }
 

--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -95,7 +95,7 @@ interface ExecutionContextInterface
      *     {
      *         $validator = $this->context->getValidator();
      *
-     *         $violations = $validator->validate($value, new Length(['min' => 3]));
+     *         $violations = $validator->validate($value, new Length(min: 3));
      *
      *         if (count($violations) > 0) {
      *             // ...

--- a/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
@@ -97,9 +97,19 @@ abstract class AbstractLoader implements LoaderInterface
                 return new $className($options['value']);
             }
 
+            if (array_is_list($options)) {
+                return new $className($options);
+            }
+
             return new $className(...$options);
         }
 
-        return new $className($options);
+        if ($options) {
+            trigger_deprecation('symfony/validator', '7.2', 'Using constraints not supporting named arguments is deprecated. Try adding the HasNamedArguments attribute to %s.', $className);
+
+            return new $className($options);
+        }
+
+        return new $className();
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
@@ -134,7 +134,7 @@ final class PropertyInfoLoader implements LoaderInterface
 
                         $metadata->addPropertyConstraint($property, $this->getTypeConstraintLegacy($builtinTypes[0], $types[0]));
                     } elseif ($scalar) {
-                        $metadata->addPropertyConstraint($property, new Type(['type' => 'scalar']));
+                        $metadata->addPropertyConstraint($property, new Type(type: 'scalar'));
                     }
                 }
             } else {
@@ -203,10 +203,10 @@ final class PropertyInfoLoader implements LoaderInterface
     private function getTypeConstraintLegacy(string $builtinType, PropertyInfoType $type): Type
     {
         if (PropertyInfoType::BUILTIN_TYPE_OBJECT === $builtinType && null !== $className = $type->getClassName()) {
-            return new Type(['type' => $className]);
+            return new Type(type: $className);
         }
 
-        return new Type(['type' => $builtinType]);
+        return new Type(type: $builtinType);
     }
 
     private function getTypeConstraint(TypeInfoType $type): ?Type
@@ -220,11 +220,11 @@ final class PropertyInfoLoader implements LoaderInterface
             $baseType = $type->getBaseType();
 
             if ($baseType instanceof ObjectType) {
-                return new Type(['type' => $baseType->getClassName()]);
+                return new Type(type: $baseType->getClassName());
             }
 
             if (TypeIdentifier::MIXED !== $baseType->getTypeIdentifier()) {
-                return new Type(['type' => $baseType->getTypeIdentifier()->value]);
+                return new Type(type: $baseType->getTypeIdentifier()->value);
             }
 
             return null;
@@ -238,7 +238,7 @@ final class PropertyInfoLoader implements LoaderInterface
                 TypeIdentifier::BOOL,
                 TypeIdentifier::TRUE,
                 TypeIdentifier::FALSE,
-            ) ? new Type(['type' => 'scalar']) : null;
+            ) ? new Type(type: 'scalar') : null;
         }
 
         while ($type instanceof WrappingTypeInterface) {
@@ -246,11 +246,11 @@ final class PropertyInfoLoader implements LoaderInterface
         }
 
         if ($type instanceof ObjectType) {
-            return new Type(['type' => $type->getClassName()]);
+            return new Type(type: $type->getClassName());
         }
 
         if ($type instanceof BuiltinType && TypeIdentifier::MIXED !== $type->getTypeIdentifier()) {
-            return new Type(['type' => $type->getTypeIdentifier()->value]);
+            return new Type(type: $type->getTypeIdentifier()->value);
         }
 
         return null;
@@ -284,7 +284,7 @@ final class PropertyInfoLoader implements LoaderInterface
         }
 
         if (null === $allConstraint) {
-            $metadata->addPropertyConstraint($property, new All(['constraints' => $constraints]));
+            $metadata->addPropertyConstraint($property, new All(constraints: $constraints));
         } else {
             $allConstraint->constraints = array_merge($allConstraint->constraints, $constraints);
         }
@@ -318,7 +318,7 @@ final class PropertyInfoLoader implements LoaderInterface
         }
 
         if (null === $allConstraint) {
-            $metadata->addPropertyConstraint($property, new All(['constraints' => $constraints]));
+            $metadata->addPropertyConstraint($property, new All(constraints: $constraints));
         } else {
             $allConstraint->constraints = array_merge($allConstraint->constraints, $constraints);
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -27,7 +27,7 @@ class AllValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new All(new Range(['min' => 4])));
+        $this->validator->validate(null, new All(new Range(min: 4)));
 
         $this->assertNoViolation();
     }
@@ -35,7 +35,7 @@ class AllValidatorTest extends ConstraintValidatorTestCase
     public function testThrowsExceptionIfNotTraversable()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate('foo.barbar', new All(new Range(['min' => 4])));
+        $this->validator->validate('foo.barbar', new All(new Range(min: 4)));
     }
 
     /**
@@ -43,7 +43,7 @@ class AllValidatorTest extends ConstraintValidatorTestCase
      */
     public function testWalkSingleConstraint($array)
     {
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
         $i = 0;
 
@@ -61,7 +61,7 @@ class AllValidatorTest extends ConstraintValidatorTestCase
      */
     public function testWalkMultipleConstraints($array)
     {
-        $constraint1 = new Range(['min' => 4]);
+        $constraint1 = new Range(min: 4);
         $constraint2 = new NotNull();
 
         $constraints = [$constraint1, $constraint2];

--- a/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
@@ -66,31 +66,31 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
     {
         return [
             ['symfony', [
-                new Length(['min' => 10]),
-                new EqualTo(['value' => 'symfony']),
+                new Length(min: 10),
+                new EqualTo(value: 'symfony'),
             ]],
             [150, [
-                new Range(['min' => 10, 'max' => 20]),
-                new GreaterThanOrEqual(['value' => 100]),
+                new Range(min: 10, max: 20),
+                new GreaterThanOrEqual(value: 100),
             ]],
             [7, [
-                new LessThan(['value' => 5]),
-                new IdenticalTo(['value' => 7]),
+                new LessThan(value: 5),
+                new IdenticalTo(value: 7),
             ]],
             [-3, [
-                new DivisibleBy(['value' => 4]),
+                new DivisibleBy(value: 4),
                 new Negative(),
             ]],
             ['FOO', [
-                new Choice(['choices' => ['bar', 'BAR']]),
-                new Regex(['pattern' => '/foo/i']),
+                new Choice(choices: ['bar', 'BAR']),
+                new Regex(pattern: '/foo/i'),
             ]],
             ['fr', [
                 new Country(),
                 new Language(),
             ]],
             [[1, 3, 5], [
-                new Count(['min' => 5]),
+                new Count(min: 5),
                 new Unique(),
             ]],
         ];
@@ -101,7 +101,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidCombinationsWithDefaultMessage($value, $constraints)
     {
-        $atLeastOneOf = new AtLeastOneOf(['constraints' => $constraints]);
+        $atLeastOneOf = new AtLeastOneOf(constraints: $constraints);
         $validator = Validation::createValidator();
 
         $message = [$atLeastOneOf->message];
@@ -123,7 +123,11 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidCombinationsWithCustomMessage($value, $constraints)
     {
-        $atLeastOneOf = new AtLeastOneOf(['constraints' => $constraints, 'message' => 'foo', 'includeInternalMessages' => false]);
+        $atLeastOneOf = new AtLeastOneOf(
+            constraints: $constraints,
+            message: 'foo',
+            includeInternalMessages: false,
+        );
 
         $violations = Validation::createValidator()->validate($value, $atLeastOneOf);
 
@@ -135,31 +139,31 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
     {
         return [
             ['symphony', [
-                new Length(['min' => 10]),
-                new EqualTo(['value' => 'symfony']),
+                new Length(min: 10),
+                new EqualTo(value: 'symfony'),
             ]],
             [70, [
-                new Range(['min' => 10, 'max' => 20]),
-                new GreaterThanOrEqual(['value' => 100]),
+                new Range(min: 10, max: 20),
+                new GreaterThanOrEqual(value: 100),
             ]],
             [8, [
-                new LessThan(['value' => 5]),
-                new IdenticalTo(['value' => 7]),
+                new LessThan(value: 5),
+                new IdenticalTo(value: 7),
             ]],
             [3, [
-                new DivisibleBy(['value' => 4]),
+                new DivisibleBy(value: 4),
                 new Negative(),
             ]],
             ['F_O_O', [
-                new Choice(['choices' => ['bar', 'BAR']]),
-                new Regex(['pattern' => '/foo/i']),
+                new Choice(choices: ['bar', 'BAR']),
+                new Regex(pattern: '/foo/i'),
             ]],
             ['f_r', [
                 new Country(),
                 new Language(),
             ]],
             [[1, 3, 3], [
-                new Count(['min' => 5]),
+                new Count(min: 5),
                 new Unique(),
             ]],
         ];
@@ -169,21 +173,21 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
     {
         $validator = Validation::createValidator();
 
-        $violations = $validator->validate(50, new AtLeastOneOf([
-            'constraints' => [
-                new Range([
-                    'groups' => 'non_default_group',
-                    'min' => 10,
-                    'max' => 20,
-                ]),
-                new Range([
-                    'groups' => 'non_default_group',
-                    'min' => 30,
-                    'max' => 40,
-                ]),
+        $violations = $validator->validate(50, new AtLeastOneOf(
+            constraints: [
+                new Range(
+                    groups: ['non_default_group'],
+                    min: 10,
+                    max: 20,
+                ),
+                new Range(
+                    groups: ['non_default_group'],
+                    min: 30,
+                    max: 40,
+                ),
             ],
-            'groups' => 'non_default_group',
-        ]), 'non_default_group');
+            groups: ['non_default_group'],
+        ), ['non_default_group']);
 
         $this->assertCount(1, $violations);
     }
@@ -221,9 +225,9 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
                 public function getMetadataFor($classOrObject): MetadataInterface
                 {
                     return (new ClassMetadata(Data::class))
-                        ->addPropertyConstraint('foo', new NotNull(['message' => 'custom message foo']))
+                        ->addPropertyConstraint('foo', new NotNull(message: 'custom message foo'))
                         ->addPropertyConstraint('bar', new AtLeastOneOf([
-                            new NotNull(['message' => 'custom message bar']),
+                            new NotNull(message: 'custom message bar'),
                         ]))
                     ;
                 }
@@ -247,20 +251,20 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
     {
         $validator = Validation::createValidator();
 
-        $violations = $validator->validate(50, new AtLeastOneOf([
-            'constraints' => [
-                new Range([
-                    'groups' => 'adult',
-                    'min' => 18,
-                    'max' => 55,
-                ]),
-                new GreaterThan([
-                    'groups' => 'senior',
-                    'value' => 55,
-                ]),
+        $violations = $validator->validate(50, new AtLeastOneOf(
+            constraints: [
+                new Range(
+                    groups: ['adult'],
+                    min: 18,
+                    max: 55,
+                ),
+                new GreaterThan(
+                    groups: ['senior'],
+                    value: 55,
+                ),
             ],
-            'groups' => ['adult', 'senior'],
-        ]), 'senior');
+            groups: ['adult', 'senior'],
+        ), 'senior');
 
         $this->assertCount(1, $violations);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -44,7 +44,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidComparisonToPropertyPath()
     {
-        $constraint = new Bic(['ibanPropertyPath' => 'value']);
+        $constraint = new Bic(ibanPropertyPath: 'value');
 
         $object = new BicComparisonTestClass('FR14 2004 1010 0505 0001 3M02 606');
 
@@ -57,7 +57,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidComparisonToPropertyPath()
     {
-        $constraint = new Bic(['ibanPropertyPath' => 'value']);
+        $constraint = new Bic(ibanPropertyPath: 'value');
         $constraint->ibanMessage = 'Constraint Message';
 
         $object = new BicComparisonTestClass('FR14 2004 1010 0505 0001 3M02 606');
@@ -95,14 +95,14 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new BicTypedDummy());
 
-        $this->validator->validate('UNCRIT2B912', new Bic(['ibanPropertyPath' => 'iban']));
+        $this->validator->validate('UNCRIT2B912', new Bic(ibanPropertyPath: 'iban'));
 
         $this->assertNoViolation();
     }
 
     public function testValidComparisonToValue()
     {
-        $constraint = new Bic(['iban' => 'FR14 2004 1010 0505 0001 3M02 606']);
+        $constraint = new Bic(iban: 'FR14 2004 1010 0505 0001 3M02 606');
         $constraint->ibanMessage = 'Constraint Message';
 
         $this->validator->validate('SOGEFRPP', $constraint);
@@ -112,7 +112,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidComparisonToValue()
     {
-        $constraint = new Bic(['iban' => 'FR14 2004 1010 0505 0001 3M02 606']);
+        $constraint = new Bic(iban: 'FR14 2004 1010 0505 0001 3M02 606');
         $constraint->ibanMessage = 'Constraint Message';
 
         $this->validator->validate('UNCRIT2B912', $constraint);
@@ -142,7 +142,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
     public function testNoViolationOnNullObjectWithPropertyPath()
     {
-        $constraint = new Bic(['ibanPropertyPath' => 'propertyPath']);
+        $constraint = new Bic(ibanPropertyPath: 'propertyPath');
 
         $this->setObject(null);
 
@@ -155,10 +155,10 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('The "iban" and "ibanPropertyPath" options of the Iban constraint cannot be used at the same time');
-        new Bic([
-            'iban' => 'value',
-            'ibanPropertyPath' => 'propertyPath',
-        ]);
+        new Bic(
+            iban: 'value',
+            ibanPropertyPath: 'propertyPath',
+        );
     }
 
     public function testThrowsConstraintExceptionIfBothValueAndPropertyPathNamed()
@@ -171,7 +171,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidValuePath()
     {
-        $constraint = new Bic(['ibanPropertyPath' => 'foo']);
+        $constraint = new Bic(ibanPropertyPath: 'foo');
 
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage(\sprintf('Invalid property path "foo" provided to "%s" constraint', $constraint::class));
@@ -217,9 +217,9 @@ class BicValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidBics($bic, $code)
     {
-        $constraint = new Bic([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Bic(
+            message: 'myMessage',
+        );
 
         $this->validator->validate($bic, $constraint);
 
@@ -277,7 +277,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidBicSpecialCases(string $bic, string $iban)
     {
-        $constraint = new Bic(['iban' => $iban]);
+        $constraint = new Bic(iban: $iban);
         $this->validator->validate($bic, $constraint);
 
         $this->assertNoViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
@@ -41,9 +41,9 @@ class BlankValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValues($value, $valueAsString)
     {
-        $constraint = new Blank([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Blank(
+            message: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -74,7 +74,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
     public function testSingleMethodExplicitName()
     {
         $object = new CallbackValidatorTest_Object();
-        $constraint = new Callback(['callback' => 'validate']);
+        $constraint = new Callback(callback: 'validate');
 
         $this->validator->validate($object, $constraint);
 
@@ -129,13 +129,11 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
     public function testClosureExplicitName()
     {
         $object = new CallbackValidatorTest_Object();
-        $constraint = new Callback([
-            'callback' => function ($object, ExecutionContextInterface $context) {
-                $context->addViolation('My message', ['{{ value }}' => 'foobar']);
+        $constraint = new Callback(callback: function ($object, ExecutionContextInterface $context) {
+            $context->addViolation('My message', ['{{ value }}' => 'foobar']);
 
-                return false;
-            },
-        ]);
+            return false;
+        });
 
         $this->validator->validate($object, $constraint);
 
@@ -170,9 +168,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
     public function testArrayCallableExplicitName()
     {
         $object = new CallbackValidatorTest_Object();
-        $constraint = new Callback([
-            'callback' => [__CLASS__.'_Class', 'validateCallback'],
-        ]);
+        $constraint = new Callback(callback: [__CLASS__.'_Class', 'validateCallback']);
 
         $this->validator->validate($object, $constraint);
 
@@ -186,7 +182,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(ConstraintDefinitionException::class);
         $object = new CallbackValidatorTest_Object();
 
-        $this->validator->validate($object, new Callback(['callback' => ['foobar']]));
+        $this->validator->validate($object, new Callback(callback: ['foobar']));
     }
 
     public function testExpectValidCallbacks()
@@ -194,12 +190,12 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(ConstraintDefinitionException::class);
         $object = new CallbackValidatorTest_Object();
 
-        $this->validator->validate($object, new Callback(['callback' => ['foo', 'bar']]));
+        $this->validator->validate($object, new Callback(callback: ['foo', 'bar']));
     }
 
     public function testConstraintGetTargets()
     {
-        $constraint = new Callback([]);
+        $constraint = new Callback(callback: []);
         $targets = [Constraint::CLASS_CONSTRAINT, Constraint::PROPERTY_CONSTRAINT];
 
         $this->assertEquals($targets, $constraint->getTargets());
@@ -215,16 +211,16 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
 
     public function testAttributeInvocationSingleValued()
     {
-        $constraint = new Callback(['value' => 'validateStatic']);
+        $constraint = new Callback(callback: 'validateStatic');
 
-        $this->assertEquals(new Callback('validateStatic'), $constraint);
+        $this->assertEquals(new Callback(callback: 'validateStatic'), $constraint);
     }
 
     public function testAttributeInvocationMultiValued()
     {
-        $constraint = new Callback(['value' => [__CLASS__.'_Class', 'validateCallback']]);
+        $constraint = new Callback(callback: [__CLASS__.'_Class', 'validateCallback']);
 
-        $this->assertEquals(new Callback([__CLASS__.'_Class', 'validateCallback']), $constraint);
+        $this->assertEquals(new Callback(callback: [__CLASS__.'_Class', 'validateCallback']), $constraint);
     }
 
     public function testPayloadIsPassedToCallback()
@@ -235,10 +231,10 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
             $payloadCopy = $payload;
         };
 
-        $constraint = new Callback([
-            'callback' => $callback,
-            'payload' => 'Hello world!',
-        ]);
+        $constraint = new Callback(
+            callback: $callback,
+            payload: 'Hello world!',
+        );
         $this->validator->validate($object, $constraint);
         $this->assertEquals('Hello world!', $payloadCopy);
 
@@ -248,9 +244,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $this->assertEquals('Hello world!', $payloadCopy);
 
         $payloadCopy = 'Replace me!';
-        $constraint = new Callback([
-            'callback' => $callback,
-        ]);
+        $constraint = new Callback(callback: $callback);
         $this->validator->validate($object, $constraint);
         $this->assertNull($payloadCopy);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -24,14 +24,14 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new CardScheme(['schemes' => []]));
+        $this->validator->validate(null, new CardScheme(schemes: []));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new CardScheme(['schemes' => []]));
+        $this->validator->validate('', new CardScheme(schemes:[]));
 
         $this->assertNoViolation();
     }
@@ -41,7 +41,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidNumbers($scheme, $number)
     {
-        $this->validator->validate($number, new CardScheme(['schemes' => $scheme]));
+        $this->validator->validate($number, new CardScheme(schemes: $scheme));
 
         $this->assertNoViolation();
     }
@@ -51,7 +51,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidNumbersWithNewLine($scheme, $number)
     {
-        $this->validator->validate($number."\n", new CardScheme(['schemes' => $scheme, 'message' => 'myMessage']));
+        $this->validator->validate($number."\n", new CardScheme(schemes: $scheme, message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$number."\n\"")
@@ -74,10 +74,10 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidNumbers($scheme, $number, $code)
     {
-        $constraint = new CardScheme([
-            'schemes' => $scheme,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new CardScheme(
+            schemes: $scheme,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($number, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
@@ -31,7 +31,7 @@ class CidrTest extends TestCase
 
     public function testForV4()
     {
-        $cidrConstraint = new Cidr(['version' => Ip::V4]);
+        $cidrConstraint = new Cidr(version: Ip::V4);
 
         self::assertEquals(Ip::V4, $cidrConstraint->version);
         self::assertEquals(0, $cidrConstraint->netmaskMin);
@@ -40,7 +40,7 @@ class CidrTest extends TestCase
 
     public function testForV6()
     {
-        $cidrConstraint = new Cidr(['version' => Ip::V6]);
+        $cidrConstraint = new Cidr(version: Ip::V6);
 
         self::assertEquals(Ip::V6, $cidrConstraint->version);
         self::assertEquals(0, $cidrConstraint->netmaskMin);
@@ -62,7 +62,7 @@ class CidrTest extends TestCase
         self::expectException(ConstraintDefinitionException::class);
         self::expectExceptionMessage(\sprintf('The option "version" must be one of "%s".', implode('", "', $availableVersions)));
 
-        new Cidr(['version' => '8']);
+        new Cidr(version: '8');
     }
 
     /**
@@ -70,11 +70,11 @@ class CidrTest extends TestCase
      */
     public function testWithValidMinMaxValues(string $ipVersion, int $netmaskMin, int $netmaskMax)
     {
-        $cidrConstraint = new Cidr([
-            'version' => $ipVersion,
-            'netmaskMin' => $netmaskMin,
-            'netmaskMax' => $netmaskMax,
-        ]);
+        $cidrConstraint = new Cidr(
+            version: $ipVersion,
+            netmaskMin: $netmaskMin,
+            netmaskMax: $netmaskMax,
+        );
 
         self::assertEquals($ipVersion, $cidrConstraint->version);
         self::assertEquals($netmaskMin, $cidrConstraint->netmaskMin);
@@ -91,11 +91,11 @@ class CidrTest extends TestCase
         self::expectException(ConstraintDefinitionException::class);
         self::expectExceptionMessage(\sprintf('The netmask range must be between 0 and %d.', $expectedMax));
 
-        new Cidr([
-            'version' => $ipVersion,
-            'netmaskMin' => $netmaskMin,
-            'netmaskMax' => $netmaskMax,
-        ]);
+        new Cidr(
+            version: $ipVersion,
+            netmaskMin: $netmaskMin,
+            netmaskMax: $netmaskMax,
+        );
     }
 
     public static function getInvalidMinMaxValues(): array

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
@@ -86,7 +86,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidCidr(string|\Stringable $cidr, string $version)
     {
-        $this->validator->validate($cidr, new Cidr(['version' => $version]));
+        $this->validator->validate($cidr, new Cidr(version: $version));
 
         $this->assertNoViolation();
     }
@@ -108,11 +108,11 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
      */
     public function testOutOfRangeNetmask(string $cidr, int $maxExpected, ?string $version = null, ?int $min = null, ?int $max = null)
     {
-        $cidrConstraint = new Cidr([
-            'version' => $version,
-            'netmaskMin' => $min,
-            'netmaskMax' => $max,
-        ]);
+        $cidrConstraint = new Cidr(
+            version: $version,
+            netmaskMin: $min,
+            netmaskMax: $max,
+        );
         $this->validator->validate($cidr, $cidrConstraint);
 
         $this
@@ -128,7 +128,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
      */
     public function testWrongVersion(string $cidr, string $version)
     {
-        $this->validator->validate($cidr, new Cidr(['version' => $version]));
+        $this->validator->validate($cidr, new Cidr(version: $version));
 
         $this
             ->buildViolation('This value is not a valid CIDR notation.')

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
@@ -25,6 +25,9 @@ use Symfony\Component\Validator\Exception\InvalidOptionsException;
  */
 class CollectionTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testRejectNonConstraints()
     {
         $this->expectException(InvalidOptionsException::class);
@@ -59,18 +62,14 @@ class CollectionTest extends TestCase
 
     public function testAcceptOptionalConstraintAsOneElementArray()
     {
-        $collection1 = new Collection([
-            'fields' => [
-                'alternate_email' => [
-                    new Optional(new Email()),
-                ],
+        $collection1 = new Collection(fields: [
+            'alternate_email' => [
+                new Optional(new Email()),
             ],
         ]);
 
-        $collection2 = new Collection([
-            'fields' => [
-                'alternate_email' => new Optional(new Email()),
-            ],
+        $collection2 = new Collection(fields: [
+            'alternate_email' => new Optional(new Email()),
         ]);
 
         $this->assertEquals($collection1, $collection2);
@@ -78,18 +77,14 @@ class CollectionTest extends TestCase
 
     public function testAcceptRequiredConstraintAsOneElementArray()
     {
-        $collection1 = new Collection([
-            'fields' => [
-                'alternate_email' => [
-                    new Required(new Email()),
-                ],
+        $collection1 = new Collection(fields: [
+            'alternate_email' => [
+                new Required(new Email()),
             ],
         ]);
 
-        $collection2 = new Collection([
-            'fields' => [
-                'alternate_email' => new Required(new Email()),
-            ],
+        $collection2 = new Collection(fields: [
+            'alternate_email' => new Required(new Email()),
         ]);
 
         $this->assertEquals($collection1, $collection2);
@@ -107,6 +102,9 @@ class CollectionTest extends TestCase
         $this->assertEquals(['Default'], $constraint->fields['bar']->groups);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOnlySomeKeysAreKnowOptions()
     {
         $constraint = new Collection([
@@ -125,15 +123,15 @@ class CollectionTest extends TestCase
 
     public function testAllKeysAreKnowOptions()
     {
-        $constraint = new Collection([
-            'fields' => [
+        $constraint = new Collection(
+            fields: [
                 'fields' => [new Required()],
                 'properties' => [new Required()],
                 'catalog' => [new Optional()],
             ],
-            'allowExtraFields' => true,
-            'extraFieldsMessage' => 'foo bar baz',
-        ]);
+            allowExtraFields: true,
+            extraFieldsMessage: 'foo bar baz',
+        );
 
         $this->assertArrayHasKey('fields', $constraint->fields);
         $this->assertInstanceOf(Required::class, $constraint->fields['fields']);
@@ -156,11 +154,11 @@ class CollectionTest extends TestCase
 
     public function testEmptyFieldsInOptions()
     {
-        $constraint = new Collection([
-            'fields' => [],
-            'allowExtraFields' => true,
-            'extraFieldsMessage' => 'foo bar baz',
-        ]);
+        $constraint = new Collection(
+            fields: [],
+            allowExtraFields: true,
+            extraFieldsMessage: 'foo bar baz',
+        );
 
         $this->assertSame([], $constraint->fields);
         $this->assertTrue($constraint->allowExtraFields);
@@ -196,13 +194,13 @@ class CollectionTest extends TestCase
      */
     public function testEmptyConstraintListForFieldInOptions(?array $fieldConstraint)
     {
-        $constraint = new Collection([
-            'fields' => [
+        $constraint = new Collection(
+            fields: [
                 'foo' => $fieldConstraint,
             ],
-            'allowExtraFields' => true,
-            'extraFieldsMessage' => 'foo bar baz',
-        ]);
+            allowExtraFields: true,
+            extraFieldsMessage: 'foo bar baz',
+        );
 
         $this->assertArrayHasKey('foo', $constraint->fields);
         $this->assertInstanceOf(Required::class, $constraint->fields['foo']);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTestCase.php
@@ -31,16 +31,16 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Collection(['fields' => [
-            'foo' => new Range(['min' => 4]),
-        ]]));
+        $this->validator->validate(null, new Collection(fields: [
+            'foo' => new Range(min: 4),
+        ]));
 
         $this->assertNoViolation();
     }
 
     public function testFieldsAsDefaultOption()
     {
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
         $data = $this->prepareTestData(['foo' => 'foobar']);
 
@@ -56,14 +56,14 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
     public function testThrowsExceptionIfNotTraversable()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate('foobar', new Collection(['fields' => [
-            'foo' => new Range(['min' => 4]),
-        ]]));
+        $this->validator->validate('foobar', new Collection(fields: [
+            'foo' => new Range(min: 4),
+        ]));
     }
 
     public function testWalkSingleConstraint()
     {
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
         $array = [
             'foo' => 3,
@@ -78,12 +78,12 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => $constraint,
                 'bar' => $constraint,
             ],
-        ]));
+        ));
 
         $this->assertNoViolation();
     }
@@ -91,7 +91,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
     public function testWalkMultipleConstraints()
     {
         $constraints = [
-            new Range(['min' => 4]),
+            new Range(min: 4),
             new NotNull(),
         ];
 
@@ -108,19 +108,19 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => $constraints,
                 'bar' => $constraints,
             ],
-        ]));
+        ));
 
         $this->assertNoViolation();
     }
 
     public function testExtraFieldsDisallowed()
     {
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
         $data = $this->prepareTestData([
             'foo' => 5,
@@ -129,12 +129,12 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $this->expectValidateValueAt(0, '[foo]', $data['foo'], [$constraint]);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => $constraint,
             ],
-            'extraFieldsMessage' => 'myMessage',
-        ]));
+            extraFieldsMessage: 'myMessage',
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ field }}', '"baz"')
@@ -152,12 +152,12 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'baz' => 6,
         ]);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => $constraint,
             ],
-            'extraFieldsMessage' => 'myMessage',
-        ]));
+            extraFieldsMessage: 'myMessage',
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ field }}', '"baz"')
@@ -174,15 +174,15 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'foo' => null,
         ]);
 
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
         $this->expectValidateValueAt(0, '[foo]', $data['foo'], [$constraint]);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => $constraint,
             ],
-        ]));
+        ));
 
         $this->assertNoViolation();
     }
@@ -194,16 +194,16 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'bar' => 6,
         ]);
 
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
         $this->expectValidateValueAt(0, '[foo]', $data['foo'], [$constraint]);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => $constraint,
             ],
-            'allowExtraFields' => true,
-        ]));
+            allowExtraFields: true,
+        ));
 
         $this->assertNoViolation();
     }
@@ -212,14 +212,14 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
     {
         $data = $this->prepareTestData([]);
 
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => $constraint,
             ],
-            'missingFieldsMessage' => 'myMessage',
-        ]));
+            missingFieldsMessage: 'myMessage',
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ field }}', '"foo"')
@@ -233,14 +233,14 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
     {
         $data = $this->prepareTestData([]);
 
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => $constraint,
             ],
-            'allowMissingFields' => true,
-        ]));
+            allowMissingFields: true,
+        ));
 
         $this->assertNoViolation();
     }
@@ -275,7 +275,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'foo' => 5,
         ];
 
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
         $this->expectValidateValueAt(0, '[foo]', $array['foo'], [$constraint]);
 
@@ -296,7 +296,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraints = [
             new NotNull(),
-            new Range(['min' => 4]),
+            new Range(min: 4),
         ];
 
         $this->expectValidateValueAt(0, '[foo]', $array['foo'], $constraints);
@@ -327,12 +327,12 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
     {
         $data = $this->prepareTestData([]);
 
-        $this->validator->validate($data, new Collection([
-            'fields' => [
+        $this->validator->validate($data, new Collection(
+            fields: [
                 'foo' => new Required(),
             ],
-            'missingFieldsMessage' => 'myMessage',
-        ]));
+            missingFieldsMessage: 'myMessage',
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ field }}', '"foo"')
@@ -348,7 +348,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'foo' => 5,
         ];
 
-        $constraint = new Range(['min' => 4]);
+        $constraint = new Range(min: 4);
 
         $this->expectValidateValueAt(0, '[foo]', $array['foo'], [$constraint]);
 
@@ -369,7 +369,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraints = [
             new NotNull(),
-            new Range(['min' => 4]),
+            new Range(min: 4),
         ];
 
         $this->expectValidateValueAt(0, '[foo]', $array['foo'], $constraints);
@@ -389,15 +389,15 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'foo' => 3,
         ]);
 
-        $constraint = new Range(['min' => 2]);
+        $constraint = new Range(min: 2);
 
         $this->expectValidateValueAt(0, '[foo]', $value['foo'], [$constraint]);
 
-        $this->validator->validate($value, new Collection([
-            'fields' => [
+        $this->validator->validate($value, new Collection(
+            fields: [
                 'foo' => $constraint,
             ],
-        ]));
+        ));
 
         $this->assertEquals([
             'foo' => 3,

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -66,8 +66,8 @@ class CompositeTest extends TestCase
     public function testMergeNestedGroupsIfNoExplicitParentGroup()
     {
         $constraint = new ConcreteComposite([
-            new NotNull(['groups' => 'Default']),
-            new NotBlank(['groups' => ['Default', 'Strict']]),
+            new NotNull(groups: ['Default']),
+            new NotBlank(groups: ['Default', 'Strict']),
         ]);
 
         $this->assertEquals(['Default', 'Strict'], $constraint->groups);
@@ -94,8 +94,8 @@ class CompositeTest extends TestCase
     {
         $constraint = new ConcreteComposite([
             'constraints' => [
-                new NotNull(['groups' => 'Default']),
-                new NotBlank(['groups' => 'Strict']),
+                new NotNull(groups: ['Default']),
+                new NotBlank(groups: ['Strict']),
             ],
             'groups' => ['Default', 'Strict'],
         ]);
@@ -110,7 +110,7 @@ class CompositeTest extends TestCase
         $this->expectException(ConstraintDefinitionException::class);
         new ConcreteComposite([
             'constraints' => [
-                new NotNull(['groups' => ['Default', 'Foobar']]),
+                new NotNull(groups: ['Default', 'Foobar']),
             ],
             'groups' => ['Default', 'Strict'],
         ]);
@@ -119,8 +119,8 @@ class CompositeTest extends TestCase
     public function testImplicitGroupNamesAreForwarded()
     {
         $constraint = new ConcreteComposite([
-            new NotNull(['groups' => 'Default']),
-            new NotBlank(['groups' => 'Strict']),
+            new NotNull(groups: ['Default']),
+            new NotBlank(groups: ['Strict']),
         ]);
 
         $constraint->addImplicitGroupName('ImplicitGroup');
@@ -142,7 +142,7 @@ class CompositeTest extends TestCase
     {
         $this->expectException(ConstraintDefinitionException::class);
         new ConcreteComposite([
-            new NotNull(['groups' => 'Default']),
+            new NotNull(groups: ['Default']),
             'NotBlank',
         ]);
     }
@@ -151,7 +151,7 @@ class CompositeTest extends TestCase
     {
         $this->expectException(ConstraintDefinitionException::class);
         new ConcreteComposite([
-            new NotNull(['groups' => 'Default']),
+            new NotNull(groups: ['Default']),
             new \ArrayObject(),
         ]);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompoundTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompoundTest.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 class CompoundTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testItCannotRedefineConstraintsOption()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -72,7 +75,7 @@ class ForwardingOptionCompound extends Compound
     protected function getConstraints(array $options): array
     {
         return [
-            new Length(['min' => $options['min'] ?? null]),
+            new Length(min: $options['min'] ?? null),
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTestCase.php
@@ -70,6 +70,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getThreeOrLessElements
      */
     public function testValidValuesMax($value)
@@ -92,6 +93,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getFiveOrMoreElements
      */
     public function testValidValuesMin($value)
@@ -114,6 +116,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getFourElements
      */
     public function testValidValuesExact($value)
@@ -136,6 +139,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getFiveOrMoreElements
      */
     public function testTooManyValues($value)
@@ -175,6 +179,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getThreeOrLessElements
      */
     public function testTooFewValues($value)
@@ -214,6 +219,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getFiveOrMoreElements
      */
     public function testTooManyValuesExact($value)
@@ -258,11 +264,11 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
      */
     public function testTooFewValuesExact($value)
     {
-        $constraint = new Count([
-            'min' => 4,
-            'max' => 4,
-            'exactMessage' => 'myMessage',
-        ]);
+        $constraint = new Count(
+            min: 4,
+            max: 4,
+            exactMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -285,7 +291,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
 
     public function testConstraintAttributeDefaultOption()
     {
-        $constraint = new Count(['value' => 5, 'exactMessage' => 'message']);
+        $constraint = new Count(exactly: 5, exactMessage: 'message');
 
         $this->assertEquals(5, $constraint->min);
         $this->assertEquals(5, $constraint->max);
@@ -296,15 +302,15 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     // is called with the right DivisibleBy constraint.
     public function testDivisibleBy()
     {
-        $constraint = new Count([
-            'divisibleBy' => 123,
-            'divisibleByMessage' => 'foo {{ compared_value }}',
-        ]);
+        $constraint = new Count(
+            divisibleBy: 123,
+            divisibleByMessage: 'foo {{ compared_value }}',
+        );
 
-        $this->expectValidateValue(0, 3, [new DivisibleBy([
-            'value' => 123,
-            'message' => 'foo {{ compared_value }}',
-        ])], $this->group);
+        $this->expectValidateValue(0, 3, [new DivisibleBy(
+            value: 123,
+            message: 'foo {{ compared_value }}',
+        )], $this->group);
 
         $this->validator->validate(['foo', 'bar', 'ccc'], $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -84,9 +84,7 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidCountries($country)
     {
-        $constraint = new Country([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Country(message: 'myMessage');
 
         $this->validator->validate($country, $constraint);
 
@@ -109,9 +107,7 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidAlpha3Countries($country)
     {
-        $this->validator->validate($country, new Country([
-            'alpha3' => true,
-        ]));
+        $this->validator->validate($country, new Country(alpha3: true));
 
         $this->assertNoViolation();
     }
@@ -130,10 +126,10 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidAlpha3Countries($country)
     {
-        $constraint = new Country([
-            'alpha3' => true,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Country(
+            alpha3: true,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($country, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -100,9 +100,7 @@ class CurrencyValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidCurrencies($currency)
     {
-        $constraint = new Currency([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Currency(message: 'myMessage');
 
         $this->validator->validate($currency, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -63,9 +63,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidDateTimes($format, $dateTime)
     {
-        $constraint = new DateTime([
-            'format' => $format,
-        ]);
+        $constraint = new DateTime(format: $format);
 
         $this->validator->validate($dateTime, $constraint);
 
@@ -88,10 +86,10 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidDateTimes($format, $dateTime, $code)
     {
-        $constraint = new DateTime([
-            'message' => 'myMessage',
-            'format' => $format,
-        ]);
+        $constraint = new DateTime(
+            message: 'myMessage',
+            format: $format,
+        );
 
         $this->validator->validate($dateTime, $constraint);
 
@@ -133,9 +131,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
 
     public function testDateTimeWithTrailingData()
     {
-        $this->validator->validate('1995-05-10 00:00:00', new DateTime([
-            'format' => 'Y-m-d+',
-        ]));
+        $this->validator->validate('1995-05-10 00:00:00', new DateTime(format: 'Y-m-d+'));
         $this->assertNoViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -58,7 +58,7 @@ class DateValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidDatesWithNewLine(string $date)
     {
-        $this->validator->validate($date."\n", new Date(['message' => 'myMessage']));
+        $this->validator->validate($date."\n", new Date(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$date."\n\"")
@@ -80,9 +80,7 @@ class DateValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidDates($date, $code)
     {
-        $constraint = new Date([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Date(message: 'myMessage');
 
         $this->validator->validate($date, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DisableAutoMappingTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DisableAutoMappingTest.php
@@ -23,6 +23,9 @@ use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
  */
 class DisableAutoMappingTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testGroups()
     {
         $this->expectException(ConstraintDefinitionException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -32,7 +32,11 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new DivisibleBy($options);
+        if (null !== $options) {
+            return new DivisibleBy(...$options);
+        }
+
+        return new DivisibleBy();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
@@ -21,14 +21,14 @@ class EmailTest extends TestCase
 {
     public function testConstructorStrict()
     {
-        $subject = new Email(['mode' => Email::VALIDATION_MODE_STRICT]);
+        $subject = new Email(mode: Email::VALIDATION_MODE_STRICT);
 
         $this->assertEquals(Email::VALIDATION_MODE_STRICT, $subject->mode);
     }
 
     public function testConstructorHtml5AllowNoTld()
     {
-        $subject = new Email(['mode' => Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD]);
+        $subject = new Email(mode: Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD);
 
         $this->assertEquals(Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD, $subject->mode);
     }
@@ -37,7 +37,7 @@ class EmailTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "mode" parameter value is not valid.');
-        new Email(['mode' => 'Unknown Mode']);
+        new Email(mode: 'Unknown Mode');
     }
 
     public function testUnknownModeArgumentsTriggerException()
@@ -49,11 +49,14 @@ class EmailTest extends TestCase
 
     public function testNormalizerCanBeSet()
     {
-        $email = new Email(['normalizer' => 'trim']);
+        $email = new Email(normalizer: 'trim');
 
         $this->assertEquals('trim', $email->normalizer);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -61,6 +64,9 @@ class EmailTest extends TestCase
         new Email(['normalizer' => 'Unknown Callable']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -97,7 +97,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidNormalizedEmails($email)
     {
-        $this->validator->validate($email, new Email(['normalizer' => 'trim']));
+        $this->validator->validate($email, new Email(normalizer: 'trim'));
 
         $this->assertNoViolation();
     }
@@ -115,7 +115,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidEmailsHtml5($email)
     {
-        $this->validator->validate($email, new Email(['mode' => Email::VALIDATION_MODE_HTML5]));
+        $this->validator->validate($email, new Email(mode: Email::VALIDATION_MODE_HTML5));
 
         $this->assertNoViolation();
     }
@@ -135,9 +135,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidEmails($email)
     {
-        $constraint = new Email([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Email(message: 'myMessage');
 
         $this->validator->validate($email, $constraint);
 
@@ -162,10 +160,10 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidHtml5Emails($email)
     {
-        $constraint = new Email([
-            'message' => 'myMessage',
-            'mode' => Email::VALIDATION_MODE_HTML5,
-        ]);
+        $constraint = new Email(
+            message: 'myMessage',
+            mode: Email::VALIDATION_MODE_HTML5,
+        );
 
         $this->validator->validate($email, $constraint);
 
@@ -202,10 +200,10 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidAllowNoTldEmails($email)
     {
-        $constraint = new Email([
-            'message' => 'myMessage',
-            'mode' => Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD,
-        ]);
+        $constraint = new Email(
+            message: 'myMessage',
+            mode: Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD,
+        );
 
         $this->validator->validate($email, $constraint);
 
@@ -228,7 +226,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
     public function testModeStrict()
     {
-        $constraint = new Email(['mode' => Email::VALIDATION_MODE_STRICT]);
+        $constraint = new Email(mode: Email::VALIDATION_MODE_STRICT);
 
         $this->validator->validate('example@mywebsite.tld', $constraint);
 
@@ -237,7 +235,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
     public function testModeHtml5()
     {
-        $constraint = new Email(['mode' => Email::VALIDATION_MODE_HTML5]);
+        $constraint = new Email(mode: Email::VALIDATION_MODE_HTML5);
 
         $this->validator->validate('example@example..com', $constraint);
 
@@ -249,7 +247,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
     public function testModeHtml5AllowNoTld()
     {
-        $constraint = new Email(['mode' => Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD]);
+        $constraint = new Email(mode: Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD);
 
         $this->validator->validate('example@example', $constraint);
 
@@ -272,10 +270,10 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
      */
     public function testStrictWithInvalidEmails($email)
     {
-        $constraint = new Email([
-            'message' => 'myMessage',
-            'mode' => Email::VALIDATION_MODE_STRICT,
-        ]);
+        $constraint = new Email(
+            message: 'myMessage',
+            mode: Email::VALIDATION_MODE_STRICT,
+        );
 
         $this->validator->validate($email, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EnableAutoMappingTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EnableAutoMappingTest.php
@@ -23,6 +23,9 @@ use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
  */
 class EnableAutoMappingTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testGroups()
     {
         $this->expectException(ConstraintDefinitionException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -34,7 +34,11 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new EqualTo($options);
+        if (null !== $options) {
+            return new EqualTo(...$options);
+        }
+
+        return new EqualTo();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxTest.php
@@ -36,14 +36,22 @@ class ExpressionSyntaxTest extends TestCase
 
     public static function provideServiceValidatedConstraints(): iterable
     {
-        yield 'Doctrine style' => [new ExpressionSyntax(['service' => 'my_service'])];
-
         yield 'named arguments' => [new ExpressionSyntax(service: 'my_service')];
 
         $metadata = new ClassMetadata(ExpressionSyntaxDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         yield 'attribute' => [$metadata->properties['b']->constraints[0]];
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testValidatedByServiceDoctrineStyle()
+    {
+        $constraint = new ExpressionSyntax(['service' => 'my_service']);
+
+        self::assertSame('my_service', $constraint->validatedBy());
     }
 
     public function testAttributes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxValidatorTest.php
@@ -40,49 +40,47 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpressionValid()
     {
-        $this->validator->validate('1 + 1', new ExpressionSyntax([
-            'message' => 'myMessage',
-            'allowedVariables' => [],
-        ]));
+        $this->validator->validate('1 + 1', new ExpressionSyntax(
+            message: 'myMessage',
+            allowedVariables: [],
+        ));
 
         $this->assertNoViolation();
     }
 
     public function testStringableExpressionValid()
     {
-        $this->validator->validate(new StringableValue('1 + 1'), new ExpressionSyntax([
-            'message' => 'myMessage',
-            'allowedVariables' => [],
-        ]));
+        $this->validator->validate(new StringableValue('1 + 1'), new ExpressionSyntax(
+            message: 'myMessage',
+            allowedVariables: [],
+        ));
 
         $this->assertNoViolation();
     }
 
     public function testExpressionWithoutNames()
     {
-        $this->validator->validate('1 + 1', new ExpressionSyntax([
-            'message' => 'myMessage',
-        ], null, null, []));
+        $this->validator->validate('1 + 1', new ExpressionSyntax(null, 'myMessage', null, []));
 
         $this->assertNoViolation();
     }
 
     public function testExpressionWithAllowedVariableName()
     {
-        $this->validator->validate('a + 1', new ExpressionSyntax([
-            'message' => 'myMessage',
-            'allowedVariables' => ['a'],
-        ]));
+        $this->validator->validate('a + 1', new ExpressionSyntax(
+            message: 'myMessage',
+            allowedVariables: ['a'],
+        ));
 
         $this->assertNoViolation();
     }
 
     public function testExpressionIsNotValid()
     {
-        $this->validator->validate('a + 1', new ExpressionSyntax([
-            'message' => 'myMessage',
-            'allowedVariables' => [],
-        ]));
+        $this->validator->validate('a + 1', new ExpressionSyntax(
+            message: 'myMessage',
+            allowedVariables: [],
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ syntax_error }}', '"Variable "a" is not valid around position 1 for expression `a + 1`."')
@@ -93,10 +91,10 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
 
     public function testStringableExpressionIsNotValid()
     {
-        $this->validator->validate(new StringableValue('a + 1'), new ExpressionSyntax([
-            'message' => 'myMessage',
-            'allowedVariables' => [],
-        ]));
+        $this->validator->validate(new StringableValue('a + 1'), new ExpressionSyntax(
+            message: 'myMessage',
+            allowedVariables: [],
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ syntax_error }}', '"Variable "a" is not valid around position 1 for expression `a + 1`."')

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -31,10 +31,10 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpressionIsEvaluatedWithNullValue()
     {
-        $constraint = new Expression([
-            'expression' => 'false',
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Expression(
+            expression: 'false',
+            message: 'myMessage',
+        );
 
         $this->validator->validate(null, $constraint);
 
@@ -46,10 +46,10 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpressionIsEvaluatedWithEmptyStringValue()
     {
-        $constraint = new Expression([
-            'expression' => 'false',
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Expression(
+            expression: 'false',
+            message: 'myMessage',
+        );
 
         $this->validator->validate('', $constraint);
 
@@ -75,10 +75,10 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testFailingExpressionAtObjectLevel()
     {
-        $constraint = new Expression([
-            'expression' => 'this.data == 1',
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Expression(
+            expression: 'this.data == 1',
+            message: 'myMessage',
+        );
 
         $object = new Entity();
         $object->data = '2';
@@ -109,10 +109,10 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testFailingExpressionAtObjectLevelWithToString()
     {
-        $constraint = new Expression([
-            'expression' => 'this.data == 1',
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Expression(
+            expression: 'this.data == 1',
+            message: 'myMessage',
+        );
 
         $object = new ToString();
         $object->data = '2';
@@ -145,10 +145,10 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testFailingExpressionAtPropertyLevel()
     {
-        $constraint = new Expression([
-            'expression' => 'value == this.data',
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Expression(
+            expression: 'value == this.data',
+            message: 'myMessage',
+        );
 
         $object = new Entity();
         $object->data = '1';
@@ -187,10 +187,10 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testFailingExpressionAtNestedPropertyLevel()
     {
-        $constraint = new Expression([
-            'expression' => 'value == this.data',
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Expression(
+            expression: 'value == this.data',
+            message: 'myMessage',
+        );
 
         $object = new Entity();
         $object->data = '1';
@@ -234,10 +234,10 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
      */
     public function testFailingExpressionAtPropertyLevelWithoutRoot()
     {
-        $constraint = new Expression([
-            'expression' => 'value == "1"',
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Expression(
+            expression: 'value == "1"',
+            message: 'myMessage',
+        );
 
         $this->setRoot('2');
         $this->setPropertyPath('');
@@ -254,9 +254,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpressionLanguageUsage()
     {
-        $constraint = new Expression([
-            'expression' => 'false',
-        ]);
+        $constraint = new Expression(expression: 'false');
 
         $expressionLanguage = $this->createMock(ExpressionLanguage::class);
 
@@ -278,12 +276,12 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testPassingCustomValues()
     {
-        $constraint = new Expression([
-            'expression' => 'value + custom == 2',
-            'values' => [
+        $constraint = new Expression(
+            expression: 'value + custom == 2',
+            values: [
                 'custom' => 1,
             ],
-        ]);
+        );
 
         $this->validator->validate(1, $constraint);
 
@@ -292,13 +290,13 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testViolationOnPass()
     {
-        $constraint = new Expression([
-            'expression' => 'value + custom != 2',
-            'values' => [
+        $constraint = new Expression(
+            expression: 'value + custom != 2',
+            values: [
                 'custom' => 1,
             ],
-            'negate' => false,
-        ]);
+            negate: false,
+        );
 
         $this->validator->validate(2, $constraint);
 
@@ -311,10 +309,11 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testIsValidExpression()
     {
-        $constraints = [new NotNull(), new Range(['min' => 2])];
+        $constraints = [new NotNull(), new Range(min: 2)];
 
         $constraint = new Expression(
-            ['expression' => 'is_valid(this.data, a)', 'values' => ['a' => $constraints]]
+            expression: 'is_valid(this.data, a)',
+            values: ['a' => $constraints],
         );
 
         $object = new Entity();
@@ -331,10 +330,11 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     public function testIsValidExpressionInvalid()
     {
-        $constraints = [new Range(['min' => 2, 'max' => 5])];
+        $constraints = [new Range(min: 2, max: 5)];
 
         $constraint = new Expression(
-            ['expression' => 'is_valid(this.data, a)', 'values' => ['a' => $constraints]]
+            expression: 'is_valid(this.data, a)',
+            values: ['a' => $constraints],
         );
 
         $object = new Entity();

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
@@ -24,7 +24,7 @@ class FileTest extends TestCase
      */
     public function testMaxSize($maxSize, $bytes, $binaryFormat)
     {
-        $file = new File(['maxSize' => $maxSize]);
+        $file = new File(maxSize: $maxSize);
 
         $this->assertSame($bytes, $file->maxSize);
         $this->assertSame($binaryFormat, $file->binaryFormat);
@@ -33,7 +33,7 @@ class FileTest extends TestCase
 
     public function testMagicIsset()
     {
-        $file = new File(['maxSize' => 1]);
+        $file = new File(maxSize: 1);
 
         $this->assertTrue($file->__isset('maxSize'));
         $this->assertTrue($file->__isset('groups'));
@@ -57,7 +57,7 @@ class FileTest extends TestCase
      */
     public function testInvalidValueForMaxSizeThrowsExceptionAfterInitialization($maxSize)
     {
-        $file = new File(['maxSize' => 1000]);
+        $file = new File(maxSize: 1000);
 
         $this->expectException(ConstraintDefinitionException::class);
 
@@ -69,7 +69,7 @@ class FileTest extends TestCase
      */
     public function testMaxSizeCannotBeSetToInvalidValueAfterInitialization($maxSize)
     {
-        $file = new File(['maxSize' => 1000]);
+        $file = new File(maxSize: 1000);
 
         try {
             $file->maxSize = $maxSize;
@@ -85,7 +85,7 @@ class FileTest extends TestCase
     public function testInvalidMaxSize($maxSize)
     {
         $this->expectException(ConstraintDefinitionException::class);
-        new File(['maxSize' => $maxSize]);
+        new File(maxSize: $maxSize);
     }
 
     public static function provideValidSizes()
@@ -125,7 +125,7 @@ class FileTest extends TestCase
      */
     public function testBinaryFormat($maxSize, $guessedFormat, $binaryFormat)
     {
-        $file = new File(['maxSize' => $maxSize, 'binaryFormat' => $guessedFormat]);
+        $file = new File(maxSize: $maxSize, binaryFormat: $guessedFormat);
 
         $this->assertSame($binaryFormat, $file->binaryFormat);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
@@ -22,9 +22,9 @@ class FileValidatorPathTest extends FileValidatorTestCase
 
     public function testFileNotFound()
     {
-        $constraint = new File([
-            'notFoundMessage' => 'myMessage',
-        ]);
+        $constraint = new File(
+            notFoundMessage: 'myMessage',
+        );
 
         $this->validator->validate('foobar', $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -34,7 +34,11 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new GreaterThanOrEqual($options);
+        if (null !== $options) {
+            return new GreaterThanOrEqual(...$options);
+        }
+
+        return new GreaterThanOrEqual();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -61,6 +61,9 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Abstra
         ];
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -69,6 +72,9 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Abstra
         return new PositiveOrZero(['propertyPath' => 'field']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfValue()
     {
         $this->expectException(ConstraintDefinitionException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -34,7 +34,11 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new GreaterThan($options);
+        if (null !== $options) {
+            return new GreaterThan(...$options);
+        }
+
+        return new GreaterThan();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -58,6 +58,9 @@ class GreaterThanValidatorWithPositiveConstraintTest extends AbstractComparisonV
         ];
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -66,6 +69,9 @@ class GreaterThanValidatorWithPositiveConstraintTest extends AbstractComparisonV
         return new Positive(['propertyPath' => 'field']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfValue()
     {
         $this->expectException(ConstraintDefinitionException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/HostnameValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/HostnameValidatorTest.php
@@ -57,7 +57,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidTldDomainsPassValidationIfTldNotRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(['requireTld' => false]));
+        $this->validator->validate($domain, new Hostname(requireTld: false));
 
         $this->assertNoViolation();
     }
@@ -81,9 +81,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidDomainsRaiseViolationIfTldRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname([
-            'message' => 'myMessage',
-        ]));
+        $this->validator->validate($domain, new Hostname(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$domain.'"')
@@ -96,10 +94,10 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidDomainsRaiseViolationIfTldNotRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname([
-            'message' => 'myMessage',
-            'requireTld' => false,
-        ]));
+        $this->validator->validate($domain, new Hostname(
+            message: 'myMessage',
+            requireTld: false,
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$domain.'"')
@@ -123,7 +121,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
      */
     public function testReservedDomainsPassValidationIfTldNotRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(['requireTld' => false]));
+        $this->validator->validate($domain, new Hostname(requireTld: false));
 
         $this->assertNoViolation();
     }
@@ -133,10 +131,10 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
      */
     public function testReservedDomainsRaiseViolationIfTldRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname([
-            'message' => 'myMessage',
-            'requireTld' => true,
-        ]));
+        $this->validator->validate($domain, new Hostname(
+            message: 'myMessage',
+            requireTld: true,
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$domain.'"')
@@ -176,7 +174,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
      */
     public function testTopLevelDomainsPassValidationIfTldNotRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(['requireTld' => false]));
+        $this->validator->validate($domain, new Hostname(requireTld: false));
 
         $this->assertNoViolation();
     }
@@ -186,10 +184,10 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
      */
     public function testTopLevelDomainsRaiseViolationIfTldRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname([
-            'message' => 'myMessage',
-            'requireTld' => true,
-        ]));
+        $this->validator->validate($domain, new Hostname(
+            message: 'myMessage',
+            requireTld: true,
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$domain.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -488,9 +488,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
 
     private function assertViolationRaised($iban, $code)
     {
-        $constraint = new Iban([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Iban(message: 'myMessage');
 
         $this->validator->validate($iban, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -34,7 +34,11 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new IdenticalTo($options);
+        if (null !== $options) {
+            return new IdenticalTo(...$options);
+        }
+
+        return new IdenticalTo();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -72,12 +72,10 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * Checks that the logic from FileValidator still works.
-     *
-     * @dataProvider provideConstraintsWithNotFoundMessage
      */
-    public function testFileNotFound(Image $constraint)
+    public function testFileNotFound()
     {
-        $this->validator->validate('foobar', $constraint);
+        $this->validator->validate('foobar', new Image(notFoundMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ file }}', '"foobar"')
@@ -85,36 +83,40 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideConstraintsWithNotFoundMessage(): iterable
+    /**
+     * Checks that the logic from FileValidator still works.
+     *
+     * @group legacy
+     */
+    public function testFileNotFoundDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate('foobar', new Image([
             'notFoundMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(notFoundMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ file }}', '"foobar"')
+            ->setCode(Image::NOT_FOUND_ERROR)
+            ->assertRaised();
     }
 
     public function testValidSize()
     {
-        $constraint = new Image([
-            'minWidth' => 1,
-            'maxWidth' => 2,
-            'minHeight' => 1,
-            'maxHeight' => 2,
-        ]);
+        $constraint = new Image(
+            minWidth: 1,
+            maxWidth: 2,
+            minHeight: 1,
+            maxHeight: 2,
+        );
 
         $this->validator->validate($this->image, $constraint);
 
         $this->assertNoViolation();
     }
 
-    /**
-     * @dataProvider provideMinWidthConstraints
-     */
-    public function testWidthTooSmall(Image $constraint)
+    public function testWidthTooSmall()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(minWidth: 3, minWidthMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', '2')
@@ -123,23 +125,26 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideMinWidthConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testWidthTooSmallDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'minWidth' => 3,
             'minWidthMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(minWidth: 3, minWidthMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', '2')
+            ->setParameter('{{ min_width }}', '3')
+            ->setCode(Image::TOO_NARROW_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideMaxWidthConstraints
-     */
-    public function testWidthTooBig(Image $constraint)
+    public function testWidthTooBig()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(maxWidth: 1, maxWidthMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', '2')
@@ -148,23 +153,26 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideMaxWidthConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testWidthTooBigDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'maxWidth' => 1,
             'maxWidthMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(maxWidth: 1, maxWidthMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', '2')
+            ->setParameter('{{ max_width }}', '1')
+            ->setCode(Image::TOO_WIDE_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideMinHeightConstraints
-     */
-    public function testHeightTooSmall(Image $constraint)
+    public function testHeightTooSmall()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(minHeight: 3, minHeightMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ height }}', '2')
@@ -173,23 +181,26 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideMinHeightConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testHeightTooSmallDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'minHeight' => 3,
             'minHeightMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(minHeight: 3, minHeightMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ height }}', '2')
+            ->setParameter('{{ min_height }}', '3')
+            ->setCode(Image::TOO_LOW_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideMaxHeightConstraints
-     */
-    public function testHeightTooBig(Image $constraint)
+    public function testHeightTooBig()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(maxHeight: 1, maxHeightMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ height }}', '2')
@@ -198,23 +209,26 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideMaxHeightConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testHeightTooBigDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'maxHeight' => 1,
             'maxHeightMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(maxHeight: 1, maxHeightMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ height }}', '2')
+            ->setParameter('{{ max_height }}', '1')
+            ->setCode(Image::TOO_HIGH_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideMinPixelsConstraints
-     */
-    public function testPixelsTooFew(Image $constraint)
+    public function testPixelsTooFew()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(minPixels: 5, minPixelsMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
@@ -225,23 +239,28 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideMinPixelsConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testPixelsTooFewDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'minPixels' => 5,
             'minPixelsMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(minPixels: 5, minPixelsMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ pixels }}', '4')
+            ->setParameter('{{ min_pixels }}', '5')
+            ->setParameter('{{ height }}', '2')
+            ->setParameter('{{ width }}', '2')
+            ->setCode(Image::TOO_FEW_PIXEL_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideMaxPixelsConstraints
-     */
-    public function testPixelsTooMany(Image $constraint)
+    public function testPixelsTooMany()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(maxPixels: 3, maxPixelsMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
@@ -252,23 +271,28 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideMaxPixelsConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testPixelsTooManyDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'maxPixels' => 3,
             'maxPixelsMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(maxPixels: 3, maxPixelsMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ pixels }}', '4')
+            ->setParameter('{{ max_pixels }}', '3')
+            ->setParameter('{{ height }}', '2')
+            ->setParameter('{{ width }}', '2')
+            ->setCode(Image::TOO_MANY_PIXEL_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideMinRatioConstraints
-     */
-    public function testRatioTooSmall(Image $constraint)
+    public function testRatioTooSmall()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(minRatio: 2, minRatioMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ ratio }}', 1)
@@ -277,23 +301,26 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideMinRatioConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testRatioTooSmallDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'minRatio' => 2,
             'minRatioMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(minRatio: 2, minRatioMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ ratio }}', 1)
+            ->setParameter('{{ min_ratio }}', 2)
+            ->setCode(Image::RATIO_TOO_SMALL_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideMaxRatioConstraints
-     */
-    public function testRatioTooBig(Image $constraint)
+    public function testRatioTooBig()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(maxRatio: 0.5, maxRatioMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ ratio }}', 1)
@@ -302,22 +329,26 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideMaxRatioConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testRatioTooBigDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'maxRatio' => 0.5,
             'maxRatioMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(maxRatio: 0.5, maxRatioMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ ratio }}', 1)
+            ->setParameter('{{ max_ratio }}', 0.5)
+            ->setCode(Image::RATIO_TOO_BIG_ERROR)
+            ->assertRaised();
     }
 
     public function testMaxRatioUsesTwoDecimalsOnly()
     {
-        $constraint = new Image([
-            'maxRatio' => 1.33,
-        ]);
+        $constraint = new Image(maxRatio: 1.33);
 
         $this->validator->validate($this->image4By3, $constraint);
 
@@ -326,9 +357,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testMinRatioUsesInputMoreDecimals()
     {
-        $constraint = new Image([
-            'minRatio' => 4 / 3,
-        ]);
+        $constraint = new Image(minRatio: 4 / 3);
 
         $this->validator->validate($this->image4By3, $constraint);
 
@@ -337,21 +366,16 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testMaxRatioUsesInputMoreDecimals()
     {
-        $constraint = new Image([
-            'maxRatio' => 16 / 9,
-        ]);
+        $constraint = new Image(maxRatio: 16 / 9);
 
         $this->validator->validate($this->image16By9, $constraint);
 
         $this->assertNoViolation();
     }
 
-    /**
-     * @dataProvider provideAllowSquareConstraints
-     */
-    public function testSquareNotAllowed(Image $constraint)
+    public function testSquareNotAllowed()
     {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(allowSquare: false, allowSquareMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 2)
@@ -360,23 +384,26 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideAllowSquareConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testSquareNotAllowedDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'allowSquare' => false,
             'allowSquareMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(allowSquare: false, allowSquareMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 2)
+            ->setParameter('{{ height }}', 2)
+            ->setCode(Image::SQUARE_NOT_ALLOWED_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideAllowLandscapeConstraints
-     */
-    public function testLandscapeNotAllowed(Image $constraint)
+    public function testLandscapeNotAllowed()
     {
-        $this->validator->validate($this->imageLandscape, $constraint);
+        $this->validator->validate($this->imageLandscape, new Image(allowLandscape: false, allowLandscapeMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 2)
@@ -385,23 +412,26 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideAllowLandscapeConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testLandscapeNotAllowedDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->imageLandscape, new Image([
             'allowLandscape' => false,
             'allowLandscapeMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(allowLandscape: false, allowLandscapeMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 2)
+            ->setParameter('{{ height }}', 1)
+            ->setCode(Image::LANDSCAPE_NOT_ALLOWED_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideAllowPortraitConstraints
-     */
-    public function testPortraitNotAllowed(Image $constraint)
+    public function testPortraitNotAllowed()
     {
-        $this->validator->validate($this->imagePortrait, $constraint);
+        $this->validator->validate($this->imagePortrait, new Image(allowPortrait: false, allowPortraitMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 1)
@@ -410,25 +440,55 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideAllowPortraitConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testPortraitNotAllowedDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->imagePortrait, new Image([
             'allowPortrait' => false,
             'allowPortraitMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(allowPortrait: false, allowPortraitMessage: 'myMessage'),
-        ];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 1)
+            ->setParameter('{{ height }}', 2)
+            ->setCode(Image::PORTRAIT_NOT_ALLOWED_ERROR)
+            ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideDetectCorruptedConstraints
-     */
-    public function testCorrupted(Image $constraint)
+    public function testCorrupted()
     {
         if (!\function_exists('imagecreatefromstring')) {
             $this->markTestSkipped('This test require GD extension');
         }
+
+        $constraint = new Image(detectCorrupted: true, corruptedMessage: 'myMessage');
+
+        $this->validator->validate($this->image, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->validator->validate($this->imageCorrupted, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setCode(Image::CORRUPTED_IMAGE_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCorruptedDoctrineStyle()
+    {
+        if (!\function_exists('imagecreatefromstring')) {
+            $this->markTestSkipped('This test require GD extension');
+        }
+
+        $constraint = new Image([
+            'detectCorrupted' => true,
+            'corruptedMessage' => 'myMessage',
+        ]);
 
         $this->validator->validate($this->image, $constraint);
 
@@ -456,23 +516,12 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideDetectCorruptedConstraints(): iterable
+    public function testInvalidMimeTypeWithNarrowedSet()
     {
-        yield 'Doctrine style' => [new Image([
-            'detectCorrupted' => true,
-            'corruptedMessage' => 'myMessage',
-        ])];
-        yield 'Named arguments' => [
-            new Image(detectCorrupted: true, corruptedMessage: 'myMessage'),
-        ];
-    }
-
-    /**
-     * @dataProvider provideInvalidMimeTypeWithNarrowedSet
-     */
-    public function testInvalidMimeTypeWithNarrowedSet(Image $constraint)
-    {
-        $this->validator->validate($this->image, $constraint);
+        $this->validator->validate($this->image, new Image(mimeTypes: [
+            'image/jpeg',
+            'image/png',
+        ]));
 
         $this->buildViolation('The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.')
             ->setParameter('{{ file }}', \sprintf('"%s"', $this->image))
@@ -483,20 +532,25 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideInvalidMimeTypeWithNarrowedSet()
+    /**
+     * @group legacy
+     */
+    public function testInvalidMimeTypeWithNarrowedSetDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Image([
+        $this->validator->validate($this->image, new Image([
             'mimeTypes' => [
                 'image/jpeg',
                 'image/png',
             ],
-        ])];
-        yield 'Named arguments' => [
-            new Image(mimeTypes: [
-                'image/jpeg',
-                'image/png',
-            ]),
-        ];
+        ]));
+
+        $this->buildViolation('The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.')
+            ->setParameter('{{ file }}', sprintf('"%s"', $this->image))
+            ->setParameter('{{ type }}', '"image/gif"')
+            ->setParameter('{{ types }}', '"image/jpeg", "image/png"')
+            ->setParameter('{{ name }}', '"test.gif"')
+            ->setCode(Image::INVALID_MIME_TYPE_ERROR)
+            ->assertRaised();
     }
 
     /** @dataProvider provideSvgWithViolation */

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpTest.php
@@ -24,11 +24,14 @@ class IpTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $ip = new Ip(['normalizer' => 'trim']);
+        $ip = new Ip(normalizer: 'trim');
 
         $this->assertEquals('trim', $ip->normalizer);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -36,6 +39,9 @@ class IpTest extends TestCase
         new Ip(['normalizer' => 'Unknown Callable']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -47,9 +47,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidValidatorVersion()
     {
         $this->expectException(ConstraintDefinitionException::class);
-        new Ip([
-            'version' => 666,
-        ]);
+        new Ip(version: 666);
     }
 
     /**
@@ -57,9 +55,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidIpsV4($ip)
     {
-        $this->validator->validate($ip, new Ip([
-            'version' => Ip::V4,
-        ]));
+        $this->validator->validate($ip, new Ip(version: Ip::V4));
 
         $this->assertNoViolation();
     }
@@ -83,10 +79,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidIpsV4WithWhitespaces($ip)
     {
-        $this->validator->validate($ip, new Ip([
-            'version' => Ip::V4,
-            'normalizer' => 'trim',
-        ]));
+        $this->validator->validate($ip, new Ip(
+            version: Ip::V4,
+            normalizer: 'trim',
+        ));
 
         $this->assertNoViolation();
     }
@@ -118,9 +114,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidIpsV6($ip)
     {
-        $this->validator->validate($ip, new Ip([
-            'version' => Ip::V6,
-        ]));
+        $this->validator->validate($ip, new Ip(version: Ip::V6));
 
         $this->assertNoViolation();
     }
@@ -155,9 +149,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidIpsAll($ip)
     {
-        $this->validator->validate($ip, new Ip([
-            'version' => Ip::ALL,
-        ]));
+        $this->validator->validate($ip, new Ip(version: Ip::ALL));
 
         $this->assertNoViolation();
     }
@@ -172,10 +164,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidIpsV4($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V4,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V4,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -190,10 +182,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidNoPublicIpsV4($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V4_NO_PUBLIC,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V4_NO_PUBLIC,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -232,9 +224,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidPrivateIpsV4($ip)
     {
-        $this->validator->validate($ip, new Ip([
-            'version' => Ip::V4_ONLY_PRIVATE,
-        ]));
+        $this->validator->validate($ip, new Ip(version: Ip::V4_ONLY_PRIVATE));
 
         $this->assertNoViolation();
     }
@@ -244,10 +234,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPrivateIpsV4($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V4_NO_PRIVATE,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V4_NO_PRIVATE,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -262,10 +252,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidOnlyPrivateIpsV4($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V4_ONLY_PRIVATE,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V4_ONLY_PRIVATE,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -294,9 +284,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidReservedIpsV4($ip)
     {
-        $this->validator->validate($ip, new Ip([
-            'version' => Ip::V4_ONLY_RESERVED,
-        ]));
+        $this->validator->validate($ip, new Ip(version: Ip::V4_ONLY_RESERVED));
 
         $this->assertNoViolation();
     }
@@ -306,10 +294,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidReservedIpsV4($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V4_NO_RESERVED,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V4_NO_RESERVED,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -324,10 +312,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidOnlyReservedIpsV4($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V4_ONLY_RESERVED,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V4_ONLY_RESERVED,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -356,10 +344,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPublicIpsV4($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V4_ONLY_PUBLIC,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V4_ONLY_PUBLIC,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -379,10 +367,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidIpsV6($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V6,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V6,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -416,10 +404,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPrivateIpsV6($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V6_NO_PRIVATE,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V6_NO_PRIVATE,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -443,10 +431,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidReservedIpsV6($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V6_NO_RESERVED,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V6_NO_RESERVED,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -469,10 +457,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPublicIpsV6($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::V6_ONLY_PUBLIC,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::V6_ONLY_PUBLIC,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -492,10 +480,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidIpsAll($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::ALL,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::ALL,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -515,10 +503,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPrivateIpsAll($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::ALL_NO_PRIVATE,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::ALL_NO_PRIVATE,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -538,10 +526,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidReservedIpsAll($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::ALL_NO_RESERVED,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::ALL_NO_RESERVED,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 
@@ -561,10 +549,10 @@ class IpValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPublicIpsAll($ip)
     {
-        $constraint = new Ip([
-            'version' => Ip::ALL_ONLY_PUBLIC,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Ip(
+            version: Ip::ALL_ONLY_PUBLIC,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($ip, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
@@ -36,12 +36,9 @@ class IsFalseValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @dataProvider provideInvalidConstraints
-     */
-    public function testTrueIsInvalid(IsFalse $constraint)
+    public function testTrueIsInvalid()
     {
-        $this->validator->validate(true, $constraint);
+        $this->validator->validate(true, new IsFalse(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'true')
@@ -49,11 +46,20 @@ class IsFalseValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideInvalidConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testTrueIsInvalidDoctrineStyle()
     {
-        yield 'Doctrine style' => [new IsFalse([
+        $constraint = new IsFalse([
             'message' => 'myMessage',
-        ])];
-        yield 'named parameters' => [new IsFalse(message: 'myMessage')];
+        ]);
+
+        $this->validator->validate(true, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'true')
+            ->setCode(IsFalse::NOT_FALSE_ERROR)
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
@@ -34,9 +34,7 @@ class IsNullValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValues($value, $valueAsString)
     {
-        $constraint = new IsNull([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new IsNull(message: 'myMessage');
 
         $this->validator->validate($value, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
@@ -36,12 +36,9 @@ class IsTrueValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @dataProvider provideInvalidConstraints
-     */
-    public function testFalseIsInvalid(IsTrue $constraint)
+    public function testFalseIsInvalid()
     {
-        $this->validator->validate(false, $constraint);
+        $this->validator->validate(false, new IsTrue(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'false')
@@ -49,11 +46,18 @@ class IsTrueValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideInvalidConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testFalseIsInvalidDoctrineStyle()
     {
-        yield 'Doctrine style' => [new IsTrue([
+        $this->validator->validate(false, new IsTrue([
             'message' => 'myMessage',
-        ])];
-        yield 'named parameters' => [new IsTrue(message: 'myMessage')];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'false')
+            ->setCode(IsTrue::NOT_TRUE_ERROR)
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
@@ -150,9 +150,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidIsbn10($isbn)
     {
-        $constraint = new Isbn([
-            'type' => 'isbn10',
-        ]);
+        $constraint = new Isbn(type: 'isbn10');
 
         $this->validator->validate($isbn, $constraint);
 
@@ -160,6 +158,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getInvalidIsbn10
      */
     public function testInvalidIsbn10($isbn, $code)
@@ -195,7 +194,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidIsbn13($isbn)
     {
-        $constraint = new Isbn(['type' => 'isbn13']);
+        $constraint = new Isbn(type: 'isbn13');
 
         $this->validator->validate($isbn, $constraint);
 
@@ -203,6 +202,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getInvalidIsbn13
      */
     public function testInvalidIsbn13($isbn, $code)
@@ -220,16 +220,21 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public function testInvalidIsbn13Named()
+    /**
+     * @dataProvider getInvalidIsbn13
+     */
+    public function testInvalidIsbn13Named($isbn, $code)
     {
-        $this->validator->validate(
-            '2723442284',
-            new Isbn(type: Isbn::ISBN_13, isbn13Message: 'myMessage')
+        $constraint = new Isbn(
+            type: Isbn::ISBN_13,
+            isbn13Message: 'myMessage',
         );
 
+        $this->validator->validate($isbn, $constraint);
+
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '"2723442284"')
-            ->setCode(Isbn::TOO_SHORT_ERROR)
+            ->setParameter('{{ value }}', '"'.$isbn.'"')
+            ->setCode($code)
             ->assertRaised();
     }
 
@@ -250,9 +255,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidIsbnAnyIsbn10($isbn, $code)
     {
-        $constraint = new Isbn([
-            'bothIsbnMessage' => 'myMessage',
-        ]);
+        $constraint = new Isbn(bothIsbnMessage: 'myMessage');
 
         $this->validator->validate($isbn, $constraint);
 
@@ -272,9 +275,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidIsbnAnyIsbn13($isbn, $code)
     {
-        $constraint = new Isbn([
-            'bothIsbnMessage' => 'myMessage',
-        ]);
+        $constraint = new Isbn(bothIsbnMessage: 'myMessage');
 
         $this->validator->validate($isbn, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsinValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsinValidatorTest.php
@@ -130,9 +130,7 @@ class IsinValidatorTest extends ConstraintValidatorTestCase
 
     private function assertViolationRaised($isin, $code)
     {
-        $constraint = new Isin([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Isin(message: 'myMessage');
 
         $this->validator->validate($isin, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
@@ -119,10 +119,10 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
      */
     public function testCaseSensitiveIssns($issn)
     {
-        $constraint = new Issn([
-            'caseSensitive' => true,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Issn(
+            caseSensitive: true,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($issn, $constraint);
 
@@ -137,10 +137,10 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
      */
     public function testRequireHyphenIssns($issn)
     {
-        $constraint = new Issn([
-            'requireHyphen' => true,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Issn(
+            requireHyphen: true,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($issn, $constraint);
 
@@ -167,9 +167,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidIssn($issn, $code)
     {
-        $constraint = new Issn([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Issn(message: 'myMessage');
 
         $this->validator->validate($issn, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/JsonValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/JsonValidatorTest.php
@@ -37,9 +37,7 @@ class JsonValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValues($value)
     {
-        $constraint = new Json([
-            'message' => 'myMessageTest',
-        ]);
+        $constraint = new Json(message: 'myMessageTest');
 
         $this->validator->validate($value, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -83,9 +83,7 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidLanguages($language)
     {
-        $constraint = new Language([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Language(message: 'myMessage');
 
         $this->validator->validate($language, $constraint);
 
@@ -108,9 +106,7 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidAlpha3Languages($language)
     {
-        $this->validator->validate($language, new Language([
-            'alpha3' => true,
-        ]));
+        $this->validator->validate($language, new Language(alpha3: true));
 
         $this->assertNoViolation();
     }
@@ -129,10 +125,10 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidAlpha3Languages($language)
     {
-        $constraint = new Language([
-            'alpha3' => true,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Language(
+            alpha3: true,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($language, $constraint);
 
@@ -172,9 +168,7 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
         \Locale::setDefault('fr_FR');
         $existingLanguage = 'en';
 
-        $this->validator->validate($existingLanguage, new Language([
-            'message' => 'aMessage',
-        ]));
+        $this->validator->validate($existingLanguage, new Language(message: 'aMessage'));
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
@@ -24,11 +24,18 @@ class LengthTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $length = new Length(['min' => 0, 'max' => 10, 'normalizer' => 'trim']);
+        $length = new Length(
+            min: 0,
+            max: 10,
+            normalizer: 'trim',
+        );
 
         $this->assertEquals('trim', $length->normalizer);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -36,6 +43,9 @@ class LengthTest extends TestCase
         new Length(['min' => 0, 'max' => 10, 'normalizer' => 'Unknown Callable']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -45,13 +55,13 @@ class LengthTest extends TestCase
 
     public function testDefaultCountUnitIsUsed()
     {
-        $length = new Length(['min' => 0, 'max' => 10]);
+        $length = new Length(min: 0, max: 10);
         $this->assertSame(Length::COUNT_CODEPOINTS, $length->countUnit);
     }
 
     public function testNonDefaultCountUnitCanBeSet()
     {
-        $length = new Length(['min' => 0, 'max' => 10, 'countUnit' => Length::COUNT_GRAPHEMES]);
+        $length = new Length(min: 0, max: 10, countUnit: Length::COUNT_GRAPHEMES);
         $this->assertSame(Length::COUNT_GRAPHEMES, $length->countUnit);
     }
 
@@ -59,7 +69,7 @@ class LengthTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('The "countUnit" option must be one of the "%s"::COUNT_* constants ("%s" given).', Length::class, 'nonExistentCountUnit'));
-        new Length(['min' => 0, 'max' => 10, 'countUnit' => 'nonExistentCountUnit']);
+        new Length(min: 0, max: 10, countUnit: 'nonExistentCountUnit');
     }
 
     public function testConstraintDefaultOption()
@@ -72,7 +82,7 @@ class LengthTest extends TestCase
 
     public function testConstraintAttributeDefaultOption()
     {
-        $constraint = new Length(['value' => 5, 'exactMessage' => 'message']);
+        $constraint = new Length(exactly: 5, exactMessage: 'message');
 
         self::assertEquals(5, $constraint->min);
         self::assertEquals(5, $constraint->max);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -25,17 +25,17 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Length(['value' => 6]));
+        $this->validator->validate(null, new Length(exactly: 6));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsInvalid()
     {
-        $this->validator->validate('', new Length([
-            'value' => $limit = 6,
-            'exactMessage' => 'myMessage',
-        ]));
+        $this->validator->validate('', new Length(
+            exactly: $limit = 6,
+            exactMessage: 'myMessage',
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '""')
@@ -50,7 +50,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Length(['value' => 5]));
+        $this->validator->validate(new \stdClass(), new Length(exactly: 5));
     }
 
     public static function getThreeOrLessCharacters()
@@ -118,7 +118,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValuesMin(int|string $value)
     {
-        $constraint = new Length(['min' => 5]);
+        $constraint = new Length(min: 5);
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -129,7 +129,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValuesMax(int|string $value)
     {
-        $constraint = new Length(['max' => 3]);
+        $constraint = new Length(max: 3);
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -151,7 +151,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidNormalizedValues($value)
     {
-        $constraint = new Length(['min' => 3, 'max' => 3, 'normalizer' => 'trim']);
+        $constraint = new Length(min: 3, max: 3, normalizer: 'trim');
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -186,10 +186,10 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValuesMin(int|string $value, int $valueLength)
     {
-        $constraint = new Length([
-            'min' => 4,
-            'minMessage' => 'myMessage',
-        ]);
+        $constraint = new Length(
+            min: 4,
+            minMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -227,10 +227,10 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValuesMax(int|string $value, int $valueLength)
     {
-        $constraint = new Length([
-            'max' => 4,
-            'maxMessage' => 'myMessage',
-        ]);
+        $constraint = new Length(
+            max: 4,
+            maxMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -268,11 +268,11 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValuesExactLessThanFour(int|string $value, int $valueLength)
     {
-        $constraint = new Length([
-            'min' => 4,
-            'max' => 4,
-            'exactMessage' => 'myMessage',
-        ]);
+        $constraint = new Length(
+            min: 4,
+            max: 4,
+            exactMessage:  'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -310,11 +310,11 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValuesExactMoreThanFour(int|string $value, int $valueLength)
     {
-        $constraint = new Length([
-            'min' => 4,
-            'max' => 4,
-            'exactMessage' => 'myMessage',
-        ]);
+        $constraint = new Length(
+            min: 4,
+            max: 4,
+            exactMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -333,12 +333,12 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testOneCharset($value, $charset, $isValid)
     {
-        $constraint = new Length([
-            'min' => 1,
-            'max' => 1,
-            'charset' => $charset,
-            'charsetMessage' => 'myMessage',
-        ]);
+        $constraint = new Length(
+            min: 1,
+            max: 1,
+            charset: $charset,
+            charsetMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -34,7 +34,11 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new LessThanOrEqual($options);
+        if (null !== $options) {
+            return new LessThanOrEqual(...$options);
+        }
+
+        return new LessThanOrEqual();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -59,6 +59,9 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends AbstractC
         ];
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -67,6 +70,9 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends AbstractC
         return new NegativeOrZero(['propertyPath' => 'field']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfValue()
     {
         $this->expectException(ConstraintDefinitionException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -34,7 +34,11 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new LessThan($options);
+        if (null !== $options) {
+            return new LessThan(...$options);
+        }
+
+        return new LessThan();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -58,6 +58,9 @@ class LessThanValidatorWithNegativeConstraintTest extends AbstractComparisonVali
         ];
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -66,6 +69,9 @@ class LessThanValidatorWithNegativeConstraintTest extends AbstractComparisonVali
         return new Negative(['propertyPath' => 'field']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfValue()
     {
         $this->expectException(ConstraintDefinitionException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -71,9 +71,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidLocales($locale)
     {
-        $constraint = new Locale([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Locale(message: 'myMessage');
 
         $this->validator->validate($locale, $constraint);
 
@@ -96,9 +94,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidLocalesWithCanonicalization(string $locale)
     {
-        $constraint = new Locale([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Locale(message: 'myMessage');
 
         $this->validator->validate($locale, $constraint);
 
@@ -110,10 +106,10 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidLocalesWithoutCanonicalization(string $locale)
     {
-        $constraint = new Locale([
-            'message' => 'myMessage',
-            'canonicalize' => false,
-        ]);
+        $constraint = new Locale(
+            message: 'myMessage',
+            canonicalize: false,
+        );
 
         $this->validator->validate($locale, $constraint);
 
@@ -125,10 +121,10 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidLocalesWithoutCanonicalization(string $locale)
     {
-        $constraint = new Locale([
-            'message' => 'myMessage',
-            'canonicalize' => false,
-        ]);
+        $constraint = new Locale(
+            message: 'myMessage',
+            canonicalize: false,
+        );
 
         $this->validator->validate($locale, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -76,9 +76,7 @@ class LuhnValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidNumbers($number, $code)
     {
-        $constraint = new Luhn([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Luhn(message: 'myMessage');
 
         $this->validator->validate($number, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NoSuspiciousCharactersValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NoSuspiciousCharactersValidatorTest.php
@@ -32,7 +32,7 @@ class NoSuspiciousCharactersValidatorTest extends ConstraintValidatorTestCase
      */
     public function testNonSuspiciousStrings(string $string, array $options = [])
     {
-        $this->validator->validate($string, new NoSuspiciousCharacters($options));
+        $this->validator->validate($string, new NoSuspiciousCharacters(...$options));
 
         $this->assertNoViolation();
     }
@@ -58,7 +58,7 @@ class NoSuspiciousCharactersValidatorTest extends ConstraintValidatorTestCase
      */
     public function testSuspiciousStrings(string $string, array $options, array $errors)
     {
-        $this->validator->validate($string, new NoSuspiciousCharacters($options));
+        $this->validator->validate($string, new NoSuspiciousCharacters(...$options));
 
         $violations = null;
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankTest.php
@@ -24,7 +24,7 @@ class NotBlankTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $notBlank = new NotBlank(['normalizer' => 'trim']);
+        $notBlank = new NotBlank(normalizer: 'trim');
 
         $this->assertEquals('trim', $notBlank->normalizer);
     }
@@ -45,6 +45,9 @@ class NotBlankTest extends TestCase
         self::assertSame('myMessage', $bConstraint->message);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -52,6 +55,9 @@ class NotBlankTest extends TestCase
         new NotBlank(['normalizer' => 'Unknown Callable']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -45,9 +45,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsInvalid()
     {
-        $constraint = new NotBlank([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new NotBlank(message: 'myMessage');
 
         $this->validator->validate(null, $constraint);
 
@@ -59,9 +57,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
 
     public function testBlankIsInvalid()
     {
-        $constraint = new NotBlank([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new NotBlank(message: 'myMessage');
 
         $this->validator->validate('', $constraint);
 
@@ -73,9 +69,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
 
     public function testFalseIsInvalid()
     {
-        $constraint = new NotBlank([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new NotBlank(message: 'myMessage');
 
         $this->validator->validate(false, $constraint);
 
@@ -87,9 +81,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
 
     public function testEmptyArrayIsInvalid()
     {
-        $constraint = new NotBlank([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new NotBlank(message: 'myMessage');
 
         $this->validator->validate([], $constraint);
 
@@ -101,10 +93,10 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
 
     public function testAllowNullTrue()
     {
-        $constraint = new NotBlank([
-            'message' => 'myMessage',
-            'allowNull' => true,
-        ]);
+        $constraint = new NotBlank(
+            message: 'myMessage',
+            allowNull: true,
+        );
 
         $this->validator->validate(null, $constraint);
         $this->assertNoViolation();
@@ -112,10 +104,10 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
 
     public function testAllowNullFalse()
     {
-        $constraint = new NotBlank([
-            'message' => 'myMessage',
-            'allowNull' => false,
-        ]);
+        $constraint = new NotBlank(
+            message: 'myMessage',
+            allowNull: false,
+        );
 
         $this->validator->validate(null, $constraint);
 
@@ -130,10 +122,10 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
      */
     public function testNormalizedStringIsInvalid($value)
     {
-        $constraint = new NotBlank([
-            'message' => 'myMessage',
-            'normalizer' => 'trim',
-        ]);
+        $constraint = new NotBlank(
+            message: 'myMessage',
+            normalizer: 'trim',
+        );
 
         $this->validator->validate($value, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
@@ -87,7 +87,7 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
 
     public function testThresholdReached()
     {
-        $constraint = new NotCompromisedPassword(['threshold' => 3]);
+        $constraint = new NotCompromisedPassword(threshold: 3);
         $this->validator->validate(self::PASSWORD_LEAKED, $constraint);
 
         $this->buildViolation($constraint->message)
@@ -95,20 +95,21 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    /**
-     * @dataProvider provideConstraintsWithThreshold
-     */
-    public function testThresholdNotReached(NotCompromisedPassword $constraint)
+    public function testThresholdNotReached()
     {
-        $this->validator->validate(self::PASSWORD_LEAKED, $constraint);
+        $this->validator->validate(self::PASSWORD_LEAKED, new NotCompromisedPassword(threshold: 10));
 
         $this->assertNoViolation();
     }
 
-    public static function provideConstraintsWithThreshold(): iterable
+    /**
+     * @group legacy
+     */
+    public function testThresholdNotReachedDoctrineStyle()
     {
-        yield 'Doctrine style' => [new NotCompromisedPassword(['threshold' => 10])];
-        yield 'named arguments' => [new NotCompromisedPassword(threshold: 10)];
+        $this->validator->validate(self::PASSWORD_LEAKED, new NotCompromisedPassword(['threshold' => 10]));
+
+        $this->assertNoViolation();
     }
 
     public function testValidPassword()
@@ -208,20 +209,21 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate(self::PASSWORD_TRIGGERING_AN_ERROR, new NotCompromisedPassword());
     }
 
-    /**
-     * @dataProvider provideErrorSkippingConstraints
-     */
-    public function testApiErrorSkipped(NotCompromisedPassword $constraint)
+    public function testApiErrorSkipped()
     {
         $this->expectNotToPerformAssertions();
 
-        $this->validator->validate(self::PASSWORD_TRIGGERING_AN_ERROR, $constraint);
+        $this->validator->validate(self::PASSWORD_TRIGGERING_AN_ERROR, new NotCompromisedPassword(skipOnError: true));
     }
 
-    public static function provideErrorSkippingConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testApiErrorSkippedDoctrineStyle()
     {
-        yield 'Doctrine style' => [new NotCompromisedPassword(['skipOnError' => true])];
-        yield 'named arguments' => [new NotCompromisedPassword(skipOnError: true)];
+        $this->expectNotToPerformAssertions();
+
+        $this->validator->validate(self::PASSWORD_TRIGGERING_AN_ERROR, new NotCompromisedPassword(['skipOnError' => true]));
     }
 
     private function createHttpClientStub(?string $returnValue = null): HttpClientInterface

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -34,7 +34,11 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new NotEqualTo($options);
+        if (null !== $options) {
+            return new NotEqualTo(...$options);
+        }
+
+        return new NotEqualTo();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -34,7 +34,11 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
 
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new NotIdenticalTo($options);
+        if (null !== $options) {
+            return new NotIdenticalTo(...$options);
+        }
+
+        return new NotIdenticalTo();
     }
 
     protected function getErrorCode(): ?string

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
@@ -42,12 +42,9 @@ class NotNullValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideInvalidConstraints
-     */
-    public function testNullIsInvalid(NotNull $constraint)
+    public function testNullIsInvalid()
     {
-        $this->validator->validate(null, $constraint);
+        $this->validator->validate(null, new NotNull(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'null')
@@ -55,11 +52,18 @@ class NotNullValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideInvalidConstraints(): iterable
+    /**
+     * @group legacy
+     */
+    public function testNullIsInvalidDoctrineStyle()
     {
-        yield 'Doctrine style' => [new NotNull([
+        $this->validator->validate(null, new NotNull([
             'message' => 'myMessage',
-        ])];
-        yield 'named parameters' => [new NotNull(message: 'myMessage')];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'null')
+            ->setCode(NotNull::IS_NULL_ERROR)
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 class RangeTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfBothMinLimitAndPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -35,6 +38,9 @@ class RangeTest extends TestCase
         new Range(min: 'min', minPropertyPath: 'minPropertyPath');
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintExceptionIfBothMaxLimitAndPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -86,6 +92,9 @@ class RangeTest extends TestCase
         new Range(min: 'min', max: 'max', maxMessage: 'maxMessage');
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMinMessageAndMaxMessageOptions()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -98,6 +107,9 @@ class RangeTest extends TestCase
         ]);
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMinMessageOptions()
     {
         $this->expectException(ConstraintDefinitionException::class);
@@ -109,6 +121,9 @@ class RangeTest extends TestCase
         ]);
     }
 
+    /**
+     * @group legacy
+     */
     public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMaxMessageOptions()
     {
         $this->expectException(ConstraintDefinitionException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -30,7 +30,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Range(['min' => 10, 'max' => 20]));
+        $this->validator->validate(null, new Range(min: 10, max: 20));
 
         $this->assertNoViolation();
     }
@@ -70,6 +70,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getTenToTwenty
      */
     public function testValidValuesMin($value)
@@ -92,6 +93,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getTenToTwenty
      */
     public function testValidValuesMax($value)
@@ -114,6 +116,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getTenToTwenty
      */
     public function testValidValuesMinMax($value)
@@ -136,6 +139,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getLessThanTen
      */
     public function testInvalidValuesMin($value, $formattedValue)
@@ -171,6 +175,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getMoreThanTwenty
      */
     public function testInvalidValuesMax($value, $formattedValue)
@@ -206,6 +211,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getMoreThanTwenty
      */
     public function testInvalidValuesCombinedMax($value, $formattedValue)
@@ -244,6 +250,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getLessThanTen
      */
     public function testInvalidValuesCombinedMin($value, $formattedValue)
@@ -345,7 +352,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidDatesMin($value)
     {
-        $constraint = new Range(['min' => 'March 10, 2014']);
+        $constraint = new Range(min: 'March 10, 2014');
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -356,7 +363,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidDatesMax($value)
     {
-        $constraint = new Range(['max' => 'March 20, 2014']);
+        $constraint = new Range(max: 'March 20, 2014');
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -367,7 +374,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidDatesMinMax($value)
     {
-        $constraint = new Range(['min' => 'March 10, 2014', 'max' => 'March 20, 2014']);
+        $constraint = new Range(min: 'March 10, 2014', max: 'March 20, 2014');
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -382,10 +389,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         // Make sure we have the correct version loaded
         IntlTestHelper::requireIntl($this, '57.1');
 
-        $constraint = new Range([
-            'min' => 'March 10, 2014',
-            'minMessage' => 'myMessage',
-        ]);
+        $constraint = new Range(
+            min: 'March 10, 2014',
+            minMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -405,10 +412,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         // Make sure we have the correct version loaded
         IntlTestHelper::requireIntl($this, '57.1');
 
-        $constraint = new Range([
-            'max' => 'March 20, 2014',
-            'maxMessage' => 'myMessage',
-        ]);
+        $constraint = new Range(
+            max: 'March 20, 2014',
+            maxMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -428,11 +435,11 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         // Make sure we have the correct version loaded
         IntlTestHelper::requireIntl($this, '57.1');
 
-        $constraint = new Range([
-            'min' => 'March 10, 2014',
-            'max' => 'March 20, 2014',
-            'notInRangeMessage' => 'myNotInRangeMessage',
-        ]);
+        $constraint = new Range(
+            min: 'March 10, 2014',
+            max: 'March 20, 2014',
+            notInRangeMessage: 'myNotInRangeMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -453,11 +460,11 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         // Make sure we have the correct version loaded
         IntlTestHelper::requireIntl($this, '57.1');
 
-        $constraint = new Range([
-            'min' => 'March 10, 2014',
-            'max' => 'March 20, 2014',
-            'notInRangeMessage' => 'myNotInRangeMessage',
-        ]);
+        $constraint = new Range(
+            min: 'March 10, 2014',
+            max: 'March 20, 2014',
+            notInRangeMessage: 'myNotInRangeMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -482,10 +489,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNonNumeric()
     {
-        $constraint = new Range([
-            'min' => 10,
-            'max' => 20,
-        ]);
+        $constraint = new Range(
+            min: 10,
+            max: 20,
+        );
 
         $this->validator->validate('abcd', $constraint);
 
@@ -497,9 +504,9 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNonNumericWithParsableDatetimeMinAndMaxNull()
     {
-        $constraint = new Range([
-            'min' => 'March 10, 2014',
-        ]);
+        $constraint = new Range(
+            min: 'March 10, 2014',
+        );
 
         $this->validator->validate('abcd', $constraint);
 
@@ -511,9 +518,9 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNonNumericWithParsableDatetimeMaxAndMinNull()
     {
-        $constraint = new Range([
-            'max' => 'March 20, 2014',
-        ]);
+        $constraint = new Range(
+            max: 'March 20, 2014',
+        );
 
         $this->validator->validate('abcd', $constraint);
 
@@ -525,10 +532,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNonNumericWithParsableDatetimeMinAndMax()
     {
-        $constraint = new Range([
-            'min' => 'March 10, 2014',
-            'max' => 'March 20, 2014',
-        ]);
+        $constraint = new Range(
+            min: 'March 10, 2014',
+            max: 'March 20, 2014',
+        );
 
         $this->validator->validate('abcd', $constraint);
 
@@ -540,10 +547,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNonNumericWithNonParsableDatetimeMin()
     {
-        $constraint = new Range([
-            'min' => 'March 40, 2014',
-            'max' => 'March 20, 2014',
-        ]);
+        $constraint = new Range(
+            min: 'March 40, 2014',
+            max: 'March 20, 2014',
+        );
 
         $this->validator->validate('abcd', $constraint);
 
@@ -555,10 +562,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNonNumericWithNonParsableDatetimeMax()
     {
-        $constraint = new Range([
-            'min' => 'March 10, 2014',
-            'max' => 'March 50, 2014',
-        ]);
+        $constraint = new Range(
+            min: 'March 10, 2014',
+            max: 'March 50, 2014',
+        );
 
         $this->validator->validate('abcd', $constraint);
 
@@ -570,10 +577,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNonNumericWithNonParsableDatetimeMinAndMax()
     {
-        $constraint = new Range([
-            'min' => 'March 40, 2014',
-            'max' => 'March 50, 2014',
-        ]);
+        $constraint = new Range(
+            min: 'March 40, 2014',
+            max: 'March 50, 2014',
+        );
 
         $this->validator->validate('abcd', $constraint);
 
@@ -591,10 +598,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        $this->validator->validate($value, new Range([
-            'min' => $min,
-            'max' => $max,
-        ]));
+        $this->validator->validate($value, new Range(
+            min: $min,
+            max: $max,
+        ));
     }
 
     public static function throwsOnInvalidStringDatesProvider(): array
@@ -612,15 +619,16 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(null);
 
-        $this->validator->validate(1, new Range([
-            'minPropertyPath' => 'minPropertyPath',
-            'maxPropertyPath' => 'maxPropertyPath',
-        ]));
+        $this->validator->validate(1, new Range(
+            minPropertyPath: 'minPropertyPath',
+            maxPropertyPath: 'maxPropertyPath',
+        ));
 
         $this->assertNoViolation();
     }
 
     /**
+     * @group legacy
      * @dataProvider getTenToTwenty
      */
     public function testValidValuesMinPropertyPath($value)
@@ -653,9 +661,9 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit(20));
 
-        $this->validator->validate($value, new Range([
-            'maxPropertyPath' => 'value',
-        ]));
+        $this->validator->validate($value, new Range(
+            maxPropertyPath: 'value',
+        ));
 
         $this->assertNoViolation();
     }
@@ -679,10 +687,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new MinMax(10, 20));
 
-        $this->validator->validate($value, new Range([
-            'minPropertyPath' => 'min',
-            'maxPropertyPath' => 'max',
-        ]));
+        $this->validator->validate($value, new Range(
+            minPropertyPath: 'min',
+            maxPropertyPath: 'max',
+        ));
 
         $this->assertNoViolation();
     }
@@ -694,10 +702,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit(10));
 
-        $constraint = new Range([
-            'minPropertyPath' => 'value',
-            'minMessage' => 'myMessage',
-        ]);
+        $constraint = new Range(
+            minPropertyPath: 'value',
+            minMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -716,10 +724,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit(20));
 
-        $constraint = new Range([
-            'maxPropertyPath' => 'value',
-            'maxMessage' => 'myMessage',
-        ]);
+        $constraint = new Range(
+            maxPropertyPath: 'value',
+            maxMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -732,6 +740,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getMoreThanTwenty
      */
     public function testInvalidValuesCombinedMaxPropertyPath($value, $formattedValue)
@@ -782,6 +791,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getLessThanTen
      */
     public function testInvalidValuesCombinedMinPropertyPath($value, $formattedValue)
@@ -838,11 +848,11 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(null);
 
-        $this->validator->validate($value, new Range([
-            'min' => 10,
-            'maxPropertyPath' => 'max',
-            'minMessage' => 'myMessage',
-        ]));
+        $this->validator->validate($value, new Range(
+            min: 10,
+            maxPropertyPath: 'max',
+            minMessage: 'myMessage',
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -859,11 +869,11 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(null);
 
-        $this->validator->validate($value, new Range([
-            'minPropertyPath' => 'min',
-            'max' => 20,
-            'maxMessage' => 'myMessage',
-        ]));
+        $this->validator->validate($value, new Range(
+            minPropertyPath: 'min',
+            max: 20,
+            maxMessage: 'myMessage',
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -880,7 +890,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit('March 10, 2014'));
 
-        $this->validator->validate($value, new Range(['minPropertyPath' => 'value']));
+        $this->validator->validate($value, new Range(minPropertyPath: 'value'));
 
         $this->assertNoViolation();
     }
@@ -892,7 +902,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit('March 20, 2014'));
 
-        $constraint = new Range(['maxPropertyPath' => 'value']);
+        $constraint = new Range(maxPropertyPath: 'value');
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -905,7 +915,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new MinMax('March 10, 2014', 'March 20, 2014'));
 
-        $constraint = new Range(['minPropertyPath' => 'min', 'maxPropertyPath' => 'max']);
+        $constraint = new Range(minPropertyPath: 'min', maxPropertyPath: 'max');
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -922,10 +932,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject(new Limit('March 10, 2014'));
 
-        $constraint = new Range([
-            'minPropertyPath' => 'value',
-            'minMessage' => 'myMessage',
-        ]);
+        $constraint = new Range(
+            minPropertyPath: 'value',
+            minMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -948,10 +958,10 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject(new Limit('March 20, 2014'));
 
-        $constraint = new Range([
-            'maxPropertyPath' => 'value',
-            'maxMessage' => 'myMessage',
-        ]);
+        $constraint = new Range(
+            maxPropertyPath: 'value',
+            maxMessage: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -974,11 +984,11 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject(new MinMax('March 10, 2014', 'March 20, 2014'));
 
-        $constraint = new Range([
-            'minPropertyPath' => 'min',
-            'maxPropertyPath' => 'max',
-            'notInRangeMessage' => 'myNotInRangeMessage',
-        ]);
+        $constraint = new Range(
+            minPropertyPath: 'min',
+            maxPropertyPath: 'max',
+            notInRangeMessage: 'myNotInRangeMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -1003,11 +1013,11 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject(new MinMax('March 10, 2014', 'March 20, 2014'));
 
-        $constraint = new Range([
-            'minPropertyPath' => 'min',
-            'maxPropertyPath' => 'max',
-            'notInRangeMessage' => 'myNotInRangeMessage',
-        ]);
+        $constraint = new Range(
+            minPropertyPath: 'min',
+            maxPropertyPath: 'max',
+            notInRangeMessage: 'myNotInRangeMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -1027,7 +1037,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $object->max = 5;
         $this->setObject($object);
 
-        $this->validator->validate(5, new Range(['minPropertyPath' => 'min', 'maxPropertyPath' => 'max']));
+        $this->validator->validate(5, new Range(minPropertyPath: 'min', maxPropertyPath: 'max'));
 
         $this->assertNoViolation();
     }
@@ -1038,14 +1048,14 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $object->min = 5;
         $this->setObject($object);
 
-        $this->validator->validate(5, new Range(['minPropertyPath' => 'min', 'maxPropertyPath' => 'max']));
+        $this->validator->validate(5, new Range(minPropertyPath: 'min', maxPropertyPath: 'max'));
 
         $this->assertNoViolation();
     }
 
     public static function provideMessageIfMinAndMaxSet(): array
     {
-        $notInRangeMessage = (new Range(['min' => '']))->notInRangeMessage;
+        $notInRangeMessage = (new Range(min: ''))->notInRangeMessage;
 
         return [
             [
@@ -1068,7 +1078,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testMessageIfMinAndMaxSet(array $constraintExtraOptions, int $value, string $expectedMessage, string $expectedCode)
     {
-        $constraint = new Range(array_merge(['min' => 1, 'max' => 10], $constraintExtraOptions));
+        $constraint = new Range(...array_merge(['min' => 1, 'max' => 10], $constraintExtraOptions));
         $this->validator->validate($value, $constraint);
 
         $this

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexTest.php
@@ -69,10 +69,10 @@ class RegexTest extends TestCase
      */
     public function testGetHtmlPattern($pattern, $htmlPattern, $match = true)
     {
-        $constraint = new Regex([
-            'pattern' => $pattern,
-            'match' => $match,
-        ]);
+        $constraint = new Regex(
+            pattern: $pattern,
+            match: $match,
+        );
 
         $this->assertSame($pattern, $constraint->pattern);
         $this->assertSame($htmlPattern, $constraint->getHtmlPattern());
@@ -80,10 +80,10 @@ class RegexTest extends TestCase
 
     public function testGetCustomHtmlPattern()
     {
-        $constraint = new Regex([
-            'pattern' => '((?![0-9]$|[a-z]+).)*',
-            'htmlPattern' => 'foobar',
-        ]);
+        $constraint = new Regex(
+            pattern: '((?![0-9]$|[a-z]+).)*',
+            htmlPattern: 'foobar',
+        );
 
         $this->assertSame('((?![0-9]$|[a-z]+).)*', $constraint->pattern);
         $this->assertSame('foobar', $constraint->getHtmlPattern());
@@ -91,11 +91,14 @@ class RegexTest extends TestCase
 
     public function testNormalizerCanBeSet()
     {
-        $regex = new Regex(['pattern' => '/^[0-9]+$/', 'normalizer' => 'trim']);
+        $regex = new Regex(pattern: '/^[0-9]+$/', normalizer: 'trim');
 
         $this->assertEquals('trim', $regex->normalizer);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -103,6 +106,9 @@ class RegexTest extends TestCase
         new Regex(['pattern' => '/^[0-9]+$/', 'normalizer' => 'Unknown Callable']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -25,14 +25,14 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Regex(['pattern' => '/^[0-9]+$/']));
+        $this->validator->validate(null, new Regex(pattern: '/^[0-9]+$/'));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Regex(['pattern' => '/^[0-9]+$/']));
+        $this->validator->validate('', new Regex(pattern: '/^[0-9]+$/'));
 
         $this->assertNoViolation();
     }
@@ -40,7 +40,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Regex(['pattern' => '/^[0-9]+$/']));
+        $this->validator->validate(new \stdClass(), new Regex(pattern: '/^[0-9]+$/'));
     }
 
     /**
@@ -48,13 +48,14 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValues($value)
     {
-        $constraint = new Regex(['pattern' => '/^[0-9]+$/']);
+        $constraint = new Regex(pattern: '/^[0-9]+$/');
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
 
     /**
+     * @group legacy
      * @dataProvider getValidValuesWithWhitespaces
      */
     public function testValidValuesWithWhitespaces($value)
@@ -105,6 +106,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getInvalidValues
      */
     public function testInvalidValues($value)

--- a/src/Symfony/Component/Validator/Tests/Constraints/SequentiallyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SequentiallyValidatorTest.php
@@ -33,7 +33,7 @@ class SequentiallyValidatorTest extends ConstraintValidatorTestCase
     {
         $constraints = [
             new Type('number'),
-            new Range(['min' => 4]),
+            new Range(min: 4),
         ];
 
         $value = 6;
@@ -50,7 +50,7 @@ class SequentiallyValidatorTest extends ConstraintValidatorTestCase
     {
         $constraints = [
             new Type('string'),
-            new Regex(['pattern' => '[a-z]']),
+            new Regex(pattern: '[a-z]'),
             new NotEqualTo('Foo'),
         ];
 
@@ -68,20 +68,20 @@ class SequentiallyValidatorTest extends ConstraintValidatorTestCase
     {
         $validator = Validation::createValidator();
 
-        $violations = $validator->validate(50, new Sequentially([
-            'constraints' => [
-                new GreaterThan([
-                    'groups' => 'senior',
-                    'value' => 55,
-                ]),
-                new Range([
-                    'groups' => 'adult',
-                    'min' => 18,
-                    'max' => 55,
-                ]),
+        $violations = $validator->validate(50, new Sequentially(
+            constraints: [
+                new GreaterThan(
+                    groups: ['senior'],
+                    value: 55,
+                ),
+                new Range(
+                    groups: ['adult'],
+                    min: 18,
+                    max: 55,
+                ),
             ],
-            'groups' => ['adult', 'senior'],
-        ]), 'adult');
+            groups: ['adult', 'senior'],
+        ), 'adult');
 
         $this->assertCount(0, $violations);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -87,9 +87,7 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidTimesWithoutSeconds(string $time)
     {
-        $this->validator->validate($time, new Time([
-            'withSeconds' => false,
-        ]));
+        $this->validator->validate($time, new Time(withSeconds: false));
 
         $this->assertNoViolation();
     }
@@ -143,9 +141,7 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidTimes($time, $code)
     {
-        $constraint = new Time([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Time(message: 'myMessage');
 
         $this->validator->validate($time, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
@@ -25,12 +25,12 @@ class TimezoneTest extends TestCase
     public function testValidTimezoneConstraints()
     {
         new Timezone();
-        new Timezone(['zone' => \DateTimeZone::ALL]);
+        new Timezone(zone: \DateTimeZone::ALL);
         new Timezone(\DateTimeZone::ALL_WITH_BC);
-        new Timezone([
-            'zone' => \DateTimeZone::PER_COUNTRY,
-            'countryCode' => 'AR',
-        ]);
+        new Timezone(
+            zone: \DateTimeZone::PER_COUNTRY,
+            countryCode: 'AR',
+        );
 
         $this->addToAssertionCount(1);
     }
@@ -38,16 +38,16 @@ class TimezoneTest extends TestCase
     public function testExceptionForGroupedTimezonesByCountryWithWrongZone()
     {
         $this->expectException(ConstraintDefinitionException::class);
-        new Timezone([
-            'zone' => \DateTimeZone::ALL,
-            'countryCode' => 'AR',
-        ]);
+        new Timezone(
+            zone: \DateTimeZone::ALL,
+            countryCode: 'AR',
+        );
     }
 
     public function testExceptionForGroupedTimezonesByCountryWithoutZone()
     {
         $this->expectException(ConstraintDefinitionException::class);
-        new Timezone(['countryCode' => 'AR']);
+        new Timezone(countryCode: 'AR');
     }
 
     /**
@@ -56,7 +56,7 @@ class TimezoneTest extends TestCase
     public function testExceptionForInvalidGroupedTimezones(int $zone)
     {
         $this->expectException(ConstraintDefinitionException::class);
-        new Timezone(['zone' => $zone]);
+        new Timezone(zone: $zone);
     }
 
     public static function provideInvalidZones(): iterable

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -92,9 +92,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidGroupedTimezones(string $timezone, int $zone)
     {
-        $constraint = new Timezone([
-            'zone' => $zone,
-        ]);
+        $constraint = new Timezone(zone: $zone);
 
         $this->validator->validate($timezone, $constraint);
 
@@ -125,9 +123,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidTimezoneWithoutZone(string $timezone)
     {
-        $constraint = new Timezone([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Timezone(message: 'myMessage');
 
         $this->validator->validate($timezone, $constraint);
 
@@ -150,10 +146,10 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidGroupedTimezones(string $timezone, int $zone)
     {
-        $constraint = new Timezone([
-            'zone' => $zone,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Timezone(
+            zone: $zone,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($timezone, $constraint);
 
@@ -193,10 +189,10 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidGroupedTimezonesByCountry(string $timezone, string $country)
     {
-        $constraint = new Timezone([
-            'zone' => \DateTimeZone::PER_COUNTRY,
-            'countryCode' => $country,
-        ]);
+        $constraint = new Timezone(
+            zone: \DateTimeZone::PER_COUNTRY,
+            countryCode: $country,
+        );
 
         $this->validator->validate($timezone, $constraint);
 
@@ -230,11 +226,11 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidGroupedTimezonesByCountry(string $timezone, string $countryCode)
     {
-        $constraint = new Timezone([
-            'message' => 'myMessage',
-            'zone' => \DateTimeZone::PER_COUNTRY,
-            'countryCode' => $countryCode,
-        ]);
+        $constraint = new Timezone(
+            message: 'myMessage',
+            zone: \DateTimeZone::PER_COUNTRY,
+            countryCode: $countryCode,
+        );
 
         $this->validator->validate($timezone, $constraint);
 
@@ -255,11 +251,11 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
 
     public function testGroupedTimezonesWithInvalidCountry()
     {
-        $constraint = new Timezone([
-            'message' => 'myMessage',
-            'zone' => \DateTimeZone::PER_COUNTRY,
-            'countryCode' => 'foobar',
-        ]);
+        $constraint = new Timezone(
+            message: 'myMessage',
+            zone: \DateTimeZone::PER_COUNTRY,
+            countryCode: 'foobar',
+        );
 
         $this->validator->validate('Europe/Amsterdam', $constraint);
 
@@ -286,9 +282,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
      */
     public function testDeprecatedTimezonesAreInvalidWithoutBC(string $timezone)
     {
-        $constraint = new Timezone([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Timezone(message: 'myMessage');
 
         $this->validator->validate($timezone, $constraint);
 
@@ -332,10 +326,10 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             $this->markTestSkipped('"Europe/Saratov" is expired until 2017, current version is '.$tzDbVersion);
         }
 
-        $constraint = new Timezone([
-            'message' => 'myMessage',
-            'intlCompatible' => true,
-        ]);
+        $constraint = new Timezone(
+            message: 'myMessage',
+            intlCompatible: true,
+        );
 
         $this->validator->validate('Europe/Saratov', $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -26,7 +26,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $constraint = new Type(['type' => 'integer']);
+        $constraint = new Type(type: 'integer');
 
         $this->validator->validate(null, $constraint);
 
@@ -35,7 +35,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
 
     public function testEmptyIsValidIfString()
     {
-        $constraint = new Type(['type' => 'string']);
+        $constraint = new Type(type: 'string');
 
         $this->validator->validate('', $constraint);
 
@@ -44,10 +44,10 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
 
     public function testEmptyIsInvalidIfNoString()
     {
-        $constraint = new Type([
-            'type' => 'integer',
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Type(
+            type: 'integer',
+            message: 'myMessage',
+        );
 
         $this->validator->validate('', $constraint);
 
@@ -63,7 +63,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValues($value, $type)
     {
-        $constraint = new Type(['type' => $type]);
+        $constraint = new Type(type: $type);
 
         $this->validator->validate($value, $constraint);
 
@@ -123,10 +123,10 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValues($value, $type, $valueAsString)
     {
-        $constraint = new Type([
-            'type' => $type,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Type(
+            type: $type,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($value, $constraint);
 
@@ -195,7 +195,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValuesMultipleTypes($value, array $types)
     {
-        $constraint = new Type(['type' => $types]);
+        $constraint = new Type(type: $types);
 
         $this->validator->validate($value, $constraint);
 
@@ -210,12 +210,9 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideConstraintsWithMultipleTypes
-     */
-    public function testInvalidValuesMultipleTypes(Type $constraint)
+    public function testInvalidValuesMultipleTypes()
     {
-        $this->validator->validate('12345', $constraint);
+        $this->validator->validate('12345', new Type(type: ['boolean', 'array'], message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"12345"')
@@ -224,13 +221,21 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public static function provideConstraintsWithMultipleTypes()
+    /**
+     * @group legacy
+     */
+    public function testInvalidValuesMultipleTypesDoctrineStyle()
     {
-        yield 'Doctrine style' => [new Type([
+        $this->validator->validate('12345', new Type([
             'type' => ['boolean', 'array'],
             'message' => 'myMessage',
-        ])];
-        yield 'named arguments' => [new Type(type: ['boolean', 'array'], message: 'myMessage')];
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"12345"')
+            ->setParameter('{{ type }}', implode('|', ['boolean', 'array']))
+            ->setCode(Type::INVALID_TYPE_ERROR)
+            ->assertRaised();
     }
 
     protected static function createFile()

--- a/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
@@ -72,9 +72,7 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidUlid(string $ulid, string $code)
     {
-        $constraint = new Ulid([
-            'message' => 'testMessage',
-        ]);
+        $constraint = new Ulid(message: 'testMessage');
 
         $this->validator->validate($ulid, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueTest.php
@@ -37,6 +37,9 @@ class UniqueTest extends TestCase
         self::assertSame('intval', $dConstraint->normalizer);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -44,6 +47,9 @@ class UniqueTest extends TestCase
         new Unique(['normalizer' => 'Unknown Callable']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -63,9 +63,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidValues($value, $expectedMessageParam)
     {
-        $constraint = new Unique([
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Unique(message: 'myMessage');
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
@@ -118,9 +116,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
         $value = [$object1, $object2, $object3];
 
-        $this->validator->validate($value, new Unique([
-            'normalizer' => $callback,
-        ]));
+        $this->validator->validate($value, new Unique(normalizer: $callback));
 
         $this->assertNoViolation();
     }
@@ -144,10 +140,10 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
         $value = [$object1, $object2, $object3];
 
-        $this->validator->validate($value, new Unique([
-            'message' => 'myMessage',
-            'normalizer' => $callback,
-        ]));
+        $this->validator->validate($value, new Unique(
+            message: 'myMessage',
+            normalizer: $callback,
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'array')
@@ -168,10 +164,10 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpectsInvalidNonStrictComparison()
     {
-        $this->validator->validate([1, '1', 1.0, '1.0'], new Unique([
-            'message' => 'myMessage',
-            'normalizer' => 'intval',
-        ]));
+        $this->validator->validate([1, '1', 1.0, '1.0'], new Unique(
+            message: 'myMessage',
+            normalizer: 'intval',
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '1')
@@ -183,9 +179,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     {
         $callback = static fn ($item) => (int) $item;
 
-        $this->validator->validate([1, '2', 3, '4.0'], new Unique([
-            'normalizer' => $callback,
-        ]));
+        $this->validator->validate([1, '2', 3, '4.0'], new Unique(normalizer: $callback));
 
         $this->assertNoViolation();
     }
@@ -194,10 +188,10 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     {
         $callback = static fn ($item) => mb_strtolower($item);
 
-        $this->validator->validate(['Hello', 'hello', 'HELLO', 'hellO'], new Unique([
-            'message' => 'myMessage',
-            'normalizer' => $callback,
-        ]));
+        $this->validator->validate(['Hello', 'hello', 'HELLO', 'hellO'], new Unique(
+            message: 'myMessage',
+            normalizer: $callback,
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"hello"')
@@ -209,9 +203,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     {
         $callback = static fn ($item) => mb_strtolower($item);
 
-        $this->validator->validate(['Hello', 'World'], new Unique([
-            'normalizer' => $callback,
-        ]));
+        $this->validator->validate(['Hello', 'World'], new Unique(normalizer: $callback));
 
         $this->assertNoViolation();
     }
@@ -248,9 +240,10 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidCollectionValues(array $value, array $fields, string $expectedMessageParam)
     {
-        $this->validator->validate($value, new Unique([
-            'message' => 'myMessage',
-        ], fields: $fields));
+        $this->validator->validate($value, new Unique(
+            message: 'myMessage',
+            fields: $fields,
+        ));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $expectedMessageParam)

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
@@ -24,11 +24,14 @@ class UrlTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $url = new Url(['normalizer' => 'trim', 'requireTld' => true]);
+        $url = new Url(normalizer: 'trim', requireTld: true);
 
         $this->assertEquals('trim', $url->normalizer);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -36,6 +39,9 @@ class UrlTest extends TestCase
         new Url(['normalizer' => 'Unknown Callable', 'requireTld' => true]);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -78,10 +78,10 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidUrlsWithWhitespaces($url)
     {
-        $this->validator->validate($url, new Url([
-            'normalizer' => 'trim',
-            'requireTld' => true,
-        ]));
+        $this->validator->validate($url, new Url(
+            normalizer: 'trim',
+            requireTld: true,
+        ));
 
         $this->assertNoViolation();
     }
@@ -92,10 +92,10 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidRelativeUrl($url)
     {
-        $constraint = new Url([
-            'relativeProtocol' => true,
-            'requireTld' => false,
-        ]);
+        $constraint = new Url(
+            relativeProtocol: true,
+            requireTld: false,
+        );
 
         $this->validator->validate($url, $constraint);
 
@@ -229,10 +229,10 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidUrls($url)
     {
-        $constraint = new Url([
-            'message' => 'myMessage',
-            'requireTld' => false,
-        ]);
+        $constraint = new Url(
+            message: 'myMessage',
+            requireTld: false,
+        );
 
         $this->validator->validate($url, $constraint);
 
@@ -248,11 +248,11 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidRelativeUrl($url)
     {
-        $constraint = new Url([
-            'message' => 'myMessage',
-            'relativeProtocol' => true,
-            'requireTld' => false,
-        ]);
+        $constraint = new Url(
+            message: 'myMessage',
+            relativeProtocol: true,
+            requireTld: false,
+        );
 
         $this->validator->validate($url, $constraint);
 
@@ -331,10 +331,10 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      */
     public function testCustomProtocolIsValid($url, $requireTld)
     {
-        $constraint = new Url([
-            'protocols' => ['ftp', 'file', 'git'],
-            'requireTld' => $requireTld,
-        ]);
+        $constraint = new Url(
+            protocols: ['ftp', 'file', 'git'],
+            requireTld: $requireTld,
+        );
 
         $this->validator->validate($url, $constraint);
 
@@ -355,9 +355,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      */
     public function testRequiredTld(string $url, bool $requireTld, bool $isValid)
     {
-        $constraint = new Url([
-            'requireTld' => $requireTld,
-        ]);
+        $constraint = new Url(requireTld: $requireTld);
 
         $this->validator->validate($url, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidTest.php
@@ -24,11 +24,14 @@ class UuidTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $uuid = new Uuid(['normalizer' => 'trim']);
+        $uuid = new Uuid(normalizer: 'trim');
 
         $this->assertEquals('trim', $uuid->normalizer);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -36,6 +39,9 @@ class UuidTest extends TestCase
         new Uuid(['normalizer' => 'Unknown Callable']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidNormalizerObjectThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -93,7 +93,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidStrictUuidsWithWhitespaces($uuid, $versions = null)
     {
-        $constraint = new Uuid(['normalizer' => 'trim']);
+        $constraint = new Uuid(normalizer: 'trim');
 
         if (null !== $versions) {
             $constraint->versions = $versions;
@@ -131,9 +131,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidStrictUuids($uuid, $code, $versions = null)
     {
-        $constraint = new Uuid([
-            'message' => 'testMessage',
-        ]);
+        $constraint = new Uuid(message: 'testMessage');
 
         if (null !== $versions) {
             $constraint->versions = $versions;
@@ -195,9 +193,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidNonStrictUuids($uuid)
     {
-        $constraint = new Uuid([
-            'strict' => false,
-        ]);
+        $constraint = new Uuid(strict: false);
 
         $this->validator->validate($uuid, $constraint);
 
@@ -226,10 +222,10 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidNonStrictUuids($uuid, $code)
     {
-        $constraint = new Uuid([
-            'strict' => false,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new Uuid(
+            strict: false,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($uuid, $constraint);
 
@@ -270,9 +266,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
      */
     public function testTimeBasedUuid(string $uid, bool $expectedTimeBased)
     {
-        $constraint = new Uuid([
-            'versions' => Uuid::TIME_BASED_VERSIONS,
-        ]);
+        $constraint = new Uuid(versions: Uuid::TIME_BASED_VERSIONS);
 
         $this->validator->validate($uid, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
@@ -23,7 +23,7 @@ class ValidTest extends TestCase
 {
     public function testGroupsCanBeSet()
     {
-        $constraint = new Valid(['groups' => 'foo']);
+        $constraint = new Valid(groups: ['foo']);
 
         $this->assertSame(['foo'], $constraint->groups);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -24,6 +24,9 @@ use Symfony\Component\Validator\Tests\Constraints\Fixtures\WhenTestWithAttribute
 
 final class WhenTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testMissingOptionsExceptionIsThrown()
     {
         $this->expectException(MissingOptionsException::class);
@@ -51,10 +54,10 @@ final class WhenTest extends TestCase
         self::assertInstanceOf(When::class, $classConstraint);
         self::assertSame('true', $classConstraint->expression);
         self::assertEquals([
-            new Callback([
-                'callback' => 'callback',
-                'groups' => ['Default', 'WhenTestWithAttributes'],
-            ]),
+            new Callback(
+                callback: 'callback',
+                groups: ['Default', 'WhenTestWithAttributes'],
+            ),
         ], $classConstraint->constraints);
 
         [$fooConstraint] = $metadata->properties['foo']->getConstraints();
@@ -62,12 +65,8 @@ final class WhenTest extends TestCase
         self::assertInstanceOf(When::class, $fooConstraint);
         self::assertSame('true', $fooConstraint->expression);
         self::assertEquals([
-            new NotNull([
-                'groups' => ['Default', 'WhenTestWithAttributes'],
-            ]),
-            new NotBlank([
-                'groups' => ['Default', 'WhenTestWithAttributes'],
-            ]),
+            new NotNull(groups: ['Default', 'WhenTestWithAttributes']),
+            new NotBlank(groups: ['Default', 'WhenTestWithAttributes']),
         ], $fooConstraint->constraints);
         self::assertSame(['Default', 'WhenTestWithAttributes'], $fooConstraint->groups);
 
@@ -76,12 +75,8 @@ final class WhenTest extends TestCase
         self::assertInstanceOf(When::class, $fooConstraint);
         self::assertSame('false', $barConstraint->expression);
         self::assertEquals([
-            new NotNull([
-                'groups' => ['foo'],
-            ]),
-            new NotBlank([
-                'groups' => ['foo'],
-            ]),
+            new NotNull(groups: ['foo']),
+            new NotBlank(groups: ['foo']),
         ], $barConstraint->constraints);
         self::assertSame(['foo'], $barConstraint->groups);
 
@@ -89,11 +84,7 @@ final class WhenTest extends TestCase
 
         self::assertInstanceOf(When::class, $quxConstraint);
         self::assertSame('true', $quxConstraint->expression);
-        self::assertEquals([
-            new NotNull([
-                'groups' => ['foo'],
-            ]),
-        ], $quxConstraint->constraints);
+        self::assertEquals([new NotNull(groups: ['foo'])], $quxConstraint->constraints);
         self::assertSame(['foo'], $quxConstraint->groups);
 
         [$bazConstraint] = $metadata->getters['baz']->getConstraints();
@@ -101,12 +92,8 @@ final class WhenTest extends TestCase
         self::assertInstanceOf(When::class, $bazConstraint);
         self::assertSame('true', $bazConstraint->expression);
         self::assertEquals([
-            new NotNull([
-                'groups' => ['Default', 'WhenTestWithAttributes'],
-            ]),
-            new NotBlank([
-                'groups' => ['Default', 'WhenTestWithAttributes'],
-            ]),
+            new NotNull(groups: ['Default', 'WhenTestWithAttributes']),
+            new NotBlank(groups: ['Default', 'WhenTestWithAttributes']),
         ], $bazConstraint->constraints);
         self::assertSame(['Default', 'WhenTestWithAttributes'], $bazConstraint->groups);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
@@ -33,10 +33,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'Foo', $constraints);
 
-        $this->validator->validate('Foo', new When([
-            'expression' => 'true',
-            'constraints' => $constraints,
-        ]));
+        $this->validator->validate('Foo', new When(
+            expression: 'true',
+            constraints: $constraints,
+        ));
     }
 
     public function testConstraintIsExecuted()
@@ -44,10 +44,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
         $constraint = new NotNull();
         $this->expectValidateValue(0, 'Foo', [$constraint]);
 
-        $this->validator->validate('Foo', new When([
-            'expression' => 'true',
-            'constraints' => $constraint,
-        ]));
+        $this->validator->validate('Foo', new When(
+            expression: 'true',
+            constraints: $constraint,
+        ));
     }
 
     public function testConstraintsAreExecutedWithNull()
@@ -58,10 +58,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, null, $constraints);
 
-        $this->validator->validate(null, new When([
-            'expression' => 'true',
-            'constraints' => $constraints,
-        ]));
+        $this->validator->validate(null, new When(
+            expression: 'true',
+            constraints: $constraints,
+        ));
     }
 
     public function testConstraintsAreExecutedWithObject()
@@ -79,10 +79,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, $number->value, $constraints);
 
-        $this->validator->validate($number->value, new When([
-            'expression' => 'this.type === "positive"',
-            'constraints' => $constraints,
-        ]));
+        $this->validator->validate($number->value, new When(
+            expression: 'this.type === "positive"',
+            constraints: $constraints,
+        ));
     }
 
     public function testConstraintsAreExecutedWithNestedObject()
@@ -104,10 +104,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, $number->value, $constraints);
 
-        $this->validator->validate($number->value, new When([
-            'expression' => 'context.getRoot().ok === true',
-            'constraints' => $constraints,
-        ]));
+        $this->validator->validate($number->value, new When(
+            expression: 'context.getRoot().ok === true',
+            constraints: $constraints,
+        ));
     }
 
     public function testConstraintsAreExecutedWithValue()
@@ -118,10 +118,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'foo', $constraints);
 
-        $this->validator->validate('foo', new When([
-            'expression' => 'value === "foo"',
-            'constraints' => $constraints,
-        ]));
+        $this->validator->validate('foo', new When(
+            expression: 'value === "foo"',
+            constraints: $constraints,
+        ));
     }
 
     public function testConstraintsAreExecutedWithExpressionValues()
@@ -132,14 +132,14 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'foo', $constraints);
 
-        $this->validator->validate('foo', new When([
-            'expression' => 'activated && value === compared_value',
-            'constraints' => $constraints,
-            'values' => [
+        $this->validator->validate('foo', new When(
+            expression: 'activated && value === compared_value',
+            constraints: $constraints,
+            values: [
                 'activated' => true,
                 'compared_value' => 'foo',
             ],
-        ]));
+        ));
     }
 
     public function testConstraintsNotExecuted()
@@ -151,10 +151,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate('', new When([
-            'expression' => 'false',
-            'constraints' => $constraints,
-        ]));
+        $this->validator->validate('', new When(
+            expression: 'false',
+            constraints: $constraints,
+        ));
 
         $this->assertNoViolation();
     }
@@ -174,10 +174,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate($number->value, new When([
-            'expression' => 'this.type !== "positive"',
-            'constraints' => $constraints,
-        ]));
+        $this->validator->validate($number->value, new When(
+            expression: 'this.type !== "positive"',
+            constraints: $constraints,
+        ));
 
         $this->assertNoViolation();
     }
@@ -190,10 +190,10 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate('foo', new When([
-            'expression' => 'value === null',
-            'constraints' => $constraints,
-        ]));
+        $this->validator->validate('foo', new When(
+            expression: 'value === null',
+            constraints: $constraints,
+        ));
 
         $this->assertNoViolation();
     }
@@ -206,14 +206,14 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate('foo', new When([
-            'expression' => 'activated && value === compared_value',
-            'constraints' => $constraints,
-            'values' => [
+        $this->validator->validate('foo', new When(
+            expression: 'activated && value === compared_value',
+            constraints: $constraints,
+            values: [
                 'activated' => true,
                 'compared_value' => 'bar',
             ],
-        ]));
+        ));
 
         $this->assertNoViolation();
     }
@@ -221,9 +221,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
     public function testConstraintViolations()
     {
         $constraints = [
-            new Blank([
-                'message' => 'my_message',
-            ]),
+            new Blank(message: 'my_message'),
         ];
         $this->expectFailingValueValidation(
             0,

--- a/src/Symfony/Component/Validator/Tests/Fixtures/DummyCompoundConstraint.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/DummyCompoundConstraint.php
@@ -22,7 +22,7 @@ class DummyCompoundConstraint extends Compound
     {
         return [
             new NotBlank(),
-            new Length(['max' => 3]),
+            new Length(max: 3),
             new Regex('/[a-z]+/'),
             new Regex('/[0-9]+/'),
         ];

--- a/src/Symfony/Component/Validator/Tests/Fixtures/DummyEntityConstraintWithoutNamedArguments.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/DummyEntityConstraintWithoutNamedArguments.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class DummyEntityConstraintWithoutNamedArguments
+{
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCar.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCar.php
@@ -18,6 +18,6 @@ class EntityStaticCar extends EntityStaticVehicle
 {
     public static function loadValidatorMetadata(ClassMetadata $metadata)
     {
-        $metadata->addPropertyConstraint('wheels', new Length(['max' => 99]));
+        $metadata->addPropertyConstraint('wheels', new Length(max: 99));
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCarTurbo.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCarTurbo.php
@@ -18,6 +18,6 @@ class EntityStaticCarTurbo extends EntityStaticCar
 {
     public static function loadValidatorMetadata(ClassMetadata $metadata)
     {
-        $metadata->addPropertyConstraint('wheels', new Length(['max' => 99]));
+        $metadata->addPropertyConstraint('wheels', new Length(max: 99));
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticVehicle.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticVehicle.php
@@ -20,6 +20,6 @@ class EntityStaticVehicle
 
     public static function loadValidatorMetadata(ClassMetadata $metadata)
     {
-        $metadata->addPropertyConstraint('wheels', new Length(['max' => 99]));
+        $metadata->addPropertyConstraint('wheels', new Length(max: 99));
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -38,8 +38,8 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
 
         $constraints = [
-            new ConstraintA(['groups' => ['Default', 'EntityParent']]),
-            new ConstraintA(['groups' => ['Default', 'EntityInterfaceA', 'EntityParent']]),
+            new ConstraintA(groups: ['Default', 'EntityParent']),
+            new ConstraintA(groups: ['Default', 'EntityInterfaceA', 'EntityParent']),
         ];
 
         $this->assertEquals($constraints, $metadata->getConstraints());
@@ -51,31 +51,31 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $metadata = $factory->getMetadataFor(self::CLASS_NAME);
 
         $constraints = [
-            new ConstraintA(['groups' => [
+            new ConstraintA(groups: [
                 'Default',
                 'Entity',
-            ]]),
-            new ConstraintA(['groups' => [
+            ]),
+            new ConstraintA(groups: [
                 'Default',
                 'EntityParent',
                 'Entity',
-            ]]),
-            new ConstraintA(['groups' => [
+            ]),
+            new ConstraintA(groups: [
                 'Default',
                 'EntityInterfaceA',
                 'EntityParent',
                 'Entity',
-            ]]),
-            new ConstraintA(['groups' => [
+            ]),
+            new ConstraintA(groups: [
                 'Default',
                 'EntityInterfaceB',
                 'Entity',
-            ]]),
-            new ConstraintA(['groups' => [
+            ]),
+            new ConstraintA(groups: [
                 'Default',
                 'EntityParentInterface',
                 'Entity',
-            ]]),
+            ]),
         ];
 
         $this->assertEquals($constraints, $metadata->getConstraints());
@@ -87,8 +87,8 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $factory = new LazyLoadingMetadataFactory(new TestLoader(), $cache);
 
         $expectedConstraints = [
-            new ConstraintA(['groups' => ['Default', 'EntityParent']]),
-            new ConstraintA(['groups' => ['Default', 'EntityInterfaceA', 'EntityParent']]),
+            new ConstraintA(groups: ['Default', 'EntityParent']),
+            new ConstraintA(groups: ['Default', 'EntityInterfaceA', 'EntityParent']),
         ];
 
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -66,29 +66,29 @@ class AttributeLoaderTest extends TestCase
         $expected->addConstraint(new Sequentially([
             new Expression('this.getFirstName() != null'),
         ]));
-        $expected->addConstraint(new Callback(['callback' => 'validateMe', 'payload' => 'foo']));
+        $expected->addConstraint(new Callback(callback: 'validateMe', payload: 'foo'));
         $expected->addConstraint(new Callback('validateMeStatic'));
         $expected->addPropertyConstraint('firstName', new NotNull());
-        $expected->addPropertyConstraint('firstName', new Range(['min' => 3]));
-        $expected->addPropertyConstraint('firstName', new All([new NotNull(), new Range(['min' => 3])]));
-        $expected->addPropertyConstraint('firstName', new All(['constraints' => [new NotNull(), new Range(['min' => 3])]]));
-        $expected->addPropertyConstraint('firstName', new Collection([
-            'foo' => [new NotNull(), new Range(['min' => 3])],
-            'bar' => new Range(['min' => 5]),
+        $expected->addPropertyConstraint('firstName', new Range(min: 3));
+        $expected->addPropertyConstraint('firstName', new All(constraints: [new NotNull(), new Range(min: 3)]));
+        $expected->addPropertyConstraint('firstName', new All(constraints: [new NotNull(), new Range(min: 3)]));
+        $expected->addPropertyConstraint('firstName', new Collection(fields: [
+            'foo' => [new NotNull(), new Range(min: 3)],
+            'bar' => new Range(min: 5),
             'baz' => new Required([new Email()]),
             'qux' => new Optional([new NotBlank()]),
-        ], null, null, true));
-        $expected->addPropertyConstraint('firstName', new Choice([
-            'message' => 'Must be one of %choices%',
-            'choices' => ['A', 'B'],
-        ]));
+        ], allowExtraFields: true));
+        $expected->addPropertyConstraint('firstName', new Choice(
+            message: 'Must be one of %choices%',
+            choices: ['A', 'B'],
+        ));
         $expected->addPropertyConstraint('firstName', new AtLeastOneOf([
             new NotNull(),
-            new Range(['min' => 3]),
+            new Range(min: 3),
         ], null, null, 'foo', null, false));
         $expected->addPropertyConstraint('firstName', new Sequentially([
             new NotBlank(),
-            new Range(['min' => 5]),
+            new Range(min: 5),
         ]));
         $expected->addPropertyConstraint('childA', new Valid());
         $expected->addPropertyConstraint('childB', new Valid());
@@ -152,29 +152,29 @@ class AttributeLoaderTest extends TestCase
         $expected->addConstraint(new Sequentially([
             new Expression('this.getFirstName() != null'),
         ]));
-        $expected->addConstraint(new Callback(['callback' => 'validateMe', 'payload' => 'foo']));
+        $expected->addConstraint(new Callback(callback: 'validateMe', payload: 'foo'));
         $expected->addConstraint(new Callback('validateMeStatic'));
         $expected->addPropertyConstraint('firstName', new NotNull());
-        $expected->addPropertyConstraint('firstName', new Range(['min' => 3]));
-        $expected->addPropertyConstraint('firstName', new All([new NotNull(), new Range(['min' => 3])]));
-        $expected->addPropertyConstraint('firstName', new All(['constraints' => [new NotNull(), new Range(['min' => 3])]]));
-        $expected->addPropertyConstraint('firstName', new Collection([
-            'foo' => [new NotNull(), new Range(['min' => 3])],
-            'bar' => new Range(['min' => 5]),
+        $expected->addPropertyConstraint('firstName', new Range(min: 3));
+        $expected->addPropertyConstraint('firstName', new All(constraints: [new NotNull(), new Range(min: 3)]));
+        $expected->addPropertyConstraint('firstName', new All(constraints: [new NotNull(), new Range(min: 3)]));
+        $expected->addPropertyConstraint('firstName', new Collection(fields: [
+            'foo' => [new NotNull(), new Range(min: 3)],
+            'bar' => new Range(min: 5),
             'baz' => new Required([new Email()]),
             'qux' => new Optional([new NotBlank()]),
-        ], null, null, true));
-        $expected->addPropertyConstraint('firstName', new Choice([
-            'message' => 'Must be one of %choices%',
-            'choices' => ['A', 'B'],
-        ]));
+        ], allowExtraFields: true));
+        $expected->addPropertyConstraint('firstName', new Choice(
+            message: 'Must be one of %choices%',
+            choices: ['A', 'B'],
+        ));
         $expected->addPropertyConstraint('firstName', new AtLeastOneOf([
             new NotNull(),
-            new Range(['min' => 3]),
+            new Range(min: 3),
         ], null, null, 'foo', null, false));
         $expected->addPropertyConstraint('firstName', new Sequentially([
             new NotBlank(),
-            new Range(['min' => 5]),
+            new Range(min: 5),
         ]));
         $expected->addPropertyConstraint('childA', new Valid());
         $expected->addPropertyConstraint('childB', new Valid());

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/Fixtures/ConstraintWithoutNamedArguments.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/Fixtures/ConstraintWithoutNamedArguments.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+
+class ConstraintWithoutNamedArguments extends Constraint
+{
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Mapping\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Choice;
@@ -29,6 +30,7 @@ use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
+use Symfony\Component\Validator\Tests\Fixtures\DummyEntityConstraintWithoutNamedArguments;
 use Symfony\Component\Validator\Tests\Fixtures\Entity_81;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\GroupSequenceProviderEntity;
@@ -37,6 +39,8 @@ use Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithoutV
 
 class XmlFileLoaderTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
         $loader = new XmlFileLoader(__DIR__.'/constraint-mapping.xml');
@@ -72,18 +76,18 @@ class XmlFileLoaderTest extends TestCase
         $expected->addConstraint(new ConstraintWithNamedArguments(['foo', 'bar']));
         $expected->addConstraint(new ConstraintWithoutValueWithNamedArguments(['foo']));
         $expected->addPropertyConstraint('firstName', new NotNull());
-        $expected->addPropertyConstraint('firstName', new Range(['min' => 3]));
+        $expected->addPropertyConstraint('firstName', new Range(min: 3));
         $expected->addPropertyConstraint('firstName', new Choice(['A', 'B']));
-        $expected->addPropertyConstraint('firstName', new All([new NotNull(), new Range(['min' => 3])]));
-        $expected->addPropertyConstraint('firstName', new All(['constraints' => [new NotNull(), new Range(['min' => 3])]]));
-        $expected->addPropertyConstraint('firstName', new Collection(['fields' => [
-            'foo' => [new NotNull(), new Range(['min' => 3])],
-            'bar' => [new Range(['min' => 5])],
-        ]]));
-        $expected->addPropertyConstraint('firstName', new Choice([
-            'message' => 'Must be one of %choices%',
-            'choices' => ['A', 'B'],
+        $expected->addPropertyConstraint('firstName', new All(constraints: [new NotNull(), new Range(min: 3)]));
+        $expected->addPropertyConstraint('firstName', new All(constraints: [new NotNull(), new Range(min: 3)]));
+        $expected->addPropertyConstraint('firstName', new Collection(fields: [
+            'foo' => [new NotNull(), new Range(min: 3)],
+            'bar' => [new Range(min: 5)],
         ]));
+        $expected->addPropertyConstraint('firstName', new Choice(
+            message: 'Must be one of %choices%',
+            choices: ['A', 'B'],
+        ));
         $expected->addGetterConstraint('lastName', new NotNull());
         $expected->addGetterConstraint('valid', new IsTrue());
         $expected->addGetterConstraint('permissions', new IsTrue());
@@ -99,7 +103,7 @@ class XmlFileLoaderTest extends TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected = new ClassMetadata(Entity::class);
-        $expected->addPropertyConstraint('firstName', new Regex(['pattern' => '/^1/', 'match' => false]));
+        $expected->addPropertyConstraint('firstName', new Regex(pattern: '/^1/', match: false));
 
         $properties = $metadata->getPropertyMetadata('firstName');
         $constraints = $properties[0]->getConstraints();
@@ -170,5 +174,18 @@ class XmlFileLoaderTest extends TestCase
             $this->expectException(MappingException::class);
             $loader->loadClassMetadata($metadata);
         }
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLoadConstraintWithoutNamedArgumentsSupport()
+    {
+        $loader = new XmlFileLoader(__DIR__.'/constraint-without-named-arguments-support.xml');
+        $metadata = new ClassMetadata(DummyEntityConstraintWithoutNamedArguments::class);
+
+        $this->expectUserDeprecationMessage('Since symfony/validator 7.2: Using constraints not supporting named arguments is deprecated. Try adding the HasNamedArguments attribute to Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithoutNamedArguments.');
+
+        $loader->loadClassMetadata($metadata);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-without-named-arguments-support.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-without-named-arguments-support.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+    <class name="Symfony\Component\Validator\Tests\Fixtures\DummyEntityConstraintWithoutNamedArguments">
+        <constraint name="Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithoutNamedArguments">
+            <option name="groups">foo</option>
+        </constraint>
+    </class>
+</constraint-mapping>

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-without-named-arguments-support.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-without-named-arguments-support.yml
@@ -1,0 +1,4 @@
+Symfony\Component\Validator\Tests\Fixtures\DummyEntityConstraintWithoutNamedArguments:
+    constraints:
+        - Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithoutNamedArguments:
+              groups: foo

--- a/src/Symfony/Component/Validator/Tests/Mapping/MemberMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/MemberMetadataTest.php
@@ -84,7 +84,7 @@ class MemberMetadataTest extends TestCase
 
     public function testSerializeCollectionCascaded()
     {
-        $this->metadata->addConstraint(new Valid(['traverse' => true]));
+        $this->metadata->addConstraint(new Valid(traverse: true));
 
         $metadata = unserialize(serialize($this->metadata));
 
@@ -93,7 +93,7 @@ class MemberMetadataTest extends TestCase
 
     public function testSerializeCollectionNotCascaded()
     {
-        $this->metadata->addConstraint(new Valid(['traverse' => false]));
+        $this->metadata->addConstraint(new Valid(traverse: false));
 
         $metadata = unserialize(serialize($this->metadata));
 

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -113,10 +113,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $constraint = new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]);
+        $constraint = new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        );
 
         $violations = $this->validate('Bernhard', $constraint, 'Group');
 
@@ -149,10 +149,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -188,10 +188,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addPropertyConstraint('firstName', new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addPropertyConstraint('firstName', new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -227,10 +227,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addGetterConstraint('lastName', new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addGetterConstraint('lastName', new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -264,10 +264,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($array, null, 'Group');
 
@@ -301,10 +301,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($array, null, 'Group');
 
@@ -338,10 +338,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($traversable, null, 'Group');
 
@@ -377,10 +377,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($traversable, null, 'Group');
 
@@ -415,10 +415,10 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadata->addPropertyConstraint('reference', new Valid());
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -456,10 +456,10 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadata->addPropertyConstraint('reference', new Valid());
-        $this->referenceMetadata->addPropertyConstraint('value', new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addPropertyConstraint('value', new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -497,10 +497,10 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadata->addPropertyConstraint('reference', new Valid());
-        $this->referenceMetadata->addPropertyConstraint('privateValue', new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addPropertyConstraint('privateValue', new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -563,10 +563,10 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadata->$constraintMethod('reference', new Valid());
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -604,10 +604,10 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadata->$constraintMethod('reference', new Valid());
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -632,14 +632,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addPropertyConstraint('reference', new Callback([
-            'callback' => function () {},
-            'groups' => 'Group',
-        ]));
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addPropertyConstraint('reference', new Callback(
+            callback: function () {},
+            groups: ['Group'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -659,9 +659,9 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->$constraintMethod('reference', new Valid([
-            'traverse' => false,
-        ]));
+        $this->metadata->$constraintMethod('reference', new Valid(
+            traverse: false,
+        ));
         $this->referenceMetadata->addConstraint(new Callback($callback));
 
         $violations = $this->validate($entity);
@@ -682,9 +682,9 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->$constraintMethod('reference', new Valid([
-            'traverse' => false,
-        ]));
+        $this->metadata->$constraintMethod('reference', new Valid(
+            traverse: false,
+        ));
 
         $this->referenceMetadata->addConstraint(new Callback($callback));
 
@@ -745,10 +745,10 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadata->addPropertyConstraint('reference', new Valid());
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -774,9 +774,9 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadataFactory->addMetadata(new ClassMetadata('ArrayIterator'));
-        $this->metadata->addPropertyConstraint('reference', new Valid([
-            'traverse' => false,
-        ]));
+        $this->metadata->addPropertyConstraint('reference', new Valid(
+            traverse: false,
+        ));
         $this->referenceMetadata->addConstraint(new Callback($callback));
 
         $violations = $this->validate($entity);
@@ -790,9 +790,9 @@ class RecursiveValidatorTest extends TestCase
         $entity = new Entity();
         $entity->reference = new \ArrayIterator();
 
-        $this->metadata->addPropertyConstraint('reference', new Valid([
-            'traverse' => false,
-        ]));
+        $this->metadata->addPropertyConstraint('reference', new Valid(
+            traverse: false,
+        ));
 
         $this->expectException(NoSuchMetadataException::class);
 
@@ -819,13 +819,13 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addPropertyConstraint('reference', new Valid([
-            'traverse' => true,
-        ]));
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addPropertyConstraint('reference', new Valid(
+            traverse: true,
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group');
 
@@ -866,14 +866,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Other violation');
         };
 
-        $this->metadata->addPropertyConstraint('firstName', new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group',
-        ]));
-        $this->metadata->addPropertyConstraint('lastName', new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addPropertyConstraint('firstName', new Callback(
+            callback: $callback1,
+            groups: ['Group'],
+        ));
+        $this->metadata->addPropertyConstraint('lastName', new Callback(
+            callback: $callback2,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validateProperty($entity, 'firstName', 'Group');
 
@@ -924,14 +924,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Other violation');
         };
 
-        $this->metadata->addPropertyConstraint('firstName', new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group',
-        ]));
-        $this->metadata->addPropertyConstraint('lastName', new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addPropertyConstraint('firstName', new Callback(
+            callback: $callback1,
+            groups: ['Group'],
+        ));
+        $this->metadata->addPropertyConstraint('lastName', new Callback(
+            callback: $callback2,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validatePropertyValue(
             $entity,
@@ -973,14 +973,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Other violation');
         };
 
-        $this->metadata->addPropertyConstraint('firstName', new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group',
-        ]));
-        $this->metadata->addPropertyConstraint('lastName', new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addPropertyConstraint('firstName', new Callback(
+            callback: $callback1,
+            groups: ['Group'],
+        ));
+        $this->metadata->addPropertyConstraint('lastName', new Callback(
+            callback: $callback2,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validatePropertyValue(
             self::ENTITY_CLASS,
@@ -1060,14 +1060,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message');
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group 1',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group 2',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group 1'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group 2'],
+        ));
 
         $violations = $this->validate($entity, null, 'Group 2');
 
@@ -1083,14 +1083,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message');
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group 1',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group 2',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group 1'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group 2'],
+        ));
 
         $violations = $this->validate($entity, null, ['Group 1', 'Group 2']);
 
@@ -1109,18 +1109,18 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Violation in Group 3');
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => function () {},
-            'groups' => 'Group 1',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group 2',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group 3',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: function () {},
+            groups: ['Group 1'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Group 2'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 3'],
+        ));
 
         $sequence = new GroupSequence(['Group 1', 'Group 2', 'Group 3', 'Entity']);
         $this->metadata->setGroupSequence($sequence);
@@ -1143,18 +1143,18 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Violation in Group 3');
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => function () {},
-            'groups' => 'Group 1',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group 2',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group 3',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: function () {},
+            groups: ['Group 1'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Group 2'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 3'],
+        ));
 
         $sequence = ['Group 1', 'Group 2', 'Group 3', 'Entity'];
         $this->metadata->setGroupSequence($sequence);
@@ -1179,14 +1179,14 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadata->addPropertyConstraint('reference', new Valid());
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Default',
-        ]));
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group 1',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Default'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 1'],
+        ));
 
         $sequence = new GroupSequence(['Group 1', 'Entity']);
         $this->metadata->setGroupSequence($sequence);
@@ -1209,14 +1209,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Violation in group sequence');
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Other Group',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group 1',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Other Group'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 1'],
+        ));
 
         $sequence = new GroupSequence(['Group 1', 'Entity']);
         $this->metadata->setGroupSequence($sequence);
@@ -1243,18 +1243,18 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $metadata = new ClassMetadata($entity::class);
-        $metadata->addConstraint(new Callback([
-            'callback' => function () {},
-            'groups' => 'Group 1',
-        ]));
-        $metadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group 2',
-        ]));
-        $metadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group 3',
-        ]));
+        $metadata->addConstraint(new Callback(
+            callback: function () {},
+            groups: ['Group 1'],
+        ));
+        $metadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Group 2'],
+        ));
+        $metadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 3'],
+        ));
         $metadata->setGroupSequenceProvider(true);
 
         $this->metadataFactory->addMetadata($metadata);
@@ -1348,18 +1348,18 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message 2');
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => function () {},
-            'groups' => 'Group 1',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group 2',
-        ]));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group 3',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: function () {},
+            groups: ['Group 1'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Group 2'],
+        ));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 3'],
+        ));
 
         $sequence = new GroupSequence(['Group 1', 'Group 2', 'Group 3']);
         $violations = $this->validator->validate($entity, new Valid(), $sequence);
@@ -1382,14 +1382,14 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadata->addPropertyConstraint('reference', new Valid());
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group 1',
-        ]));
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group 2',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Group 1'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 2'],
+        ));
 
         $sequence = new GroupSequence(['Group 1', 'Entity']);
         $violations = $this->validator->validate($entity, new Valid(), $sequence);
@@ -1442,14 +1442,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group',
-        ]));
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Group'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validator->validate($entity, new Valid(), 'Group');
 
@@ -1498,14 +1498,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group',
-        ]));
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Group'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validator->validate($entity, new Valid(), 'Group');
 
@@ -1561,14 +1561,14 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message %param%', ['%param%' => 'value']);
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback1,
-            'groups' => 'Group',
-        ]));
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback2,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Group'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validator->validate($entity, new Valid(), 'Group');
 
@@ -1603,10 +1603,10 @@ class RecursiveValidatorTest extends TestCase
         };
 
         $this->metadataFactory->addMetadata(new ClassMetadata('ArrayIterator'));
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($traversable, new Valid(), 'Group');
 
@@ -1635,10 +1635,10 @@ class RecursiveValidatorTest extends TestCase
         $traversableMetadata->addConstraint(new Traverse(true));
 
         $this->metadataFactory->addMetadata($traversableMetadata);
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($traversable, new Valid(), 'Group');
 
@@ -1659,10 +1659,10 @@ class RecursiveValidatorTest extends TestCase
         $traversableMetadata->addConstraint(new Traverse(false));
 
         $this->metadataFactory->addMetadata($traversableMetadata);
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($traversable, new Valid(), 'Group');
 
@@ -1692,10 +1692,10 @@ class RecursiveValidatorTest extends TestCase
         $traversableMetadata->addConstraint(new Traverse(false));
 
         $this->metadataFactory->addMetadata($traversableMetadata);
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
         $this->metadata->addPropertyConstraint('reference', new Valid());
 
         $violations = $this->validate($entity, new Valid(), 'Group');
@@ -1717,13 +1717,13 @@ class RecursiveValidatorTest extends TestCase
         $traversableMetadata->addConstraint(new Traverse(false));
 
         $this->metadataFactory->addMetadata($traversableMetadata);
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
-        $this->metadata->addPropertyConstraint('reference', new Valid([
-            'traverse' => true,
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
+        $this->metadata->addPropertyConstraint('reference', new Valid(
+            traverse: true,
+        ));
 
         $violations = $this->validate($entity, new Valid(), 'Group');
 
@@ -1744,13 +1744,13 @@ class RecursiveValidatorTest extends TestCase
         $traversableMetadata->addConstraint(new Traverse(true));
 
         $this->metadataFactory->addMetadata($traversableMetadata);
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
-        $this->metadata->addPropertyConstraint('reference', new Valid([
-            'traverse' => false,
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
+        $this->metadata->addPropertyConstraint('reference', new Valid(
+            traverse: false,
+        ));
 
         $violations = $this->validate($entity, new Valid(), 'Group');
 
@@ -1767,10 +1767,10 @@ class RecursiveValidatorTest extends TestCase
             $this->fail('Should not be called');
         };
 
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, new Valid(), 'Group');
 
@@ -1789,10 +1789,10 @@ class RecursiveValidatorTest extends TestCase
             $this->fail('Should not be called');
         };
 
-        $this->referenceMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $violations = $this->validate($entity, new Valid(), 'Group');
 
@@ -1816,10 +1816,10 @@ class RecursiveValidatorTest extends TestCase
         $cascadingMetadata->addConstraint(new Cascade());
 
         $cascadedMetadata = new ClassMetadata(CascadedChild::class);
-        $cascadedMetadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => 'Group',
-        ]));
+        $cascadedMetadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group'],
+        ));
 
         $this->metadataFactory->addMetadata($cascadingMetadata);
         $this->metadataFactory->addMetadata($cascadedMetadata);
@@ -1868,10 +1868,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message');
         };
 
-        $this->metadata->addConstraint(new Callback([
-            'callback' => $callback,
-            'groups' => ['Group 1', 'Group 2'],
-        ]));
+        $this->metadata->addConstraint(new Callback(
+            callback: $callback,
+            groups: ['Group 1', 'Group 2'],
+        ));
 
         $violations = $this->validator->validate($entity, new Valid(), ['Group 1', 'Group 2']);
 
@@ -1887,10 +1887,10 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Message');
         };
 
-        $this->metadata->addPropertyConstraint('firstName', new Callback([
-            'callback' => $callback,
-            'groups' => ['Group 1', 'Group 2'],
-        ]));
+        $this->metadata->addPropertyConstraint('firstName', new Callback(
+            callback: $callback,
+            groups: ['Group 1', 'Group 2'],
+        ));
 
         $violations = $this->validator->validate($entity, new Valid(), ['Group 1', 'Group 2']);
 
@@ -2007,8 +2007,8 @@ class RecursiveValidatorTest extends TestCase
         $reference->value = '';
         $entity->childA = $reference;
 
-        $this->metadata->addPropertyConstraint('firstName', new NotBlank(['groups' => 'group1']));
-        $this->metadata->addPropertyConstraint('childA', new Valid(['groups' => 'group1']));
+        $this->metadata->addPropertyConstraint('firstName', new NotBlank(groups: ['group1']));
+        $this->metadata->addPropertyConstraint('childA', new Valid(groups: ['group1']));
         $this->referenceMetadata->addPropertyConstraint('value', new NotBlank());
 
         $violations = $this->validator->validate($entity, null, []);
@@ -2024,9 +2024,9 @@ class RecursiveValidatorTest extends TestCase
         $reference->value = '';
         $entity->childA = $reference;
 
-        $this->metadata->addPropertyConstraint('firstName', new NotBlank(['groups' => 'group1']));
-        $this->metadata->addPropertyConstraint('childA', new Valid(['groups' => 'group1']));
-        $this->referenceMetadata->addPropertyConstraint('value', new NotBlank(['groups' => 'group1']));
+        $this->metadata->addPropertyConstraint('firstName', new NotBlank(groups: ['group1']));
+        $this->metadata->addPropertyConstraint('childA', new Valid(groups: ['group1']));
+        $this->referenceMetadata->addPropertyConstraint('value', new NotBlank(groups: ['group1']));
 
         $violations = $this->validator->validate($entity, null, ['Default', 'group1']);
 
@@ -2044,10 +2044,10 @@ class RecursiveValidatorTest extends TestCase
         $entity->childA = $reference;
 
         $this->metadata->addPropertyConstraint('firstName', new NotBlank());
-        $this->metadata->addPropertyConstraint('childA', new Valid(['groups' => ['group1', 'group2']]));
+        $this->metadata->addPropertyConstraint('childA', new Valid(groups: ['group1', 'group2']));
 
-        $this->referenceMetadata->addPropertyConstraint('value', new NotBlank(['groups' => 'group1']));
-        $this->referenceMetadata->addPropertyConstraint('value', new NotNull(['groups' => 'group2']));
+        $this->referenceMetadata->addPropertyConstraint('value', new NotBlank(groups: ['group1']));
+        $this->referenceMetadata->addPropertyConstraint('value', new NotNull(groups: ['group2']));
 
         $violations = $this->validator->validate($entity, null, ['Default', 'group1', 'group2']);
 
@@ -2136,10 +2136,10 @@ class RecursiveValidatorTest extends TestCase
 
     public function testCollectionConstraintValidateAllGroupsForNestedConstraints()
     {
-        $this->metadata->addPropertyConstraint('data', new Collection(['fields' => [
-            'one' => [new NotBlank(['groups' => 'one']), new Length(['min' => 2, 'groups' => 'two'])],
-            'two' => [new NotBlank(['groups' => 'two'])],
-        ]]));
+        $this->metadata->addPropertyConstraint('data', new Collection(fields: [
+            'one' => [new NotBlank(groups: ['one']), new Length(min: 2, groups: ['two'])],
+            'two' => [new NotBlank(groups: ['two'])],
+        ]));
 
         $entity = new Entity();
         $entity->data = ['one' => 't', 'two' => ''];
@@ -2154,9 +2154,9 @@ class RecursiveValidatorTest extends TestCase
     public function testGroupedMethodConstraintValidateInSequence()
     {
         $metadata = new ClassMetadata(EntityWithGroupedConstraintOnMethods::class);
-        $metadata->addPropertyConstraint('bar', new NotNull(['groups' => 'Foo']));
-        $metadata->addGetterMethodConstraint('validInFoo', 'isValidInFoo', new IsTrue(['groups' => 'Foo']));
-        $metadata->addGetterMethodConstraint('bar', 'getBar', new NotNull(['groups' => 'Bar']));
+        $metadata->addPropertyConstraint('bar', new NotNull(groups: ['Foo']));
+        $metadata->addGetterMethodConstraint('validInFoo', 'isValidInFoo', new IsTrue(groups: ['Foo']));
+        $metadata->addGetterMethodConstraint('bar', 'getBar', new NotNull(groups: ['Bar']));
 
         $this->metadataFactory->addMetadata($metadata);
 
@@ -2197,10 +2197,13 @@ class RecursiveValidatorTest extends TestCase
 
     public function testAllConstraintValidateAllGroupsForNestedConstraints()
     {
-        $this->metadata->addPropertyConstraint('data', new All(['constraints' => [
-            new NotBlank(['groups' => 'one']),
-            new Length(['min' => 2, 'groups' => 'two']),
-        ]]));
+        $this->metadata->addPropertyConstraint('data', new All(constraints: [
+            new NotBlank(groups: ['one']),
+            new Length(
+                min: 2,
+                groups: ['two'],
+            ),
+        ]));
 
         $entity = new Entity();
         $entity->data = ['one' => 't', 'two' => ''];
@@ -2330,8 +2333,8 @@ class RecursiveValidatorTest extends TestCase
     public function testValidatedConstraintsHashesDoNotCollide()
     {
         $metadata = new ClassMetadata(Entity::class);
-        $metadata->addPropertyConstraint('initialized', new NotNull(['groups' => 'should_pass']));
-        $metadata->addPropertyConstraint('initialized', new IsNull(['groups' => 'should_fail']));
+        $metadata->addPropertyConstraint('initialized', new NotNull(groups: ['should_pass']));
+        $metadata->addPropertyConstraint('initialized', new IsNull(groups: ['should_fail']));
 
         $this->metadataFactory->addMetadata($metadata);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #51393
| License       | MIT
