### PR TITLE
[Serializer] Rename object to data in ``NormalizerInterface::normalize``

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -22,9 +22,9 @@ use Symfony\Component\Serializer\Exception\LogicException;
 interface NormalizerInterface
 {
     /**
-     * Normalizes an object into a set of arrays/scalars.
+     * Normalizes data into a set of arrays/scalars.
      *
-     * @param mixed       $object  Object to normalize
+     * @param mixed       $data    Data to normalize
      * @param string|null $format  Format the normalization result will be encoded as
      * @param array       $context Context options for the normalizer
      *
@@ -36,7 +36,7 @@ interface NormalizerInterface
      * @throws LogicException             Occurs when the normalizer is not called in an expected context
      * @throws ExceptionInterface         Occurs for all the other cases of errors
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
 
     /**
      * Checks whether the given class is supported for normalization by this normalizer.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54774
| License       | MIT

~~Rename sttribure of ``Serializer::normalize`` to the naming of the interface to make the usage of named attributes possible.~~

From the discussion of this PR I changed it to rename the first parameter of ``NormalizerInterface::normalize`` from `object` to `data` because it can't handle only objects, it's type `mixed`.