### PR TITLE
[FrameworkBundle] Derivate `kernel.secret` from the decryption secret when its env var is not defined

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for setting `headers` with `Symfony\Bundle\FrameworkBundle\Controller\TemplateController`
+ * Derivate `kernel.secret` from the decryption secret when its env var is not defined
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/secrets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/secrets.php
@@ -21,6 +21,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('Secret dir, set in FrameworkExtension'),
                 service('secrets.decryption_key')->ignoreOnInvalid(),
+                abstract_arg('Secret env var, set in FrameworkExtension'),
             ])
 
         ->set('secrets.env_var_loader', StaticEnvVarLoader::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
@@ -75,4 +75,13 @@ class SodiumVaultTest extends TestCase
 
         $this->assertSame([], $vault->list());
     }
+
+    public function testDerivedSecretEnvVar()
+    {
+        $vault = new SodiumVault($this->secretsDir, null, 'MY_SECRET');
+        $vault->generateKeys();
+        $vault->seal('FOO', 'bar');
+
+        $this->assertSame(['FOO', 'MY_SECRET'], array_keys($vault->loadEnvVars()));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #38021
| License       | MIT

I'm pursuing the goal of making `APP_SECRET` empty in the default recipe. See https://github.com/symfony/recipes/pull/1314 for background.

At the moment, `kernel.secret` is used for remember-be, login-links and ESI. This means that when you start a project, you don't need it. But once you do enable those features, you'll get an "APP_SECRET env var not found" error message.

I think we can live with this error and the related DX. We need good doc of course.
Still, in order to make DX a bit smoother, I propose to derivate APP_SECRET from SYMFONY_DECRYPTION_SECRET when it's set.

This is what this PR does.

Of course, we should also document that creating a separate `APP_SECRET` is likely a good idea.
FTR, here is how one can trivially generate a value for APP_SECRET and put it in the vault, thus fixing #38021:

```sh
symfony console secrets:set APP_SECRET --random
```
