### PR TITLE
[Security] Show user account specific errors

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -91,6 +91,7 @@ class MainConfiguration implements ConfigurationInterface
                     ->defaultValue(SessionAuthenticationStrategy::MIGRATE)
                 ->end()
                 ->booleanNode('hide_user_not_found')->defaultTrue()->end()
+                ->booleanNode('show_account_status_exceptions')->defaultFalse()->end()
                 ->booleanNode('always_authenticate_before_granting')
                     ->defaultFalse()
                     ->setDeprecated('symfony/security-bundle', '5.4')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -170,6 +170,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         $container->setParameter('security.access.always_authenticate_before_granting', $config['always_authenticate_before_granting']);
         $container->setParameter('security.authentication.hide_user_not_found', $config['hide_user_not_found']);
+        $container->setParameter('security.authentication.show_account_status_exceptions', $config['show_account_status_exceptions']);
 
         if (class_exists(Application::class)) {
             $loader->load('debug_console.php');

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.php
@@ -50,6 +50,7 @@ return static function (ContainerConfigurator $container) {
                 service('logger')->nullOnInvalid(),
                 param('security.authentication.hide_user_not_found'),
                 service('security.token_storage'),
+                param('security.authentication.show_account_status_exceptions'),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
             ->deprecate('symfony/security-bundle', '5.3', 'The "%service_id%" service is deprecated, use the new authenticator system instead.')

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -46,6 +46,7 @@ return static function (ContainerConfigurator $container) {
                 param('security.authentication.manager.erase_credentials'),
                 param('security.authentication.hide_user_not_found'),
                 abstract_arg('required badges'),
+                param('security.authentication.show_account_status_exceptions'),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_legacy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_legacy.php
@@ -122,6 +122,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('Provider-shared Key'),
                 service('security.password_hasher_factory'),
                 param('security.authentication.hide_user_not_found'),
+                param('security.authentication.show_account_status_exceptions'),
             ])
             ->deprecate('symfony/security-bundle', '5.3', 'The "%service_id%" service is deprecated, use the new authenticator system instead.')
 
@@ -136,6 +137,7 @@ return static function (ContainerConfigurator $container) {
                 param('security.authentication.hide_user_not_found'),
                 abstract_arg('search dn'),
                 abstract_arg('search password'),
+                param('security.authentication.show_account_status_exceptions'),
             ])
             ->deprecate('symfony/security-bundle', '5.3', 'The "%service_id%" service is deprecated, use the new authenticator system instead.')
 

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -42,9 +42,9 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
     /**
      * @param PasswordHasherFactoryInterface $hasherFactory
      */
-    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, string $providerKey, $hasherFactory, bool $hideUserNotFoundExceptions = true)
+    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, string $providerKey, $hasherFactory, bool $hideUserNotFoundExceptions = true, bool $showAccountStatusExceptions = false)
     {
-        parent::__construct($userChecker, $providerKey, $hideUserNotFoundExceptions);
+        parent::__construct($userChecker, $providerKey, $hideUserNotFoundExceptions, $showAccountStatusExceptions);
 
         if ($hasherFactory instanceof EncoderFactoryInterface) {
             trigger_deprecation('symfony/security-core', '5.3', 'Passing a "%s" instance to the "%s" constructor is deprecated, use "%s" instead.', EncoderFactoryInterface::class, __CLASS__, PasswordHasherFactoryInterface::class);

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
@@ -42,9 +42,9 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
     private $searchDn;
     private $searchPassword;
 
-    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, string $providerKey, LdapInterface $ldap, string $dnString = '{user_identifier}', bool $hideUserNotFoundExceptions = true, string $searchDn = '', string $searchPassword = '')
+    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, string $providerKey, LdapInterface $ldap, string $dnString = '{user_identifier}', bool $hideUserNotFoundExceptions = true, string $searchDn = '', string $searchPassword = '', bool $showAccountStatusExceptions = false)
     {
-        parent::__construct($userChecker, $providerKey, $hideUserNotFoundExceptions);
+        parent::__construct($userChecker, $providerKey, $hideUserNotFoundExceptions, $showAccountStatusExceptions);
 
         $this->userProvider = $userProvider;
         $this->ldap = $ldap;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature? | yes 
| Deprecations? | no
| Issues        | Fix #50028
| License       | MIT

According to the `hideUserNotFoundExceptions` flag, only `UserNotFoundException` should be hidden, but the implementation was also silencing account specific errors.

To fix the issue in a BC way, a new `show_account_status_exceptions` config key was introduced to show account exceptions.