### PR TITLE
[HttpClient] Fix sending content type based on `CURLOPT_INFILESIZE`

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -247,7 +247,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             if (isset($options['normalized_headers']['content-length'][0])) {
                 $curlopts[\CURLOPT_INFILESIZE] = (int) substr($options['normalized_headers']['content-length'][0], \strlen('Content-Length: '));
             } elseif (!isset($options['normalized_headers']['transfer-encoding'])) {
-                $curlopts[\CURLOPT_INFILESIZE] = -1;
+                unset($curlopts[\CURLOPT_INFILESIZE]);
             }
 
             if ('POST' !== $method) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

⚠️ Currently debugging, AppVeyor requires a PR to be triggered

Since #54517, CurlHttpClient test is broken on AppVeyor (see https://ci.appveyor.com/project/fabpot/symfony/builds/49568707#L2472).