### PR TITLE
Password Strength estimator extraction to dedicated service (no Backward Compatibility)

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
@@ -15,14 +15,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Password\PasswordStrengthEstimatorInterface;
 
 final class PasswordStrengthValidator extends ConstraintValidator
 {
-    /**
-     * @param (\Closure(string):PasswordStrength::STRENGTH_*)|null $passwordStrengthEstimator
-     */
     public function __construct(
-        private readonly ?\Closure $passwordStrengthEstimator = null,
+        private readonly PasswordStrengthEstimatorInterface $passwordStrengthEstimator
     ) {
     }
 
@@ -39,8 +37,8 @@ final class PasswordStrengthValidator extends ConstraintValidator
         if (!\is_string($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
         }
-        $passwordStrengthEstimator = $this->passwordStrengthEstimator ?? self::estimateStrength(...);
-        $strength = $passwordStrengthEstimator((string) $value);
+
+        $strength = $this->passwordStrengthEstimator->estimateStrength((string) $value);
 
         if ($strength < $constraint->minScore) {
             $this->context->buildViolation($constraint->message)
@@ -48,44 +46,5 @@ final class PasswordStrengthValidator extends ConstraintValidator
                 ->setParameter('{{ strength }}', $strength)
                 ->addViolation();
         }
-    }
-
-    /**
-     * Returns the estimated strength of a password.
-     *
-     * The higher the value, the stronger the password.
-     *
-     * @return PasswordStrength::STRENGTH_*
-     */
-    private static function estimateStrength(#[\SensitiveParameter] string $password): int
-    {
-        if (!$length = \strlen($password)) {
-            return PasswordStrength::STRENGTH_VERY_WEAK;
-        }
-        $password = count_chars($password, 1);
-        $chars = \count($password);
-
-        $control = $digit = $upper = $lower = $symbol = $other = 0;
-        foreach ($password as $chr => $count) {
-            match (true) {
-                $chr < 32 || 127 === $chr => $control = 33,
-                48 <= $chr && $chr <= 57 => $digit = 10,
-                65 <= $chr && $chr <= 90 => $upper = 26,
-                97 <= $chr && $chr <= 122 => $lower = 26,
-                128 <= $chr => $other = 128,
-                default => $symbol = 33,
-            };
-        }
-
-        $pool = $lower + $upper + $digit + $symbol + $control + $other;
-        $entropy = $chars * log($pool, 2) + ($length - $chars) * log($chars, 2);
-
-        return match (true) {
-            $entropy >= 120 => PasswordStrength::STRENGTH_VERY_STRONG,
-            $entropy >= 100 => PasswordStrength::STRENGTH_STRONG,
-            $entropy >= 80 => PasswordStrength::STRENGTH_MEDIUM,
-            $entropy >= 60 => PasswordStrength::STRENGTH_WEAK,
-            default => PasswordStrength::STRENGTH_VERY_WEAK,
-        };
     }
 }

--- a/src/Symfony/Component/Validator/Password/PasswordStrengthEstimator.php
+++ b/src/Symfony/Component/Validator/Password/PasswordStrengthEstimator.php
@@ -7,7 +7,7 @@ use Symfony\Component\Validator\Constraints\PasswordStrength;
 
 class PasswordStrengthEstimator implements PasswordStrengthEstimatorInterface
 {
-    public static function estimateStrength(#[\SensitiveParameter] string|Stringable $password): int
+    public function estimateStrength(#[\SensitiveParameter] string|Stringable $password): int
     {
         if (!$length = \strlen($password)) {
             return PasswordStrength::STRENGTH_VERY_WEAK;

--- a/src/Symfony/Component/Validator/Password/PasswordStrengthEstimator.php
+++ b/src/Symfony/Component/Validator/Password/PasswordStrengthEstimator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Symfony\Component\Validator\Password;
+
+use Stringable;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
+
+class PasswordStrengthEstimator implements PasswordStrengthEstimatorInterface
+{
+    public static function estimateStrength(#[\SensitiveParameter] string|Stringable $password): int
+    {
+        if (!$length = \strlen($password)) {
+            return PasswordStrength::STRENGTH_VERY_WEAK;
+        }
+        $password = count_chars($password, 1);
+        $chars = \count($password);
+
+        $control = $digit = $upper = $lower = $symbol = $other = 0;
+        foreach ($password as $chr => $count) {
+            match (true) {
+                $chr < 32 || 127 === $chr => $control = 33,
+                48 <= $chr && $chr <= 57 => $digit = 10,
+                65 <= $chr && $chr <= 90 => $upper = 26,
+                97 <= $chr && $chr <= 122 => $lower = 26,
+                128 <= $chr => $other = 128,
+                default => $symbol = 33,
+            };
+        }
+
+        $pool = $lower + $upper + $digit + $symbol + $control + $other;
+        $entropy = $chars * log($pool, 2) + ($length - $chars) * log($chars, 2);
+
+        return match (true) {
+            $entropy >= 120 => PasswordStrength::STRENGTH_VERY_STRONG,
+            $entropy >= 100 => PasswordStrength::STRENGTH_STRONG,
+            $entropy >= 80 => PasswordStrength::STRENGTH_MEDIUM,
+            $entropy >= 60 => PasswordStrength::STRENGTH_WEAK,
+            default => PasswordStrength::STRENGTH_VERY_WEAK,
+        };
+    }
+}

--- a/src/Symfony/Component/Validator/Password/PasswordStrengthEstimatorInterface.php
+++ b/src/Symfony/Component/Validator/Password/PasswordStrengthEstimatorInterface.php
@@ -13,5 +13,5 @@ interface PasswordStrengthEstimatorInterface
      *
      * @return PasswordStrength::STRENGTH_*
      */
-    public static function estimateStrength(#[\SensitiveParameter] string|Stringable $password): int;
+    public function estimateStrength(#[\SensitiveParameter] string|Stringable $password): int;
 }

--- a/src/Symfony/Component/Validator/Password/PasswordStrengthEstimatorInterface.php
+++ b/src/Symfony/Component/Validator/Password/PasswordStrengthEstimatorInterface.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Validator\Password;
 
 use Stringable;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
 
 interface PasswordStrengthEstimatorInterface
 {

--- a/src/Symfony/Component/Validator/Password/PasswordStrengthEstimatorInterface.php
+++ b/src/Symfony/Component/Validator/Password/PasswordStrengthEstimatorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Validator\Password;
+
+use Stringable;
+
+interface PasswordStrengthEstimatorInterface
+{
+    /**
+     * Returns the estimated strength of a password.
+     *
+     * The higher the value, the stronger the password.
+     *
+     * @return PasswordStrength::STRENGTH_*
+     */
+    public static function estimateStrength(#[\SensitiveParameter] string|Stringable $password): int;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\PasswordStrength;
 use Symfony\Component\Validator\Constraints\PasswordStrengthValidator;
+use Symfony\Component\Validator\Password\PasswordStrengthEstimator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Symfony\Component\Validator\Tests\Constraints\Fixtures\StringableValue;
 
@@ -20,7 +21,7 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
 {
     protected function createValidator(): PasswordStrengthValidator
     {
-        return new PasswordStrengthValidator();
+        return new PasswordStrengthValidator(new PasswordStrengthEstimator());
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Password/PasswordStrengthEstimatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Password/PasswordStrengthEstimatorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Password;
+
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
+use Symfony\Component\Validator\Password\PasswordStrengthEstimator;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\StringableValue;
+
+class PasswordStrengthEstimatorTest extends TestCase
+{
+    /** @dataProvider getPasswords */
+    public function testEstimateStrength(string|Stringable $password, int $expectedStrength): void
+    {
+        self::assertEquals($expectedStrength, PasswordStrengthEstimator::estimateStrength($password));
+    }
+
+    /** @return array<string, array<string, int>> */
+    public function getPasswords(): iterable
+    {
+        yield ['How-is-this', PasswordStrength::STRENGTH_WEAK];
+        yield ['Reasonable-pwd', PasswordStrength::STRENGTH_MEDIUM];
+        yield ['This 1s a very g00d Pa55word! ;-)', PasswordStrength::STRENGTH_VERY_STRONG];
+        yield ['pudding-smack-👌🏼-fox-😎', PasswordStrength::STRENGTH_VERY_STRONG];
+        yield [new StringableValue('How-is-this'), PasswordStrength::STRENGTH_WEAK];
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Password/PasswordStrengthEstimatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Password/PasswordStrengthEstimatorTest.php
@@ -13,7 +13,7 @@ class PasswordStrengthEstimatorTest extends TestCase
     /** @dataProvider getPasswords */
     public function testEstimateStrength(string|Stringable $password, int $expectedStrength): void
     {
-        self::assertEquals($expectedStrength, (new PasswordStrengthEstimator())->estimateStrength($password));
+        self::assertSame($expectedStrength, (new PasswordStrengthEstimator())->estimateStrength($password));
     }
 
     /** @return array<string, array<string, int>> */

--- a/src/Symfony/Component/Validator/Tests/Password/PasswordStrengthEstimatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Password/PasswordStrengthEstimatorTest.php
@@ -13,7 +13,7 @@ class PasswordStrengthEstimatorTest extends TestCase
     /** @dataProvider getPasswords */
     public function testEstimateStrength(string|Stringable $password, int $expectedStrength): void
     {
-        self::assertEquals($expectedStrength, PasswordStrengthEstimator::estimateStrength($password));
+        self::assertEquals($expectedStrength, (new PasswordStrengthEstimator())->estimateStrength($password));
     }
 
     /** @return array<string, array<string, int>> */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 (?8.0)
| Bug fix?      | no
| New feature?  | yes (allows for externally accessing password strength estimator)
| Deprecations? | no
| Issues        | na
| License       | MIT

Linked to the PasswordStrength Constraint, the need is to be able to get the "strength" of a password and not just only if it's strong enough. For instance, the need is to show a "score" bar in the frontend. 

Currently, the strength is being computed by a private function within the PasswordStrengthValidator not accessible directly. The proposed change is to extract that computation in a specific `PasswordStrengthEstimator` service for it to be accessible from the "external" world.

This PR is proposing a no Backward Ccompatibility version with changing the constructor of the Validator. However, I created the same PR but without BC here : #54881 