### PR TITLE
[DoctrineBridge] Undeprecate DoctrineExtractor::getTypes()

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -4,7 +4,6 @@ CHANGELOG
 7.1
 ---
 
- * Deprecate the `DoctrineExtractor::getTypes()` method, use `DoctrineExtractor::getType()` instead
  * Allow `EntityValueResolver` to return a list of entities
  * Add support for auto-closing idle connections
  * Allow validating every class against `UniqueEntity` constraint

--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -161,13 +161,8 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         };
     }
 
-    /**
-     * @deprecated since Symfony 7.1, use "getType" instead
-     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
-        trigger_deprecation('symfony/property-info', '7.1', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
-
         if (null === $metadata = $this->getMetadata($class)) {
             return null;
         }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -108,8 +108,6 @@ class DoctrineExtractorTest extends TestCase
     }
 
     /**
-     * @group legacy
-     *
      * @dataProvider legacyTypesProvider
      */
     public function testExtractLegacy(string $property, ?array $type = null)
@@ -117,9 +115,6 @@ class DoctrineExtractorTest extends TestCase
         $this->assertEquals($type, $this->createExtractor()->getTypes(DoctrineDummy::class, $property, []));
     }
 
-    /**
-     * @group legacy
-     */
     public function testExtractWithEmbeddedLegacy()
     {
         $expectedTypes = [new LegacyType(
@@ -137,9 +132,6 @@ class DoctrineExtractorTest extends TestCase
         $this->assertEquals($expectedTypes, $actualTypes);
     }
 
-    /**
-     * @group legacy
-     */
     public function testExtractEnumLegacy()
     {
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, EnumString::class)], $this->createExtractor()->getTypes(DoctrineEnum::class, 'enumString', []));
@@ -149,9 +141,6 @@ class DoctrineExtractorTest extends TestCase
         $this->assertNull($this->createExtractor()->getTypes(DoctrineEnum::class, 'enumCustom', []));
     }
 
-    /**
-     * @group legacy
-     */
     public static function legacyTypesProvider(): array
     {
         // DBAL 4 has a special fallback strategy for BINGINT (int -> string)
@@ -251,9 +240,6 @@ class DoctrineExtractorTest extends TestCase
         $this->assertNull($this->createExtractor()->getProperties('Not\Exist'));
     }
 
-    /**
-     * @group legacy
-     */
     public function testGetTypesCatchExceptionLegacy()
     {
         $this->assertNull($this->createExtractor()->getTypes('Not\Exist', 'baz'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The deprecation of the `PropertyTypeExtractorInterface::getTypes()` method was taken back in #54789. As long as the method exists on the interface, we cannot remove any implementations. Thus, I'm undeprecating the implementation in `DoctrineExtractor` as well.
