### PR TITLE
[String] Fix folded in compat mode

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -195,7 +195,7 @@ abstract class AbstractUnicodeString extends AbstractString
 
         if (!$compat || \PHP_VERSION_ID < 70300 || !\defined('Normalizer::NFKC_CF')) {
             $str->string = normalizer_normalize($str->string, $compat ? \Normalizer::NFKC : \Normalizer::NFC);
-            $str->string = mb_strtolower(str_replace(self::FOLD_FROM, self::FOLD_TO, $this->string), 'UTF-8');
+            $str->string = mb_strtolower(str_replace(self::FOLD_FROM, self::FOLD_TO, $str->string), 'UTF-8');
         } else {
             $str->string = normalizer_normalize($str->string, \Normalizer::NFKC_CF);
         }

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -470,10 +470,10 @@ END'],
         );
     }
 
-    public static function provideToFoldedCase(): array
+    public static function provideFolded(): array
     {
         return array_merge(
-            parent::provideToFoldedCase(),
+            parent::provideFolded(),
             [
                 ['déjà', 'DéjÀ'],
                 ['σσσ', 'Σσς'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

(Spotted by PHPStorm)

Both those lines of code were setting `$str->string` value, the second line cancelling any effect of the first.

```php
$str->string = normalizer_normalize($str->string, $compat ? \Normalizer::NFKC : \Normalizer::NFC);
$str->string = mb_strtolower(str_replace(self::FOLD_FROM, self::FOLD_TO, $this->string), 'UTF-8');
```

Did not know if i had to add tests, as the `$compat` argument is not really defined in the interface... and seems unused in the codebase 🤷‍♂️ 

(It also took me a bit of time to realize the `dataProvider` problem 😮‍💨 ) 