### PR TITLE
[VarExporter] fix `ProxyHelper::generateLazyProxy()` when a method returns null

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -231,7 +231,7 @@ class ReflectionCaster
         if (isset($a[$prefix.'returnType'])) {
             $v = $a[$prefix.'returnType'];
             $v = $v instanceof \ReflectionNamedType ? $v->getName() : (string) $v;
-            $a[$prefix.'returnType'] = new ClassStub($a[$prefix.'returnType'] instanceof \ReflectionNamedType && $a[$prefix.'returnType']->allowsNull() && 'mixed' !== $v ? '?'.$v : $v, [class_exists($v, false) || interface_exists($v, false) || trait_exists($v, false) ? $v : '', '']);
+            $a[$prefix.'returnType'] = new ClassStub($a[$prefix.'returnType'] instanceof \ReflectionNamedType && $a[$prefix.'returnType']->allowsNull() && !\in_array($v, ['mixed', 'null'], true) ? '?'.$v : $v, [class_exists($v, false) || interface_exists($v, false) || trait_exists($v, false) ? $v : '', '']);
         }
         if (isset($a[$prefix.'class'])) {
             $a[$prefix.'class'] = new ClassStub($a[$prefix.'class']);
@@ -413,7 +413,7 @@ class ReflectionCaster
                     if (!$type instanceof \ReflectionNamedType) {
                         $signature .= $type.' ';
                     } else {
-                        if ($param->allowsNull() && 'mixed' !== $type->getName()) {
+                        if ($param->allowsNull() && !\in_array($type->getName(), ['mixed', 'null'], true)) {
                             $signature .= '?';
                         }
                         $signature .= substr(strrchr('\\'.$type->getName(), '\\'), 1).' ';

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\VarDumper\Tests\Fixtures\ExtendsReflectionTypeFixture;
 use Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo;
 use Symfony\Component\VarDumper\Tests\Fixtures\LotsOfAttributes;
 use Symfony\Component\VarDumper\Tests\Fixtures\NotLoadableClass;
+use Symfony\Component\VarDumper\Tests\Fixtures\Php82NullStandaloneReturnType;
 use Symfony\Component\VarDumper\Tests\Fixtures\ReflectionIntersectionTypeFixture;
 use Symfony\Component\VarDumper\Tests\Fixtures\ReflectionNamedTypeFixture;
 use Symfony\Component\VarDumper\Tests\Fixtures\ReflectionUnionTypeFixture;
@@ -95,7 +96,7 @@ Closure($x) {
     $b: & 123
   }
   file: "%sReflectionCasterTest.php"
-  line: "88 to 88"
+  line: "%s"
 }
 EOTXT
             , $var
@@ -403,6 +404,26 @@ Closure(): mixed {
 }
 EOTXT
             , $f
+        );
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testNullReturnType()
+    {
+        $className = Php82NullStandaloneReturnType::class;
+
+        $this->assertDumpMatchesFormat(
+            <<<EOTXT
+{$className}::foo(null \$bar): null {
+  returnType: "null"
+  this: {$className} { …}
+  file: "%s"
+  line: "%s"
+}
+EOTXT
+            , (new Php82NullStandaloneReturnType())->foo(...)
         );
     }
 

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/Php82NullStandaloneReturnType.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/Php82NullStandaloneReturnType.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Fixtures;
+
+class Php82NullStandaloneReturnType
+{
+    public function foo(null $bar): null
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -311,7 +311,7 @@ final class ProxyHelper
             return '';
         }
         if (null === $glue) {
-            return (!$noBuiltin && $type->allowsNull() && 'mixed' !== $name ? '?' : '').$types[0];
+            return (!$noBuiltin && $type->allowsNull() && !\in_array($name, ['mixed', 'null'], true) ? '?' : '').$types[0];
         }
         sort($types);
 

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/Php82NullStandaloneReturnType.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/Php82NullStandaloneReturnType.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
+
+class Php82NullStandaloneReturnType
+{
+    public function foo(): null
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\VarExporter\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\ProxyHelper;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Php82NullStandaloneReturnType;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\StringMagicGetClass;
 
 class ProxyHelperTest extends TestCase
@@ -187,6 +188,17 @@ class ProxyHelperTest extends TestCase
     {
         $this->expectException(LogicException::class);
         ProxyHelper::generateLazyGhost(new \ReflectionClass(StringMagicGetClass::class));
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testNullStandaloneReturnType()
+    {
+        self::assertStringContainsString(
+            'public function foo(): null',
+            ProxyHelper::generateLazyProxy(new \ReflectionClass(Php82NullStandaloneReturnType::class))
+        );
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When a methods has such a signature: 
```php
public function foo(): null
```

the method `ProxyHelper::generateLazyProxy()` produces a wrong code:

```php
public function foo(): ?null
```

This PR fixes this.