### PR TITLE
[Security] Deprecate argument $secret of RememberMeToken and RememberMeAuthenticator

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -1,0 +1,14 @@
+UPGRADE FROM 7.1 to 7.2
+=======================
+
+Symfony 7.2 is a minor release. According to the Symfony release process, there should be no significant
+backward compatibility breaks. Minor backward compatibility breaks are prefixed in this document with
+`[BC BREAK]`, make sure your code is compatible with these entries before upgrading.
+Read more about this in the [Symfony documentation](https://symfony.com/doc/7.2/setup/upgrade_minor.html).
+
+If you're upgrading from a version below 7.1, follow the [7.1 upgrade guide](UPGRADE-7.1.md) first.
+
+Security
+--------
+
+ * Deprecate argument `$secret` of `RememberMeToken` and `RememberMeAuthenticator`

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -107,7 +107,7 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
         $container
             ->setDefinition($authenticatorId, new ChildDefinition('security.authenticator.remember_me'))
             ->replaceArgument(0, new Reference($rememberMeHandlerId))
-            ->replaceArgument(3, $config['name'] ?? $this->options['name'])
+            ->replaceArgument(2, $config['name'] ?? $this->options['name'])
         ;
 
         return $authenticatorId;

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
@@ -85,7 +85,6 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 abstract_arg('remember me handler'),
-                param('kernel.secret'),
                 service('security.token_storage'),
                 abstract_arg('options'),
                 service('logger')->nullOnInvalid(),

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -26,9 +26,9 @@
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/password-hasher": "^6.4|^7.0",
-        "symfony/security-core": "^6.4|^7.0",
+        "symfony/security-core": "^7.2",
         "symfony/security-csrf": "^6.4|^7.0",
-        "symfony/security-http": "^7.1",
+        "symfony/security-http": "^7.2",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -21,20 +21,19 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class RememberMeToken extends AbstractToken
 {
-    private string $secret;
+    private ?string $secret = null;
     private string $firewallName;
 
     /**
-     * @param string $secret A secret used to make sure the token is created by the app and not by a malicious client
-     *
      * @throws \InvalidArgumentException
      */
-    public function __construct(UserInterface $user, string $firewallName, #[\SensitiveParameter] string $secret)
+    public function __construct(UserInterface $user, string $firewallName)
     {
         parent::__construct($user->getRoles());
 
-        if (!$secret) {
-            throw new InvalidArgumentException('A non-empty secret is required.');
+        if (\func_num_args() > 2) {
+            trigger_deprecation('symfony/security-core', '7.2', 'The "$secret" argument of "%s()" is deprecated.', __METHOD__);
+            $this->secret = func_get_arg(2);
         }
 
         if (!$firewallName) {
@@ -42,7 +41,6 @@ class RememberMeToken extends AbstractToken
         }
 
         $this->firewallName = $firewallName;
-        $this->secret = $secret;
 
         $this->setUser($user);
     }
@@ -52,13 +50,19 @@ class RememberMeToken extends AbstractToken
         return $this->firewallName;
     }
 
+    /**
+     * @deprecated since Symfony 7.2
+     */
     public function getSecret(): string
     {
-        return $this->secret;
+        trigger_deprecation('symfony/security-core', '7.2', 'The "%s()" method is deprecated.', __METHOD__);
+
+        return $this->secret ??= base64_encode(random_bytes(8));
     }
 
     public function __serialize(): array
     {
+        // $this->firewallName should be kept at index 1 for compatibility with payloads generated before Symfony 8
         return [$this->secret, $this->firewallName, parent::__serialize()];
     }
 

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Deprecate argument `$secret` of `RememberMeToken`
 
 7.0
 ---

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -72,7 +72,7 @@ class AuthenticationTrustResolverTest extends TestCase
     {
         $user = new InMemoryUser('wouter', '', ['ROLE_USER']);
 
-        return new RememberMeToken($user, 'main', 'secret');
+        return new RememberMeToken($user, 'main');
     }
 }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -20,22 +20,22 @@ class RememberMeTokenTest extends TestCase
     public function testConstructor()
     {
         $user = $this->getUser();
-        $token = new RememberMeToken($user, 'fookey', 'foo');
+        $token = new RememberMeToken($user, 'fookey');
 
         $this->assertEquals('fookey', $token->getFirewallName());
-        $this->assertEquals('foo', $token->getSecret());
         $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertSame($user, $token->getUser());
     }
 
-    public function testConstructorSecretCannotBeEmptyString()
+    /**
+     * @group legacy
+     */
+    public function testSecret()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        new RememberMeToken(
-            $this->getUser(),
-            '',
-            ''
-        );
+        $user = $this->getUser();
+        $token = new RememberMeToken($user, 'fookey', 'foo');
+
+        $this->assertEquals('foo', $token->getSecret());
     }
 
     protected function getUser($roles = ['ROLE_FOO'])

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
@@ -50,7 +50,7 @@ class ExpressionLanguageTest extends TestCase
         $user = new InMemoryUser('username', 'password', $roles);
 
         $noToken = null;
-        $rememberMeToken = new RememberMeToken($user, 'firewall-name', 'firewall');
+        $rememberMeToken = new RememberMeToken($user, 'firewall-name');
         $usernamePasswordToken = new UsernamePasswordToken($user, 'firewall-name', $roles);
 
         return [

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -101,7 +101,7 @@ class AuthenticatedVoterTest extends TestCase
         }
 
         if ('remembered' === $authenticated) {
-            return new RememberMeToken($user, 'foo', 'bar');
+            return new RememberMeToken($user, 'foo');
         }
 
         if ('impersonated' === $authenticated) {

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/password-hasher": "^6.4|^7.0"

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -19,7 +19,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CookieTheftException;
-use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
@@ -50,14 +49,23 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
     private string $cookieName;
     private ?LoggerInterface $logger;
 
-    public function __construct(RememberMeHandlerInterface $rememberMeHandler, #[\SensitiveParameter] string $secret, TokenStorageInterface $tokenStorage, string $cookieName, ?LoggerInterface $logger = null)
+    /**
+     * @param TokenStorageInterface $tokenStorage
+     * @param string                $cookieName
+     * @param ?LoggerInterface      $logger
+     */
+    public function __construct(RememberMeHandlerInterface $rememberMeHandler, #[\SensitiveParameter] TokenStorageInterface|string $tokenStorage, string|TokenStorageInterface $cookieName, LoggerInterface|string|null $logger = null)
     {
-        if (!$secret) {
-            throw new InvalidArgumentException('A non-empty secret is required.');
+        if (\is_string($tokenStorage)) {
+            trigger_deprecation('symfony/security-core', '7.2', 'The "$secret" argument of "%s()" is deprecated.', __METHOD__);
+
+            $this->secret = $tokenStorage;
+            $tokenStorage = $cookieName;
+            $cookieName = $logger;
+            $logger = \func_num_args() > 4 ? func_get_arg(4) : null;
         }
 
         $this->rememberMeHandler = $rememberMeHandler;
-        $this->secret = $secret;
         $this->tokenStorage = $tokenStorage;
         $this->cookieName = $cookieName;
         $this->logger = $logger;
@@ -99,7 +107,11 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
 
     public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
-        return new RememberMeToken($passport->getUser(), $firewallName, $this->secret);
+        if (isset($this->secret)) {
+            return new RememberMeToken($passport->getUser(), $firewallName, $this->secret);
+        }
+
+        return new RememberMeToken($passport->getUser(), $firewallName);
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Deprecate argument `$secret` of `RememberMeAuthenticator`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -34,7 +34,7 @@ class RememberMeAuthenticatorTest extends TestCase
     {
         $this->rememberMeHandler = $this->createMock(RememberMeHandlerInterface::class);
         $this->tokenStorage = new TokenStorage();
-        $this->authenticator = new RememberMeAuthenticator($this->rememberMeHandler, 's3cr3t', $this->tokenStorage, '_remember_me_cookie');
+        $this->authenticator = new RememberMeAuthenticator($this->rememberMeHandler, $this->tokenStorage, '_remember_me_cookie');
     }
 
     public function testSupportsTokenStorageWithToken()

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/property-access": "^6.4|^7.0",
-        "symfony/security-core": "^6.4|^7.0",
+        "symfony/security-core": "^7.2",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

One less use for `kernel.secret`.
The secret is not used since the new authentication system.