### PR TITLE
[Security][SecurityBundle] OIDC discovery

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -60,6 +60,8 @@ Security
  * Add argument `$accessDecision` to `AccessDecisionManagerInterface::decide()` and `AuthorizationCheckerInterface::isGranted()`;
    it should be used to report the reason of a decision, including all the related votes.
 
+ * Add discovery support to `OidcTokenHandler` and `OidcUserInfoTokenHandler`
+
 Console
 -------
 

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Deprecate the `security.hide_user_not_found` config option in favor of `security.expose_security_errors`
  * Add ability to fetch LDAP roles
  * Add `OAuth2TokenHandlerFactory` for `AccessTokenFactory`
+ * Add discovery support to `OidcTokenHandler` and `OidcUserInfoTokenHandler`
 
 7.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -17,6 +17,8 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Configures a token handler for decoding and validating an OIDC token.
@@ -38,9 +40,29 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
         $tokenHandlerDefinition->replaceArgument(0, (new ChildDefinition('security.access_token_handler.oidc.signature'))
             ->replaceArgument(0, $config['algorithms']));
 
+        if (isset($config['discovery'])) {
+            if (!ContainerBuilder::willBeAvailable('symfony/http-client', HttpClientInterface::class, ['symfony/security-bundle'])) {
+                throw new LogicException('You cannot use the "oidc" token handler with "discovery" since the HttpClient component is not installed. Try running "composer require symfony/http-client".');
+            }
+
+            // disable JWKSet argument
+            $tokenHandlerDefinition->replaceArgument(1, null);
+            $tokenHandlerDefinition->addMethodCall(
+                'enableDiscovery',
+                [
+                    new Reference($config['discovery']['cache']['id']),
+                    (new ChildDefinition('security.access_token_handler.oidc_discovery.http_client'))
+                        ->replaceArgument(0, ['base_uri' => $config['discovery']['base_uri']]),
+                    "$id.oidc_configuration",
+                    "$id.oidc_jwk_set",
+                ]
+            );
+
+            return;
+        }
+
         $tokenHandlerDefinition->replaceArgument(1, (new ChildDefinition('security.access_token_handler.oidc.jwkset'))
-            ->replaceArgument(0, $config['keyset'])
-        );
+            ->replaceArgument(0, $config['keyset']));
 
         if ($config['encryption']['enabled']) {
             $algorithmManager = (new ChildDefinition('security.access_token_handler.oidc.encryption'))
@@ -74,8 +96,8 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                     ->thenInvalid('You must set either "algorithm" or "algorithms".')
                 ->end()
                 ->validate()
-                    ->ifTrue(static fn ($v) => !isset($v['key']) && !isset($v['keyset']))
-                    ->thenInvalid('You must set either "key" or "keyset".')
+                    ->ifTrue(static fn ($v) => !isset($v['discovery']) && !isset($v['key']) && !isset($v['keyset']))
+                    ->thenInvalid('You must set either "discovery" or "key" or "keyset".')
                 ->end()
                 ->beforeNormalization()
                     ->ifTrue(static fn ($v) => isset($v['algorithm']) && \is_string($v['algorithm']))
@@ -101,6 +123,25 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                     })
                 ->end()
                 ->children()
+                    ->arrayNode('discovery')
+                        ->info('Enable the OIDC discovery.')
+                        ->children()
+                            ->scalarNode('base_uri')
+                                ->info('Base URI of the OIDC server.')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                            ->end()
+                            ->arrayNode('cache')
+                                ->children()
+                                    ->scalarNode('id')
+                                        ->info('Cache service id to use to cache the OIDC discovery configuration.')
+                                        ->isRequired()
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
                     ->scalarNode('claim')
                         ->info('Claim which contains the user identifier (e.g.: sub, email..).')
                         ->defaultValue('sub')
@@ -129,7 +170,6 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                     ->end()
                     ->scalarNode('keyset')
                         ->info('JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).')
-                        ->isRequired()
                     ->end()
                     ->arrayNode('encryption')
                         ->canBeEnabled()

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -92,6 +92,11 @@ return static function (ContainerConfigurator $container) {
                 service('clock'),
             ])
 
+        ->set('security.access_token_handler.oidc_discovery.http_client', HttpClientInterface::class)
+            ->abstract()
+            ->factory([service('http_client'), 'withOptions'])
+            ->args([abstract_arg('http client options')])
+
         ->set('security.access_token_handler.oidc.jwk', JWK::class)
             ->abstract()
             ->deprecate('symfony/security-http', '7.1', 'The "%service_id%" service is deprecated. Please use "security.access_token_handler.oidc.jwkset" instead')

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -114,7 +114,7 @@ class AccessTokenFactoryTest extends TestCase
         $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The child config "keyset" under "access_token.token_handler.oidc" must be configured: JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).');
+        $this->expectExceptionMessage('You must set either "discovery" or "key" or "keyset".');
 
         $this->processConfig($config, $factory);
     }
@@ -340,6 +340,58 @@ class AccessTokenFactoryTest extends TestCase
         $this->processConfig($config, $factory);
     }
 
+    public function testOidcTokenHandlerConfigurationWithDiscovery()
+    {
+        $container = new ContainerBuilder();
+        $jwkset = '{"keys":[{"kty":"EC","crv":"P-256","x":"FtgMtrsKDboRO-Zo0XC7tDJTATHVmwuf9GK409kkars","y":"rWDE0ERU2SfwGYCo1DWWdgFEbZ0MiAXLRBBOzBgs_jY","d":"4G7bRIiKih0qrFxc0dtvkHUll19tTyctoCR3eIbOrO0"},{"kty":"EC","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220"}]}';
+        $config = [
+            'token_handler' => [
+                'oidc' => [
+                    'discovery' => [
+                        'base_uri' => 'https://www.example.com/realms/demo/',
+                        'cache' => [
+                            'id' => 'oidc_cache',
+                        ],
+                    ],
+                    'algorithms' => ['RS256', 'ES256'],
+                    'issuers' => ['https://www.example.com'],
+                    'audience' => 'audience',
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.access_token.firewall1'));
+        $this->assertTrue($container->hasDefinition('security.access_token_handler.firewall1'));
+
+        $expectedArgs = [
+            'index_0' => (new ChildDefinition('security.access_token_handler.oidc.signature'))
+                ->replaceArgument(0, ['RS256', 'ES256']),
+            'index_1' => null,
+            'index_2' => 'audience',
+            'index_3' => ['https://www.example.com'],
+            'index_4' => 'sub',
+        ];
+        $expectedCalls = [
+            [
+                'enableDiscovery',
+                [
+                    new Reference('oidc_cache'),
+                    (new ChildDefinition('security.access_token_handler.oidc_discovery.http_client'))
+                        ->replaceArgument(0, ['base_uri' => 'https://www.example.com/realms/demo/']),
+                    'security.access_token_handler.firewall1.oidc_configuration',
+                    'security.access_token_handler.firewall1.oidc_jwk_set',
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedArgs, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
+        $this->assertEquals($expectedCalls, $container->getDefinition('security.access_token_handler.firewall1')->getMethodCalls());
+    }
+
     public function testOidcUserInfoTokenHandlerConfigurationWithExistingClient()
     {
         $container = new ContainerBuilder();
@@ -405,6 +457,48 @@ class AccessTokenFactoryTest extends TestCase
     {
         yield [['base_uri' => 'https://www.example.com/realms/demo/protocol/openid-connect/userinfo']];
         yield ['https://www.example.com/realms/demo/protocol/openid-connect/userinfo'];
+    }
+
+    public function testOidcUserInfoTokenHandlerConfigurationWithDiscovery()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => [
+                'oidc_user_info' => [
+                    'discovery' => [
+                        'cache' => [
+                            'id' => 'oidc_cache',
+                        ],
+                    ],
+                    'base_uri' => 'https://www.example.com/realms/demo/protocol/openid-connect/userinfo',
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.access_token.firewall1'));
+        $this->assertTrue($container->hasDefinition('security.access_token_handler.firewall1'));
+
+        $expectedArgs = [
+            'index_0' => (new ChildDefinition('security.access_token_handler.oidc_user_info.http_client'))
+                ->replaceArgument(0, ['base_uri' => 'https://www.example.com/realms/demo/protocol/openid-connect/userinfo']),
+            'index_2' => 'sub',
+        ];
+        $expectedCalls = [
+            [
+                'enableDiscovery',
+                [
+                    new Reference('oidc_cache'),
+                    'security.access_token_handler.firewall1.oidc_configuration',
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedArgs, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
+        $this->assertEquals($expectedCalls, $container->getDefinition('security.access_token_handler.firewall1')->getMethodCalls());
     }
 
     public function testMultipleTokenHandlersSet()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
@@ -24,7 +24,7 @@ security:
                         claim: 'username'
                         audience: 'Symfony OIDC'
                         issuers: [ 'https://www.example.com' ]
-                        algorithm: 'ES256'
+                        algorithms: [ 'ES256' ]
                         # tip: use https://mkjwk.org/ to generate a JWK
                         keyset: '{"keys":[{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}]}'
                         encryption:

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -34,6 +34,8 @@ use Symfony\Component\Security\Http\AccessToken\Oidc\Exception\InvalidSignatureE
 use Symfony\Component\Security\Http\AccessToken\Oidc\Exception\MissingClaimException;
 use Symfony\Component\Security\Http\Authenticator\FallbackUserLoader;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * The token handler decodes and validates the token, and retrieves the user identifier from it.
@@ -45,9 +47,14 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
     private ?AlgorithmManager $decryptionAlgorithms = null;
     private bool $enforceEncryption = false;
 
+    private ?CacheInterface $discoveryCache = null;
+    private ?HttpClientInterface $discoveryClient = null;
+    private ?string $oidcConfigurationCacheKey = null;
+    private ?string $oidcJWKSetCacheKey = null;
+
     public function __construct(
         private Algorithm|AlgorithmManager $signatureAlgorithm,
-        private JWK|JWKSet $signatureKeyset,
+        private JWK|JWKSet|null $signatureKeyset,
         private string $audience,
         private array $issuers,
         private string $claim = 'sub',
@@ -71,15 +78,64 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         $this->enforceEncryption = $enforceEncryption;
     }
 
+    public function enabledDiscovery(CacheInterface $cache, HttpClientInterface $client, string $oidcConfigurationCacheKey, string $oidcJWKSetCacheKey): void
+    {
+        $this->discoveryCache = $cache;
+        $this->discoveryClient = $client;
+        $this->oidcConfigurationCacheKey = $oidcConfigurationCacheKey;
+        $this->oidcJWKSetCacheKey = $oidcJWKSetCacheKey;
+    }
+
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
         if (!class_exists(JWSVerifier::class) || !class_exists(Checker\HeaderCheckerManager::class)) {
             throw new \LogicException('You cannot use the "oidc" token handler since "web-token/jwt-signature" and "web-token/jwt-checker" are not installed. Try running "composer require web-token/jwt-signature web-token/jwt-checker".');
         }
 
+        if (!$this->discoveryCache && !$this->signatureKeyset) {
+            throw new \LogicException('You cannot use the "oidc" token handler without JWKSet nor "discovery". Please configure JWKSet in the constructor, or call "enableDiscovery" method.');
+        }
+
+        $jwkset = $this->signatureKeyset;
+        if ($this->discoveryCache) {
+            try {
+                $oidcConfiguration = json_decode($this->discoveryCache->get($this->oidcConfigurationCacheKey, function (): string {
+                    $response = $this->discoveryClient->request('GET', '.well-known/openid-configuration');
+
+                    return $response->getContent();
+                }), true, 512, \JSON_THROW_ON_ERROR);
+            } catch (\Throwable $e) {
+                $this->logger?->error('An error occurred while requesting OIDC configuration.', [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+
+                throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
+            }
+
+            try {
+                $jwkset = JWKSet::createFromJson(
+                    $this->discoveryCache->get($this->oidcJWKSetCacheKey, function () use ($oidcConfiguration): string {
+                        $response = $this->discoveryClient->request('GET', $oidcConfiguration['jwks_uri']);
+                        // we only need signature key
+                        $keys = array_filter($response->toArray()['keys'], static fn (array $key) => 'sig' === $key['use']);
+
+                        return json_encode(['keys' => $keys]);
+                    })
+                );
+            } catch (\Throwable $e) {
+                $this->logger?->error('An error occurred while requesting OIDC certs.', [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+
+                throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
+            }
+        }
+
         try {
             $accessToken = $this->decryptIfNeeded($accessToken);
-            $claims = $this->loadAndVerifyJws($accessToken);
+            $claims = $this->loadAndVerifyJws($accessToken, $jwkset);
             $this->verifyClaims($claims);
 
             if (empty($claims[$this->claim])) {
@@ -98,7 +154,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         }
     }
 
-    private function loadAndVerifyJws(string $accessToken): array
+    private function loadAndVerifyJws(string $accessToken, JWKSet $jwkset): array
     {
         // Decode the token
         $jwsVerifier = new JWSVerifier($this->signatureAlgorithm);
@@ -106,7 +162,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         $jws = $serializerManager->unserialize($accessToken);
 
         // Verify the signature
-        if (!$jwsVerifier->verifyWithKeySet($jws, $this->signatureKeyset, 0)) {
+        if (!$jwsVerifier->verifyWithKeySet($jws, $jwkset, 0)) {
             throw new InvalidSignatureException();
         }
 

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\AccessToken\Oidc\Exception\MissingClaimException;
 use Symfony\Component\Security\Http\Authenticator\FallbackUserLoader;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -26,6 +27,9 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
 {
     use OidcTrait;
 
+    private ?CacheInterface $discoveryCache = null;
+    private ?string $oidcConfigurationCacheKey = null;
+
     public function __construct(
         private HttpClientInterface $client,
         private ?LoggerInterface $logger = null,
@@ -33,12 +37,37 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
     ) {
     }
 
+    public function enabledDiscovery(CacheInterface $cache, string $oidcConfigurationCacheKey): void
+    {
+        $this->discoveryCache = $cache;
+        $this->oidcConfigurationCacheKey = $oidcConfigurationCacheKey;
+    }
+
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
+        if (null !== $this->discoveryCache) {
+            try {
+                // Call OIDC discovery to retrieve userinfo endpoint
+                // OIDC configuration is stored in cache
+                $oidcConfiguration = json_decode($this->discoveryCache->get($this->oidcConfigurationCacheKey, function (): string {
+                    $response = $this->client->request('GET', '.well-known/openid-configuration');
+
+                    return $response->getContent();
+                }), true, 512, \JSON_THROW_ON_ERROR);
+            } catch (\Throwable $e) {
+                $this->logger?->error('An error occurred while requesting OIDC configuration.', [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+
+                throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
+            }
+        }
+
         try {
             // Call the OIDC server to retrieve the user info
             // If the token is invalid or expired, the OIDC server will return an error
-            $claims = $this->client->request('GET', '', [
+            $claims = $this->client->request('GET', $this->discoveryCache ? $oidcConfiguration['userinfo_endpoint'] : '', [
                 'auth_bearer' => $accessToken,
             ])->toArray();
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Support hashing the hashed password using crc32c when putting the user in the session
  * Add support for closures in `#[IsGranted]`
  * Add `OAuth2TokenHandler` with OAuth2 Token Introspection support for `AccessTokenAuthenticator`
+ * Add discovery support to `OidcTokenHandler` and `OidcUserInfoTokenHandler`
 
 7.2
 ---


### PR DESCRIPTION
This PR introduces [OIDC discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse) on `oidc` and `oidc_user_info` token handlers.

| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #50433 Fix #50434
| License       | MIT
| Doc PR | https://github.com/symfony/symfony-docs/pull/20579 |

### TODO

- [x] use JWSLoader in OidcTokenHandler
- [x] introduce OidcUserInfoDiscoveryTokenHandler
- [x] introduce OidcDiscoveryTokenHandler
- [x] update src/**/CHANGELOG.md files
- [x] update UPGRADE-*.md files
- [x] add tests on AccessTokenFactoryTest with discovery
- [x] create documentation PR

### What is OIDC Discovery?

[OIDC discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse) is a generic endpoint on the OIDC server, which gives any public information such as signature public keys and endpoints URIs (userinfo, token, etc.). An example is available on the API Platform Demo:
https://demo.api-platform.com/oidc/realms/demo/.well-known/openid-configuration.

Using the OIDC discovery simplifies the `oidc` security configuration, allowing to just configure the discovery and let Symfony store the configuration and the keyset in cache. For instance, if the _userinfo_endpoint_ or _signature keyset_ change on the OIDC server, no need to update the environment variables in the Symfony application, just clear the corresponding cache and it'll retrieve the configuration and the keyset accordingly on the next request.

In the `oidc_user_info` security configuration, it does the same logic but only about _userinfo_endpoint_ as this token handler doesn't need the _keyset_.

### How Do I Use This New Feature in Symfony?

The current `oidc` token handler configuration requires a `keyset` option which may change on the OIDC server. It is configured as following:
```yaml
# config/packages/security.yaml
security:
    firewalls:
        main:
            access_token:
                oidc:
                    claim: 'email'
                    audience: 'symfony'
                    issuers: ['https://example.com/']
                    algorithms: ['RS256']
                    keyset: '{"keys":[{"kty":"EC",...}]}'
```

> Note: those parameters should be configured with environment variables.

With the `discovery` option, Symfony will retrieve the `keyset` directly from the OIDC discovery URI and store it in a cache:
```yaml
# config/packages/security.yaml
security:
    firewalls:
        main:
            access_token:
                oidc:
                    # 'keyset' option is not necessary anymore as it's retrieved from OIDC discovery and stored in cache
                    claim: 'email'
                    audience: 'symfony'
                    issuers: ['https://example.com/']
                    algorithms: ['RS256']
                    discovery:
                        base_uri: 'https://example.com/oidc/realms/master/'
                        cache:
                            id: cache.app # require to create this cache in framework.yaml
```

> Note: some other parameters might be retrieven from the OIDC discovery, maybe 'algorithm' or 'issuers'. To discuss.

The current `oidc_user_info` token handler required a `base_uri` corresponding to the _userinfo_endpoint_ URI on the OIDC server. This URI may change if it's changed on the OIDC server. Introducing the discovery helps to configure it dynamically.

The current configuration looks like the following:
```yaml
# config/packages/security.yaml
security:
    firewalls:
        main:
            access_token:
                oidc_user_info:
                    # 'base_uri' is the userinfo_endpoint URI
                    base_uri: 'https://example.com/oidc/realms/master/protocol/openid-connect/userinfo'
                    claim: 'email'
```

With the `discovery`, it will look like this:
```yaml
# config/packages/security.yaml
security:
    firewalls:
        main:
            access_token:
                oidc_user_info:
                    # 'base_uri' can be the userinfo_endpoint for backward compatibility
                    # and can be the OIDC server url in addition of 'discovery' option
                    base_uri: 'https://example.com/oidc/realms/master/'
                    claim: 'email'
                    discovery:
                        cache:
                            id: cache.app # require to create this cache in framework.yaml
```