### PR TITLE
BicValidator add strict mode to validate bics in strict mode

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -100,6 +100,9 @@ class BicValidator extends ConstraintValidator
         }
 
         $bicCountryCode = substr($canonicalize, 4, 2);
+        if (Bic::VALIDATION_MODE_CASE_INSENSITIVE === $constraint->mode) {
+            $bicCountryCode = strtoupper($bicCountryCode);
+        }
         if (!isset(self::BIC_COUNTRY_TO_IBAN_COUNTRY_MAP[$bicCountryCode]) && !Countries::exists($bicCountryCode)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
@@ -109,8 +112,8 @@ class BicValidator extends ConstraintValidator
             return;
         }
 
-        // should contain uppercase characters only
-        if (strtoupper($canonicalize) !== $canonicalize) {
+        // should contain uppercase characters only in strict mode
+        if (Bic::VALIDATION_MODE_STRICT === $constraint->mode && strtoupper($canonicalize) !== $canonicalize) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Bic::INVALID_CASE_ERROR)

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraints\Bic;
 use Symfony\Component\Validator\Constraints\BicValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
@@ -300,6 +301,36 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         // ES related special cases
         yield ['CAIXICBBXXX', 'ES79 2100 0813 6101 2345 6789'];
         yield ['CAIXEABBXXX', 'ES79 2100 0813 6101 2345 6789'];
+    }
+
+    /**
+     * @dataProvider getValidBicsWithNormalizerToUpper
+     */
+    public function testValidBicsWithNormalizerToUpper($bic)
+    {
+        $this->validator->validate($bic, new Bic(mode: Bic::VALIDATION_MODE_CASE_INSENSITIVE));
+
+        $this->assertNoViolation();
+    }
+
+    public static function getValidBicsWithNormalizerToUpper()
+    {
+        return [
+            ['ASPKAT2LXXX'],
+            ['ASPKat2LXXX'],
+            ['ASPKaT2LXXX'],
+            ['ASPKAt2LXXX'],
+            ['aspkat2lxxx'],
+        ];
+    }
+
+    public function testFailOnInvalidMode()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->validator->validate('ASPKAT2LXXX', new Bic(mode: 'invalid'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->validator->validate('ASPKAT2LXXX', new Bic(options: ['mode' => 'invalid']));
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -53,6 +53,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
         return [
             ['CH9300762011623852957'], // Switzerland without spaces
             ['CH93  0076 2011 6238 5295 7'], // Switzerland with multiple spaces
+            ['ch93 0076 2011 6238 5295 7'], // Switzerland lower case
 
             // Country list
             // http://www.rbs.co.uk/corporate/international/g0/guide-to-international-business/regulatory-information/iban/iban-example.ashx


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54822
| License       | MIT

Add a strict mode for bic validation (default strict, behavior before the pr is strict). But it is possible to set strict to `false` to allow lowercase input.

I'll add it to the docs when this PR is merged.
