### PR TITLE
[DependencyInjection] Process PHP configs using the ContainerConfigurator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -145,16 +145,8 @@ class PhpFileLoader extends FileLoader
 
         $callback(...$arguments);
 
-        $this->loadFromExtensions($configBuilders);
-    }
-
-    /**
-     * @param iterable<ConfigBuilderInterface> $configBuilders
-     */
-    private function loadFromExtensions(iterable $configBuilders): void
-    {
         foreach ($configBuilders as $configBuilder) {
-            $this->loadExtensionConfig($configBuilder->getExtensionAlias(), $configBuilder->toArray());
+            $containerConfigurator->extension($configBuilder->getExtensionAlias(), $configBuilder->toArray(), $this->prepend);
         }
 
         $this->loadExtensionConfigs();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder_env_configurator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder_env_configurator.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+
+return function (AcmeConfig $config) {
+    $config->color(env('COLOR'));
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -243,4 +243,14 @@ class PhpFileLoaderTest extends TestCase
         $values = ['foo' => new Definition(\stdClass::class), 'bar' => new Definition(\stdClass::class)];
         $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_inline_service')->getArguments());
     }
+
+    public function testConfigBuilderEnvConfigurator()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new \AcmeExtension());
+        $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Fixtures'), 'prod', new ConfigBuilderGenerator(sys_get_temp_dir()), true);
+        $loader->load('config/config_builder_env_configurator.php');
+
+        $this->assertIsString($container->getExtensionConfig('acme')[0]['color']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54852
| License       | MIT

Since #52843, `ContainerConfigurator::extension` is not called anymore which means `ParamConfigurator`s are no longer processed and converted to strings, and makes nodes validation fail: e.g. `framework.secret` would receive an `EnvConfigurator` and throw because it is not a scalar.