### PR TITLE
[TypeInfo] end/current instead of array_pop

### DIFF
--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -50,11 +50,11 @@ final class TypeContextFactory
         $calledClassPath = explode('\\', $calledClassName);
         $declaringClassPath = explode('\\', $declaringClassName);
 
-        $declaringClassReflection = (self::$reflectionClassCache[$declaringClassName] ??= new \ReflectionClass($declaringClassName));
+        $declaringClassReflection = self::$reflectionClassCache[$declaringClassName] ??= new \ReflectionClass($declaringClassName);
 
         $typeContext = new TypeContext(
-            array_pop($calledClassPath),
-            array_pop($declaringClassPath),
+            end($calledClassPath),
+            end($declaringClassPath),
             trim($declaringClassReflection->getNamespaceName(), '\\'),
             $this->collectUses($declaringClassReflection),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

We don't need to modify the array here, I think it's a micro-optimization to use `end` and `current` instead of changing an array size.