### PR TITLE
[DependencyInjection] Add simple tagging to phpdoc for Autoconfigure attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -20,16 +20,16 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 class Autoconfigure
 {
     /**
-     * @param array<array-key, array<array-key, mixed>>|null $tags         The tags to add to the service
-     * @param array<string, array<array-key, mixed>>|null    $calls        The calls to be made when instantiating the service
-     * @param array<string, mixed>|null                      $bind         The bindings to declare for the service
-     * @param bool|string|null                               $lazy         Whether the service is lazy-loaded
-     * @param bool|null                                      $public       Whether to declare the service as public
-     * @param bool|null                                      $shared       Whether to declare the service as shared
-     * @param bool|null                                      $autowire     Whether to declare the service as autowired
-     * @param array<string, mixed>|null                      $properties   The properties to define when creating the service
-     * @param array<class-string, string>|string|null        $configurator A PHP function, reference or an array containing a class/Reference and a method to call after the service is fully initialized
-     * @param string|null                                    $constructor  The public static method to use to instantiate the service
+     * @param array<array-key, array<array-key, mixed>>|string[]|null $tags         The tags to add to the service
+     * @param array<string, array<array-key, mixed>>|null             $calls        The calls to be made when instantiating the service
+     * @param array<string, mixed>|null                               $bind         The bindings to declare for the service
+     * @param bool|string|null                                        $lazy         Whether the service is lazy-loaded
+     * @param bool|null                                               $public       Whether to declare the service as public
+     * @param bool|null                                               $shared       Whether to declare the service as shared
+     * @param bool|null                                               $autowire     Whether to declare the service as autowired
+     * @param array<string, mixed>|null                               $properties   The properties to define when creating the service
+     * @param array<class-string, string>|string|null                 $configurator A PHP function, reference or an array containing a class/Reference and a method to call after the service is fully initialized
+     * @param string|null                                             $constructor  The public static method to use to instantiate the service
      */
     public function __construct(
         public ?array $tags = null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

7.1RC1 added PHPdoc comments to DI attributes. For the following code:
```php
#[Autoconfigure(tags: [self::class], shared: false)]
interface TaskMessageInterface extends MessageInterface
{
}
```
PHPstan now fails:
```
Parameter $tags of attribute class Symfony\Component\DependencyInjection\Attribute\Autoconfigure constructor expects array<array>|null, array<int, string> given. 
```
So it would appear someone missed the simple and plain notation of an array of strings. Attached PR adds `string[]` to the attribute, fixing the omission.
