### PR TITLE
[PropertyInfo] remove deprecations, mark TypeInfo as experimental

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -81,45 +81,6 @@ Mailer
 
  * Postmark's "406 - Inactive recipient" API error code now results in a `PostmarkDeliveryEvent` instead of throwing a `HttpTransportException`
 
-PropertyInfo
-------------
-
- * Deprecate the `Type` class, use `Symfony\Component\TypeInfo\Type` class of `symfony/type-info` component instead
-
-   *Before*
-   ```php
-   use Symfony\Component\PropertyInfo\Type;
-
-   // bool
-   $boolType = new Type(LegacyType::BUILTIN_TYPE_BOOL);
-   // bool|null
-   $nullableType = new Type(LegacyType::BUILTIN_TYPE_BOOL, nullable: true);
-   // array<int, string|null>
-   $arrayType = new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING, true));
-
-   $arrayType->getBuiltinType(); // returns "array"
-   $arrayType->getCollectionKeyTypes(); // returns an array with an "int" Type instance
-   $arrayType->getCollectionValueTypes()[0]->isNullable(); // returns true
-   ```
-
-   *After*
-   ```php
-   use Symfony\Component\TypeInfo\Type;
-
-   // bool
-   $boolType = Type::bool();
-   // bool|null
-   $nullableType = Type::nullable(Type::bool());
-   // array<int, string|null>
-   $arrayType = Type::array(Type::nullable(Type::string()), Type::int());
-
-   (string) $arrayType->getBaseType(); // returns "array"
-   $arrayType->getCollectionKeyType(); // returns an "int" Type instance
-   $arrayType->getCollectionValueType()->isNullable(); // returns true
-   ```
-
- * Deprecate `PropertyTypeExtractorInterface::getTypes()`, use `PropertyTypeExtractorInterface::getType()` instead
-
 HttpKernel
 ----------
 

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -6,8 +6,7 @@ CHANGELOG
 
  * Introduce `PropertyDocBlockExtractorInterface` to extract a property's doc block
  * Restrict access to `PhpStanExtractor` based on visibility
- * Deprecate the `Type` class, use `Symfony\Component\TypeInfo\Type` class of `symfony/type-info` component instead
- * Deprecate the `PropertyTypeExtractorInterface::getTypes()` method, use `PropertyTypeExtractorInterface::getType()` instead
+ * Add `PropertyTypeExtractorInterface::getType()` as experimental
 
 6.4
 ---

--- a/src/Symfony/Component/PropertyInfo/Extractor/ConstructorExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ConstructorExtractor.php
@@ -29,6 +29,9 @@ final class ConstructorExtractor implements PropertyTypeExtractorInterface
     ) {
     }
 
+    /**
+     * @experimental
+     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         foreach ($this->extractors as $extractor) {
@@ -40,13 +43,8 @@ final class ConstructorExtractor implements PropertyTypeExtractorInterface
         return null;
     }
 
-    /**
-     * @deprecated since Symfony 7.1, use "getType" instead
-     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
-
         foreach ($this->extractors as $extractor) {
             $value = $extractor->getTypesFromConstructor($class, $property);
             if (null !== $value) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -118,13 +118,8 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         return '' === $contents ? null : $contents;
     }
 
-    /**
-     * @deprecated since Symfony 7.1, use "getType" instead
-     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
-
         /** @var $docBlock DocBlock */
         [$docBlock, $source, $prefix] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
@@ -176,13 +171,8 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         return [new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, false, null, true, new LegacyType(LegacyType::BUILTIN_TYPE_INT), $types[0])];
     }
 
-    /**
-     * @deprecated since Symfony 7.1, use "getTypeFromConstructor" instead
-     */
     public function getTypesFromConstructor(string $class, string $property): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
-
         $docBlock = $this->getDocBlockFromConstructor($class, $property);
 
         if (!$docBlock) {
@@ -204,6 +194,9 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         return array_merge([], ...$types);
     }
 
+    /**
+     * @experimental
+     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         /** @var $docBlock DocBlock */
@@ -263,6 +256,9 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         return Type::list($type);
     }
 
+    /**
+     * @experimental
+     */
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
         if (!$docBlock = $this->getDocBlockFromConstructor($class, $property)) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -82,13 +82,8 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
         $this->typeContextFactory = new TypeContextFactory($this->stringTypeResolver);
     }
 
-    /**
-     * @deprecated since Symfony 7.1, use "getType" instead
-     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
-
         /** @var PhpDocNode|null $docNode */
         [$docNode, $source, $prefix, $declaringClass] = $this->getDocBlock($class, $property);
         $nameScope = $this->nameScopeFactory->create($class, $declaringClass);
@@ -159,14 +154,10 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
     }
 
     /**
-     * @deprecated since Symfony 7.1, use "getTypeFromConstructor" instead
-     *
      * @return LegacyType[]|null
      */
     public function getTypesFromConstructor(string $class, string $property): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
-
         if (null === $tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
             return null;
         }
@@ -183,6 +174,9 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
         return $types;
     }
 
+    /**
+     * @experimental
+     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         /** @var PhpDocNode|null $docNode */
@@ -229,6 +223,9 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
         return Type::list($type);
     }
 
+    /**
+     * @experimental
+     */
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
         if (!$tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -140,13 +140,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return $properties ? array_values($properties) : null;
     }
 
-    /**
-     * @deprecated since Symfony 7.1, use "getType" instead
-     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
-
         if ($fromMutator = $this->extractFromMutator($class, $property)) {
             return $fromMutator;
         }
@@ -170,14 +165,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     }
 
     /**
-     * @deprecated since Symfony 7.1, use "getTypeFromConstructor" instead
-     *
      * @return LegacyType[]|null
      */
     public function getTypesFromConstructor(string $class, string $property): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
-
         try {
             $reflection = new \ReflectionClass($class);
         } catch (\ReflectionException) {
@@ -199,6 +190,9 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return $types;
     }
 
+    /**
+     * @experimental
+     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         [$mutatorReflection, $prefix] = $this->getMutatorMethod($class, $property);
@@ -260,6 +254,9 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return $type;
     }
 
+    /**
+     * @experimental
+     */
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
         try {

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -56,6 +56,9 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
         return $this->extract('getProperties', [$class, $context]);
     }
 
+    /**
+     * @experimental
+     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         return $this->extract('getType', [$class, $property, $context]);
@@ -66,8 +69,6 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
      */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
-
         return $this->extract('getTypes', [$class, $property, $context]);
     }
 

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -53,18 +53,16 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
         return $this->extract($this->descriptionExtractors, 'getLongDescription', [$class, $property, $context]);
     }
 
+    /**
+     * @experimental
+     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         return $this->extract($this->typeExtractors, 'getType', [$class, $property, $context]);
     }
 
-    /**
-     * @deprecated since Symfony 7.1, use "getType" instead
-     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
-
         return $this->extract($this->typeExtractors, 'getTypes', [$class, $property, $context]);
     }
 

--- a/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
@@ -26,8 +26,6 @@ interface PropertyTypeExtractorInterface
     /**
      * Gets types of a property.
      *
-     * @deprecated since Symfony 7.1, use "getType" instead
-     *
      * @return LegacyType[]|null
      */
     public function getTypes(string $class, string $property, array $context = []): ?array;

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -11,14 +11,10 @@
 
 namespace Symfony\Component\PropertyInfo;
 
-trigger_deprecation('symfony/property-info', '7.1', 'The "%s" class is deprecated. Use "%s" from the "symfony/type-info" component instead.', Type::class, \Symfony\Component\TypeInfo\Type::class);
-
 /**
  * Type value object (immutable).
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
- *
- * @deprecated since Symfony 7.1, use "Symfony\Component\TypeInfo\Type" from the "symfony/type-info" component instead
  *
  * @final
  */

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -41,14 +41,10 @@ final class PhpDocTypeHelper
     /**
      * Creates a {@see LegacyType} from a PHPDoc type.
      *
-     * @deprecated since Symfony 7.1, use "getType" instead
-     *
      * @return LegacyType[]
      */
     public function getTypes(DocType $varType): array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
-
         if ($varType instanceof ConstExpression) {
             // It's safer to fall back to other extractors here, as resolving const types correctly is not easy at the moment
             return [];
@@ -110,6 +106,8 @@ final class PhpDocTypeHelper
 
     /**
      * Creates a {@see Type} from a PHPDoc type.
+     *
+     * @experimental
      */
     public function getType(DocType $varType): ?Type
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Follows https://github.com/symfony/symfony/pull/54788 as we can introduce these deprecation back when we feel the component is stable enough. Software like API Platform that heavily relies on the deprecated functionalities will have a really hard time migrating, we don't want to work more then needed and need to know we won't have to do the same work again in the next years. 
This also suggest that PropertyInfo can work with or without the new TypeInfo component while it's being experimental.