### PR TITLE
[HttpClient] Fix that staged exceptions were not thrown when calling `MockResponse::getStatusCode()`

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -291,10 +291,8 @@ class MockResponse implements ResponseInterface, StreamableInterface
             try {
                 foreach ($body as $chunk) {
                     if ($chunk instanceof \Throwable) {
-                        throw $chunk;
-                    }
-
-                    if ('' === $chunk = (string) $chunk) {
+                        $response->body[] = new ErrorChunk($offset, $chunk);
+                    } else if ('' === $chunk = (string) $chunk) {
                         // simulate an idle timeout
                         $response->body[] = new ErrorChunk($offset, sprintf('Idle timeout reached for "%s".', $response->info['url']));
                     } else {
@@ -305,7 +303,7 @@ class MockResponse implements ResponseInterface, StreamableInterface
                     }
                 }
             } catch (\Throwable $e) {
-                $response->body[] = $e;
+                $response->body[] = new ErrorChunk($offset, $e);
             }
         } elseif ('' !== $body) {
             $response->body[] = $body;

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -222,26 +222,43 @@ class MockHttpClientTest extends HttpClientTestCase
         $this->assertFalse(isset($requestOptions['normalized_headers']['content-length']));
     }
 
-    public function testThrowExceptionInBodyGenerator()
+    public function testThrowExceptionInBodyGeneratorWhenAccessingContent()
     {
         $mockHttpClient = new MockHttpClient([
-            new MockResponse((static function (): \Generator {
-                yield 'foo';
-                throw new TransportException('foo ccc');
-            })()),
-            new MockResponse((static function (): \Generator {
-                yield 'bar';
-                throw new \RuntimeException('bar ccc');
-            })()),
+            new MockResponse(
+                (static function (): \Generator {
+                    // We _must_ yield a first chunk here...
+                    yield 'first chunk';
+                    // otherwise the exception would be thrown already when setting up the test.
+                    throw new TransportException('foo ccc');
+                })()
+            ),
         ]);
 
+        $response = $mockHttpClient->request('GET', 'https://symfony.com', []);
+
+        // Since the exception is not thrown unless the first chunk has been processed,
+        // the status code is 200 (depends on the first chunk).
+        self::assertSame(200, $response->getStatusCode());
+
         try {
-            $mockHttpClient->request('GET', 'https://symfony.com', [])->getContent();
+            // Accessing the content has to fail, since we now hit the exception throwing code in the generator
+            $response->getContent();
             $this->fail();
         } catch (TransportException $e) {
             $this->assertEquals(new TransportException('foo ccc'), $e->getPrevious());
             $this->assertSame('foo ccc', $e->getMessage());
         }
+    }
+
+    public function testThrowExceptionInBodyGeneratorWhenStreaming()
+    {
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse((static function (): \Generator {
+                yield 'bar';
+                throw new \RuntimeException('bar ccc');
+            })()),
+        ]);
 
         $chunks = [];
         try {
@@ -262,6 +279,42 @@ class MockHttpClientTest extends HttpClientTestCase
         $this->assertSame('bar ccc', $chunks[2]->getError());
     }
 
+    public function testYieldExceptionFromBodyGeneratorWhenAccessingStatusCode()
+    {
+        $exception = new \RuntimeException('Something went wrong at the transport level');
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse(
+                (static function () use ($exception): \Generator {
+                    yield $exception;
+                })()
+            ),
+        ]);
+
+        try {
+            $mockHttpClient->request('GET', 'https://symfony.com', [])->getStatusCode();
+            $this->fail();
+        } catch (TransportException $e) {
+            $this->assertSame('Something went wrong at the transport level', $e->getMessage());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+
+    public function testExceptionInBodyPartArrayWhenAccessingStatusCode()
+    {
+        $exception = new \RuntimeException('Something went wrong at the transport level');
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse([$exception]),
+        ]);
+
+        try {
+            $mockHttpClient->request('GET', 'https://symfony.com', [])->getStatusCode();
+            $this->fail();
+        } catch (TransportException $e) {
+            $this->assertSame('Something went wrong at the transport level', $e->getMessage());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+
     public function testMergeDefaultOptions()
     {
         $mockHttpClient = new MockHttpClient(null, 'https://example.com');
@@ -271,23 +324,59 @@ class MockHttpClientTest extends HttpClientTestCase
         $mockHttpClient->request('GET', '/foo', ['base_uri' => null]);
     }
 
-    public function testExceptionDirectlyInBody()
+    public function testExceptionInBodyPartArrayWhenAccessingContent()
     {
         $mockHttpClient = new MockHttpClient([
             new MockResponse(['foo', new \RuntimeException('foo ccc')]),
-            new MockResponse((static function (): \Generator {
-                yield 'bar';
-                yield new TransportException('bar ccc');
-            })()),
         ]);
 
+        $response = $mockHttpClient->request('GET', 'https://symfony.com', []);
+
+        // Since the exception is not thrown unless the first chunk has been processed,
+        // the status code is 200 (depends on the first chunk).
+        self::assertSame(200, $response->getStatusCode());
+
         try {
-            $mockHttpClient->request('GET', 'https://symfony.com', [])->getContent();
+            $response->getContent();
             $this->fail();
         } catch (TransportException $e) {
             $this->assertEquals(new \RuntimeException('foo ccc'), $e->getPrevious());
             $this->assertSame('foo ccc', $e->getMessage());
         }
+    }
+
+    public function testExceptionYieldedFromBodyPartGeneratorWhenAccessingContent()
+    {
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse((static function (): \Generator {
+                yield 'foo';
+                yield new \RuntimeException('foo ccc');
+            })()),
+        ]);
+
+        $response = $mockHttpClient->request('GET', 'https://symfony.com', []);
+
+        // Since the exception is not thrown unless the first chunk has been processed,
+        // the status code is 200 (depends on the first chunk).
+        self::assertSame(200, $response->getStatusCode());
+
+        try {
+            $response->getContent();
+            $this->fail();
+        } catch (TransportException $e) {
+            $this->assertEquals(new \RuntimeException('foo ccc'), $e->getPrevious());
+            $this->assertSame('foo ccc', $e->getMessage());
+        }
+    }
+
+    public function testExceptionDirectlyInBody()
+    {
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse((static function (): \Generator {
+                yield 'bar';
+                yield new TransportException('bar ccc');
+            })()),
+        ]);
 
         $chunks = [];
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Disclaimer: I don't fully grasp all the internal workings and the async tricks the HTTP Client does, so take this with a grain of salt.

I have application code like the following:

```php
$response = $httpClient->request('GET', $url);

if (200 !== $response->getStatusCode()) {
  // ... do something about it
}
```

To my understanding, conditions like e. g. a DNS resolution error will lead to a `TransportException` being thrown, and this may happen from `getStatusCode()`, since this is the first method that really has to wait for results to arrive over the network.

I'd like to write a test to make sure my code deals with the exception in an appropriate way. I have been following the examples given at https://symfony.com/doc/current/http_client.html#testing-network-transport-exceptions, and also at the definition of `ExternalArticleService::createArticle()` as given in https://symfony.com/doc/current/http_client.html#full-example. Note that `createArticle()` also accesses `getStatusCode()`, like my code does.

However, I could not get this test to work. Defining `$httpClient` either as 

```php
$httpClient = new MockHttpClient([
    new MockResponse([new \RuntimeException('Error at transport level')]),
]);
```
or 
```php
$httpClient = new MockHttpClient((static function (): \Generator {
    yield new TransportException('Error at transport level');
})());
```

did not lead to the exception being thrown when accessing `$response->getStatusCode()`.

Digging into `\Symfony\Component\HttpClient\Response\MockResponse::readResponse` I noticed that the canned exception was thrown only to be caught again a few lines down, seemingly using it as a plain body part. I do not fully understand what the code is trying to do there. Maybe the code is the result of #44438 and #44568 that were merged in close timely relationship, but against different target branches (4.4 and 6.1).

I have added new tests to cover exception handling also when accessing the `getStatusCode()` method, with exceptions being yielded from a generator or being part of an array. 

Also, I split up some test cases where – to my understanding – two different things were tested at the same time.