### PR TITLE
[HttpKernel] Fix variadic TypeError for `#[MapUploadedFile]`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -170,7 +170,11 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 };
             }
 
-            $arguments[$i] = $payload;
+            if ($argument->metadata->isVariadic() && \is_array($payload)) {
+                array_splice($arguments, $i, 1, $payload);
+            } else {
+                $arguments[$i] = $payload;
+            }
         }
 
         $event->setArguments($arguments);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -269,7 +269,7 @@ class UploadedFileValueResolverTest extends TestCase
         $resolver->onKernelControllerArguments($event);
 
         /** @var UploadedFile[] $data */
-        $data = $event->getArguments()[0];
+        $data = $event->getArguments();
 
         $this->assertCount(2, $data);
         $this->assertSame('file-small.txt', $data[0]->getFilename());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This PR fixes a bug introduced in https://github.com/symfony/symfony/pull/49978 where using `#[MapUploadedFile]` with a variadic argument causes a `TypeError`:
```php
class MyController
{
    public function __invoke(
        #[MapUploadedFile] UploadedFile ...$documents,
    ): Response {
    }
}
```
```
Argument #1 must be of type Symfony\\Component\\HttpFoundation\\File\\UploadedFile, array given
```

(Bug fix taken from https://github.com/symfony/symfony/pull/54817)