### PR TITLE
PHP 8.4 nullability deprecation

### DIFF
--- a/src/Symfony/Component/Validator/Validation.php
+++ b/src/Symfony/Component/Validator/Validation.php
@@ -40,7 +40,7 @@ final class Validation
     /**
      * Creates a callable that returns true/false instead of throwing validation exceptions.
      *
-     * @return callable(mixed $value, ConstraintViolationListInterface &$violations = null): bool
+     * @return callable(mixed $value, ?ConstraintViolationListInterface &$violations = null): bool
      */
     public static function createIsValidCallable(Constraint|ValidatorInterface|null $constraintOrValidator = null, Constraint ...$constraints): callable
     {

--- a/src/Symfony/Contracts/HttpClient/Test/TestHttpServer.php
+++ b/src/Symfony/Contracts/HttpClient/Test/TestHttpServer.php
@@ -21,7 +21,7 @@ class TestHttpServer
     /**
      * @param string|null $workingDirectory
      */
-    public static function start(int $port = 8057/* , string $workingDirectory = null */): Process
+    public static function start(int $port = 8057/* , ?string $workingDirectory = null */): Process
     {
         $workingDirectory = \func_get_args()[1] ?? __DIR__.'/Fixtures/web';
 


### PR DESCRIPTION
### PHP 8.4 deprecation of implicit nullability.

| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Because PHP 8.4 is adding deprecation warnings for non-nullable parameters with null default, change typehints.

This relates to the [implicit nullability RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) in PHP 8.4.
