### PR TITLE
[Mailer] Add `retry_period` option for email transport

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -58,6 +58,11 @@ class TransportTest extends TestCase
             'roundrobin(dummy://a failover(dummy://b dummy://a) dummy://b)',
             new RoundRobinTransport([$transportA, new FailoverTransport([$transportB, $transportA]), $transportB]),
         ];
+
+        yield 'round robin transport with retry period' => [
+            'roundrobin(dummy://a dummy://b)?retry_period=15',
+            new RoundRobinTransport([$transportA, $transportB], 15),
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/50981 https://github.com/symfony/symfony/issues/52551
| License       | MIT

RoundRobinTransport constructor has retryPeriod set to 60 seconds. This cannot be configured right now.

Let's say all the transports fail (e.g. email address with domain that does not exist).
Problems:

1. When sending more than one email synchronously we can't send emails following the one that failed. We have to sleep(x) where x >= 60sec. (of course we have to handle the TransportException thrown by invalid email but this is another topic)
2. When using Messenger and async emails we don't have to worry about handling TransportException because invalid message will be sent back to the queue however the worker cannot consume another messages for the next 60 seconds. Also logs will be flooded with exceptions because in this 60s window a lot of messages could be tried.

This PR permits to specify a retry period using a new DNS option `retry_period` like `MAILER_DSN="roundrobin(postmark+api://ID@default sendgrid+smtp://KEY@default)?retry_period=15"`
