### PR TITLE
[Console] Fix issue with reserved keyword "command" as argument name

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -72,6 +72,10 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 class Application implements ResetInterface
 {
+    /**
+     * Description of the command to be executed.
+     */
+    public const COMMAND_ARGUMENT_DESCRIPTION = 'The command to execute';
     private array $commands = [];
     private bool $wantHelps = false;
     private ?Command $runningCommand = null;
@@ -1082,7 +1086,7 @@ class Application implements ResetInterface
     protected function getDefaultInputDefinition(): InputDefinition
     {
         return new InputDefinition([
-            new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
+            new InputArgument('command', InputArgument::REQUIRED, self::COMMAND_ARGUMENT_DESCRIPTION),
             new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display help for the given command. When no command is given display help for the <info>'.$this->defaultCommand.'</info> command'),
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `ArgvInput::getRawTokens()`
+ * Throws `InvalidArgumentException` if an argument was created with the reserved keyword `command` as name and is not the `command name` argument.
 
 7.0
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -407,7 +407,7 @@ class Command
      *
      * @return $this
      *
-     * @throws InvalidArgumentException When argument mode is not valid
+     * @throws InvalidArgumentException When argument name is 'command' or mode is not valid
      */
     public function addArgument(string $name, ?int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -407,7 +407,7 @@ class Command
      *
      * @return $this
      *
-     * @throws InvalidArgumentException When argument name is 'command' or mode is not valid
+     * @throws InvalidArgumentException When argument name is "command" or mode is not valid
      */
     public function addArgument(string $name, ?int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -50,7 +50,7 @@ class InputArgument
      * @param string|bool|int|float|array|null                                              $default         The default value (for self::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
-     * @throws InvalidArgumentException When argument mode is not valid
+     * @throws InvalidArgumentException When argument name is 'command' or mode is not valid
      */
     public function __construct(
         private string $name,
@@ -59,6 +59,9 @@ class InputArgument
         string|bool|int|float|array|null $default = null,
         private \Closure|array $suggestedValues = [],
     ) {
+        if ('command' === $name && 'The command to execute' !== $description) {
+            throw new InvalidArgumentException('Reserved keyword "command" was used as argument name.');
+        }
         if (null === $mode) {
             $mode = self::OPTIONAL;
         } elseif ($mode >= (self::IS_ARRAY << 1) || $mode < 1) {

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Input;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -59,7 +60,7 @@ class InputArgument
         string|bool|int|float|array|null $default = null,
         private \Closure|array $suggestedValues = [],
     ) {
-        if ('command' === $name && 'The command to execute' !== $description) {
+        if ('command' === $name && Application::COMMAND_ARGUMENT_DESCRIPTION !== $description) {
             throw new InvalidArgumentException('The "command" keyword cannot be used as the argument name of a command.');
         }
         if (null === $mode) {

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -50,7 +50,7 @@ class InputArgument
      * @param string|bool|int|float|array|null                                              $default         The default value (for self::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
-     * @throws InvalidArgumentException When argument name is 'command' or mode is not valid
+     * @throws InvalidArgumentException When argument name is "command" or mode is not valid
      */
     public function __construct(
         private string $name,
@@ -60,7 +60,7 @@ class InputArgument
         private \Closure|array $suggestedValues = [],
     ) {
         if ('command' === $name && 'The command to execute' !== $description) {
-            throw new InvalidArgumentException('Reserved keyword "command" was used as argument name.');
+            throw new InvalidArgumentException('The "command" keyword cannot be used as the argument name of a command.');
         }
         if (null === $mode) {
             $mode = self::OPTIONAL;

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1303,7 +1303,7 @@ class ApplicationTest extends TestCase
     public static function getAddingAlreadySetDefinitionElementData(): array
     {
         return [
-            [new InputArgument('command', InputArgument::REQUIRED)],
+            [new InputArgument('command', InputArgument::REQUIRED, 'The command to execute')],
             [new InputOption('quiet', '', InputOption::VALUE_NONE)],
             [new InputOption('query', 'q', InputOption::VALUE_NONE)],
         ];

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1303,7 +1303,7 @@ class ApplicationTest extends TestCase
     public static function getAddingAlreadySetDefinitionElementData(): array
     {
         return [
-            [new InputArgument('command', InputArgument::REQUIRED, 'The command to execute')],
+            [new InputArgument('command', InputArgument::REQUIRED, Application::COMMAND_ARGUMENT_DESCRIPTION)],
             [new InputOption('quiet', '', InputOption::VALUE_NONE)],
             [new InputOption('query', 'q', InputOption::VALUE_NONE)],
         ];

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -316,7 +316,7 @@ class ArgvInputTest extends TestCase
             ],
             [
                 ['cli.php', 'acme:foo', 'bar'],
-                new InputDefinition([new InputArgument('command', InputArgument::REQUIRED)]),
+                new InputDefinition([new InputArgument('command', InputArgument::REQUIRED, 'The command to execute')]),
                 'No arguments expected for "acme:foo" command, got "bar"',
             ],
             [

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Input;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -316,7 +317,7 @@ class ArgvInputTest extends TestCase
             ],
             [
                 ['cli.php', 'acme:foo', 'bar'],
-                new InputDefinition([new InputArgument('command', InputArgument::REQUIRED, 'The command to execute')]),
+                new InputDefinition([new InputArgument('command', InputArgument::REQUIRED, Application::COMMAND_ARGUMENT_DESCRIPTION)]),
                 'No arguments expected for "acme:foo" command, got "bar"',
             ],
             [

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Completion\Suggestion;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -24,6 +25,13 @@ class InputArgumentTest extends TestCase
     {
         $argument = new InputArgument('foo');
         $this->assertEquals('foo', $argument->getName(), '__construct() takes a name as its first argument');
+    }
+
+    public function testReservedArgumentName(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('Reserved keyword "command" was used as argument name.');
+        new InputArgument('command');
     }
 
     public function testModes()

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -27,7 +27,7 @@ class InputArgumentTest extends TestCase
         $this->assertEquals('foo', $argument->getName(), '__construct() takes a name as its first argument');
     }
 
-    public function testReservedArgumentName(): void
+    public function testReservedArgumentName()
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Reserved keyword "command" was used as argument name.');

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -27,10 +27,10 @@ class InputArgumentTest extends TestCase
         $this->assertEquals('foo', $argument->getName(), '__construct() takes a name as its first argument');
     }
 
-    public function testReservedArgumentName()
+    public function testCommandAsArgumentName()
     {
         self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage('Reserved keyword "command" was used as argument name.');
+        self::expectExceptionMessage('The "command" keyword cannot be used as the argument name of a command.');
         new InputArgument('command');
     }
 

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
@@ -30,7 +31,7 @@ class CommandTesterTest extends TestCase
     protected function setUp(): void
     {
         $this->command = new Command('foo');
-        $this->command->addArgument('command');
+        $this->command->addArgument('command', InputArgument::REQUIRED, 'The command to execute');
         $this->command->addArgument('foo');
         $this->command->setCode(function ($input, $output) { $output->writeln('foo'); });
 
@@ -231,7 +232,7 @@ class CommandTesterTest extends TestCase
     public function testErrorOutput()
     {
         $command = new Command('foo');
-        $command->addArgument('command');
+        $command->addArgument('command', InputArgument::REQUIRED, 'The command to execute');
         $command->addArgument('foo');
         $command->setCode(function ($input, $output) {
             $output->getErrorOutput()->write('foo');

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -31,7 +31,7 @@ class CommandTesterTest extends TestCase
     protected function setUp(): void
     {
         $this->command = new Command('foo');
-        $this->command->addArgument('command', InputArgument::REQUIRED, 'The command to execute');
+        $this->command->addArgument('command', InputArgument::REQUIRED, Application::COMMAND_ARGUMENT_DESCRIPTION);
         $this->command->addArgument('foo');
         $this->command->setCode(function ($input, $output) { $output->writeln('foo'); });
 
@@ -232,7 +232,7 @@ class CommandTesterTest extends TestCase
     public function testErrorOutput()
     {
         $command = new Command('foo');
-        $command->addArgument('command', InputArgument::REQUIRED, 'The command to execute');
+        $command->addArgument('command', InputArgument::REQUIRED, Application::COMMAND_ARGUMENT_DESCRIPTION);
         $command->addArgument('foo');
         $command->setCode(function ($input, $output) {
             $output->getErrorOutput()->write('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54729 
| License       | MIT

In the `InputArgument` constructor, an `InvalidArgumentException` is thrown if the reserved keyword `command` is used as the name and is not the argument `command name`.

The change to this PR is a new non-breaking feature, but could also be merged into older versions as a bugfix.