### PR TITLE
[Serializer] Fix `GetSetMethodNormalizer` not working with setters with optional args

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -107,7 +107,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
     {
         return !$method->isStatic()
             && (\PHP_VERSION_ID < 80000 || !$method->getAttributes(Ignore::class))
-            && 1 === $method->getNumberOfRequiredParameters()
+            && 0 < $method->getNumberOfParameters()
             && str_starts_with($method->name, 'set');
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -538,6 +538,18 @@ class GetSetMethodNormalizerTest extends TestCase
         $obj = $this->normalizer->denormalize(['foo' => 'foo'], GetSetDummyChild::class);
         $this->assertSame('foo', $obj->getFoo());
     }
+
+    /**
+     * @testWith [{"foo":"foo"}, "getFoo", "foo"]
+     *           [{"bar":"bar"}, "getBar", "bar"]
+     */
+    public function testSupportsAndDenormalizeWithOptionalSetterArgument(array $data, string $method, string $expected)
+    {
+        $this->assertTrue($this->normalizer->supportsDenormalization($data, GetSetDummyWithOptionalAndMultipleSetterArgs::class));
+
+        $obj = $this->normalizer->denormalize($data, GetSetDummyWithOptionalAndMultipleSetterArgs::class);
+        $this->assertSame($expected, $obj->$method());
+    }
 }
 
 class GetSetDummy
@@ -859,5 +871,31 @@ class GetSetDummyParent
     public function setFoo($foo)
     {
         $this->foo = $foo;
+    }
+}
+
+class GetSetDummyWithOptionalAndMultipleSetterArgs
+{
+    private $foo;
+    private $bar;
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function setFoo($foo = null)
+    {
+        $this->foo = $foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function setBar($bar = null, $other = true)
+    {
+        $this->bar = $bar;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54784
| License       | MIT

Prior to #52917 setters could have an optional argument or even multiple ones. This restores the previous behavior.