### PR TITLE
Remove calls to `TestCase::iniSet()` and calls to deprecated methods of `MockBuilder`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/MockableRepository.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/MockableRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\EntityRepository;
+
+class MockableRepository extends EntityRepository
+{
+    public function findByCustom()
+    {
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -28,6 +28,7 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeObjectNoToStringIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNullableNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Employee;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\MockableRepository;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Person;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity;
@@ -97,14 +98,10 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     protected function createRepositoryMock()
     {
-        $repository = $this->getMockBuilder(EntityRepository::class)
+        return $this->getMockBuilder(MockableRepository::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['find', 'findAll', 'findOneBy', 'findBy', 'getClassName'])
-            ->addMethods(['findByCustom'])
-            ->getMock()
-        ;
-
-        return $repository;
+            ->onlyMethods(['find', 'findAll', 'findOneBy', 'findBy', 'getClassName', 'findByCustom'])
+            ->getMock();
     }
 
     protected function createEntityManagerMock($repositoryMock)

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -31,14 +31,14 @@ class HttpKernelExtensionTest extends TestCase
     public function testFragmentWithError()
     {
         $this->expectException(\Twig\Error\RuntimeError::class);
-        $renderer = $this->getFragmentHandler($this->throwException(new \Exception('foo')));
+        $renderer = $this->getFragmentHandler(new \Exception('foo'));
 
         $this->renderTemplate($renderer);
     }
 
     public function testRenderFragment()
     {
-        $renderer = $this->getFragmentHandler($this->returnValue(new Response('html')));
+        $renderer = $this->getFragmentHandler(new Response('html'));
 
         $response = $this->renderTemplate($renderer);
 
@@ -87,11 +87,17 @@ TWIG
         $this->assertSame('/_fragment?_hash=PP8%2FeEbn1pr27I9wmag%2FM6jYGVwUZ0l2h0vhh2OJ6CI%3D&amp;_path=template%3Dfoo.html.twig%26_format%3Dhtml%26_locale%3Den%26_controller%3DSymfonyBundleFrameworkBundleControllerTemplateController%253A%253AtemplateAction', $twig->render('index'));
     }
 
-    protected function getFragmentHandler($return)
+    protected function getFragmentHandler($returnOrException): FragmentHandler
     {
         $strategy = $this->createMock(FragmentRendererInterface::class);
         $strategy->expects($this->once())->method('getName')->willReturn('inline');
-        $strategy->expects($this->once())->method('render')->will($return);
+
+        $mocker = $strategy->expects($this->once())->method('render');
+        if ($returnOrException instanceof \Exception) {
+            $mocker->willThrowException($returnOrException);
+        } else {
+            $mocker->willReturn($returnOrException);
+        }
 
         $context = $this->createMock(RequestStack::class);
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/RuntimeLoaderProvider.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/RuntimeLoaderProvider.php
@@ -20,9 +20,9 @@ trait RuntimeLoaderProvider
     protected function registerTwigRuntimeLoader(Environment $environment, FormRenderer $renderer)
     {
         $loader = $this->createMock(RuntimeLoaderInterface::class);
-        $loader->expects($this->any())->method('load')->will($this->returnValueMap([
+        $loader->expects($this->any())->method('load')->willReturnMap([
             ['Symfony\Component\Form\FormRenderer', $renderer],
-        ]));
+        ]);
         $environment->addRuntimeLoader($loader);
     }
 }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -41,6 +41,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\SignalRegistry\SignalRegistry;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\Console\Tests\Fixtures\MockableAppliationWithTerminalWidth;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -876,7 +877,9 @@ class ApplicationTest extends TestCase
 
     public function testRenderExceptionLineBreaks()
     {
-        $application = $this->getMockBuilder(Application::class)->addMethods(['getTerminalWidth'])->getMock();
+        $application = $this->getMockBuilder(MockableAppliationWithTerminalWidth::class)
+            ->onlyMethods(['getTerminalWidth'])
+            ->getMock();
         $application->setAutoExit(false);
         $application->expects($this->any())
             ->method('getTerminalWidth')

--- a/src/Symfony/Component/Console/Tests/Fixtures/MockableAppliationWithTerminalWidth.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/MockableAppliationWithTerminalWidth.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Application;
+
+class MockableAppliationWithTerminalWidth extends Application
+{
+    public function getTerminalWidth(): int
+    {
+        return 0;
+    }
+}

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -36,8 +36,8 @@ trait ValidatorExtensionTrait
 
         $this->validator = $this->createMock(ValidatorInterface::class);
         $metadata = $this->getMockBuilder(ClassMetadata::class)->setConstructorArgs([''])->onlyMethods(['addPropertyConstraint'])->getMock();
-        $this->validator->expects($this->any())->method('getMetadataFor')->will($this->returnValue($metadata));
-        $this->validator->expects($this->any())->method('validate')->will($this->returnValue(new ConstraintViolationList()));
+        $this->validator->expects($this->any())->method('getMetadataFor')->willReturn($metadata);
+        $this->validator->expects($this->any())->method('validate')->willReturn(new ConstraintViolationList());
 
         return new ValidatorExtension($this->validator, false);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -25,14 +25,17 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
     protected $dateTimeWithoutSeconds;
     private $defaultLocale;
 
+    private $initialTestCaseUseException;
+    private $initialTestCaseErrorLevel;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         // Normalize intl. configuration settings.
         if (\extension_loaded('intl')) {
-            $this->iniSet('intl.use_exceptions', 0);
-            $this->iniSet('intl.error_level', 0);
+            $this->initialTestCaseUseException = ini_set('intl.use_exceptions', 0);
+            $this->initialTestCaseErrorLevel = ini_set('intl.error_level', 0);
         }
 
         // Since we test against "de_AT", we need the full implementation
@@ -50,6 +53,11 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         $this->dateTime = null;
         $this->dateTimeWithoutSeconds = null;
         \Locale::setDefault($this->defaultLocale);
+
+        if (\extension_loaded('intl')) {
+            ini_set('intl.use_exceptions', $this->initialTestCaseUseException);
+            ini_set('intl.error_level', $this->initialTestCaseUseException);
+        }
     }
 
     public static function dataProvider()
@@ -339,11 +347,15 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
             $this->markTestSkipped('intl extension is not loaded');
         }
 
-        $this->iniSet('intl.error_level', \E_WARNING);
+        $errorLevel = ini_set('intl.error_level', \E_WARNING);
 
-        $this->expectException(TransformationFailedException::class);
-        $transformer = new DateTimeToLocalizedStringTransformer();
-        $transformer->reverseTransform('12345');
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new DateTimeToLocalizedStringTransformer();
+            $transformer->reverseTransform('12345');
+        } finally {
+            ini_set('intl.error_level', $errorLevel);
+        }
     }
 
     public function testReverseTransformWrapsIntlErrorsWithExceptions()
@@ -352,11 +364,15 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
             $this->markTestSkipped('intl extension is not loaded');
         }
 
-        $this->iniSet('intl.use_exceptions', 1);
+        $initialUseExceptions = ini_set('intl.use_exceptions', 1);
 
-        $this->expectException(TransformationFailedException::class);
-        $transformer = new DateTimeToLocalizedStringTransformer();
-        $transformer->reverseTransform('12345');
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new DateTimeToLocalizedStringTransformer();
+            $transformer->reverseTransform('12345');
+        } finally {
+            ini_set('intl.use_exceptions', $initialUseExceptions);
+        }
     }
 
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
@@ -365,12 +381,17 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
             $this->markTestSkipped('intl extension is not loaded');
         }
 
-        $this->iniSet('intl.use_exceptions', 1);
-        $this->iniSet('intl.error_level', \E_WARNING);
+        $initialUseExceptions = ini_set('intl.use_exceptions', 1);
+        $initialErrorLevel = ini_set('intl.error_level', \E_WARNING);
 
-        $this->expectException(TransformationFailedException::class);
-        $transformer = new DateTimeToLocalizedStringTransformer();
-        $transformer->reverseTransform('12345');
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new DateTimeToLocalizedStringTransformer();
+            $transformer->reverseTransform('12345');
+        } finally {
+            ini_set('intl.use_exceptions', $initialUseExceptions);
+            ini_set('intl.error_level', $initialErrorLevel);
+        }
     }
 
     protected function createDateTimeTransformer(?string $inputTimezone = null, ?string $outputTimezone = null): BaseDateTimeTransformer

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -34,10 +34,14 @@ class NativeSessionStorageTest extends TestCase
 {
     private $savePath;
 
+    private $initialSessionSaveHandler;
+    private $initialSessionSavePath;
+
     protected function setUp(): void
     {
-        $this->iniSet('session.save_handler', 'files');
-        $this->iniSet('session.save_path', $this->savePath = sys_get_temp_dir().'/sftest');
+        $this->initialSessionSaveHandler = ini_set('session.save_handler', 'files');
+        $this->initialSessionSavePath = ini_set('session.save_path', $this->savePath = sys_get_temp_dir().'/sftest');
+
         if (!is_dir($this->savePath)) {
             mkdir($this->savePath);
         }
@@ -52,6 +56,8 @@ class NativeSessionStorageTest extends TestCase
         }
 
         $this->savePath = null;
+        ini_set('session.save_handler', $this->initialSessionSaveHandler);
+        ini_set('session.save_path', $this->initialSessionSavePath);
     }
 
     protected function getStorage(array $options = []): NativeSessionStorage
@@ -154,18 +160,26 @@ class NativeSessionStorageTest extends TestCase
 
     public function testDefaultSessionCacheLimiter()
     {
-        $this->iniSet('session.cache_limiter', 'nocache');
+        $initialLimiter = ini_set('session.cache_limiter', 'nocache');
 
-        new NativeSessionStorage();
-        $this->assertEquals('', \ini_get('session.cache_limiter'));
+        try {
+            new NativeSessionStorage();
+            $this->assertEquals('', \ini_get('session.cache_limiter'));
+        } finally {
+            ini_set('session.cache_limiter', $initialLimiter);
+        }
     }
 
     public function testExplicitSessionCacheLimiter()
     {
-        $this->iniSet('session.cache_limiter', 'nocache');
+        $initialLimiter = ini_set('session.cache_limiter', 'nocache');
 
-        new NativeSessionStorage(['cache_limiter' => 'public']);
-        $this->assertEquals('public', \ini_get('session.cache_limiter'));
+        try {
+            new NativeSessionStorage(['cache_limiter' => 'public']);
+            $this->assertEquals('public', \ini_get('session.cache_limiter'));
+        } finally {
+            ini_set('session.cache_limiter', $initialLimiter);
+        }
     }
 
     public function testCookieOptions()
@@ -208,20 +222,25 @@ class NativeSessionStorageTest extends TestCase
 
     public function testSetSaveHandler()
     {
-        $this->iniSet('session.save_handler', 'files');
-        $storage = $this->getStorage();
-        $storage->setSaveHandler();
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
-        $storage->setSaveHandler(null);
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
-        $storage->setSaveHandler(new SessionHandlerProxy(new NativeFileSessionHandler()));
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
-        $storage->setSaveHandler(new NativeFileSessionHandler());
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
-        $storage->setSaveHandler(new SessionHandlerProxy(new NullSessionHandler()));
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
-        $storage->setSaveHandler(new NullSessionHandler());
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+        $initialSaveHandler = ini_set('session.save_handler', 'files');
+
+        try {
+            $storage = $this->getStorage();
+            $storage->setSaveHandler();
+            $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+            $storage->setSaveHandler(null);
+            $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+            $storage->setSaveHandler(new SessionHandlerProxy(new NativeFileSessionHandler()));
+            $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+            $storage->setSaveHandler(new NativeFileSessionHandler());
+            $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+            $storage->setSaveHandler(new SessionHandlerProxy(new NullSessionHandler()));
+            $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+            $storage->setSaveHandler(new NullSessionHandler());
+            $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+        } finally {
+            ini_set('session.save_handler', $initialSaveHandler);
+        }
     }
 
     public function testStarted()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -30,10 +30,14 @@ class PhpBridgeSessionStorageTest extends TestCase
 {
     private $savePath;
 
+    private $initialSessionSaveHandler;
+    private $initialSessionSavePath;
+
     protected function setUp(): void
     {
-        $this->iniSet('session.save_handler', 'files');
-        $this->iniSet('session.save_path', $this->savePath = sys_get_temp_dir().'/sftest');
+        $this->initialSessionSaveHandler = ini_set('session.save_handler', 'files');
+        $this->initialSessionSavePath = ini_set('session.save_path', $this->savePath = sys_get_temp_dir().'/sftest');
+
         if (!is_dir($this->savePath)) {
             mkdir($this->savePath);
         }
@@ -48,6 +52,8 @@ class PhpBridgeSessionStorageTest extends TestCase
         }
 
         $this->savePath = null;
+        ini_set('session.save_handler', $this->initialSessionSaveHandler);
+        ini_set('session.save_path', $this->initialSessionSavePath);
     }
 
     protected function getStorage(): PhpBridgeSessionStorage

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -54,21 +54,25 @@ class ErrorListenerTest extends TestCase
      */
     public function testHandleWithoutLogger($event, $event2)
     {
-        $this->iniSet('error_log', file_exists('/dev/null') ? '/dev/null' : 'nul');
-
-        $l = new ErrorListener('foo');
-        $l->logKernelException($event);
-        $l->onKernelException($event);
-
-        $this->assertEquals(new Response('foo'), $event->getResponse());
+        $initialErrorLog = ini_set('error_log', file_exists('/dev/null') ? '/dev/null' : 'nul');
 
         try {
-            $l->logKernelException($event2);
-            $l->onKernelException($event2);
-            $this->fail('RuntimeException expected');
-        } catch (\RuntimeException $e) {
-            $this->assertSame('bar', $e->getMessage());
-            $this->assertSame('foo', $e->getPrevious()->getMessage());
+            $l = new ErrorListener('foo');
+            $l->logKernelException($event);
+            $l->onKernelException($event);
+
+            $this->assertEquals(new Response('foo'), $event->getResponse());
+
+            try {
+                $l->logKernelException($event2);
+                $l->onKernelException($event2);
+                $this->fail('RuntimeException expected');
+            } catch (\RuntimeException $e) {
+                $this->assertSame('bar', $e->getMessage());
+                $this->assertSame('foo', $e->getPrevious()->getMessage());
+            }
+        } finally {
+            ini_set('error_log', $initialErrorLog);
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTestWithLoadClassCache.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTestWithLoadClassCache.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+class KernelForTestWithLoadClassCache extends KernelForTest
+{
+    public function doLoadClassCache(): void
+    {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/MockableUploadFileWithClientSize.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/MockableUploadFileWithClientSize.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class MockableUploadFileWithClientSize extends UploadedFile
+{
+    public function getClientSize(): int
+    {
+        return 0;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -43,14 +43,14 @@ class FragmentHandlerTest extends TestCase
     public function testRenderWithUnknownRenderer()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $handler = $this->getHandler($this->returnValue(new Response('foo')));
+        $handler = $this->getHandler(new Response('foo'));
 
         $handler->render('/', 'bar');
     }
 
     public function testDeliverWithUnsuccessfulResponse()
     {
-        $handler = $this->getHandler($this->returnValue(new Response('foo', 404)));
+        $handler = $this->getHandler(new Response('foo', 404));
         try {
             $handler->render('/', 'foo');
             $this->fail('->render() throws a \RuntimeException exception if response is not successful');
@@ -70,7 +70,7 @@ class FragmentHandlerTest extends TestCase
     {
         $expectedRequest = Request::create('/');
         $handler = $this->getHandler(
-            $this->returnValue(new Response('foo')),
+            new Response('foo'),
             [
                 '/',
                 $this->callback(function (Request $request) use ($expectedRequest) {
@@ -97,7 +97,7 @@ class FragmentHandlerTest extends TestCase
         $e = $renderer
             ->expects($this->any())
             ->method('render')
-            ->will($returnValue)
+            ->willReturn($returnValue)
         ;
 
         if ($arguments) {

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
+use Symfony\Component\HttpKernel\Tests\Fixtures\MockableUploadFileWithClientSize;
 use Symfony\Component\HttpKernel\Tests\Fixtures\TestClient;
 
 /**
@@ -153,10 +154,9 @@ class HttpKernelBrowserTest extends TestCase
         $client = new HttpKernelBrowser($kernel);
 
         $file = $this
-            ->getMockBuilder(UploadedFile::class)
+            ->getMockBuilder(MockableUploadFileWithClientSize::class)
             ->setConstructorArgs([$source, 'original', 'mime/original', \UPLOAD_ERR_OK, true])
-            ->onlyMethods(['getSize'])
-            ->addMethods(['getClientSize'])
+            ->onlyMethods(['getSize', 'getClientSize'])
             ->getMock()
         ;
         /* should be modified when the getClientSize will be removed */

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTestWithLoadClassCache;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelWithoutBundles;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ResettableService;
 
@@ -148,7 +149,7 @@ class KernelTest extends TestCase
 
     public function testClassCacheIsNotLoadedByDefault()
     {
-        $kernel = $this->getKernel(['initializeBundles'], [], false, ['doLoadClassCache']);
+        $kernel = $this->getKernel(['initializeBundles', 'doLoadClassCache'], [], false, KernelForTestWithLoadClassCache::class);
         $kernel->expects($this->never())
             ->method('doLoadClassCache');
 
@@ -663,19 +664,15 @@ EOF
      * @param array $methods Additional methods to mock (besides the abstract ones)
      * @param array $bundles Bundles to register
      */
-    protected function getKernel(array $methods = [], array $bundles = [], bool $debug = false, array $methodsToAdd = []): Kernel
+    protected function getKernel(array $methods = [], array $bundles = [], bool $debug = false, string $kernelClass = KernelForTest::class): Kernel
     {
         $methods[] = 'registerBundles';
 
         $kernelMockBuilder = $this
-            ->getMockBuilder(KernelForTest::class)
+            ->getMockBuilder($kernelClass)
             ->onlyMethods($methods)
             ->setConstructorArgs(['test', $debug])
         ;
-
-        if (0 !== \count($methodsToAdd)) {
-            $kernelMockBuilder->addMethods($methodsToAdd);
-        }
 
         $kernel = $kernelMockBuilder->getMock();
         $kernel->expects($this->any())

--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -43,14 +43,19 @@ class UriSignerTest extends TestCase
 
     public function testCheckWithDifferentArgSeparator()
     {
-        $this->iniSet('arg_separator.output', '&amp;');
-        $signer = new UriSigner('foobar');
+        $initialSeparatorOutput = ini_set('arg_separator.output', '&amp;');
 
-        $this->assertSame(
-            'http://example.com/foo?_hash=rIOcC%2FF3DoEGo%2FvnESjSp7uU9zA9S%2F%2BOLhxgMexoPUM%3D&baz=bay&foo=bar',
-            $signer->sign('http://example.com/foo?foo=bar&baz=bay')
-        );
-        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
+        try {
+            $signer = new UriSigner('foobar');
+
+            $this->assertSame(
+                'http://example.com/foo?_hash=rIOcC%2FF3DoEGo%2FvnESjSp7uU9zA9S%2F%2BOLhxgMexoPUM%3D&baz=bay&foo=bar',
+                $signer->sign('http://example.com/foo?foo=bar&baz=bay')
+            );
+            $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
+        } finally {
+            ini_set('arg_separator.output', $initialSeparatorOutput);
+        }
     }
 
     public function testCheckWithRequest()

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -109,12 +109,16 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
-        $this->iniSet('open_basedir', \dirname(\PHP_BINARY).\PATH_SEPARATOR.'/');
+        $initialOpenBaseDir = ini_set('open_basedir', \dirname(\PHP_BINARY).\PATH_SEPARATOR.'/');
 
-        $finder = new ExecutableFinder();
-        $result = $finder->find($this->getPhpBinaryName());
+        try {
+            $finder = new ExecutableFinder();
+            $result = $finder->find($this->getPhpBinaryName());
 
-        $this->assertSamePath(\PHP_BINARY, $result);
+            $this->assertSamePath(\PHP_BINARY, $result);
+        } finally {
+            ini_set('open_basedir', $initialOpenBaseDir);
+        }
     }
 
     /**
@@ -130,12 +134,17 @@ class ExecutableFinderTest extends TestCase
         }
 
         $this->setPath('');
-        $this->iniSet('open_basedir', \PHP_BINARY.\PATH_SEPARATOR.'/');
 
-        $finder = new ExecutableFinder();
-        $result = $finder->find($this->getPhpBinaryName(), false);
+        $initialOpenBaseDir = ini_set('open_basedir', \PHP_BINARY.\PATH_SEPARATOR.'/');
 
-        $this->assertSamePath(\PHP_BINARY, $result);
+        try {
+            $finder = new ExecutableFinder();
+            $result = $finder->find($this->getPhpBinaryName(), false);
+
+            $this->assertSamePath(\PHP_BINARY, $result);
+        } finally {
+            ini_set('open_basedir', $initialOpenBaseDir);
+        }
     }
 
     public function testFindBatchExecutableOnWindows()

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
@@ -81,9 +81,8 @@ class ObjectLoaderTest extends TestCase
     public function testExceptionOnMethodNotReturningCollection()
     {
         $this->expectException(\LogicException::class);
-        $service = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['loadRoutes'])
-            ->getMock();
+
+        $service = $this->createMock(CustomRouteLoader::class);
         $service->expects($this->once())
             ->method('loadRoutes')
             ->willReturn('NOT_A_COLLECTION');
@@ -107,6 +106,11 @@ class TestObjectLoader extends ObjectLoader
     {
         return $this->loaderMap[$id] ?? null;
     }
+}
+
+interface CustomRouteLoader
+{
+    public function loadRoutes();
 }
 
 class TestObjectLoaderRouteService

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\Tests\Fixtures\MockableUsernamePasswordTokenWithRoles;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -232,7 +233,9 @@ class UserAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken()
     {
-        $mock = $this->getMockBuilder(UsernamePasswordToken::class)->onlyMethods(['getCredentials', 'getFirewallName'])->addMethods(['getRoles'])->disableOriginalConstructor()->getMock();
+        $mock = $this->getMockBuilder(MockableUsernamePasswordTokenWithRoles::class)
+            ->onlyMethods(['getCredentials', 'getFirewallName', 'getRoles'])
+            ->disableOriginalConstructor()->getMock();
         $mock
             ->expects($this->any())
             ->method('getFirewallName')

--- a/src/Symfony/Component/Security/Core/Tests/Fixtures/MockableUsernamePasswordTokenWithRoles.php
+++ b/src/Symfony/Component/Security/Core/Tests/Fixtures/MockableUsernamePasswordTokenWithRoles.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class MockableUsernamePasswordTokenWithRoles extends UsernamePasswordToken
+{
+    public function getRoles(): array
+    {
+        return [];
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php
@@ -53,9 +53,7 @@ class UriSafeTokenGeneratorTest extends TestCase
         $token = $this->generator->generateToken();
 
         $this->assertTrue(ctype_print($token), 'is printable');
-        $this->assertStringNotMatchesFormat('%S+%S', $token, 'is URI safe');
-        $this->assertStringNotMatchesFormat('%S/%S', $token, 'is URI safe');
-        $this->assertStringNotMatchesFormat('%S=%S', $token, 'is URI safe');
+        $this->assertDoesNotMatchRegularExpression('#.+([+/=]).+#', $token, 'is URI safe');
     }
 
     /**

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -159,12 +159,11 @@ class GuardAuthenticatorHandlerTest extends TestCase
 
     public function testSessionIsNotInstantiatedOnStatelessFirewall()
     {
-        $sessionFactory = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['__invoke'])
-            ->getMock();
+        $this->expectNotToPerformAssertions();
 
-        $sessionFactory->expects($this->never())
-            ->method('__invoke');
+        $sessionFactory = static function (): void {
+            throw new \LogicException('This should not be called');
+        };
 
         $this->request->setSessionFactory($sessionFactory);
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -366,8 +366,11 @@ class ContextListenerTest extends TestCase
 
     public function testSessionIsNotReported()
     {
-        $usageReporter = $this->getMockBuilder(\stdClass::class)->addMethods(['__invoke'])->getMock();
-        $usageReporter->expects($this->never())->method('__invoke');
+        $this->expectNotToPerformAssertions();
+
+        $usageReporter = static function (): void {
+            throw new \LogicException('This should not be called');
+        };
 
         $session = new Session(new MockArraySessionStorage(), null, null, $usageReporter);
 

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
@@ -45,7 +45,7 @@ class HtmlDescriptorTest extends TestCase
 
         $descriptor->describe($output, new Data([[123]]), ['timestamp' => 1544804268.3668], 1);
 
-        $this->assertStringNotMatchesFormat('<style>%A</style><script>%A</script>%A', $output->fetch(), 'styles & scripts are output only once');
+        $this->assertDoesNotMatchRegularExpression('#<style>(.*?)</style><script>(.*?)</script>(.*)#', $output->fetch(), 'styles & scripts are output only once');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Last round (before new deprecations 🙂). All deprecations [listed here](https://github.com/sebastianbergmann/phpunit/blob/main/DEPRECATIONS.md) should be gone.