### PR TITLE
[Serializer] Support enums that implement `JsonSerializable` in `BackedEnumNormalizer`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/JsonSerializableBackedEnum.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/JsonSerializableBackedEnum.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+use JsonSerializable;
+
+enum JsonSerializableBackedEnum: string implements JsonSerializable
+{
+    case Get = 'GET';
+
+    public function jsonSerialize(): string {
+        return 'custom_get_string';
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\JsonSerializableBackedEnum;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TranslatableBackedEnum;
 
 /**
@@ -77,6 +78,15 @@ class SerializerTest extends AbstractWebTestCase
         $serializer = static::getContainer()->get('serializer.alias');
 
         $this->assertEquals('GET', $serializer->serialize(TranslatableBackedEnum::Get, 'yaml'));
+    }
+
+    public function testSerializeJsonSerializableBackedEnum()
+    {
+        static::bootKernel(['test_case' => 'Serializer']);
+
+        $serializer = static::getContainer()->get('serializer.alias');
+
+        $this->assertEquals('custom_get_string', $serializer->serialize(JsonSerializableBackedEnum::Get, 'yaml'));
     }
 }
 

--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -40,6 +40,10 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
             throw new InvalidArgumentException('The data must belong to a backed enumeration.');
         }
 
+        if ($object instanceof \JsonSerializable) {
+            return $object->jsonSerialize();
+        }
+
         return $object->value;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I have an enum that implement `JsonSerializable`. But looks like it is not considered when serializing.

Currently, the following code doesn't work with the Serializer but it works with `json_encode`.

```PHP
enum JsonSerializableBackedEnum: string implements JsonSerializable
{
    case Get = 'GET';

    public function jsonSerialize(): string {
        return 'custom_get_string';
    }
}
```

```PHP
class MyController {
    public function __invoke(SerializerInterface $serializer) {
        dd($serializer->serialize(MyEnum::Get)); // ""GET"" , Expected result: ""custom_get_string""
    }
}
```

This PR allows the `BackedEnumNormalizer` to handle enums that implement the `JsonSerializable` interface.