### PR TITLE
[PhpUnitBridge] Fix `DeprecationErrorHandler` with PhpUnit 10

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -368,6 +368,12 @@ class DeprecationErrorHandler
 
         if ('PHPUnit\Util\ErrorHandler::handleError' === $eh) {
             return $eh;
+        } elseif (ErrorHandler::class === $eh) {
+            return function (int $errorNumber, string $errorString, string $errorFile, int $errorLine) {
+                ErrorHandler::instance()($errorNumber, $errorString, $errorFile, $errorLine);
+
+                return true;
+            };
         }
 
         foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, when using the `DeprecationErrorHandler` with PhpUnit 10, warnings are ignored, e.g.:

```php
use PHPUnit\Framework\TestCase;

class ExampleTest extends TestCase
{
    public function testFindUniqueTournamentMonths(): void
    {
        $someVar = $nonExistentVar; // $nonExistentVar doesn't exist

        self::assertSame(1, 1);
    }
}
```

```
PHPUnit 10.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.4
Configuration: /app/phpunit.xml.dist

PHP Warning:  Undefined variable $nonExistentVar in /app/tests/ExampleTest.php on line 11

Warning: Undefined variable $nonExistentVar in /app/tests/ExampleTest.php on line 11
.                                                                   1 / 1 (100%)

Time: 00:00.010, Memory: 19.22 MB

OK (1 test, 1 assertion)
```

The reason I added the closure was to return `true`, otherwise, the errors would still be displayed, e.g.:

```diff
  if ('PHPUnit\Util\ErrorHandler::handleError' === $eh) {
      return $eh;
+ } elseif (ErrorHandler::class === $eh) {
+     return ErrorHandler::instance();
  }
```

```
PHPUnit 10.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.4
Configuration: /app/phpunit.xml.dist

PHP Warning:  Undefined variable $nonExistentVar in /app/tests/ExampleTest.php on line 11

Warning: Undefined variable $nonExistentVar in /app/tests/ExampleTest.php on line 11
W                                                                   1 / 1 (100%)

Time: 00:00.009, Memory: 19.22 MB

OK, but there were issues!
Tests: 1, Assertions: 1, Warnings: 1.
```

Now, it works as expected:

```
PHPUnit 10.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.4
Configuration: /app/phpunit.xml.dist

W                                                                   1 / 1 (100%)

Time: 00:00.008, Memory: 19.22 MB

OK, but there were issues!
Tests: 1, Assertions: 1, Warnings: 1.
```