### PR TITLE
[Stopwatch] Add `ROOT` constant to make it easier to reference

### DIFF
--- a/src/Symfony/Component/Stopwatch/CHANGELOG.md
+++ b/src/Symfony/Component/Stopwatch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `getRootSectionEvents()` method and `ROOT` constant to `Stopwatch`
+
 5.2
 ---
 

--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -23,6 +23,8 @@ class_exists(Section::class);
  */
 class Stopwatch implements ResetInterface
 {
+    public const ROOT = '__root__';
+
     /**
      * @var Section[]
      */
@@ -138,7 +140,17 @@ class Stopwatch implements ResetInterface
      */
     public function getSectionEvents(string $id): array
     {
-        return isset($this->sections[$id]) ? $this->sections[$id]->getEvents() : [];
+        return $this->sections[$id]->getEvents() ?? [];
+    }
+
+    /**
+     * Gets all events for the root section.
+     *
+     * @return StopwatchEvent[]
+     */
+    public function getRootSectionEvents(): array
+    {
+        return $this->sections[self::ROOT]->getEvents() ?? [];
     }
 
     /**
@@ -146,6 +158,6 @@ class Stopwatch implements ResetInterface
      */
     public function reset(): void
     {
-        $this->sections = $this->activeSections = ['__root__' => new Section(null, $this->morePrecision)];
+        $this->sections = $this->activeSections = [self::ROOT => new Section(null, $this->morePrecision)];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Just an DX improvement so you can reference the root section with `$stopwatch->getSectionEvents(Stopwatch::ROOT)` instead of `$stopwatch->getSectionEvents('__root__')`.