### PR TITLE
[HttpClient]  deprecate setLogger() methods of decorating clients

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -29,6 +29,7 @@ Components
  * [ExpressionLanguage](#ExpressionLanguage)
  * [Form](#Form)
  * [Intl](#Intl)
+ * [HttpClient](#HttpClient)
  * [PropertyInfo](#PropertyInfo)
  * [Translation](#Translation)
  * [Workflow](#Workflow)
@@ -71,6 +72,11 @@ FrameworkBundle
  * Mark classes `ConfigBuilderCacheWarmer`, `Router`, `SerializerCacheWarmer`, `TranslationsCacheWarmer`, `Translator` and `ValidatorCacheWarmer` as `final`
  * Deprecate the `router.cache_dir` config option, the Router will always use the `kernel.build_dir` parameter
  * Reset env vars when resetting the container
+
+HttpClient
+----------
+
+ * Deprecate the `setLogger()` methods of the `NoPrivateNetworkHttpClient`, `TraceableHttpClient` and `ScopingHttpClient` classes, configure the logger of the wrapped clients directly instead
 
 Intl
 ----

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow mocking `start_time` info in `MockResponse`
  * Add `MockResponse::fromFile()` and `JsonMockResponse::fromFile()` methods to help using fixtures files
  * Add `ThrottlingHttpClient` to enable limiting the number of requests within a certain period
+ * Deprecate the `setLogger()` methods of the `NoPrivateNetworkHttpClient`, `TraceableHttpClient` and `ScopingHttpClient` classes, configure the logger of the wrapped clients directly instead
 
 7.0
 ---

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -77,8 +77,13 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         return $this->client->stream($responses, $timeout);
     }
 
+    /**
+     * @deprecated since Symfony 7.1, configure the logger on the wrapper HTTP client directly instead
+     */
     public function setLogger(LoggerInterface $logger): void
     {
+        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapper HTTP client directly instead.');
+
         if ($this->client instanceof LoggerAwareInterface) {
             $this->client->setLogger($logger);
         }

--- a/src/Symfony/Component/HttpClient/ScopingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/ScopingHttpClient.php
@@ -100,8 +100,13 @@ class ScopingHttpClient implements HttpClientInterface, ResetInterface, LoggerAw
         }
     }
 
+    /**
+     * @deprecated since Symfony 7.1, configure the logger on the wrapper HTTP client directly instead
+     */
     public function setLogger(LoggerInterface $logger): void
     {
+        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapper HTTP client directly instead.');
+
         if ($this->client instanceof LoggerAwareInterface) {
             $this->client->setLogger($logger);
         }

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -89,8 +89,13 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
         $this->tracedRequests->exchangeArray([]);
     }
 
+    /**
+     * @deprecated since Symfony 7.1, configure the logger on the wrapper HTTP client directly instead
+     */
     public function setLogger(LoggerInterface $logger): void
     {
+        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapper HTTP client directly instead.');
+
         if ($this->client instanceof LoggerAwareInterface) {
             $this->client->setLogger($logger);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix https://github.com/symfony/symfony/pull/54674#pullrequestreview-2035168803
| License       | MIT