### PR TITLE
[Serializer] Fix CurrentType for missing property

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -418,7 +418,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(
                         sprintf('Failed to create object because the class misses the "%s" property.', $constructorParameter->name),
-                        $data,
+                        null,
                         [$constructorParameterType],
                         $context['deserialization_path'],
                         true

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1045,7 +1045,7 @@ class SerializerTest extends TestCase
                 'message' => 'The type of the "string" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74Full" must be one of "string" ("null" given).',
             ],
             [
-                'currentType' => 'array',
+                'currentType' => 'null',
                 'expectedTypes' => [
                     'unknown',
                 ],
@@ -1306,7 +1306,7 @@ class SerializerTest extends TestCase
                 'message' => 'The type of the "bool" attribute for class "Symfony\\Component\\Serializer\\Tests\\Fixtures\\Php80WithPromotedTypedConstructor" must be one of "bool" ("string" given).',
             ],
             [
-                'currentType' => 'array',
+                'currentType' => 'null',
                 'expectedTypes' => [
                     'string',
                 ],
@@ -1315,7 +1315,7 @@ class SerializerTest extends TestCase
                 'message' => 'Failed to create object because the class misses the "string" property.',
             ],
             [
-                'currentType' => 'array',
+                'currentType' => 'null',
                 'expectedTypes' => [
                     'int',
                 ],
@@ -1420,7 +1420,7 @@ class SerializerTest extends TestCase
 
         $expected = [
             [
-                'currentType' => 'array',
+                'currentType' => 'null',
                 'useMessageForUser' => true,
                 'message' => 'Failed to create object because the class misses the "get" property.',
             ],
@@ -1546,7 +1546,7 @@ class SerializerTest extends TestCase
 
         $expected = [
             [
-                'currentType' => 'array',
+                'currentType' => 'null',
                 'expectedTypes' => [
                     'string',
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

If requested data does not contain any property:

```php
class A {
    function __construct(string $a) {}
}

try {
    $a = $serializer->deserialize('{}', A::class, 'json');
} catch (NotNormalizableValueException $e) {
    var_dump($e->getMessage());       // "Failed to create object because class misses the 'a' property."
    var_dump($e->getPath());          // "a"
    var_dump($e->getExpectedTypes()); // ["string"]
    var_dump($e->getCurrentType());   // "array"
}
```

then `getCurrentType` returns incorrect `"array"` value instead of expected `"null"` value.