### PR TITLE
[Serializer] Fixed "Warning: Attempt to read property "value" on string"

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -730,7 +730,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                                 $typeIdentifier = TypeIdentifier::OBJECT;
                                 $class = $t->getClassName();
                             } else {
-                                $typeIdentifier = $t->getTypeIdentifier()->value;
+                                $typeIdentifier = $t->getTypeIdentifier();
                                 $class = null;
                             }
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 (7.1.0-BETA1)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fixed regresion of https://github.com/symfony/symfony/pull/53160
| License       | MIT

Hi! I've updated my project to `7.1.0-BETA1` and I found an error.

After update I got: `Warning: Attempt to read property "value" on string` in `vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:748` because in `733 line` the enum-case of value `TypeIdentifier` has been already readed.

![obraz](https://github.com/symfony/symfony/assets/16488888/5227ac76-0fb0-4b00-ab68-2394ab41d7b7)

Quite not sure if tests are possible here.
