### PR TITLE
[HttpKernel] Support variadic with `#[MapRequestPayload]`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Deprecate the `Symfony\Component\HttpKernel\DependencyInjection\Extension` class, use the parent `Symfony\Component\DependencyInjection\Extension\Extension` class instead
  * Allow using Expression or \Closure for `validationGroups` in `#[MapRequestPayload]` and `#[MapQueryString]`
  * Deprecate passing a `ControllerArgumentsEvent` to the `ViewEvent` constructor; pass a `ControllerArgumentsMetadata` instead
+ * Support variadic argument with `#[MapRequestPayload]`
 
 8.0
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -84,7 +84,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             return [];
         }
 
-        if (!$attribute instanceof MapUploadedFile && $argument->isVariadic()) {
+        if ($attribute instanceof MapQueryString && $argument->isVariadic()) {
             throw new \LogicException(\sprintf('Mapping variadic argument "$%s" is not supported.', $argument->getName()));
         }
 
@@ -93,7 +93,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 if (!$attribute->type) {
                     throw new NearMissValueResolverException(\sprintf('Please set the $type argument of the #[%s] attribute to the type of the objects in the expected array.', MapRequestPayload::class));
                 }
-            } elseif ($attribute->type) {
+            } elseif ($attribute->type && !$argument->isVariadic()) {
                 throw new NearMissValueResolverException(\sprintf('Please set its type to "array" when using argument $type of #[%s].', MapRequestPayload::class));
             }
         }
@@ -176,7 +176,11 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 };
             }
 
-            $arguments[$i] = $payload;
+            if ($argument->metadata->isVariadic()) {
+                array_splice($arguments, $i, 1, $payload);
+            } else {
+                $arguments[$i] = $payload;
+            }
         }
 
         $event->setArguments($arguments);
@@ -212,11 +216,11 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             throw new UnsupportedMediaTypeHttpException(\sprintf('Unsupported format, expects "%s", but "%s" given.', implode('", "', (array) $attribute->acceptFormat), $format));
         }
 
-        if ('array' === $argument->getType() && null !== $attribute->type) {
-            $type = $attribute->type.'[]';
-        } else {
-            $type = $argument->getType();
-        }
+        $type = match (true) {
+            $argument->isVariadic() => ($attribute->type ?? $argument->getType()).'[]',
+            'array' === $argument->getType() && null !== $attribute->type => $attribute->type.'[]',
+            default => $argument->getType(),
+        };
 
         if (\is_array($data)) {
             $data = $this->mergeParamsAndFiles($data, $request->files->all());

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -592,7 +592,7 @@ class RequestPayloadValueResolverTest extends TestCase
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('variadic', RequestPayload::class, true, false, null, false, [
-            MapRequestPayload::class => new MapRequestPayload(),
+            MapQueryString::class => new MapQueryString(),
         ]);
         $request = Request::create('/', 'POST');
 
@@ -976,6 +976,70 @@ class RequestPayloadValueResolverTest extends TestCase
 
         $this->assertInstanceOf(QueryPayload::class, $event->getArguments()[0]);
         $this->assertSame(1.0, $event->getArguments()[0]->page);
+    }
+
+    public function testMapRequestPayloadVariadic()
+    {
+        $input = [
+            ['price' => '50'],
+            ['price' => '23'],
+        ];
+        $payload = [
+            new RequestPayload(50),
+            new RequestPayload(23),
+        ];
+
+        $serializer = new Serializer([new ArrayDenormalizer(), new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())
+            ->method('validate')
+            ->willReturn(new ConstraintViolationList());
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $argument = new ArgumentMetadata('prices', RequestPayload::class, true, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+        $request = Request::create('/', 'POST', $input);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $this->assertEquals($payload, $event->getArguments());
+    }
+
+    public function testMapRequestPayloadVariadicJson()
+    {
+        $payload = [
+            new RequestPayload(50),
+            new RequestPayload(23),
+        ];
+
+        $serializer = new Serializer([new ArrayDenormalizer(), new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())
+            ->method('validate')
+            ->willReturn(new ConstraintViolationList());
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $argument = new ArgumentMetadata('prices', RequestPayload::class, true, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+        $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '[{"price": 50}, {"price": 23}]');
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $this->assertEquals($payload, $event->getArguments());
     }
 
     public function testMapRequestPayloadWithUploadedFiles()

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -319,7 +319,7 @@ class UploadedFileValueResolverTest extends TestCase
         $resolver->onKernelControllerArguments($event);
 
         /** @var UploadedFile[] $data */
-        $data = $event->getArguments()[0];
+        $data = $event->getArguments();
 
         $this->assertCount(2, $data);
         $this->assertSame('file-small.txt', $data[0]->getFilename());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | -
| License       | MIT

Adds support for variadic arguments in combination with `#[MapRequestPayload]`. 

#### Example request
```json
Content-Type: application/json
[
    {"price": 50},
    {"price": 23}
]
```

#### Example controller usage
```php
class MyController
{
    public function __invoke(
        #[MapRequestPayload] Price ...$prices,
    ): Response {
        // do something with $prices -> array<Price>
    }
}
```

This PR also fixes a bug introduced in https://github.com/symfony/symfony/pull/49978 where using `#[MapUploadedFile]` with a variadic argument causes a `TypeError`:
```php
class MyController
{
    public function __invoke(
        #[MapUploadedFile] UploadedFile ...$documents,
    ): Response {
    }
}
```
```
Argument #1 must be of type Symfony\\Component\\HttpFoundation\\File\\UploadedFile, array given
```