### PR TITLE
[VarExporter] Improve error message for Lazy Ghosts failing reinitializing classes due to readonly properties

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
@@ -62,8 +62,8 @@ class LazyObjectState
             $this->status = self::STATUS_UNINITIALIZED_FULL;
             $this->reset($instance);
 
-            if ($e instanceof \Error && 1 === preg_match('#^Cannot modify readonly property (.+)$#', $e->getMessage(), $matches)) {
-                throw new LogicException(sprintf('Lazy ghost cannot reinitialize readonly property "%s", remove the readonly modifier on that property and/or its containing class, or ensure the ghost will never be reinitialized.', $matches[1]));
+            if ($e::class === \Error::class && preg_match('#^Cannot modify readonly property (.+)$#', $e->getMessage(), $m)) {
+                throw new LogicException(sprintf('Lazy ghost cannot reinitialize property "%s" because it is readonly.', $m[1]));
             }
 
             throw $e;

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Internal;
 
+use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\Hydrator as PublicHydrator;
 
 /**
@@ -62,7 +63,7 @@ class LazyObjectState
             $this->reset($instance);
 
             if ($e instanceof \Error && 1 === preg_match('#^Cannot modify readonly property (.+)$#', $e->getMessage(), $matches)) {
-                throw new LogicException(sprintf('Lazy ghost cannot reinitialize readonly property "%s", remove the readonly modifier or ensure the ghost is never reinitialized', $matches[1]));
+                throw new LogicException(sprintf('Lazy ghost cannot reinitialize readonly property "%s", remove the readonly modifier on that property and/or its containing class, or ensure the ghost will never be reinitialized', $matches[1]));
             }
             
             throw $e;

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
@@ -61,6 +61,10 @@ class LazyObjectState
             $this->status = self::STATUS_UNINITIALIZED_FULL;
             $this->reset($instance);
 
+            if ($e instanceof \Error && 1 === preg_match('#^Cannot modify readonly property (.+)$#', $e->getMessage(), $matches)) {
+                throw new LogicException(sprintf('Lazy ghost cannot reinitialize readonly property "%s", remove the readonly modifier or ensure the ghost is never reinitialized', $matches[1]));
+            }
+            
             throw $e;
         }
 

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
@@ -63,9 +63,9 @@ class LazyObjectState
             $this->reset($instance);
 
             if ($e instanceof \Error && 1 === preg_match('#^Cannot modify readonly property (.+)$#', $e->getMessage(), $matches)) {
-                throw new LogicException(sprintf('Lazy ghost cannot reinitialize readonly property "%s", remove the readonly modifier on that property and/or its containing class, or ensure the ghost will never be reinitialized', $matches[1]));
+                throw new LogicException(sprintf('Lazy ghost cannot reinitialize readonly property "%s", remove the readonly modifier on that property and/or its containing class, or ensure the ghost will never be reinitialized.', $matches[1]));
             }
-            
+
             throw $e;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | sort of
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/54228
| License       | MIT

As discussed in https://github.com/symfony/symfony/issues/54228, Lazy Ghosts cannot reinitialize classes with `readonly` properties due to PHP limitations. Currently, this will often lead to a vague crash minutes or even hours later stating only:

> Cannot modify readonly property Doctrine\ORM\EntityManager::$conn

This PR improves the error message to:

> Lazy ghost cannot reinitialize readonly property "Doctrine\ORM\EntityManager::$conn", remove the readonly modifier on that property and/or its containing class, or ensure the ghost will never be reinitialized
