### PR TITLE
[Mailer] [Sendgrid] Use `DataPart::getContentId()` when `DataPart::setContentId()` is used

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -245,4 +245,45 @@ class SendgridApiTransportTest extends TestCase
         $this->assertSame('blue', $payload['personalizations'][0]['custom_args']['Color']);
         $this->assertSame('12345', $payload['personalizations'][0]['custom_args']['Client-ID']);
     }
+
+    public function testInlineWithCustomContentId()
+    {
+        $imagePart = (new DataPart('text-contents', 'text.txt'));
+        $imagePart->asInline();
+        $imagePart->setContentId('content-identifier@symfony');
+
+        $email = new Email();
+        $email->addPart($imagePart);
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('attachments', $payload);
+        $this->assertCount(1, $payload['attachments']);
+        $this->assertArrayHasKey('content_id', $payload['attachments'][0]);
+
+        $this->assertSame('content-identifier@symfony', $payload['attachments'][0]['content_id']);
+    }
+
+    public function testInlineWithoutCustomContentId()
+    {
+        $imagePart = (new DataPart('text-contents', 'text.txt'));
+        $imagePart->asInline();
+
+        $email = new Email();
+        $email->addPart($imagePart);
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('attachments', $payload);
+        $this->assertCount(1, $payload['attachments']);
+        $this->assertArrayHasKey('content_id', $payload['attachments'][0]);
+
+        $this->assertSame('text.txt', $payload['attachments'][0]['content_id']);
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -179,7 +179,7 @@ class SendgridApiTransport extends AbstractApiTransport
             ];
 
             if ('inline' === $disposition) {
-                $att['content_id'] = $filename;
+                $att['content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
             }
 
             $attachments[] = $att;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | See bellow
| License       | MIT

Fixes the content identifier set via `DataPart::setContentId()` not being respected. Instead the `$filename` of the `DataPart` was being used resulting in unexpected behaviour. To provide backwards compatibility the `DataPart::hasContentId()` is being used to keep the current behaviour.

Applied to 6.4 since `DataPart::setContentId()` was introduced in 6.2.
