### PR TITLE
[HttpClient] Fix cURL default options for PHP 8.4

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -174,10 +174,6 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
             curl_multi_remove_handle($multi->handle, $ch);
             curl_setopt_array($ch, [
                 \CURLOPT_NOPROGRESS => true,
-                \CURLOPT_PROGRESSFUNCTION => null,
-                \CURLOPT_HEADERFUNCTION => null,
-                \CURLOPT_WRITEFUNCTION => null,
-                \CURLOPT_READFUNCTION => null,
                 \CURLOPT_INFILE => null,
             ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PHP 8.4 brings a change in ext/curl (https://github.com/php/php-src/pull/13291) that requires `CurlResponse` to be updated. Curl callbacks cannot be set to null anymore and requires real callable.

Here is (one of) the CI error it fixes:

```
10) Symfony\Component\HttpClient\Tests\CurlHttpClientTest::testGzipBroken
Failed asserting that exception of type "TypeError" matches expected exception "Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface". Message was: "curl_setopt_array(): Argument #2 ($options) must be a valid callback for option CURLOPT_PROGRESSFUNCTION, no array or string given" at
/home/runner/work/symfony/symfony/src/Symfony/Component/HttpClient/Response/CurlResponse.php:175
/home/runner/work/symfony/symfony/src/Symfony/Component/HttpClient/Internal/Canary.php:32
/home/runner/work/symfony/symfony/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php:90
/home/runner/work/symfony/symfony/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php:218
/home/runner/work/symfony/symfony/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php:68
/home/runner/work/symfony/symfony/src/Symfony/Component/HttpClient/Response/CurlResponse.php:232
/home/runner/work/symfony/symfony/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php:1113
```