### PR TITLE
[Cache] fix: remove unwanted cast to int

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -499,7 +499,7 @@ trait RedisTrait
                     }
                     $this->doDelete($keys);
                 }
-            } while ($cursor = (int) $cursor);
+            } while ($cursor);
         }
 
         return $cleared;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Issues        | Fix #54773 
| License       | MIT

As discussed in the related issue, this type cast is unnecessary and can lead to unexpected behavior due to integer overflow.

I took a quick look if a testcase could be implemented, but this is not so trivial, as we'd either have to somehow configure a redis server to end up with a state that results in very high scan cursor values, or we'd have to implement a mock for the redis implementation, so we can provide all the edge case values for our tests.
