### PR TITLE
[WebProfilerBundle] Fix assignment to constant variable

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -75,7 +75,7 @@
                     }
 
                     tab.addEventListener('click', function(e) {
-                        const activeTab = e.target || e.srcElement;
+                        let activeTab = e.target || e.srcElement;
 
                         /* needed because when the tab contains HTML contents, user can click */
                         /* on any of those elements instead of their parent '<button>' element */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The current js code can trigger an error if it reaches line 83, e.g. if you click on a badge in the tab:

![image](https://github.com/symfony/symfony/assets/2445045/6ae44233-a746-43cb-a6a2-d14eda765683)

![image](https://github.com/symfony/symfony/assets/2445045/274a35db-3825-4971-9e53-badb96d83de7)
