### PR TITLE
[ExpressionLanguage] Support non-existent names when followed by null coalescing

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add support for null-coalescing unknown variables
+
 7.1
 ---
 

--- a/src/Symfony/Component/ExpressionLanguage/Node/NullCoalescedNameNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/NullCoalescedNameNode.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Node;
+
+use Symfony\Component\ExpressionLanguage\Compiler;
+
+/**
+ * @author Adam Kiss <hello@adamkiss.com>
+ *
+ * @internal
+ */
+class NullCoalescedNameNode extends Node
+{
+    public function __construct(string $name)
+    {
+        parent::__construct(
+            [],
+            ['name' => $name]
+        );
+    }
+
+    public function compile(Compiler $compiler): void
+    {
+        $compiler->raw('$'.$this->attributes['name'].' ?? null');
+    }
+
+    public function evaluate(array $functions, array $values): null
+    {
+        return null;
+    }
+
+    public function toArray(): array
+    {
+        return [$this->attributes['name'].' ?? null'];
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -246,6 +246,10 @@ class Parser
                         } else {
                             if (!($this->flags & self::IGNORE_UNKNOWN_VARIABLES)) {
                                 if (!\in_array($token->value, $this->names, true)) {
+                                    if ($this->stream->current->test(Token::PUNCTUATION_TYPE, '??')) {
+                                        return new Node\NullCoalescedNameNode($token->value);
+                                    }
+
                                     throw new SyntaxError(sprintf('Variable "%s" is not valid.', $token->value), $token->cursor, $this->stream->getExpression(), $token->value, $this->names);
                                 }
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -433,6 +433,7 @@ class ExpressionLanguageTest extends TestCase
             }
         };
 
+        yield ['bar ?? "default"', null];
         yield ['foo.bar ?? "default"', null];
         yield ['foo.bar.baz ?? "default"', (object) ['bar' => null]];
         yield ['foo.bar ?? foo.baz ?? "default"', null];

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/NullCoalescedNameNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/NullCoalescedNameNodeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Tests\Node;
+
+use Symfony\Component\ExpressionLanguage\Node\NullCoalescedNameNode;
+
+class NullCoalescedNameNodeTest extends AbstractNodeTestCase
+{
+    public static function getEvaluateData(): array
+    {
+        return [
+            [null, new NullCoalescedNameNode('foo'), []],
+        ];
+    }
+
+    public static function getCompileData(): array
+    {
+        return [
+            ['$foo ?? null', new NullCoalescedNameNode('foo')],
+        ];
+    }
+
+    public static function getDumpData(): array
+    {
+        return [
+            ['foo ?? null', new NullCoalescedNameNode('foo')],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #54359
| License       | MIT

This PR allows for null coalescing nonexistent names (`nonexistent ?? 123`) in expressions by introducing new type of node `NullCoalescedNameNode`, which compiles to `$nonexistent ?? null`, so it subsequently evaluates to null and the null coalescing takes over then.

Edit: feature/bug is questionable, because I half-consider it a bug, since it's _one of the examples in the docs_, despite my original issue being closed as "expected", and the docs issue marked resolved despite this use case throwing while existing names resolving to null pass.