### PR TITLE
[Strings][EnglishInflector] Fix incorrect pluralisation of 'Album'

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -238,6 +238,9 @@ final class EnglishInflector implements InflectorInterface
         // teeth (tooth)
         ['htoot', 5, true, true, 'teeth'],
 
+        // albums (album)
+        ['mubla', 5, true, true, 'albums'],
+
         // bacteria (bacterium), criteria (criterion), phenomena (phenomenon)
         ['mu', 2, true, true, 'a'],
 

--- a/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
@@ -24,6 +24,7 @@ class EnglishInflectorTest extends TestCase
             ['accesses', 'access'],
             ['addresses', 'address'],
             ['agendas', 'agenda'],
+            ['albums', 'album'],
             ['alumnae', 'alumna'],
             ['alumni', 'alumnus'],
             ['analyses', ['analys', 'analyse', 'analysis']],
@@ -179,6 +180,7 @@ class EnglishInflectorTest extends TestCase
             ['address', 'addresses'],
             ['agenda', 'agendas'],
             ['aircraft', 'aircraft'],
+            ['album', 'albums'],
             ['alumnus', 'alumni'],
             ['analysis', 'analyses'],
             ['antenna', 'antennas'], // antennae


### PR DESCRIPTION
Previously it incorrectly returned 'Alba' for 'Album', should be 'Albums'

| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I noticed this with Platform API. Creating an Entity call "Album", for the endpoints it would generate "/api/alba/{id}', which is wrong, should be '/api/albums/{id}'
