### PR TITLE
[PropertyInfo] Adds static cache to `PhpStanExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PhpStan/NameScopeFactory.php
+++ b/src/Symfony/Component/PropertyInfo/PhpStan/NameScopeFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\PropertyInfo\PhpStan;
 
+use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\ContextFactory;
 
 /**
@@ -20,6 +21,9 @@ use phpDocumentor\Reflection\Types\ContextFactory;
  */
 final class NameScopeFactory
 {
+    /** @var array<string, Context> */
+    private array $contexts = [];
+
     public function create(string $calledClassName, ?string $declaringClassName = null): NameScope
     {
         $declaringClassName ??= $calledClassName;
@@ -60,7 +64,7 @@ final class NameScopeFactory
             }
 
             $factory = new ContextFactory();
-            $context = $factory->createForNamespace($namespace, $contents);
+            $context = $this->contexts[$namespace.$fileName] ??= $factory->createForNamespace($namespace, $contents);
 
             return [$namespace, $context->getNamespaceAliases()];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no (performance)
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I was able to detect a performance penalty when using dozens of traits in even more classes. The `PhpStanExtractor ` creates a `NameScope` every time, but afaik this can be cached like in `PhpDocExtractor` (see #32188). 

The performance impact is impressive, as it reduces the time needed for my `TestCase` by 30%. See [Blackfire profile comparison](https://blackfire.io/profiles/compare/9eb78784-fa68-4721-9c87-f2be52da2d63/graph).

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
