### PR TITLE
[HttpClient] Revert fixing curl default options

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -174,6 +174,10 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
             curl_multi_remove_handle($multi->handle, $ch);
             curl_setopt_array($ch, [
                 \CURLOPT_NOPROGRESS => true,
+                \CURLOPT_PROGRESSFUNCTION => null,
+                \CURLOPT_HEADERFUNCTION => null,
+                \CURLOPT_WRITEFUNCTION => null,
+                \CURLOPT_READFUNCTION => null,
                 \CURLOPT_INFILE => null,
             ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Reverts #54830 because https://github.com/php/php-src/pull/14165 got merged and fixes the unintentional BC break.

(CI still red but should go to green when new nightlies are built)