### PR TITLE
[Validator] Make `PasswordStrengthValidator::estimateStrength()` public

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Make `PasswordStrengthValidator::estimateStrength()` public
+
 7.1
 ---
 

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
@@ -57,7 +57,7 @@ final class PasswordStrengthValidator extends ConstraintValidator
      *
      * @return PasswordStrength::STRENGTH_*
      */
-    private static function estimateStrength(#[\SensitiveParameter] string $password): int
+    public static function estimateStrength(#[\SensitiveParameter] string $password): int
     {
         if (!$length = \strlen($password)) {
             return PasswordStrength::STRENGTH_VERY_WEAK;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes (allows for externally
| Deprecations? | no
| Issues        | na
| License       | MIT

Linked to the PasswordStrength Constraint, the need is to be able to get the "strength" of a password and not just only if it's strong enough. For instance, the need is to show a "score" bar in the frontend. 

Currently, the strength is being computed by a private function within the PasswordStrengthValidator not accessible directly. The proposed change is to extract that computation in a specific `PasswordStrengthEstimator` service for it to be accessible from the "external" world.

The best way to do so would be to inject the service in the Validator constructor but doing that it would break the compatibility as the current constructor is receiving a Closure to allow for self-strength computation. 
So here the service is called from within the Validator directly and so maintaining the Backward Compatibility

I created the same PR but with no Backward Compatibility (service injected in the constructor) here : #54882 