### PR TITLE
[Stopwatch] Add `getLastPeriod` method to `StopwatchEvent`

### DIFF
--- a/src/Symfony/Component/Stopwatch/CHANGELOG.md
+++ b/src/Symfony/Component/Stopwatch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add method `getLastPeriod()` to `StopwatchEvent`
+
 5.2
 ---
 

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -137,6 +137,18 @@ class StopwatchEvent
     }
 
     /**
+     * Gets the last event period.
+     */
+    public function getLastPeriod(): ?StopwatchPeriod
+    {
+        if ([] === $this->periods) {
+            return null;
+        }
+
+        return $this->periods[array_key_last($this->periods)];
+    }
+
+    /**
      * Gets the relative time of the start of the first period in milliseconds.
      */
     public function getStartTime(): int|float

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Stopwatch;
 
 /**
- * Represents an Period for an Event.
+ * Represents a Period for an Event.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

It's often useful to just get the last period (if you start and stop an event several times).

### Example
https://github.com/doctrine/migrations/blob/3.7.x/lib/Doctrine/Migrations/Version/DbalExecutor.php#L167-L168

This adds a simple `getLastPeriod` method on the `StopwatchEvent` class.