### PR TITLE
[Validator] IBAN Check digits should always between 2 and 98

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -228,6 +228,18 @@ class IbanValidator extends ConstraintValidator
             return;
         }
 
+        // Check digits should always between 2 and 98
+        // A ECBS document (https://www.ecbs.org/Download/EBS204_V3.PDF) replicates part of the ISO/IEC 7064:2003 standard as a method for generating check digits in the range 02 to 98.
+        $checkDigits = (int) substr($canonicalized, 2, 2);
+        if ($checkDigits < 2 || $checkDigits > 98) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Iban::CHECKSUM_FAILED_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
         // Move the first four characters to the end
         // e.g. CH93 0076 2011 6238 5295 7
         //   -> 0076 2011 6238 5295 7 CH93

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -401,6 +401,12 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
             ['UA213223130000026007233566002'], // Ukraine
             ['AE260211000000230064017'], // United Arab Emirates
             ['VA59001123000012345671'], // Vatican City State
+
+            // Checksum digits not between 02 and 98
+            ['FO00 5432 0388 8999 44'], // Faroe Islands
+            ['NL01INGB0001393698'], // Netherlands
+            ['NL01RABO0331811235'], // Netherlands
+            ['RU99 0445 2560 0407 0281 0412 3456 7890 1'], // Russia
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes/no
| New feature?  | no 
| Deprecations? | no 
| Issues        | No existing
| License       | MIT

A ECBS document (https://www.ecbs.org/Download/EBS204_V3.PDF) replicates part of the ISO/IEC 7064:2003 standard as a method for generating check digits in the range 02 to 98.

Besides this I have a production database of 160K valid IBANs. All of them have a check digit between 02 and 98.

Example of invalid IBANs, which before were valid, are NL01INGB0001393698 and NL01RABO0331811235. You can check them at iban.com to verify they are indeed invalid.