### PR TITLE
[FrameworkBundle] Exclude constraints from container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -55,6 +55,7 @@ use Symfony\Component\Runtime\SymfonyRuntime;
 use Symfony\Component\String\LazyString;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\String\Slugger\SluggerInterface;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Workflow\WorkflowEvents;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -242,4 +243,5 @@ return static function (ContainerConfigurator $container) {
         ->set(Response::class)->abstract()->tag('container.excluded')
         ->set(SessionInterface::class)->abstract()->tag('container.excluded')
     ;
+    $container->services()->instanceof(Constraint::class)->tag('container.excluded');
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Constraints should not be registered as services but since Constraints and Validators are usually in the same directory, constraints can not be excluded using the path but only via instanceof.
