### PR TITLE
[TwigBundle] Fix deprecation warnings about base_template_class

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -11,7 +11,6 @@ $container->loadFromExtension('twig', [
         'bad' => ['key' => 'foo'],
     ],
     'auto_reload' => true,
-    'base_template_class' => 'stdClass',
     'cache' => '/tmp',
     'charset' => 'ISO-8859-1',
     'debug' => true,

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/templateClass.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/templateClass.php
@@ -1,0 +1,5 @@
+<?php
+
+$container->loadFromExtension('twig', [
+    'base_template_class' => 'stdClass',
+]);

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/extra.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/extra.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/twig https://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config auto-reload="true" base-template-class="stdClass" cache="/tmp" charset="ISO-8859-1" debug="true" strict-variables="true">
+    <twig:config auto-reload="true" cache="/tmp" charset="ISO-8859-1" debug="true" strict-variables="true">
         <twig:path namespace="namespace3">namespaced_path3</twig:path>
     </twig:config>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/twig https://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config auto-reload="true" base-template-class="stdClass" cache="/tmp" charset="ISO-8859-1" debug="true" strict-variables="true" default-path="%kernel.project_dir%/Fixtures/templates">
+    <twig:config auto-reload="true" cache="/tmp" charset="ISO-8859-1" debug="true" strict-variables="true" default-path="%kernel.project_dir%/Fixtures/templates">
         <twig:form-theme>MyBundle::form.html.twig</twig:form-theme>
         <twig:global key="foo" id="bar" type="service" />
         <twig:global key="baz">@@qux</twig:global>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/templateClass.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/templateClass.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:twig="http://symfony.com/schema/dic/twig"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/twig https://symfony.com/schema/dic/twig/twig-1.0.xsd">
+
+    <twig:config base-template-class="stdClass" />
+</container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -7,7 +7,6 @@ twig:
         pi:  3.14
         bad: {key: foo}
     auto_reload:         true
-    base_template_class: stdClass
     cache:               /tmp
     charset:             ISO-8859-1
     debug:               true

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/templateClass.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/templateClass.yml
@@ -1,0 +1,2 @@
+twig:
+    base_template_class: stdClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follows #54657
| License       | MIT

Since #54657, TwigBundle uses its own deprecated option in non-legacy tests. This PR fixes this by testing that option and the triggered deprecation message in a separate test.