### PR TITLE
[TwigBundle] Remove obsolete class_exists() call

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfigurator.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfigurator.php
@@ -15,9 +15,6 @@ use Symfony\Bridge\Twig\UndefinedCallableHandler;
 use Twig\Environment;
 use Twig\Extension\CoreExtension;
 
-// BC/FC with namespaced Twig
-class_exists(Environment::class);
-
 /**
  * Twig environment configurator.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Given that we require Twig >= 3, I believe we don't need to trigger the autoloader at this point anymore.