### PR TITLE
[Messenger] Don't mark `EnvelopeAwareExceptionInterface` internal

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `--all` option to the `messenger:consume` command
  * Add parameter `$jitter` to `MultiplierRetryStrategy` in order to randomize delay and prevent the thundering herd effect
  * Add `SIGQUIT` signal among list of signals that gracefully shut down `messenger:consume` and `messenger:failed:retry` commands
+ * Add `EnvelopeAwareExceptionInterface` for exceptions thrown from middlewares to prevent stamps added by previous middlewares being dropped
 
 7.0
 ---

--- a/src/Symfony/Component/Messenger/Exception/EnvelopeAwareExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/EnvelopeAwareExceptionInterface.php
@@ -13,9 +13,6 @@ namespace Symfony\Component\Messenger\Exception;
 
 use Symfony\Component\Messenger\Envelope;
 
-/**
- * @internal
- */
 interface EnvelopeAwareExceptionInterface
 {
     public function getEnvelope(): ?Envelope;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

As discussed [here](https://github.com/symfony/symfony/pull/54842#issuecomment-2097535140), let's expose `EnvelopeAwareExceptionInterface` to allow custom Messenger middlewares throw a custom exception without causing stamps from previous middlewares being dropped.