### PR TITLE
[Cache] Fix irrelevant deprecation when connecting to Couchbase

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -118,7 +118,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
             return MemcachedAdapter::createConnection($dsn, $options);
         }
         if (str_starts_with($dsn, 'couchbase:')) {
-            if (CouchbaseBucketAdapter::isSupported()) {
+            if (class_exists('CouchbaseBucket') && CouchbaseBucketAdapter::isSupported()) {
                 return CouchbaseBucketAdapter::createConnection($dsn, $options);
             }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
 
@@ -20,22 +19,18 @@ use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
  * @requires extension couchbase <4.0.0
  * @requires extension couchbase >=3.0.5
  *
- * @group legacy integration
+ * @group integration
  *
  * @author Antonio Jose Cerezo Aranda <aj.cerezo@gmail.com>
  */
 class CouchbaseCollectionAdapterTest extends AdapterTestCase
 {
-    use ExpectDeprecationTrait;
-
     protected $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
     ];
 
     public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
-        $this->expectDeprecation('Since symfony/cache 7.1: The "Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter" class is deprecated, use "Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter" instead.');
-
         $client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
             ['username' => getenv('COUCHBASE_USER'), 'password' => getenv('COUCHBASE_PASS')]
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follows #53124
| License       | MIT

When creating a connection for Couchbase, we currently always trigger a deprecation that we cannot opt out of. The reason is that `AbstractAdapter` calls the the `isSupported()` method of the deprecated `CouchbaseBucketAdapter` class before deciding in favor of its non-deprecated replacement `CouchbaseCollectionAdapter`.