### PR TITLE
[PhpUnitBridge] Fix error handler triggered outside of tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -368,22 +368,26 @@ class DeprecationErrorHandler
 
         if ('PHPUnit\Util\ErrorHandler::handleError' === $eh) {
             return $eh;
-        } elseif (ErrorHandler::class === $eh) {
-            return function (int $errorNumber, string $errorString, string $errorFile, int $errorLine) {
-                ErrorHandler::instance()($errorNumber, $errorString, $errorFile, $errorLine);
-
-                return true;
-            };
         }
 
         foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
-            if (isset($frame['object']) && $frame['object'] instanceof TestResult) {
+            if (!isset($frame['object'])) {
+                continue;
+            }
+
+            if ($frame['object'] instanceof TestResult) {
                 return new $eh(
                     $frame['object']->getConvertDeprecationsToExceptions(),
                     $frame['object']->getConvertErrorsToExceptions(),
                     $frame['object']->getConvertNoticesToExceptions(),
                     $frame['object']->getConvertWarningsToExceptions()
                 );
+            } elseif (ErrorHandler::class === $eh && $frame['object'] instanceof TestCase) {
+                return function (int $errorNumber, string $errorString, string $errorFile, int $errorLine) {
+                    ErrorHandler::instance()($errorNumber, $errorString, $errorFile, $errorLine);
+
+                    return true;
+                };
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57071
| License       | MIT

The error handler should be invoked only if the error occurred inside a test.