### PR TITLE
[Validator] detect wrong usages of minMessage/maxMessage in options

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -95,7 +95,7 @@ class Range extends Constraint
             throw new LogicException(sprintf('The "%s" constraint requires the Symfony PropertyAccess component to use the "minPropertyPath" or "maxPropertyPath" option. Try running "composer require symfony/property-access".', static::class));
         }
 
-        if (null !== $this->min && null !== $this->max && ($minMessage || $maxMessage)) {
+        if (null !== $this->min && null !== $this->max && ($minMessage || $maxMessage || isset($options['minMessage']) || isset($options['maxMessage']))) {
             throw new ConstraintDefinitionException(sprintf('The "%s" constraint can not use "minMessage" and "maxMessage" when the "min" and "max" options are both set. Use "notInRangeMessage" instead.', static::class));
         }
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeTest.php
@@ -30,7 +30,7 @@ class RangeTest extends TestCase
 
     public function testThrowsConstraintExceptionIfBothMinLimitAndPropertyPathNamed()
     {
-        $this->expectException(\Symfony\Component\Validator\Exception\ConstraintDefinitionException::class);
+        $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires only one of the "min" or "minPropertyPath" options to be set, not both.');
         new Range(min: 'min', minPropertyPath: 'minPropertyPath');
     }
@@ -47,7 +47,7 @@ class RangeTest extends TestCase
 
     public function testThrowsConstraintExceptionIfBothMaxLimitAndPropertyPathNamed()
     {
-        $this->expectException(\Symfony\Component\Validator\Exception\ConstraintDefinitionException::class);
+        $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires only one of the "max" or "maxPropertyPath" options to be set, not both.');
         new Range(max: 'max', maxPropertyPath: 'maxPropertyPath');
     }
@@ -65,10 +65,58 @@ class RangeTest extends TestCase
         new Range('value');
     }
 
-    public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMinMessageOrMaxMessage()
+    public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMinMessageAndMaxMessage()
     {
-        $this->expectException(\Symfony\Component\Validator\Exception\ConstraintDefinitionException::class);
+        $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('can not use "minMessage" and "maxMessage" when the "min" and "max" options are both set. Use "notInRangeMessage" instead.');
         new Range(min: 'min', max: 'max', minMessage: 'minMessage', maxMessage: 'maxMessage');
+    }
+
+    public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMinMessage()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('can not use "minMessage" and "maxMessage" when the "min" and "max" options are both set. Use "notInRangeMessage" instead.');
+        new Range(min: 'min', max: 'max', minMessage: 'minMessage');
+    }
+
+    public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMaxMessage()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('can not use "minMessage" and "maxMessage" when the "min" and "max" options are both set. Use "notInRangeMessage" instead.');
+        new Range(min: 'min', max: 'max', maxMessage: 'maxMessage');
+    }
+
+    public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMinMessageAndMaxMessageOptions()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('can not use "minMessage" and "maxMessage" when the "min" and "max" options are both set. Use "notInRangeMessage" instead.');
+        new Range([
+            'min' => 'min',
+            'minMessage' => 'minMessage',
+            'max' => 'max',
+            'maxMessage' => 'maxMessage',
+        ]);
+    }
+
+    public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMinMessageOptions()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('can not use "minMessage" and "maxMessage" when the "min" and "max" options are both set. Use "notInRangeMessage" instead.');
+        new Range([
+            'min' => 'min',
+            'minMessage' => 'minMessage',
+            'max' => 'max',
+        ]);
+    }
+
+    public function testThrowsConstraintDefinitionExceptionIfBothMinAndMaxAndMaxMessageOptions()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('can not use "minMessage" and "maxMessage" when the "min" and "max" options are both set. Use "notInRangeMessage" instead.');
+        new Range([
+            'min' => 'min',
+            'max' => 'max',
+            'maxMessage' => 'maxMessage',
+        ]);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -1037,30 +1037,6 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
                 'not_in_range_message',
                 Range::NOT_IN_RANGE_ERROR,
             ],
-            [
-                ['minMessage' => 'min_message'],
-                0,
-                $notInRangeMessage,
-                Range::NOT_IN_RANGE_ERROR,
-            ],
-            [
-                ['maxMessage' => 'max_message'],
-                0,
-                $notInRangeMessage,
-                Range::NOT_IN_RANGE_ERROR,
-            ],
-            [
-                ['minMessage' => 'min_message'],
-                15,
-                $notInRangeMessage,
-                Range::NOT_IN_RANGE_ERROR,
-            ],
-            [
-                ['maxMessage' => 'max_message'],
-                15,
-                $notInRangeMessage,
-                Range::NOT_IN_RANGE_ERROR,
-            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
