### PR TITLE
[Translation] Add `lint:translations` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -165,6 +165,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\String\LazyString;
 use Symfony\Component\String\Slugger\SluggerInterface;
 use Symfony\Component\Translation\Bridge as TranslationBridge;
+use Symfony\Component\Translation\Command\TranslationLintCommand as BaseTranslationLintCommand;
 use Symfony\Component\Translation\Command\XliffLintCommand as BaseXliffLintCommand;
 use Symfony\Component\Translation\Extractor\PhpAstExtractor;
 use Symfony\Component\Translation\LocaleSwitcher;
@@ -243,6 +244,10 @@ class FrameworkExtension extends Extension
             }
             if (!class_exists(BaseYamlLintCommand::class)) {
                 $container->removeDefinition('console.command.yaml_lint');
+            }
+
+            if (!class_exists(BaseTranslationLintCommand::class)) {
+                $container->removeDefinition('console.command.translation_lint');
             }
 
             if (!class_exists(DebugCommand::class)) {
@@ -1413,6 +1418,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('console.command.translation_extract');
             $container->removeDefinition('console.command.translation_pull');
             $container->removeDefinition('console.command.translation_push');
+            $container->removeDefinition('console.command.translation_lint');
 
             return;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -54,6 +54,7 @@ use Symfony\Component\Messenger\Command\StatsCommand;
 use Symfony\Component\Messenger\Command\StopWorkersCommand;
 use Symfony\Component\Scheduler\Command\DebugCommand as SchedulerDebugCommand;
 use Symfony\Component\Serializer\Command\DebugCommand as SerializerDebugCommand;
+use Symfony\Component\Translation\Command\TranslationLintCommand;
 use Symfony\Component\Translation\Command\TranslationPullCommand;
 use Symfony\Component\Translation\Command\TranslationPushCommand;
 use Symfony\Component\Translation\Command\XliffLintCommand;
@@ -315,6 +316,13 @@ return static function (ContainerConfigurator $container) {
             ->tag('console.command')
 
         ->set('console.command.yaml_lint', YamlLintCommand::class)
+            ->tag('console.command')
+
+        ->set('console.command.translation_lint', TranslationLintCommand::class)
+            ->args([
+                service('translator'),
+                param('kernel.enabled_locales'),
+            ])
             ->tag('console.command')
 
         ->set('console.command.form_debug', \Symfony\Component\Form\Command\DebugCommand::class)

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `lint:translations` command
+
 7.1
 ---
 

--- a/src/Symfony/Component/Translation/Command/TranslationLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationLintCommand.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Translation\Exception\ExceptionInterface;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Lint translations files syntax and outputs encountered errors.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+#[AsCommand(name: 'lint:translations', description: 'Lint translations files syntax and outputs encountered errors')]
+class TranslationLintCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private TranslatorInterface&TranslatorBagInterface $translator,
+        private array $enabledLocales = [],
+    ) {
+        parent::__construct();
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestOptionValuesFor('locales')) {
+            $suggestions->suggestValues($this->enabledLocales);
+        }
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDefinition([
+                new InputOption('locales', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Specify the locales to lint.', $this->enabledLocales),
+            ])
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</> command lint translations.
+
+  <info>php %command.full_name%</>
+EOF
+            );
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $locales = $input->getOption('locales');
+
+        /** @var array<string, array<string, array<string, \Throwable>> $errors */
+        $errors = [];
+        $domainsByLocales = [];
+
+        foreach ($locales as $locale) {
+            $messageCatalogue = $this->translator->getCatalogue($locale);
+
+            foreach ($domainsByLocales[$locale] = $messageCatalogue->getDomains() as $domain) {
+                foreach ($messageCatalogue->all($domain) as $id => $translation) {
+                    try {
+                        $this->translator->trans($id, [], $domain, $messageCatalogue->getLocale());
+                    } catch (ExceptionInterface $e) {
+                        $errors[$locale][$domain][$id] = $e;
+                    }
+                }
+            }
+        }
+
+        if (!$domainsByLocales) {
+            $this->io->error('No translation files were found.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->io->table(
+            ['Locale', 'Domains', 'Valid?'],
+            array_map(
+                static fn (string $locale, array $domains) => [
+                    $locale,
+                    implode(', ', $domains),
+                    !\array_key_exists($locale, $errors) ? '<info>Yes</>' : '<error>No</>',
+                ],
+                array_keys($domainsByLocales),
+                $domainsByLocales
+            ),
+        );
+
+        if ($errors) {
+            foreach ($errors as $locale => $domains) {
+                foreach ($domains as $domain => $domainsErrors) {
+                    $this->io->section(sprintf('Errors for locale "%s" and domain "%s"', $locale, $domain));
+
+                    foreach ($domainsErrors as $id => $error) {
+                        $this->io->text(sprintf('Translation key "%s" is invalid:', $id));
+                        $this->io->error($error->getMessage());
+                    }
+                }
+            }
+
+            return Command::FAILURE;
+        }
+
+        $this->io->success('All translations are valid.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationLintCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Translation\Command\TranslationLintCommand;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Translator;
+
+final class TranslationLintCommandTest extends TestCase
+{
+    public function testLintCorrectTranslations()
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['hello' => 'Hello!'], 'en', 'messages');
+        $translator->addResource('array', [
+            'hello_name' => 'Hello {name}!',
+            'num_of_apples' => <<<ICU
+                {apples, plural,
+                    =0    {There are no apples}
+                    =1    {There is one apple...}
+                    other {There are # apples!}
+                }
+            ICU,
+        ], 'en', 'messages+intl-icu');
+        $translator->addResource('array', ['hello' => 'Bonjour !'], 'fr', 'messages');
+        $translator->addResource('array', [
+            'hello_name' => 'Bonjour {name} !',
+            'num_of_apples' => <<<ICU
+                {apples, plural,
+                    =0    {Il n'y a pas de pommes}
+                    =1    {Il y a une pomme}
+                    other {Il y a # pommes !}
+                }
+            ICU,
+        ], 'fr', 'messages+intl-icu');
+
+        $command = $this->createCommand($translator, ['en', 'fr']);
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([], ['decorated' => false]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $display = $this->getNormalizedDisplay($commandTester);
+        $this->assertStringContainsString('[OK] All translations are valid.', $display);
+    }
+
+    public function testLintMalformedIcuTranslations()
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['hello' => 'Hello!'], 'en', 'messages');
+        $translator->addResource('array', [
+            'hello_name' => 'Hello {name}!',
+            // Missing "other" case
+            'num_of_apples' => <<<ICU
+                {apples, plural,
+                    =0    {There are no apples}
+                    =1    {There is one apple...}
+                }
+            ICU,
+        ], 'en', 'messages+intl-icu');
+        $translator->addResource('array', ['hello' => 'Bonjour !'], 'fr', 'messages');
+        $translator->addResource('array', [
+            // Missing "}"
+            'hello_name' => 'Bonjour {name !',
+            // "other" is translated
+            'num_of_apples' => <<<ICU
+                {apples, plural,
+                    =0    {Il n'y a pas de pommes}
+                    =1    {Il y a une pomme}
+                    autre {Il y a # pommes !}
+                }
+            ICU,
+        ], 'fr', 'messages+intl-icu');
+
+        $command = $this->createCommand($translator, ['en', 'fr']);
+        $commandTester = new CommandTester($command);
+
+        $this->assertSame(1, $commandTester->execute([], ['decorated' => false]));
+
+        $display = $this->getNormalizedDisplay($commandTester);
+        $this->assertStringContainsString(<<<EOF
+ -------- ---------- --------
+  Locale   Domains    Valid?
+ -------- ---------- --------
+  en       messages   No
+  fr       messages   No
+ -------- ---------- --------
+EOF, $display);
+        $this->assertStringContainsString(<<<EOF
+Errors for locale "en" and domain "messages"
+--------------------------------------------
+
+ Translation key "num_of_apples" is invalid:
+
+ [ERROR] Invalid message format (error #65807): msgfmt_create: message formatter creation failed:
+         U_DEFAULT_KEYWORD_MISSING
+EOF, $display);
+        $this->assertStringContainsString(<<<EOF
+Errors for locale "fr" and domain "messages"
+--------------------------------------------
+
+ Translation key "hello_name" is invalid:
+
+ [ERROR] Invalid message format (error #65799): pattern syntax error (parse error at offset 9, after "Bonjour {", before
+         or at "name !"): U_PATTERN_SYNTAX_ERROR
+
+ Translation key "num_of_apples" is invalid:
+
+ [ERROR] Invalid message format (error #65807): msgfmt_create: message formatter creation failed:
+         U_DEFAULT_KEYWORD_MISSING
+EOF, $display);
+    }
+
+    private function createCommand(Translator $translator, array $enabledLocales): Command
+    {
+        $command = new TranslationLintCommand($translator, $enabledLocales);
+
+        $application = new Application();
+        $application->add($command);
+
+        return $command;
+    }
+
+    /**
+     * Normalize the CommandTester display, by removing trailing spaces for each line.
+     */
+    private function getNormalizedDisplay(CommandTester $commandTester): string
+    {
+        return implode(\PHP_EOL, array_map(fn (string $line) => rtrim($line), explode(\PHP_EOL, $commandTester->getDisplay(true))));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hi everyone (cc @welcoMattic),

This PR adds a new command `lint:translations` in the Translator component, which lints the translations like `lint:yaml` could lint Yaml files, `lint:templates` lints Twig files, etc...

Why?
Our application uses translations from Lokalise. They are contributed by non-tech users and sometimes they can contains issues (missing `}`, missing `other` in `plural`, etc...). 
Thoses issues results in a error 500 because the ICU translations can not be correctly parsed, and we want to prevent this by linting the translations before deploying (if the command fails, we don't deploy, and we don't have errors 500).

The current approach is a bit naive, at the moment it simply call `TranslatorInterface#trans()` and catch exceptions (if any), but it can be improved in the future.

PS: During the time between creating the command and opening the PR, we used it on our app and we were able to detect 5/6 invalid translations :) 

WDYT? Thanks :)

--- 

Also, quick question, how do Symfony/PHP developers deals with `trim_trailing_whitespace = true` from the `.editorconfig`, and asserting on the `Console` output (which contains trailing spaces)? 
Do they disable EditorConfig in their IDE? Thanks!

**EDIT:** I don't have the issue anymore by right-trailing white chars for each lines, but I'm still curious :)