### PR TITLE
[VarDumper] Add function `jd()` to dump variables without html tags in json api call

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -66,3 +66,22 @@ if (!function_exists('dd')) {
         exit(1);
     }
 }
+
+if (!function_exists('jd')) {
+    function jd(mixed ...$vars): never
+    {
+        if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) && !headers_sent()) {
+            header('HTTP/1.1 500 Internal Server Error');
+        }
+
+        if (array_key_exists(0, $vars) && 1 === count($vars)) {
+            var_dump($vars[0]);
+        } else {
+            foreach ($vars as $var) {
+                 var_dump($var);
+            }
+        }
+
+        exit(1);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Refs #49754
| License       | MIT

_dd()_ is really useful in the browser. However, when testing my endpoints with Behat in command line, the HTML tags generated by _dd()_ make the result unreadable. To address this issue, I introduced the function _jd()_ to simply dump the variables without generating HTML tags. This approach is more convenient than replacing _dd()_ with _var_dump()_ + _die()_ + status 500.

Please see the example below:

currently, when `dd(1,2,3)`;

![current situation](https://github.com/symfony/symfony/assets/7520095/985d57f5-ad9b-47f7-91c2-ef1e0127f531)

And with `jd(1,2,3)`;

![new](https://github.com/symfony/symfony/assets/7520095/b11c5e80-24d9-4ab2-8a81-753b874482ff)
