### PR TITLE
[VarExporter] Fix exporting default values involving global constants

### DIFF
--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -37,6 +37,7 @@ class ProxyHelperTest extends TestCase
             $expected = str_replace(['.', ' .  .  . ', '\'$a\', \'$a\n\', "\$a\n"'], [' . ', '...', '\'$a\', "\$a\\\n", "\$a\n"'], $expected);
             $expected = str_replace('Bar', '\\'.Bar::class, $expected);
             $expected = str_replace('self', '\\'.TestForProxyHelper::class, $expected);
+            $expected = str_replace('= [namespace\\M_PI, new M_PI]', '= [\M_PI, new \Symfony\Component\VarExporter\Tests\M_PI()]', $expected);
 
             yield [$expected, $method];
         }
@@ -235,6 +236,10 @@ abstract class TestForProxyHelper
     }
 
     public function foo9($a = self::BOB, $b = ['$a', '$a\n', "\$a\n"], $c = ['$a', '$a\n', "\$a\n", new \stdClass()])
+    {
+    }
+
+    public function foo10($a = [namespace\M_PI, new M_PI()])
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello, we hit a case when a service works fine when injected normally but stop working when injected lazily. The reason was that the default value of a parameter was a global constant that was used without explicitly specifying `\` nor importing it. It ends up being incorrectly transformer in the proxy class as `\MyNamespace\GLOBAL_CONSTANT` instead of `\GLOBAL_CONSTANT`.

We worked around that by adding the `\` in this service which is anyway rather a good move to be explicit. However I believe the `ReflectionCaster` should support this case because:
- You might want to use a class from a third-party you don't control the code as a lazy service in Symfony and they might be legit not to use the FQCN since it's a feature provided by PHP to work.
- So you can be confident that passing an injection from non-lazy to lazy is not going to cause problem.
- It minimize surprises. We were confident that mocking this service in our tests was fine and so we didn't catch it early, it would be relatively tedious if we start to assume the proxy class can be incompatible where the normal class is and so that we would have to test all non-mocked of them in all possible situations.