### PR TITLE
[Notifier] [Mastodon][Twitter] Check for `symfony/mime` if attachment is used

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransport.php
@@ -73,7 +73,7 @@ final class MastodonTransport extends AbstractTransport
 
         try {
             if (isset($options['attach'])) {
-                if (!class_exists(\Symfony\Component\Mime\Part\File::class)) {
+                if (!class_exists(File::class)) {
                     throw new LogicException('Unable to handle attachments as the Symfony Mime Component is not installed. Try running "composer require symfony/mime".');
                 }
 

--- a/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Mastodon;
 
+use Symfony\Component\BrowserKit\Exception\LogicException;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\File;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
@@ -72,6 +73,10 @@ final class MastodonTransport extends AbstractTransport
 
         try {
             if (isset($options['attach'])) {
+                if (!class_exists(\Symfony\Component\Mime\Part\File::class)) {
+                    throw new LogicException('Unable to handle attachments as the Symfony Mime Component is not installed. Try running "composer require symfony/mime".');
+                }
+
                 $options['media_ids'] = $this->uploadMedia($options['attach']);
                 unset($options['attach']);
             }

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Twitter;
 
+use Symfony\Component\BrowserKit\Exception\LogicException;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\File;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
@@ -121,6 +122,10 @@ final class TwitterTransport extends AbstractTransport
 
         try {
             if (isset($options['attach'])) {
+                if (!class_exists(\Symfony\Component\Mime\Part\File::class)) {
+                    throw new LogicException('Unable to handle attachments as the Symfony Mime Component is not installed. Try running "composer require symfony/mime".');
+                }
+
                 $options['media']['media_ids'] = $this->uploadMedia($options['attach']);
                 unset($options['attach']);
             }

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
@@ -122,7 +122,7 @@ final class TwitterTransport extends AbstractTransport
 
         try {
             if (isset($options['attach'])) {
-                if (!class_exists(\Symfony\Component\Mime\Part\File::class)) {
+                if (!class_exists(File::class)) {
                     throw new LogicException('Unable to handle attachments as the Symfony Mime Component is not installed. Try running "composer require symfony/mime".');
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

As `symfony/mime` is in `require-dev` section, this can throw a fatal error
