### PR TITLE
Remove calls to `onConsecutiveCalls()`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -52,7 +52,7 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
     {
         $this->connection->expects($this->exactly(1))
             ->method('isTransactionActive')
-            ->will($this->onConsecutiveCalls(true, true, false))
+            ->willReturn(true, true, false)
         ;
 
         $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -117,10 +117,7 @@ class ConsoleHandlerTest extends TestCase
         $output
             ->expects($this->exactly(2))
             ->method('getVerbosity')
-            ->willReturnOnConsecutiveCalls(
-                OutputInterface::VERBOSITY_QUIET,
-                OutputInterface::VERBOSITY_DEBUG
-            )
+            ->willReturn(OutputInterface::VERBOSITY_QUIET, OutputInterface::VERBOSITY_DEBUG)
         ;
         $handler = new ConsoleHandler($output);
         $this->assertFalse($handler->isHandling(['level' => Logger::NOTICE]),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -271,7 +271,7 @@ class TranslatorTest extends TestCase
         $loader
             ->expects($this->exactly(7))
             ->method('load')
-            ->willReturnOnConsecutiveCalls(
+            ->willReturn(
                 $this->getCatalogue('fr', [
                     'foo' => 'foo (FR)',
                 ]),

--- a/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
@@ -25,13 +25,15 @@ class FileLoaderTest extends TestCase
         $locatorMock = $this->createMock(FileLocatorInterface::class);
 
         $locatorMockForAdditionalLoader = $this->createMock(FileLocatorInterface::class);
-        $locatorMockForAdditionalLoader->expects($this->any())->method('locate')->will($this->onConsecutiveCalls(
-            ['path/to/file1'],                    // Default
-            ['path/to/file1', 'path/to/file2'],   // First is imported
-            ['path/to/file1', 'path/to/file2'],   // Second is imported
-            ['path/to/file1'],                    // Exception
-            ['path/to/file1', 'path/to/file2']    // Exception
-        ));
+        $locatorMockForAdditionalLoader->expects($this->any())
+            ->method('locate')
+            ->willReturn(
+                ['path/to/file1'],
+                ['path/to/file1', 'path/to/file2'],
+                ['path/to/file1', 'path/to/file2'],
+                ['path/to/file1'],
+                ['path/to/file1', 'path/to/file2']
+            );
 
         $fileLoader = new TestFileLoader($locatorMock);
         $fileLoader->setSupports(false);

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -76,7 +76,8 @@ class XmlUtilsTest extends TestCase
         }
 
         $mock = $this->createMock(Validator::class);
-        $mock->expects($this->exactly(2))->method('validate')->will($this->onConsecutiveCalls(false, true));
+        $mock->expects($this->exactly(2))->method('validate')
+            ->willReturn(false, true);
 
         try {
             XmlUtils::loadFile($fixtures.'valid.xml', [$mock, 'validate']);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -45,7 +45,7 @@ class SessionListenerTest extends TestCase
     public function testSessionCookieOptions(array $phpSessionOptions, array $sessionOptions, array $expectedSessionOptions)
     {
         $session = $this->createMock(Session::class);
-        $session->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->method('getUsageIndex')->willReturn(0, 1);
         $session->method('getId')->willReturn('123456');
         $session->method('getName')->willReturn('PHPSESSID');
         $session->method('save');
@@ -398,7 +398,7 @@ class SessionListenerTest extends TestCase
     public function testResponseIsPrivateIfSessionStarted()
     {
         $session = $this->createMock(Session::class);
-        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->expects($this->exactly(2))->method('getUsageIndex')->willReturn(0, 1);
 
         $container = new Container();
         $container->set('initialized_session', $session);
@@ -423,7 +423,7 @@ class SessionListenerTest extends TestCase
     public function testResponseIsStillPublicIfSessionStartedAndHeaderPresent()
     {
         $session = $this->createMock(Session::class);
-        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->expects($this->exactly(2))->method('getUsageIndex')->willReturn(0, 1);
 
         $container = new Container();
         $container->set('initialized_session', $session);
@@ -450,7 +450,7 @@ class SessionListenerTest extends TestCase
     public function testSessionSaveAndResponseHasSessionCookie()
     {
         $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
-        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->expects($this->exactly(2))->method('getUsageIndex')->willReturn(0, 1);
         $session->expects($this->exactly(1))->method('getId')->willReturn('123456');
         $session->expects($this->exactly(1))->method('getName')->willReturn('PHPSESSID');
         $session->expects($this->exactly(1))->method('save');
@@ -535,7 +535,7 @@ class SessionListenerTest extends TestCase
     public function testResponseHeadersMaxAgeAndExpiresNotBeOverridenIfSessionStarted()
     {
         $session = $this->createMock(Session::class);
-        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->expects($this->exactly(2))->method('getUsageIndex')->willReturn(0, 1);
 
         $container = new Container();
         $container->set('initialized_session', $session);
@@ -565,7 +565,7 @@ class SessionListenerTest extends TestCase
     public function testResponseHeadersMaxAgeAndExpiresDefaultValuesIfSessionStarted()
     {
         $session = $this->createMock(Session::class);
-        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->expects($this->exactly(2))->method('getUsageIndex')->willReturn(0, 1);
 
         $container = new Container();
         $container->set('initialized_session', $session);
@@ -618,7 +618,7 @@ class SessionListenerTest extends TestCase
     {
         $session = $this->createMock(Session::class);
         $session->expects($this->exactly(1))->method('getName')->willReturn('PHPSESSID');
-        $session->expects($this->exactly(4))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1, 1, 1));
+        $session->expects($this->exactly(4))->method('getUsageIndex')->willReturn(0, 1, 1, 1);
 
         $container = new Container();
         $container->set('initialized_session', $session);
@@ -715,7 +715,7 @@ class SessionListenerTest extends TestCase
     public function testSessionUsageExceptionIfStatelessAndSessionUsed()
     {
         $session = $this->createMock(Session::class);
-        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->expects($this->exactly(2))->method('getUsageIndex')->willReturn(0, 1);
 
         $container = new Container();
         $container->set('initialized_session', $session);
@@ -734,7 +734,7 @@ class SessionListenerTest extends TestCase
     public function testSessionUsageLogIfStatelessAndSessionUsed()
     {
         $session = $this->createMock(Session::class);
-        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->expects($this->exactly(2))->method('getUsageIndex')->willReturn(0, 1);
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->exactly(1))->method('warning');
@@ -759,7 +759,7 @@ class SessionListenerTest extends TestCase
         $session->expects($this->exactly(1))->method('getId')->willReturn('123456');
         $session->expects($this->exactly(1))->method('getName')->willReturn('PHPSESSID');
         $session->method('isStarted')->willReturn(true);
-        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+        $session->expects($this->exactly(2))->method('getUsageIndex')->willReturn(0, 1);
         $session->expects($this->exactly(1))->method('save');
 
         $container = new Container();

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -102,10 +102,17 @@ class InlineFragmentRendererTest extends TestCase
 
     public function testRenderExceptionIgnoreErrorsWithAlt()
     {
-        $strategy = new InlineFragmentRenderer($this->getKernel($this->onConsecutiveCalls(
-            $this->throwException(new \RuntimeException('foo')),
-            $this->returnValue(new Response('bar'))
-        )));
+        $strategy = new InlineFragmentRenderer($this->getKernel($this->returnCallback(function () {
+            static $firstCall = true;
+
+            if ($firstCall) {
+                $firstCall = false;
+
+                throw new \RuntimeException('foo');
+            }
+
+            return new Response('bar');
+        })));
 
         $this->assertEquals('bar', $strategy->render('/', Request::create('/'), ['ignore_errors' => true, 'alt' => '/foo'])->getContent());
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -245,7 +245,7 @@ class EsiTest extends TestCase
         if (\is_array($response)) {
             $cache->expects($this->any())
                   ->method('handle')
-                  ->will($this->onConsecutiveCalls(...$response))
+                  ->willReturn(...$response)
             ;
         } else {
             $cache->expects($this->any())

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -201,7 +201,7 @@ class SsiTest extends TestCase
         if (\is_array($response)) {
             $cache->expects($this->any())
                   ->method('handle')
-                  ->will($this->onConsecutiveCalls(...$response))
+                  ->willReturn(...$response)
             ;
         } else {
             $cache->expects($this->any())

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -39,7 +39,7 @@ class LockTest extends TestCase
             ->method('save');
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquire(false));
     }
@@ -55,7 +55,7 @@ class LockTest extends TestCase
             ->method('save');
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquire(false));
     }
@@ -71,7 +71,7 @@ class LockTest extends TestCase
             ->method('save');
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquire(true));
     }
@@ -93,7 +93,7 @@ class LockTest extends TestCase
             });
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquire(true));
     }
@@ -110,7 +110,7 @@ class LockTest extends TestCase
             ->willThrowException(new LockConflictedException());
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertFalse($lock->acquire(false));
     }
@@ -127,7 +127,7 @@ class LockTest extends TestCase
             ->willThrowException(new LockConflictedException());
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertFalse($lock->acquire(false));
     }
@@ -146,7 +146,7 @@ class LockTest extends TestCase
             ->method('waitAndSave');
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquire(true));
     }
@@ -166,7 +166,7 @@ class LockTest extends TestCase
             ->with($key, 10);
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $lock->acquire();
     }
@@ -183,7 +183,7 @@ class LockTest extends TestCase
             ->with($key, 10);
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $lock->refresh();
     }
@@ -200,7 +200,7 @@ class LockTest extends TestCase
             ->with($key, 20);
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $lock->refresh(20);
     }
@@ -214,7 +214,7 @@ class LockTest extends TestCase
         $store
             ->method('exists')
             ->with($key)
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->isAcquired());
     }
@@ -267,8 +267,8 @@ class LockTest extends TestCase
 
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false)
-        ;
+            ->willReturn(true, false);
+
         $store
             ->expects($this->once())
             ->method('delete')
@@ -286,8 +286,8 @@ class LockTest extends TestCase
 
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false)
-        ;
+            ->willReturn(true, false);
+
         $store
             ->expects($this->never())
             ->method('delete')
@@ -313,7 +313,8 @@ class LockTest extends TestCase
         $store
             ->expects($this->never())
             ->method('exists')
-            ->with($key);
+            ->with($key)
+            ->willReturn(true);
 
         $lock->release();
     }
@@ -426,7 +427,7 @@ class LockTest extends TestCase
             ->method('saveRead');
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquireRead(false));
     }
@@ -534,7 +535,7 @@ class LockTest extends TestCase
             ->method('waitAndSaveRead');
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquireRead(true));
     }
@@ -556,7 +557,7 @@ class LockTest extends TestCase
             });
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquireRead(true));
     }
@@ -572,7 +573,7 @@ class LockTest extends TestCase
             ->method('waitAndSave');
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquireRead(true));
     }
@@ -594,7 +595,7 @@ class LockTest extends TestCase
             });
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true, false);
 
         $this->assertTrue($lock->acquireRead(true));
     }

--- a/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
@@ -120,10 +120,18 @@ class RoundRobinTransportTest extends TestCase
     {
         $t1 = $this->createMock(TransportInterface::class);
         $t1->expects($this->exactly(3))->method('send');
+
+        $matcher = $this->exactly(2);
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->expects($this->exactly(2))
+        $t2->expects($matcher)
             ->method('send')
-            ->willReturnOnConsecutiveCalls($this->throwException(new TransportException()));
+            ->willReturnCallback(function () use ($matcher) {
+                if (1 === $matcher->getInvocationCount()) {
+                    throw new TransportException();
+                }
+
+                return null;
+            });
         $t = new RoundRobinTransport([$t1, $t2], 3);
         $p = new \ReflectionProperty($t, 'cursor');
         $p->setAccessible(true);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
@@ -31,7 +31,7 @@ class AmazonSqsSenderTest extends TestCase
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers']);
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new AmazonSqsSender($connection, $serializer);
         $sender->send($envelope);
@@ -49,7 +49,7 @@ class AmazonSqsSenderTest extends TestCase
             ->with($encoded['body'], $encoded['headers'], 0, $stamp->getMessageGroupId(), $stamp->getMessageDeduplicationId());
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new AmazonSqsSender($connection, $serializer);
         $sender->send($envelope);
@@ -67,7 +67,7 @@ class AmazonSqsSenderTest extends TestCase
             ->with($encoded['body'], $encoded['headers'], 0, null, null, $stamp->getTraceId());
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new AmazonSqsSender($connection, $serializer);
         $sender->send($envelope);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpSenderTest.php
@@ -31,7 +31,7 @@ class AmqpSenderTest extends TestCase
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('publish')->with($encoded['body'], $encoded['headers']);
@@ -61,7 +61,7 @@ class AmqpSenderTest extends TestCase
         $encoded = ['body' => '...'];
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('publish')->with($encoded['body'], []);
@@ -76,7 +76,7 @@ class AmqpSenderTest extends TestCase
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class, 'Content-Type' => 'application/json']];
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
         unset($encoded['headers']['Content-Type']);
@@ -93,7 +93,7 @@ class AmqpSenderTest extends TestCase
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class, 'Content-Type' => 'application/json']];
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
         unset($encoded['headers']['Content-Type']);
@@ -110,7 +110,7 @@ class AmqpSenderTest extends TestCase
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
         $connection->method('publish')->with($encoded['body'], $encoded['headers'])->willThrowException(new \AMQPException());

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -306,7 +306,10 @@ class ConnectionTest extends TestCase
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
         $factory->method('createExchange')->willReturn($amqpExchange);
-        $factory->method('createQueue')->will($this->onConsecutiveCalls($amqpQueue0, $amqpQueue1));
+
+        $factory
+            ->method('createQueue')
+            ->willReturn($amqpQueue0, $amqpQueue1);
 
         $amqpExchange->expects($this->once())->method('declareExchange');
         $amqpExchange->expects($this->once())->method('publish')->with('body', 'routing_key', \AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]);
@@ -358,7 +361,9 @@ class ConnectionTest extends TestCase
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
         $factory->method('createExchange')->willReturn($amqpExchange);
-        $factory->method('createQueue')->will($this->onConsecutiveCalls($amqpQueue0, $amqpQueue1));
+        $factory
+            ->method('createQueue')
+            ->willReturn($amqpQueue0, $amqpQueue1);
 
         $amqpExchange->expects($this->once())->method('declareExchange');
         $amqpExchange->expects($this->once())->method('publish')->with('body', 'routing_key', \AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]);
@@ -495,14 +500,15 @@ class ConnectionTest extends TestCase
         $factory = $this->createMock(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
-        $factory->method('createQueue')->will($this->onConsecutiveCalls(
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
-            $delayQueue = $this->createMock(\AMQPQueue::class)
-        ));
-        $factory->method('createExchange')->will($this->onConsecutiveCalls(
-            $amqpExchange = $this->createMock(\AMQPExchange::class),
-            $delayExchange = $this->createMock(\AMQPExchange::class)
-        ));
+
+        $amqpQueue = $this->createMock(\AMQPQueue::class);
+        $factory
+            ->method('createQueue')
+            ->willReturn($amqpQueue, $this->createMock(\AMQPQueue::class));
+
+        $amqpExchange = $this->createMock(\AMQPExchange::class);
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $factory->method('createExchange')->willReturn($amqpExchange, $delayExchange);
 
         $amqpExchange->expects($this->once())->method('setName')->with(self::DEFAULT_EXCHANGE_NAME);
         $amqpExchange->expects($this->once())->method('declareExchange');
@@ -553,14 +559,12 @@ class ConnectionTest extends TestCase
         $factory = $this->createMock(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
-        $factory->method('createQueue')->will($this->onConsecutiveCalls(
-            $this->createMock(\AMQPQueue::class),
-            $delayQueue = $this->createMock(\AMQPQueue::class)
-        ));
-        $factory->method('createExchange')->will($this->onConsecutiveCalls(
-            $this->createMock(\AMQPExchange::class),
-            $delayExchange = $this->createMock(\AMQPExchange::class)
-        ));
+
+        $delayQueue = $this->createMock(\AMQPQueue::class);
+        $factory->method('createQueue')->willReturn($this->createMock(\AMQPQueue::class), $delayQueue);
+
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $factory->method('createExchange')->willReturn($this->createMock(\AMQPExchange::class), $delayExchange);
 
         $connectionOptions = [
             'retry' => [
@@ -693,14 +697,12 @@ class ConnectionTest extends TestCase
         $factory = $this->createMock(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
-        $factory->method('createQueue')->will($this->onConsecutiveCalls(
-            $this->createMock(\AMQPQueue::class),
-            $delayQueue = $this->createMock(\AMQPQueue::class)
-        ));
-        $factory->method('createExchange')->will($this->onConsecutiveCalls(
-            $this->createMock(\AMQPExchange::class),
-            $delayExchange = $this->createMock(\AMQPExchange::class)
-        ));
+
+        $delayQueue = $this->createMock(\AMQPQueue::class);
+        $factory->method('createQueue')->willReturn($this->createMock(\AMQPQueue::class), $delayQueue);
+
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $factory->method('createExchange')->willReturn($this->createMock(\AMQPExchange::class), $delayExchange);
 
         $connectionOptions = [
             'retry' => [
@@ -819,14 +821,10 @@ class ConnectionTest extends TestCase
         $factory = $this->createMock(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
-        $factory->method('createQueue')->will($this->onConsecutiveCalls(
-            $this->createMock(\AMQPQueue::class),
-            $delayQueue = $this->createMock(\AMQPQueue::class)
-        ));
-        $factory->method('createExchange')->will($this->onConsecutiveCalls(
-            $this->createMock(\AMQPExchange::class),
-            $delayExchange
-        ));
+
+        $delayQueue = $this->createMock(\AMQPQueue::class);
+        $factory->method('createQueue')->willReturn($this->createMock(\AMQPQueue::class), $delayQueue);
+        $factory->method('createExchange')->willReturn($this->createMock(\AMQPExchange::class), $delayExchange);
 
         $delayQueue->expects($this->once())->method('setName')->with($delayQueueName);
         $delayQueue->expects($this->once())->method('setArguments')->with([

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdSenderTest.php
@@ -30,7 +30,7 @@ final class BeanstalkdSenderTest extends TestCase
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'], 0);
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new BeanstalkdSender($connection, $serializer);
         $sender->send($envelope);
@@ -45,7 +45,7 @@ final class BeanstalkdSenderTest extends TestCase
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'], 500);
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new BeanstalkdSender($connection, $serializer);
         $sender->send($envelope);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineSenderTest.php
@@ -31,7 +31,7 @@ class DoctrineSenderTest extends TestCase
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'])->willReturn('15');
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new DoctrineSender($connection, $serializer);
         $actualEnvelope = $sender->send($envelope);
@@ -51,7 +51,7 @@ class DoctrineSenderTest extends TestCase
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'], 500);
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new DoctrineSender($connection, $serializer);
         $sender->send($envelope);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -408,7 +408,7 @@ class ConnectionTest extends TestCase
         $redis->expects($this->once())->method('xadd')->willReturn('0');
         $redis->expects($this->once())->method('xack')->willReturn(0);
 
-        $redis->method('getLastError')->willReturnOnConsecutiveCalls('xadd error', 'xack error');
+        $redis->method('getLastError')->willReturn('xadd error', 'xack error');
         $redis->expects($this->exactly(2))->method('clearLastError');
 
         $connection = Connection::fromDsn('redis://localhost/messenger-clearlasterror', ['auto_setup' => false, 'delete_after_ack' => true], $redis);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisSenderTest.php
@@ -29,7 +29,7 @@ class RedisSenderTest extends TestCase
         $connection->expects($this->once())->method('add')->with($encoded['body'], $encoded['headers']);
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new RedisSender($connection, $serializer);
         $sender->send($envelope);

--- a/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
@@ -30,10 +30,10 @@ class SetupTransportsCommandTest extends TestCase
         // get method must be call twice and will return consecutively a setup-able transport and a non setup-able transport
         $serviceLocator->expects($this->exactly(2))
             ->method('get')
-            ->will($this->onConsecutiveCalls(
+            ->willReturn(
                 $this->createMock(SetupableTransportInterface::class),
                 $this->createMock(TransportInterface::class)
-            ));
+            );
         $serviceLocator
             ->method('has')
             ->willReturn(true);
@@ -53,12 +53,10 @@ class SetupTransportsCommandTest extends TestCase
         /** @var MockObject&ServiceLocator $serviceLocator */
         $serviceLocator = $this->createMock(ServiceLocator::class);
         // get method must be call twice and will return consecutively a setup-able transport and a non setup-able transport
-        $serviceLocator->expects($this->exactly(1))
+        $serviceLocator->expects($this->once())
             ->method('get')
-            ->will($this->onConsecutiveCalls(
-                $this->createMock(SetupableTransportInterface::class)
-            ));
-        $serviceLocator->expects($this->exactly(1))
+            ->willReturn($this->createMock(SetupableTransportInterface::class));
+        $serviceLocator->expects($this->once())
             ->method('has')
             ->willReturn(true);
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Tests\Middleware;
 
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\MockObject\Stub\ReturnCallback;
 use PHPUnit\Framework\TestCase;
@@ -67,12 +68,7 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             ->with($this->callback(function (Envelope $envelope) use (&$series) {
                 return $envelope->getMessage() === array_shift($series);
             }))
-            ->willReturnOnConsecutiveCalls(
-                $this->willHandleMessage(),
-                $this->willHandleMessage(),
-                $this->willHandleMessage(),
-                $this->willHandleMessage()
-            );
+            ->will($this->willHandleMessage());
 
         $messageBus->dispatch($message);
     }
@@ -110,16 +106,19 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             $secondEvent,
         ];
 
-        $handlingMiddleware->expects($this->exactly(3))
+        $matcher = $this->exactly(3);
+        $handlingMiddleware->expects($matcher)
             ->method('handle')
             ->with($this->callback(function (Envelope $envelope) use (&$series) {
                 return $envelope->getMessage() === array_shift($series);
             }))
-            ->willReturnOnConsecutiveCalls(
-                $this->willHandleMessage(),
-                $this->throwException(new \RuntimeException('Some exception while handling first event')),
-                $this->willHandleMessage()
-            );
+            ->willReturnCallback(function ($envelope, StackInterface $stack) use ($matcher) {
+                if (2 === $matcher->getInvocationCount()) {
+                    throw new \RuntimeException('Some exception while handling first event');
+                }
+
+                return $stack->next()->handle($envelope, $stack);
+            });
 
         $this->expectException(DelayedMessageHandlingException::class);
         $this->expectExceptionMessage('RuntimeException: Some exception while handling first event');
@@ -176,34 +175,39 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             // Note: $eventL3a should not be handled.
         ];
 
-        $handlingMiddleware->expects($this->exactly(7))
+        $matcher = $this->exactly(7);
+        $handlingMiddleware->expects($matcher)
             ->method('handle')
             ->with($this->callback(function (Envelope $envelope) use (&$series) {
                 return $envelope->getMessage() === array_shift($series);
             }))
-            ->willReturnOnConsecutiveCalls(
-                $this->willHandleMessage(),
-                $this->willHandleMessage(),
-                $this->returnCallback(function ($envelope, StackInterface $stack) use ($eventBus, $eventL2a, $eventL2b) {
-                    $envelope1 = new Envelope($eventL2a, [new DispatchAfterCurrentBusStamp()]);
-                    $eventBus->dispatch($envelope1);
-                    $eventBus->dispatch(new Envelope($eventL2b, [new DispatchAfterCurrentBusStamp()]));
+            ->willReturnCallback(function ($envelope, StackInterface $stack) use ($eventBus, $eventL2a, $eventL2b, $eventL3a, $eventL3b, $matcher) {
+                switch ($matcher->getInvocationCount()) {
+                    case 1:
+                    case 2:
+                    case 4:
+                    case 7:
+                        return $stack->next()->handle($envelope, $stack);
 
-                    return $stack->next()->handle($envelope, $stack);
-                }),
-                $this->willHandleMessage(),
-                $this->returnCallback(function () use ($eventBus, $eventL3a) {
-                    $eventBus->dispatch(new Envelope($eventL3a, [new DispatchAfterCurrentBusStamp()]));
+                    case 3:
+                        $envelope1 = new Envelope($eventL2a, [new DispatchAfterCurrentBusStamp()]);
+                        $eventBus->dispatch($envelope1);
+                        $eventBus->dispatch(new Envelope($eventL2b, [new DispatchAfterCurrentBusStamp()]));
 
-                    throw new \RuntimeException('Some exception while handling Event level 2a');
-                }),
-                $this->returnCallback(function ($envelope, StackInterface $stack) use ($eventBus, $eventL3b) {
-                    $eventBus->dispatch(new Envelope($eventL3b, [new DispatchAfterCurrentBusStamp()]));
+                        return $stack->next()->handle($envelope, $stack);
 
-                    return $stack->next()->handle($envelope, $stack);
-                }),
-                $this->willHandleMessage()
-            );
+                    case 5:
+                        $eventBus->dispatch(new Envelope($eventL3a, [new DispatchAfterCurrentBusStamp()]));
+
+                        throw new \RuntimeException('Some exception while handling Event level 2a');
+                    case 6:
+                        $eventBus->dispatch(new Envelope($eventL3b, [new DispatchAfterCurrentBusStamp()]));
+
+                        return $stack->next()->handle($envelope, $stack);
+                }
+
+                throw new AssertionFailedError('Unexpected call to handle');
+            });
 
         $this->expectException(DelayedMessageHandlingException::class);
         $this->expectExceptionMessage('RuntimeException: Some exception while handling Event level 2a');

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
@@ -154,7 +154,7 @@ class UserPasswordHasherTest extends TestCase
         $mockPasswordHasherFactory->expects($this->any())
             ->method('getPasswordHasher')
             ->with($user)
-            ->will($this->onConsecutiveCalls($hasher, $hasher, new NativePasswordHasher(5, 20000, 5), $hasher));
+            ->willReturn($hasher, $hasher, new NativePasswordHasher(5, 20000, 5), $hasher);
 
         $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
 

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
@@ -86,7 +86,7 @@ class UserPasswordEncoderTest extends TestCase
         $mockEncoderFactory->expects($this->any())
             ->method('getEncoder')
             ->with($user)
-            ->will($this->onConsecutiveCalls($encoder, $encoder, new NativePasswordEncoder(5, 20000, 5), $encoder));
+            ->willReturn($encoder, $encoder, new NativePasswordEncoder(5, 20000, 5), $encoder);
 
         $passwordEncoder = new UserPasswordEncoder($mockEncoderFactory);
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -172,10 +172,10 @@ class AbstractObjectNormalizerTest extends TestCase
     {
         $extractor = $this->createMock(PhpDocExtractor::class);
         $extractor->method('getTypes')
-            ->will($this->onConsecutiveCalls(
+            ->willReturn(
                 [new Type('array', false, null, true, new Type('int'), new Type('object', false, DummyChild::class))],
                 null
-            ));
+            );
 
         $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
         $arrayDenormalizer = new ArrayDenormalizerDummy();
@@ -227,10 +227,10 @@ class AbstractObjectNormalizerTest extends TestCase
     {
         $extractor = $this->createMock(PhpDocExtractor::class);
         $extractor->method('getTypes')
-            ->will($this->onConsecutiveCalls(
+            ->willReturn(
                 [new Type('array', false, null, true, new Type('int'), new Type('string'))],
                 null
-            ));
+            );
 
         $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
         $arrayDenormalizer = new ArrayDenormalizerDummy();
@@ -417,7 +417,7 @@ class AbstractObjectNormalizerTest extends TestCase
     {
         $extractor = $this->createMock(PhpDocExtractor::class);
         $extractor->method('getTypes')
-            ->will($this->onConsecutiveCalls(
+            ->willReturn(
                 [new Type('bool')],
                 [new Type('bool')],
                 [new Type('bool')],
@@ -430,7 +430,7 @@ class AbstractObjectNormalizerTest extends TestCase
                 [new Type('float')],
                 [new Type('float')],
                 [new Type('float')]
-            ));
+            );
 
         $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
         $arrayDenormalizer = new ArrayDenormalizerDummy();
@@ -663,8 +663,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeXmlScalar()
     {
-        $normalizer = new class () extends AbstractObjectNormalizer
-        {
+        $normalizer = new class() extends AbstractObjectNormalizer {
             public function __construct()
             {
                 parent::__construct(null, new MetadataAwareNameConverter(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()))));

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -54,9 +54,10 @@ class PropertyInfoLoaderTest extends TestCase
                 'noAutoMapping',
             ])
         ;
+
         $propertyInfoStub
             ->method('getTypes')
-            ->will($this->onConsecutiveCalls(
+            ->willReturn(
                 [new Type(Type::BUILTIN_TYPE_STRING, true)],
                 [new Type(Type::BUILTIN_TYPE_STRING)],
                 [new Type(Type::BUILTIN_TYPE_STRING, true), new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_BOOL)],
@@ -69,11 +70,12 @@ class PropertyInfoLoaderTest extends TestCase
                 [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true, null, new Type(Type::BUILTIN_TYPE_FLOAT))],
                 [new Type(Type::BUILTIN_TYPE_STRING)],
                 [new Type(Type::BUILTIN_TYPE_STRING)]
-            ))
+            )
         ;
+
         $propertyInfoStub
             ->method('isWritable')
-            ->will($this->onConsecutiveCalls(
+            ->willReturn(
                 true,
                 true,
                 true,
@@ -86,7 +88,7 @@ class PropertyInfoLoaderTest extends TestCase
                 true,
                 false,
                 true
-            ))
+            )
         ;
 
         $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{.*}');
@@ -222,9 +224,10 @@ class PropertyInfoLoaderTest extends TestCase
             ->method('getProperties')
             ->willReturn(['string', 'autoMappingExplicitlyEnabled'])
         ;
+
         $propertyInfoStub
             ->method('getTypes')
-            ->willReturnOnConsecutiveCalls(
+            ->willReturn(
                 [new Type(Type::BUILTIN_TYPE_STRING)],
                 [new Type(Type::BUILTIN_TYPE_BOOL)]
             );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

cc @OskarStark as we did a lot of stuff on tests migration last year