### PR TITLE
Remove calls to `getMockForAbstractClass()`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -233,14 +233,11 @@ class EntityUserProviderTest extends TestCase
 
     private function getObjectManager($repository)
     {
-        $em = $this->getMockBuilder(ObjectManager::class)
-            ->onlyMethods(['getClassMetadata', 'getRepository'])
-            ->getMockForAbstractClass();
-        $em->expects($this->any())
-            ->method('getRepository')
+        $objectManager = $this->createMock(ObjectManager::class);
+        $objectManager->method('getRepository')
             ->willReturn($repository);
 
-        return $em;
+        return $objectManager;
     }
 
     private function createSchema($em)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -145,7 +145,12 @@ class AbstractFactoryTest extends TestCase
 
     protected function callFactory($id, $config, $userProviderId, $defaultEntryPointId)
     {
-        $factory = $this->getMockForAbstractClass(AbstractFactory::class);
+        $factory = $this->getMockBuilder(AbstractFactory::class)->onlyMethods([
+            'createAuthProvider',
+            'getListenerId',
+            'getKey',
+            'getPosition',
+        ])->getMock();
 
         $factory
             ->expects($this->once())

--- a/src/Symfony/Component/Config/Tests/Definition/BaseNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BaseNodeTest.php
@@ -36,7 +36,36 @@ class BaseNodeTest extends TestCase
             }
         }
 
-        $node = $this->getMockForAbstractClass(BaseNode::class, $constructorArgs);
+        $node = new class(...$constructorArgs) extends BaseNode {
+            protected function validateType($value): void
+            {
+            }
+
+            protected function normalizeValue($value)
+            {
+                return null;
+            }
+
+            protected function mergeValues($leftSide, $rightSide)
+            {
+                return null;
+            }
+
+            protected function finalizeValue($value)
+            {
+                return null;
+            }
+
+            public function hasDefaultValue(): bool
+            {
+                return true;
+            }
+
+            public function getDefaultValue()
+            {
+                return null;
+            }
+        };
 
         $this->assertSame($expected, $node->getPath());
     }

--- a/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
@@ -157,7 +157,7 @@ class QuestionTest extends TestCase
     public function testSetAutocompleterValuesWithTraversable()
     {
         $question1 = new Question('Test question 1');
-        $iterator1 = $this->getMockForAbstractClass(\IteratorAggregate::class);
+        $iterator1 = $this->createMock(\IteratorAggregate::class);
         $iterator1
             ->expects($this->once())
             ->method('getIterator')
@@ -165,7 +165,7 @@ class QuestionTest extends TestCase
         $question1->setAutocompleterValues($iterator1);
 
         $question2 = new Question('Test question 2');
-        $iterator2 = $this->getMockForAbstractClass(\IteratorAggregate::class);
+        $iterator2 = $this->createMock(\IteratorAggregate::class);
         $iterator2
             ->expects($this->once())
             ->method('getIterator')

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -29,7 +29,7 @@ class AbstractProxyTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->proxy = $this->getMockForAbstractClass(AbstractProxy::class);
+        $this->proxy = new class() extends AbstractProxy {};
     }
 
     protected function tearDown(): void

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionFactory;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorageFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorageFactory;
@@ -338,7 +339,13 @@ class SessionListenerTest extends TestCase
 
     public function testOnlyTriggeredOnMainRequest()
     {
-        $listener = $this->getMockForAbstractClass(AbstractSessionListener::class);
+        $listener = new class() extends AbstractSessionListener {
+            protected function getSession(): ?SessionInterface
+            {
+                return null;
+            }
+        };
+
         $event = $this->createMock(RequestEvent::class);
         $event->expects($this->once())->method('isMainRequest')->willReturn(false);
         $event->expects($this->never())->method('getRequest');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -45,11 +45,21 @@ class TestSessionListenerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->listener = $this->getMockForAbstractClass(AbstractTestSessionListener::class);
         $this->session = $this->getSession();
-        $this->listener->expects($this->any())
-             ->method('getSession')
-             ->willReturn($this->session);
+        $this->listener = new class($this->session) extends AbstractTestSessionListener {
+            private $session;
+
+            public function __construct($session)
+            {
+                parent::__construct();
+                $this->session = $session;
+            }
+
+            public function getSession(): ?SessionInterface
+            {
+                return $this->session;
+            }
+        };
     }
 
     public function testShouldSaveMainRequestSession()

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
@@ -75,7 +75,7 @@ class RoutableFragmentRendererTest extends TestCase
 
     private function callGenerateFragmentUriMethod(ControllerReference $reference, Request $request, $absolute = false)
     {
-        $renderer = $this->getMockForAbstractClass(RoutableFragmentRenderer::class);
+        $renderer = $this->createStub(RoutableFragmentRenderer::class);
         $r = new \ReflectionObject($renderer);
         $m = $r->getMethod('generateFragmentUri');
         $m->setAccessible(true);

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -400,7 +400,7 @@ EOF
         $kernel
             ->expects($this->exactly(2))
             ->method('getBundle')
-            ->willReturn($this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle', null, null, 'Bundle1Bundle'))
+            ->willReturn($this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle', null, 'Bundle1Bundle'))
         ;
 
         $this->assertEquals(
@@ -417,8 +417,8 @@ EOF
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Trying to register two bundles with the same name "DuplicateName"');
-        $fooBundle = $this->getBundle(__DIR__.'/Fixtures/FooBundle', null, 'FooBundle', 'DuplicateName');
-        $barBundle = $this->getBundle(__DIR__.'/Fixtures/BarBundle', null, 'BarBundle', 'DuplicateName');
+        $fooBundle = $this->getBundle(__DIR__.'/Fixtures/FooBundle', 'FooBundle', 'DuplicateName');
+        $barBundle = $this->getBundle(__DIR__.'/Fixtures/BarBundle', 'BarBundle', 'DuplicateName');
 
         $kernel = $this->getKernel([], [$fooBundle, $barBundle]);
         $kernel->boot();
@@ -628,11 +628,10 @@ EOF
     /**
      * Returns a mock for the BundleInterface.
      */
-    protected function getBundle($dir = null, $parent = null, $className = null, $bundleName = null): BundleInterface
+    protected function getBundle($dir = null, $className = null, $bundleName = null): BundleInterface
     {
         $bundle = $this
             ->getMockBuilder(BundleInterface::class)
-            ->onlyMethods(['getPath', 'getName'])
             ->disableOriginalConstructor()
         ;
 
@@ -640,7 +639,7 @@ EOF
             $bundle->setMockClassName($className);
         }
 
-        $bundle = $bundle->getMockForAbstractClass();
+        $bundle = $bundle->getMock();
 
         $bundle
             ->expects($this->any())

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -158,7 +158,7 @@ class SmtpTransportTest extends TestCase
 
     private function invokeAssertResponseCode(string $response, array $codes): void
     {
-        $transport = new SmtpTransport($this->getMockForAbstractClass(AbstractStream::class));
+        $transport = new SmtpTransport($this->createStub(AbstractStream::class));
         $m = new \ReflectionMethod($transport, 'assertResponseCode');
         $m->setAccessible(true);
         $m->invoke($transport, $response, $codes);

--- a/src/Symfony/Component/Routing/Tests/Loader/AbstractAnnotationLoaderTestCase.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AbstractAnnotationLoaderTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+use Symfony\Component\Routing\Route;
 
 abstract class AbstractAnnotationLoaderTestCase extends TestCase
 {
@@ -26,9 +27,10 @@ abstract class AbstractAnnotationLoaderTestCase extends TestCase
 
     public function getClassLoader($reader)
     {
-        return $this->getMockBuilder(AnnotationClassLoader::class)
-            ->setConstructorArgs([$reader])
-            ->getMockForAbstractClass()
-        ;
+        return new class($reader) extends AnnotationClassLoader {
+            protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
+            {
+            }
+        };
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -211,6 +211,9 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
 
     protected function getUrlMatcher(RouteCollection $routes, ?RequestContext $context = null)
     {
-        return $this->getMockForAbstractClass(RedirectableUrlMatcher::class, [$routes, $context ?? new RequestContext()]);
+        return $this->getMockBuilder(RedirectableUrlMatcher::class)
+            ->setConstructorArgs([$routes, $context ?? new RequestContext()])
+            ->onlyMethods(['redirect'])
+            ->getMock();
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -250,6 +250,9 @@ class UserAuthenticationProviderTest extends TestCase
             $userChecker = $this->createMock(UserCheckerInterface::class);
         }
 
-        return $this->getMockForAbstractClass(UserAuthenticationProvider::class, [$userChecker, 'key', $hide]);
+        return $this->getMockBuilder(UserAuthenticationProvider::class)
+            ->setConstructorArgs([$userChecker, 'key', $hide])
+            ->onlyMethods(['retrieveUser', 'checkAuthentication'])
+            ->getMock();
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -179,7 +179,8 @@ class AccessDecisionManagerTest extends TestCase
     public function testCacheableVoters()
     {
         $token = $this->createMock(TokenInterface::class);
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
+
         $voter
             ->expects($this->once())
             ->method('supportsAttribute')
@@ -203,7 +204,7 @@ class AccessDecisionManagerTest extends TestCase
     public function testCacheableVotersIgnoresNonStringAttributes()
     {
         $token = $this->createMock(TokenInterface::class);
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->never())
             ->method('supportsAttribute');
@@ -225,7 +226,7 @@ class AccessDecisionManagerTest extends TestCase
     public function testCacheableVotersWithMultipleAttributes()
     {
         $token = $this->createMock(TokenInterface::class);
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->exactly(2))
             ->method('supportsAttribute')
@@ -258,7 +259,7 @@ class AccessDecisionManagerTest extends TestCase
     public function testCacheableVotersWithEmptyAttributes()
     {
         $token = $this->createMock(TokenInterface::class);
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->never())
             ->method('supportsAttribute');
@@ -280,7 +281,7 @@ class AccessDecisionManagerTest extends TestCase
     public function testCacheableVotersSupportsMethodsCalledOnce()
     {
         $token = $this->createMock(TokenInterface::class);
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->once())
             ->method('supportsAttribute')
@@ -305,7 +306,7 @@ class AccessDecisionManagerTest extends TestCase
     public function testCacheableVotersNotCalled()
     {
         $token = $this->createMock(TokenInterface::class);
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->once())
             ->method('supportsAttribute')
@@ -325,7 +326,7 @@ class AccessDecisionManagerTest extends TestCase
     public function testCacheableVotersWithMultipleAttributesAndNonString()
     {
         $token = $this->createMock(TokenInterface::class);
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->once())
             ->method('supportsAttribute')

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/TraceableVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/TraceableVoterTest.php
@@ -23,18 +23,18 @@ class TraceableVoterTest extends TestCase
 {
     public function testGetDecoratedVoterClass()
     {
-        $voter = $this->getMockBuilder(VoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createStub(VoterInterface::class);
 
-        $sut = new TraceableVoter($voter, $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass());
+        $sut = new TraceableVoter($voter, $this->createStub(EventDispatcherInterface::class));
         $this->assertSame($voter, $sut->getDecoratedVoter());
     }
 
     public function testVote()
     {
-        $voter = $this->getMockBuilder(VoterInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(VoterInterface::class);
 
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
-        $token = $this->getMockBuilder(TokenInterface::class)->getMockForAbstractClass();
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $token = $this->createStub(TokenInterface::class);
 
         $voter
             ->expects($this->once())
@@ -55,8 +55,8 @@ class TraceableVoterTest extends TestCase
 
     public function testSupportsAttributeOnCacheable()
     {
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
 
         $voter
             ->expects($this->once())
@@ -71,8 +71,8 @@ class TraceableVoterTest extends TestCase
 
     public function testSupportsTypeOnCacheable()
     {
-        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
+        $voter = $this->createMock(CacheableVoterInterface::class);
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
 
         $voter
             ->expects($this->once())
@@ -87,8 +87,8 @@ class TraceableVoterTest extends TestCase
 
     public function testSupportsAttributeOnNonCacheable()
     {
-        $voter = $this->getMockBuilder(VoterInterface::class)->getMockForAbstractClass();
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
+        $voter = $this->createStub(VoterInterface::class);
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
 
         $sut = new TraceableVoter($voter, $eventDispatcher);
 
@@ -97,8 +97,8 @@ class TraceableVoterTest extends TestCase
 
     public function testSupportsTypeOnNonCacheable()
     {
-        $voter = $this->getMockBuilder(VoterInterface::class)->getMockForAbstractClass();
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
+        $voter = $this->createStub(VoterInterface::class);
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
 
         $sut = new TraceableVoter($voter, $eventDispatcher);
 

--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -252,14 +252,14 @@ class ChainUserProviderTest extends TestCase
     {
         $user = new InMemoryUser('user', 'pwd');
 
-        $provider1 = $this->getMockForAbstractClass(MigratingProvider::class);
+        $provider1 = $this->createMock(MigratingProvider::class);
         $provider1
             ->expects($this->once())
             ->method('upgradePassword')
             ->willThrowException(new UnsupportedUserException('unsupported'))
         ;
 
-        $provider2 = $this->getMockForAbstractClass(MigratingProvider::class);
+        $provider2 = $this->createMock(MigratingProvider::class);
         $provider2
             ->expects($this->once())
             ->method('upgradePassword')

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -108,7 +108,7 @@ class PasswordMigratingListenerTest extends TestCase
 
     public function testUpgradeWithUpgrader()
     {
-        $passwordUpgrader = $this->getMockForAbstractClass(TestMigratingUserProvider::class);
+        $passwordUpgrader = $this->createMock(TestMigratingUserProvider::class);
         $passwordUpgrader->expects($this->once())
             ->method('upgradePassword')
             ->with($this->user, 'new-hash')
@@ -120,7 +120,7 @@ class PasswordMigratingListenerTest extends TestCase
 
     public function testUpgradeWithoutUpgrader()
     {
-        $userLoader = $this->getMockForAbstractClass(TestMigratingUserProvider::class);
+        $userLoader = $this->createMock(TestMigratingUserProvider::class);
         $userLoader->expects($this->any())->method('loadUserByIdentifier')->willReturn($this->user);
 
         $userLoader->expects($this->exactly(2))

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
@@ -56,11 +56,15 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
             ->willReturn($token)
         ;
 
-        $listener = $this->getMockForAbstractClass(AbstractPreAuthenticatedListener::class, [
-            $tokenStorage,
-            $authenticationManager,
-            'TheProviderKey',
-        ]);
+        $listener = $this->getMockBuilder(AbstractPreAuthenticatedListener::class)
+            ->setConstructorArgs([
+                $tokenStorage,
+                $authenticationManager,
+                'TheProviderKey',
+            ])
+            ->onlyMethods(['getPreAuthenticatedData'])
+            ->getMock();
+
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
@@ -95,12 +99,15 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
             ->willThrowException($exception)
         ;
 
-        $listener = $this->getMockForAbstractClass(
-            AbstractPreAuthenticatedListener::class, [
-            $tokenStorage,
-            $authenticationManager,
-            'TheProviderKey',
-        ]);
+        $listener = $this->getMockBuilder(AbstractPreAuthenticatedListener::class)
+            ->setConstructorArgs([
+                $tokenStorage,
+                $authenticationManager,
+                'TheProviderKey',
+            ])
+            ->onlyMethods(['getPreAuthenticatedData'])
+            ->getMock();
+
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
@@ -137,12 +144,15 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
             ->willThrowException($exception)
         ;
 
-        $listener = $this->getMockForAbstractClass(
-            AbstractPreAuthenticatedListener::class, [
-            $tokenStorage,
-            $authenticationManager,
-            'TheProviderKey',
-        ]);
+        $listener = $this->getMockBuilder(AbstractPreAuthenticatedListener::class)
+            ->setConstructorArgs([
+                $tokenStorage,
+                $authenticationManager,
+                'TheProviderKey',
+            ])
+            ->onlyMethods(['getPreAuthenticatedData'])
+            ->getMock();
+
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
@@ -174,12 +184,15 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
             ->method('authenticate')
         ;
 
-        $listener = $this->getMockForAbstractClass(
-            AbstractPreAuthenticatedListener::class, [
-            $tokenStorage,
-            $authenticationManager,
-            'TheProviderKey',
-        ]);
+        $listener = $this->getMockBuilder(AbstractPreAuthenticatedListener::class)
+            ->setConstructorArgs([
+                $tokenStorage,
+                $authenticationManager,
+                'TheProviderKey',
+            ])
+            ->onlyMethods(['getPreAuthenticatedData'])
+            ->getMock();
+
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
@@ -217,12 +230,15 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
             ->willThrowException($exception)
         ;
 
-        $listener = $this->getMockForAbstractClass(
-            AbstractPreAuthenticatedListener::class, [
-            $tokenStorage,
-            $authenticationManager,
-            'TheProviderKey',
-        ]);
+        $listener = $this->getMockBuilder(AbstractPreAuthenticatedListener::class)
+            ->setConstructorArgs([
+                $tokenStorage,
+                $authenticationManager,
+                'TheProviderKey',
+            ])
+            ->onlyMethods(['getPreAuthenticatedData'])
+            ->getMock();
+
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -298,9 +298,12 @@ class AbstractRememberMeServicesTest extends TestCase
             $userProvider = $this->getProvider();
         }
 
-        return $this->getMockForAbstractClass(AbstractRememberMeServices::class, [
-            [$userProvider], 'foosecret', 'fookey', $options, $logger,
-        ]);
+        return $this->getMockBuilder(AbstractRememberMeServices::class)
+            ->setConstructorArgs([
+                [$userProvider], 'foosecret', 'fookey', $options, $logger,
+            ])
+            ->onlyMethods(['processAutoLoginCookie', 'onLoginSuccess'])
+            ->getMock();
     }
 
     protected function getProvider()

--- a/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
@@ -133,7 +133,7 @@ class DelegatingEngineTest extends TestCase
 
     private function getStreamingEngineMock($template, $supports)
     {
-        $engine = $this->getMockForAbstractClass(MyStreamingEngine::class);
+        $engine = $this->createMock(MyStreamingEngine::class);
 
         $engine->expects($this->once())
             ->method('supports')

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -45,7 +45,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsUuidConstraintCompatibleType()
     {
         $this->expectException(UnexpectedTypeException::class);
-        $constraint = $this->getMockForAbstractClass(Constraint::class);
+        $constraint = $this->createStub(Constraint::class);
 
         $this->validator->validate('216fff40-98d9-11e3-a5e2-0800200c9a66', $constraint);
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/FilesLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/FilesLoaderTest.php
@@ -36,11 +36,11 @@ class FilesLoaderTest extends TestCase
 
     public function getFilesLoader(LoaderInterface $loader)
     {
-        return $this->getMockForAbstractClass(FilesLoader::class, [[
+        return new class([
             __DIR__.'/constraint-mapping.xml',
             __DIR__.'/constraint-mapping.yaml',
             __DIR__.'/constraint-mapping.test',
             __DIR__.'/constraint-mapping.txt',
-        ], $loader]);
+        ], $loader) extends FilesLoader {};
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This method is deprecated (see https://github.com/sebastianbergmann/phpunit/issues/5241), and must be replaced where used.