### PR TITLE
[Serializer] Add `AbstractNormalizer::IGNORED_GROUPS` to make it possible to ignore groups during serialization

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `CamelCaseToSnakeCaseNameConverter::REQUIRE_SNAKE_CASE_PROPERTIES` context option
  * Deprecate `AbstractNormalizerContextBuilder::withDefaultContructorArguments(?array $defaultContructorArguments)`, use `withDefaultConstructorArguments(?array $defaultConstructorArguments)` instead (note the missing `s` character in Contructor word in deprecated method)
  * Add `XmlEncoder::CDATA_WRAPPING_PATTERN` context option
+ * Add `AbstractNormalizer::IGNORED_GROUPS` to make it possible to ignore groups during serialization
 
 7.0
 ---

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `AbstractNormalizer::SKIP_INVALID_ATTRIBUTES` to denormalize the attributes whose value cannot be used as if they were absent from the input
+ * Add `AbstractNormalizer::IGNORED_GROUPS` to exclude the attributes belonging to the given groups
  * Allow passing an associative array to `CsvEncoder::HEADERS_KEY` to map and reorder columns when encoding
  * Use the discriminator property of an object to pick its type when several types map to the same class; the first declared type is used when the property is unset or unknown
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
@@ -71,6 +71,22 @@ abstract class AbstractNormalizerContextBuilder implements ContextBuilderInterfa
     }
 
     /**
+     * Configures groups whose attributes are excluded, whichever groups are allowed.
+     *
+     * Eg: ['internal']
+     *
+     * @param list<string>|string|null $ignoredGroups
+     */
+    public function withIgnoredGroups(array|string|null $ignoredGroups): static
+    {
+        if (null === $ignoredGroups) {
+            return $this->with(AbstractNormalizer::IGNORED_GROUPS, null);
+        }
+
+        return $this->with(AbstractNormalizer::IGNORED_GROUPS, (array) $ignoredGroups);
+    }
+
+    /**
      * Configures attributes to (de)normalize.
      *
      * For nested structures, this list needs to reflect the object tree.

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -59,6 +59,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      */
     public const GROUPS = 'groups';
 
+    public const IGNORED_GROUPS = 'ignored_groups';
+
     /**
      * Limit (de)normalize to the specified names.
      *
@@ -230,6 +232,9 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         $groupsHasBeenDefined = [] !== $groups;
         $groups = array_merge($groups, ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class]);
 
+        $ignoredGroups = $this->getIgnoredGroups($context);
+        $ignoreGroupsHasBeenDefined = [] !== $ignoredGroups;
+
         $allowedAttributes = [];
         $ignoreUsed = false;
 
@@ -243,12 +248,13 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                 !$ignore
                 && (!$groupsHasBeenDefined || array_intersect(array_merge($attributeMetadata->getGroups(), ['*']), $groups))
                 && $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)
+                && count(array_intersect($attributeMetadata->getGroups(), $ignoredGroups)) === 0
             ) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;
             }
         }
 
-        if (!$ignoreUsed && !$groupsHasBeenDefined && $allowExtraAttributes) {
+        if (!$ignoreUsed && !$groupsHasBeenDefined &&!$ignoreGroupsHasBeenDefined && $allowExtraAttributes) {
             // Backward Compatibility with the code using this method written before the introduction of @Ignore
             return false;
         }
@@ -259,6 +265,13 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     protected function getGroups(array $context): array
     {
         $groups = $context[self::GROUPS] ?? $this->defaultContext[self::GROUPS] ?? [];
+
+        return \is_scalar($groups) ? (array) $groups : $groups;
+    }
+
+    protected function getIgnoredGroups(array $context): array
+    {
+        $groups = $context[self::IGNORED_GROUPS] ?? $this->defaultContext[self::IGNORED_GROUPS] ?? [];
 
         return \is_scalar($groups) ? (array) $groups : $groups;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -248,13 +248,13 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                 !$ignore
                 && (!$groupsHasBeenDefined || array_intersect(array_merge($attributeMetadata->getGroups(), ['*']), $groups))
                 && $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)
-                && count(array_intersect($attributeMetadata->getGroups(), $ignoredGroups)) === 0
+                && 0 === \count(array_intersect($attributeMetadata->getGroups(), $ignoredGroups))
             ) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;
             }
         }
 
-        if (!$ignoreUsed && !$groupsHasBeenDefined &&!$ignoreGroupsHasBeenDefined && $allowExtraAttributes) {
+        if (!$ignoreUsed && !$groupsHasBeenDefined && !$ignoreGroupsHasBeenDefined && $allowExtraAttributes) {
             // Backward Compatibility with the code using this method written before the introduction of @Ignore
             return false;
         }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -61,6 +61,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     public const GROUPS = 'groups';
 
     /**
+     * Exclude the attributes belonging to the specified groups, whichever groups are allowed.
+     */
+    public const IGNORED_GROUPS = 'ignored_groups';
+
+    /**
      * Limit (de)normalize to the specified names.
      *
      * For nested structures, this list needs to reflect the object tree.
@@ -237,6 +242,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         }
 
         $groups = $this->getGroups($context);
+        $ignoredGroups = $this->getIgnoredGroups($context);
 
         $allowedAttributes = [];
         $ignoreUsed = false;
@@ -250,13 +256,15 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             if (
                 !$ignore
                 && ([] === $groups || \in_array('*', $groups, true) || array_intersect($attributeMetadata->getGroups(), $groups))
+                && ([] === $ignoredGroups || !array_intersect($attributeMetadata->getGroups(), $ignoredGroups))
                 && $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)
             ) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;
             }
         }
 
-        if (!$ignoreUsed && $allowExtraAttributes) {
+        // returning false means "no restriction", which would defeat the exclusion
+        if (!$ignoreUsed && [] === $ignoredGroups && $allowExtraAttributes) {
             if ([] === $groups) {
                 return false;
             }
@@ -272,6 +280,13 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     protected function getGroups(array $context): array
     {
         $groups = $context[self::GROUPS] ?? $this->defaultContext[self::GROUPS] ?? [];
+
+        return \is_scalar($groups) ? (array) $groups : $groups;
+    }
+
+    protected function getIgnoredGroups(array $context): array
+    {
+        $groups = $context[self::IGNORED_GROUPS] ?? $this->defaultContext[self::IGNORED_GROUPS] ?? [];
 
         return \is_scalar($groups) ? (array) $groups : $groups;
     }

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
@@ -88,6 +88,13 @@ class AbstractNormalizerContextBuilderTest extends TestCase
         $this->assertSame([AbstractNormalizer::GROUPS => ['group']], $this->contextBuilder->withGroups('group')->toArray());
     }
 
+    public function testWithIgnoredGroups()
+    {
+        $this->assertSame([AbstractNormalizer::IGNORED_GROUPS => ['internal']], $this->contextBuilder->withIgnoredGroups('internal')->toArray());
+        $this->assertSame([AbstractNormalizer::IGNORED_GROUPS => ['a', 'b']], $this->contextBuilder->withIgnoredGroups(['a', 'b'])->toArray());
+        $this->assertSame([AbstractNormalizer::IGNORED_GROUPS => null], $this->contextBuilder->withIgnoredGroups(null)->toArray());
+    }
+
     public function testCannotSetNonStringAttributes()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -73,6 +73,7 @@ class AbstractNormalizerTest extends TestCase
         $a4 = new AttributeMetadata('a4');
         $a4->addGroup('test');
         $a4->addGroup('other');
+        $a4->addGroup('ignore');
         $classMetadata->addAttributeMetadata($a4);
 
         $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
@@ -85,6 +86,15 @@ class AbstractNormalizerTest extends TestCase
 
         $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], true);
         $this->assertEquals(['a1', 'a2', 'a3', 'a4'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['test'], AbstractNormalizer::IGNORED_GROUPS => ['ignore']], true);
+        $this->assertEquals(['a2'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*'], AbstractNormalizer::IGNORED_GROUPS => ['ignore']], true);
+        $this->assertEquals(['a1', 'a2', 'a3'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::IGNORED_GROUPS => ['ignore']], true);
+        $this->assertEquals(['a1', 'a2', 'a3'], $result);
     }
 
     public function testGetAllowedAttributesAsObjects()
@@ -105,6 +115,7 @@ class AbstractNormalizerTest extends TestCase
         $a4 = new AttributeMetadata('a4');
         $a4->addGroup('test');
         $a4->addGroup('other');
+        $a4->addGroup('ignore');
         $classMetadata->addAttributeMetadata($a4);
 
         $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
@@ -120,6 +131,9 @@ class AbstractNormalizerTest extends TestCase
 
         $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], false);
         $this->assertEquals([$a1, $a2, $a3, $a4], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::IGNORED_GROUPS => ['ignore']], false);
+        $this->assertEquals([$a1, $a2, $a3], $result);
     }
 
     public function testObjectWithStaticConstructor()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -70,6 +70,7 @@ class AbstractNormalizerTest extends TestCase
         $a4 = new AttributeMetadata('a4');
         $a4->addGroup('test');
         $a4->addGroup('other');
+        $a4->addGroup('ignore');
         $classMetadata->addAttributeMetadata($a4);
 
         $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
@@ -82,6 +83,15 @@ class AbstractNormalizerTest extends TestCase
 
         $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], true);
         $this->assertEquals(['a1', 'a2', 'a3', 'a4'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['test'], AbstractNormalizer::IGNORED_GROUPS => ['ignore']], true);
+        $this->assertEquals(['a2'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*'], AbstractNormalizer::IGNORED_GROUPS => ['ignore']], true);
+        $this->assertEquals(['a1', 'a2', 'a3'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::IGNORED_GROUPS => ['ignore']], true);
+        $this->assertEquals(['a1', 'a2', 'a3'], $result);
     }
 
     public function testGetAllowedAttributesWithWildcardGroupAndNoMetadata()
@@ -112,6 +122,7 @@ class AbstractNormalizerTest extends TestCase
         $a4 = new AttributeMetadata('a4');
         $a4->addGroup('test');
         $a4->addGroup('other');
+        $a4->addGroup('ignore');
         $classMetadata->addAttributeMetadata($a4);
 
         $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
@@ -127,6 +138,9 @@ class AbstractNormalizerTest extends TestCase
 
         $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], false);
         $this->assertEquals([$a1, $a2, $a3, $a4], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::IGNORED_GROUPS => ['ignore']], false);
+        $this->assertEquals([$a1, $a2, $a3], $result);
     }
 
     public function testObjectWithStaticConstructor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This MR makes it possible to ignore some groups during serialization process. 
Sometimes it is very handy to ignore some groups, f.e. when serializing response DTO's.

With current `Ignore` attribute it is not possible to ignore some attribute in one context and leave attribute in another context.

With thish MR is it possible to do something like that:

```php
class SomeClass {
    public function __construct(
        public readonly int $customerId,
        #[Groups(['test-group', 'ignore'])]
        public readonly int $token,
    )
    {
    }
}

// For example I want to ignore `token` attribute when returning http response, but I want it to be present when serializing and saving to the database

$this->serializer->serialize(
    $someObject,
    'json',
    [
        AbstractNormalizer::IGNORED_GROUPS => ['ignore'],
    ]
);
```

