### PR TITLE
[PropertyInfo] remove no longer needed deprecation contracts

### DIFF
--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -24,7 +24,6 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/string": "^6.4|^7.0",
         "symfony/type-info": "^7.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

the dependency was introduced in #53160, but is no longer required since we reverted the deprecations in #54789
