### PR TITLE
[TypeInfo] mark classes as experimental

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -4,4 +4,4 @@ CHANGELOG
 7.1
 ---
 
- * Add the component
+ * Add the component as experimental

--- a/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 interface ExceptionInterface extends \Throwable
 {

--- a/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Symfony/Component/TypeInfo/Exception/LogicException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/LogicException.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 class LogicException extends \LogicException implements ExceptionInterface
 {

--- a/src/Symfony/Component/TypeInfo/Exception/RuntimeException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/RuntimeException.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 class RuntimeException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Symfony/Component/TypeInfo/Exception/UnsupportedException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/UnsupportedException.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 class UnsupportedException extends \LogicException implements ExceptionInterface
 {

--- a/src/Symfony/Component/TypeInfo/README.md
+++ b/src/Symfony/Component/TypeInfo/README.md
@@ -3,6 +3,11 @@ TypeInfo Component
 
 The TypeInfo component extracts PHP types information.
 
+**This Component is experimental**.
+[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
+are not covered by Symfony's
+[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
+
 Getting Started
 ---------------
 

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -17,6 +17,8 @@ use Symfony\Component\TypeInfo\Type\ObjectType;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 abstract class Type implements \Stringable
 {

--- a/src/Symfony/Component/TypeInfo/Type/BackedEnumType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BackedEnumType.php
@@ -21,6 +21,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @template U of BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>
  *
  * @extends EnumType<T>
+ *
+ * @experimental
  */
 final class BackedEnumType extends EnumType
 {

--- a/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
@@ -20,6 +20,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of TypeIdentifier
+ *
+ * @experimental
  */
 final class BuiltinType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -24,6 +24,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType|GenericType
+ *
+ * @experimental
  */
 final class CollectionType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/EnumType.php
+++ b/src/Symfony/Component/TypeInfo/Type/EnumType.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\TypeInfo\Type;
  * @template T of class-string<\UnitEnum>
  *
  * @extends ObjectType<T>
+ *
+ * @experimental
  */
 class EnumType extends ObjectType
 {

--- a/src/Symfony/Component/TypeInfo/Type/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/Type/GenericType.php
@@ -23,6 +23,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType
+ *
+ * @experimental
  */
 final class GenericType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -19,6 +19,8 @@ use Symfony\Component\TypeInfo\Type;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of Type
+ *
+ * @experimental
  */
 final class IntersectionType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/ObjectType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectType.php
@@ -19,6 +19,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of class-string
+ *
+ * @experimental
  */
 class ObjectType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/TemplateType.php
+++ b/src/Symfony/Component/TypeInfo/Type/TemplateType.php
@@ -19,6 +19,8 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 final class TemplateType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -19,6 +19,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of Type
+ *
+ * @experimental
  */
 final class UnionType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
@@ -22,6 +22,8 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 final class TypeContext
 {

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -27,6 +27,8 @@ use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 final class TypeContextFactory
 {

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -26,6 +26,8 @@ use Symfony\Component\TypeInfo\Type\UnionType;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 trait TypeFactoryTrait
 {

--- a/src/Symfony/Component/TypeInfo/TypeIdentifier.php
+++ b/src/Symfony/Component/TypeInfo/TypeIdentifier.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\TypeInfo;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 enum TypeIdentifier: string
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolver.php
@@ -23,6 +23,8 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 final readonly class TypeResolver implements TypeResolverInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolverInterface.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolverInterface.php
@@ -20,6 +20,8 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContext;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @experimental
  */
 interface TypeResolverInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This is following a discussion on slack with authors of the component, I feel that the TypeInfo component should have an experimental phase as we need to prove the component's functionality on software that is built on top of type information extraction. Here's a non-exhaustive list of software using the PropertyInfo Type class (thanks to @mtarld): 

- api-platform/core
- nelmio/api-doc-bundle
- typo3/cms-extbase
- typo3/cms
- sonata-project/page-bundle
- jolicode/automapper
- symfony/ux-live-component

These softwares should try their best in testing the new TypeInfo component and report back misfunctionalities and/or DX improvements before we can consider this non-experimental. See also #54789