### PR TITLE
[DependencyInjection] Fix binding parameters with default empty values

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -182,10 +182,11 @@ class ResolveBindingsPass extends AbstractRecursivePass
             foreach ($reflectionMethod->getParameters() as $key => $parameter) {
                 $names[$key] = $parameter->name;
 
-                if (\array_key_exists($key, $arguments) && '' !== $arguments[$key]) {
-                    continue;
+                if (\array_key_exists($parameter->name, $arguments)) {
+                    $key = $parameter->name;
                 }
-                if (\array_key_exists($parameter->name, $arguments) && '' !== $arguments[$parameter->name]) {
+
+                if (\array_key_exists($key, $arguments) && !\in_array($arguments[$key], ['', null, []], true)) {
                     continue;
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -213,6 +213,32 @@ class ResolveBindingsPassTest extends TestCase
         $pass->process($container);
     }
 
+    /**
+     * @testWith [1, ""]
+     *           [1, null]
+     *           [1, []]
+     *           ["apiKey", ""]
+     *           ["apiKey", null]
+     *           ["apiKey", []]
+     */
+    public function testEmptyBindingWithEmptyDefaultValue($key, $value)
+    {
+        $container = new ContainerBuilder();
+
+        $bindings = [
+            '$apiKey' => new BoundArgument('foo'),
+        ];
+
+        $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
+        $definition->setArguments([$key => $value]);
+        $definition->setBindings($bindings);
+
+        $pass = new ResolveBindingsPass();
+        $pass->process($container);
+
+        $this->assertEquals([$key => 'foo'], $definition->getArguments());
+    }
+
     public function testIterableBindingTypehint()
     {
         $autoloader = static function ($class) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #56875
| License       | MIT

Caused by #54791 and #52917 (sort of). The main problem is that once the default value of `null` was added, the binding didn't resolve properly. The `serializer.normalizer.property`, and possibly others, have the same problem.