### PR TITLE
[Serializer] Add headers label support for `CsvEncoder` using `csv_headers`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+* Add headers label support for `CsvEncoder` using `csv_headers`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -86,11 +86,13 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         }
         unset($value);
 
+        $labels = array_flip($headers);
         $headers = array_merge(array_values($headers), array_diff($this->extractHeaders($data), $headers));
         $endOfLine = $context[self::END_OF_LINE] ?? $this->defaultContext[self::END_OF_LINE];
 
         if (!($context[self::NO_HEADERS_KEY] ?? $this->defaultContext[self::NO_HEADERS_KEY])) {
-            fputcsv($handle, $headers, $delimiter, $enclosure, $escapeChar);
+            $labels = array_map(fn ($header) => \is_string($labels[$header] ?? null) ? $labels[$header] : $header, $headers);
+            fputcsv($handle, $labels, $delimiter, $enclosure, $escapeChar);
             if ("\n" !== $endOfLine && 0 === fseek($handle, -1, \SEEK_CUR)) {
                 fwrite($handle, $endOfLine);
             }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -242,14 +242,38 @@ CSV;
             CsvEncoder::HEADERS_KEY => [
                 'b',
                 'c',
+                'n.0',
+                'n.k',
             ],
         ];
         $value = [
-            ['a' => 'foo', 'b' => 'bar'],
+            ['a' => 'foo', 'b' => 'bar', 'n' => ['nested_index', 'k' => 'nested_key']],
         ];
         $csv = <<<CSV
-b,c,a
-bar,,foo
+b,c,n.0,n.k,a
+bar,,nested_index,nested_key,foo
+
+CSV;
+
+        $this->assertEquals($csv, $this->encoder->encode($value, 'csv', $context));
+    }
+
+    public function testEncodeCustomHeadersWithLabels()
+    {
+        $context = [
+            CsvEncoder::HEADERS_KEY => [
+                'Label_B' => 'b',
+                'c', // No label = use header key as label
+                'Label_N_index' => 'n.0',
+                'Label_N_key' => 'n.k',
+            ],
+        ];
+        $value = [
+            ['a' => 'foo', 'b' => 'bar', 'n' => ['nested_index', 'k' => 'nested_key']],
+        ];
+        $csv = <<<CSV
+Label_B,c,Label_N_index,Label_N_key,a
+bar,,nested_index,nested_key,foo
 
 CSV;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #55048
| License       | MIT

Improve the existing `csv_headers` option of `CsvEncoder` to pass CSV headers labels.

``` php
$contextBuilder = (new CsvEncoderContextBuilder())->withHeaders([
    'Prénom' => 'firstName',
    'Nom' => 'lastName',
    'Nested field label' => 'nested.field',
]);
```