### PR TITLE
[SecurityBundle] Use %container.build_hash% instead of %kernel.secret% with the rate-limiter

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -76,7 +76,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface
             $container->register($config['limiter'] = 'security.login_throttling.'.$firewallName.'.limiter', DefaultLoginRateLimiter::class)
                 ->addArgument(new Reference('limiter.'.$globalId))
                 ->addArgument(new Reference('limiter.'.$localId))
-                ->addArgument('%kernel.secret%')
+                ->addArgument('%container.build_hash%')
             ;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In #51434, we decided to hash the username and the client IP in order to anonymize logs.
I propose to use %container.build_hash% instead of %kernel.secret% in order to use %kernel.secret% one less time.
%container.build_hash% looks good enough to me, and it doesn't need any external configuration.
Related to the discussion happening in https://github.com/symfony/recipes/pull/1314