### PR TITLE
[ErrorHandler] Do not call xdebug_get_function_stack() with xdebug >= 3.0 when not in develop mode

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Error/FatalError.php
+++ b/src/Symfony/Component/ErrorHandler/Error/FatalError.php
@@ -33,7 +33,7 @@ class FatalError extends \Error
                 }
             }
         } elseif (null !== $traceOffset) {
-            if (\function_exists('xdebug_get_function_stack') && $trace = @xdebug_get_function_stack()) {
+            if (\function_exists('xdebug_get_function_stack') && \in_array(\ini_get('xdebug.mode'), ['develop', false], true) && $trace = @xdebug_get_function_stack()) {
                 if (0 < $traceOffset) {
                     array_splice($trace, -$traceOffset);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #40677
| License       | MIT

The PR #40787 was rejected because of env var handling in xdebug_mode. https://github.com/xdebug/xdebug/pull/737 allow us to get xdebug_mode in all cases so I think we can merge this PR safely.

Tested on my setup successfully, I have no more warning.

Thanks @ralphschindler :)
