### PR TITLE
[Filesystem] Run high-deps tests with Process 7

### DIFF
--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -21,7 +21,7 @@
         "symfony/polyfill-mbstring": "~1.8"
     },
     "require-dev": {
-        "symfony/process": "^5.4|^6.4"
+        "symfony/process": "^5.4|^6.4|^7.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Filesystem\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The Filesystem component requires Process 6.4 for tests which looks unnecessarily strict. Let's allow v7 as well.