### PR TITLE
[Serializer] Fix missing test assertion

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -214,8 +214,10 @@ CSV
 
     public function testMultipleEmptyHeaderNamesWithSeparator()
     {
-        $this->encoder->decode(',.
+        $data = $this->encoder->decode(',.
 ,', 'csv');
+
+        $this->assertSame([[0 => '', 1 => [1 => '']]], $data);
     }
 
     public function testEncodeVariableStructure()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The test currently throws a warning because no assertion is done.