### PR TITLE
[Mime] Fixed `Mime\Message::ensureValidity()` when a required header is set, but has an empty body

### DIFF
--- a/src/Symfony/Component/Mime/Message.php
+++ b/src/Symfony/Component/Mime/Message.php
@@ -124,11 +124,11 @@ class Message extends RawMessage
 
     public function ensureValidity()
     {
-        if (!$this->headers->has('To') && !$this->headers->has('Cc') && !$this->headers->has('Bcc')) {
+        if (!$this->headers->get('To')?->getBody() && !$this->headers->get('Cc')?->getBody() && !$this->headers->get('Bcc')?->getBody()) {
             throw new LogicException('An email must have a "To", "Cc", or "Bcc" header.');
         }
 
-        if (!$this->headers->has('From') && !$this->headers->has('Sender')) {
+        if (!$this->headers->get('From')?->getBody() && !$this->headers->get('Sender')?->getBody()) {
             throw new LogicException('An email must have a "From" or a "Sender" header.');
         }
 

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -276,4 +276,71 @@ EOF;
         $serialized = $serializer->serialize($e, 'json');
         $this->assertSame($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
     }
+
+    /**
+     * @dataProvider ensureValidityProvider
+     */
+    public function testEnsureValidity(array $headers, ?string $exceptionClass, ?string $exceptionMessage)
+    {
+        if ($exceptionClass) {
+            $this->expectException($exceptionClass);
+            $this->expectExceptionMessage($exceptionMessage);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $m = new Message();
+        foreach ($headers as $headerName => $headerValue) {
+            $m->getHeaders()->addMailboxListHeader($headerName, $headerValue);
+        }
+        $m->ensureValidity();
+    }
+
+    public function ensureValidityProvider()
+    {
+        return [
+            'Valid address fields' => [
+                [
+                    'To' => ['dummy@symfony.com'],
+                    'From' => ['test@symfony.com'],
+                ],
+                null,
+                null,
+            ],
+
+            'No destination address fields' => [
+                [
+                    'From' => ['test@symfony.com'],
+                ],
+                LogicException::class,
+                'An email must have a "To", "Cc", or "Bcc" header.',
+            ],
+
+            'Empty destination address fields' => [
+                [
+                    'To' => [],
+                    'From' => ['test@symfony.com'],
+                ],
+                LogicException::class,
+                'An email must have a "To", "Cc", or "Bcc" header.',
+            ],
+
+            'No originator fields' => [
+                [
+                    'To' => ['dummy@symfony.com'],
+                ],
+                LogicException::class,
+                'An email must have a "From" or a "Sender" header.',
+            ],
+
+            'Empty originator fields' => [
+                [
+                    'To' => ['dummy@symfony.com'],
+                    'From' => [],
+                ],
+                LogicException::class,
+                'An email must have a "From" or a "Sender" header.',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

According to [RFC 5322 - Destination Address Fields](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
) "... Each destination field may have _one or more_ addresses ...".
Currently `Message::ensureValidity()` only checks the presence of the required fields in headers which considers the message valid if the field is present but has no body. This PR adds empty checks for the required fields so that an exception will be raised when those fields are all empty.
