### PR TITLE
[Form] rename the model_type option to input and rework it

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Add option `separator` to `ChoiceType` to use a custom separator after preferred choices (use the new `separator_html` option to display the separator text as HTML)
  * Deprecate not configuring the `default_protocol` option of the `UrlType`, it will default to `null` in 8.0 (the current default is `'http'`)
  * Add a `keep_as_list` option to `CollectionType`
- * Add a new `model_type` option to `MoneyType`, to be able to cast the transformed value to `integer`
+ * Add an `input` option to `MoneyType`, to be able to cast the transformed value to `integer`
 
 7.0
 ---

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -29,7 +29,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
         ?int $roundingMode = \NumberFormatter::ROUND_HALFUP,
         ?int $divisor = 1,
         ?string $locale = null,
-        private string $modelType = 'float',
+        private readonly string $input = 'float',
     ) {
         parent::__construct($scale ?? 2, $grouping ?? true, $roundingMode, $locale);
 
@@ -67,15 +67,15 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
     public function reverseTransform(mixed $value): int|float|null
     {
         $value = parent::reverseTransform($value);
-        if (null !== $value && 1 !== $this->divisor) {
+        if (null !== $value) {
             $value = (string) ($value * $this->divisor);
 
-            if ('float' === $this->modelType) {
+            if ('float' === $this->input) {
                 return (float) $value;
             }
 
             if ($value > \PHP_INT_MAX || $value < \PHP_INT_MIN) {
-                throw new TransformationFailedException(sprintf("The value '%d' is too large you should pass the 'model_type' to 'float'.", $value));
+                throw new TransformationFailedException(sprintf('Cannot cast "%s" to an integer. Try setting the input to "float" instead.', $value));
             }
 
             $value = (int) $value;

--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -35,7 +35,7 @@ class MoneyType extends AbstractType
                 $options['rounding_mode'],
                 $options['divisor'],
                 $options['html5'] ? 'en' : null,
-                $options['model_type'],
+                $options['input'],
             ))
         ;
     }
@@ -60,7 +60,7 @@ class MoneyType extends AbstractType
             'compound' => false,
             'html5' => false,
             'invalid_message' => 'Please enter a valid money amount.',
-            'model_type' => 'float',
+            'input' => 'float',
         ]);
 
         $resolver->setAllowedValues('rounding_mode', [
@@ -77,19 +77,11 @@ class MoneyType extends AbstractType
 
         $resolver->setAllowedTypes('html5', 'bool');
 
-        $resolver->setAllowedValues('model_type', ['float', 'integer']);
+        $resolver->setAllowedValues('input', ['float', 'integer']);
 
         $resolver->setNormalizer('grouping', static function (Options $options, $value) {
             if ($value && $options['html5']) {
                 throw new LogicException('Cannot use the "grouping" option when the "html5" option is enabled.');
-            }
-
-            return $value;
-        });
-
-        $resolver->setNormalizer('model_type', static function (Options $options, $value) {
-            if ('integer' === $value && 1 === $options['divisor']) {
-                throw new LogicException('When the "model_type" option is set to "integer", the "divisor" option should not be set to "1".');
             }
 
             return $value;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class MoneyTypeTest extends BaseTypeTestCase
@@ -125,7 +124,7 @@ class MoneyTypeTest extends BaseTypeTestCase
         $this->assertSame('number', $form->createView()->vars['type']);
     }
 
-    public function testDefaultModelType()
+    public function testDefaultInput()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['divisor' => 100]);
         $form->submit('12345.67');
@@ -133,18 +132,19 @@ class MoneyTypeTest extends BaseTypeTestCase
         $this->assertSame(1234567.0, $form->getData());
     }
 
-    public function testIntegerModelType()
+    public function testIntegerInput()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, ['divisor' => 100, 'model_type' => 'integer']);
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['divisor' => 100, 'input' => 'integer']);
         $form->submit('12345.67');
 
         $this->assertSame(1234567, $form->getData());
     }
 
-    public function testIntegerModelTypeExpectsDivisorNotEqualToOne()
+    public function testIntegerInputWithoutDivisor()
     {
-        $this->expectException(LogicException::class);
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'integer']);
+        $form->submit('1234567');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, ['divisor' => 1, 'model_type' => 'integer']);
+        $this->assertSame(1234567, $form->getData());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53488
| License       | MIT

additionally to fixing #53488 the `model_type` option is also renamed to `input` to be in line with other core form types (namely `DateIntervalType`, `DateTimeType`, `DateType`, `NumberType`, `TimeType`, `TimezoneType` and `WeekType`)