### PR TITLE
[PasswordHasher] Make bcrypt nul byte hash test tolerant to PHP related failures

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
@@ -98,15 +98,43 @@ class NativePasswordHasherTest extends TestCase
         $this->assertTrue($hasher->verify($hasher->hash($plainPassword), $plainPassword));
     }
 
-    public function testBcryptWithNulByte()
+    /**
+     * @requires PHP < 8.4
+     */
+    public function testBcryptWithNulByteWithNativePasswordHash()
     {
         $hasher = new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT);
         $plainPassword = "a\0b";
 
-        if (\PHP_VERSION_ID < 80218 || \PHP_VERSION_ID >= 80300 && \PHP_VERSION_ID < 80305) {
-            // password_hash() does not accept passwords containing NUL bytes since PHP 8.2.18 and 8.3.5
-            $this->assertFalse($hasher->verify(password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]), $plainPassword));
+        try {
+            $hash = password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]);
+        } catch (\Throwable $throwable) {
+            // we skip the test in case the current PHP version does not support NUL bytes in passwords
+            // with bcrypt
+            //
+            // @see https://github.com/php/php-src/commit/11f2568767660ffe92fbc6799800e01203aad73a
+            if (str_contains($throwable->getMessage(), 'Bcrypt password must not contain null character')) {
+                $this->markTestSkipped('password_hash() does not accept passwords containing NUL bytes.');
+            }
+
+            throw $throwable;
         }
+
+        if (null === $hash) {
+            // we also skip the test in case password_hash() returns null as
+            // implemented in security patches backports
+            //
+            // @see https://github.com/shivammathur/php-src-backports/commit/d22d9ebb29dce86edd622205dd1196a2796c08c7
+            $this->markTestSkipped('password_hash() does not accept passwords containing NUL bytes.');
+        }
+
+        $this->assertTrue($hasher->verify($hash, $plainPassword));
+    }
+
+    public function testPasswordNulByteGracefullyHandled()
+    {
+        $hasher = new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT);
+        $plainPassword = "a\0b";
 
         $this->assertTrue($hasher->verify($hasher->hash($plainPassword), $plainPassword));
     }

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
@@ -73,17 +73,45 @@ class SodiumPasswordHasherTest extends TestCase
         $this->assertTrue($hasher->verify((new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT))->hash($plainPassword), $plainPassword));
     }
 
-    public function testBcryptWithNulByte()
+    /**
+     * @requires PHP < 8.4
+     */
+    public function testBcryptWithNulByteWithNativePasswordHash()
     {
         $hasher = new SodiumPasswordHasher(null, null);
         $plainPassword = "a\0b";
 
-        if (\PHP_VERSION_ID < 80218 || \PHP_VERSION_ID >= 80300 && \PHP_VERSION_ID < 80305) {
-            // password_hash() does not accept passwords containing NUL bytes since PHP 8.2.18 and 8.3.5
-            $this->assertFalse($hasher->verify(password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]), $plainPassword));
+        try {
+            $hash = password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]);
+        } catch (\Throwable $throwable) {
+            // we skip the test in case the current PHP version does not support NUL bytes in passwords
+            // with bcrypt
+            //
+            // @see https://github.com/php/php-src/commit/11f2568767660ffe92fbc6799800e01203aad73a
+            if (str_contains($throwable->getMessage(), 'Bcrypt password must not contain null character')) {
+                $this->markTestSkipped('password_hash() does not accept passwords containing NUL bytes.');
+            }
+
+            throw $throwable;
         }
 
-        $this->assertTrue($hasher->verify((new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT))->hash($plainPassword), $plainPassword));
+        if (null === $hash) {
+            // we also skip the test in case password_hash() returns null as
+            // implemented in security patches backports
+            //
+            // @see https://github.com/shivammathur/php-src-backports/commit/d22d9ebb29dce86edd622205dd1196a2796c08c7
+            $this->markTestSkipped('password_hash() does not accept passwords containing NUL bytes.');
+        }
+
+        $this->assertTrue($hasher->verify($hash, $plainPassword));
+    }
+
+    public function testPasswordNulByteGracefullyHandled()
+    {
+        $hasher = new SodiumPasswordHasher(null, null);
+        $plainPassword = "a\0b";
+
+        $this->assertTrue($hasher->verify($hasher->hash($plainPassword), $plainPassword));
     }
 
     public function testUserProvidedSaltIsNotUsed()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Bcrypt throws on PHP < 8.2 when passing a nul byte. The related test should be skipped for these versions as `$hasher->verify()` return value cannot be asserted.

Related failure: https://github.com/symfony/symfony/actions/runs/8980661047/job/24664698662#step:7:1168