### PR TITLE
[DependencyInjection] Fix prepending strategy for php config loader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -146,7 +146,7 @@ class PhpFileLoader extends FileLoader
         $callback(...$arguments);
 
         foreach ($configBuilders as $configBuilder) {
-            $containerConfigurator->extension($configBuilder->getExtensionAlias(), $configBuilder->toArray(), $this->prepend);
+            $this->loadExtensionConfig($configBuilder->getExtensionAlias(), ContainerConfigurator::processValue($configBuilder->toArray()));
         }
 
         $this->loadExtensionConfigs();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder.expected.yml
@@ -1,5 +1,5 @@
 parameters:
-    acme.configs: [{ color: blue }]
+    acme.configs: [{ color: red }, { color: blue }]
 
 services:
     service_container:

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder.php
@@ -1,11 +1,14 @@
 <?php
 
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
 
 if ('prod' !== $env) {
     return;
 }
 
-return function (AcmeConfig $config) {
+return function (AcmeConfig $config, ContainerConfigurator $c) {
+    $c->import('nested_config_builder.php');
+
     $config->color('blue');
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/nested_config_builder.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/nested_config_builder.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
+
+if ('prod' !== $env) {
+    return;
+}
+
+return function (AcmeConfig $config) {
+    $config->color('red');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -56,6 +56,7 @@ class PhpFileLoaderTest extends TestCase
         $loader->load('config/config_builder.php');
 
         $expected = [
+            ['color' => 'red'],
             ['color' => 'blue'],
             ['foo' => 'bar'],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54852
| License       | MIT

working towards fixing https://github.com/symfony/symfony/pull/54970 