### PR TITLE
[Serializer] Fix `ObjectNormalizer` with property path

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -194,7 +194,11 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         $class = \is_object($classOrObject) ? \get_class($classOrObject) : $classOrObject;
 
         if ($context['_read_attributes'] ?? true) {
-            return $this->propertyInfoExtractor->isReadable($class, $attribute) || $this->hasAttributeAccessorMethod($class, $attribute);
+            return (\is_object($classOrObject) && $this->propertyAccessor->isReadable($classOrObject, $attribute)) || $this->propertyInfoExtractor->isReadable($class, $attribute) || $this->hasAttributeAccessorMethod($class, $attribute);
+        }
+
+        if (str_contains($attribute, '.')) {
+            return true;
         }
 
         if ($this->propertyInfoExtractor->isWritable($class, $attribute)) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/property-path-mapping.yaml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/property-path-mapping.yaml
@@ -1,0 +1,5 @@
+Symfony\Component\Serializer\Tests\Normalizer\ObjectOuter:
+    attributes:
+        inner.foo:
+            serialized_name: inner_foo
+            groups: [ 'read' ]

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
@@ -908,6 +909,40 @@ class ObjectNormalizerTest extends TestCase
 
         $expected = new ObjectDummyWithIgnoreAnnotationAndPrivateProperty();
         $expected->foo = 'set';
+
+        $this->assertEquals($expected, $obj);
+    }
+
+    public function testNormalizeWithPropertyPath()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new YamlFileLoader(__DIR__.'/../Fixtures/property-path-mapping.yaml'));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+
+        $dummyInner = new ObjectInner();
+        $dummyInner->foo = 'foo';
+        $dummy = new ObjectOuter();
+        $dummy->setInner($dummyInner);
+
+        $this->assertSame(['inner_foo' => 'foo'], $normalizer->normalize($dummy, 'json', ['groups' => 'read']));
+    }
+
+    public function testDenormalizeWithPropertyPath()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new YamlFileLoader(__DIR__.'/../Fixtures/property-path-mapping.yaml'));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+
+        $dummy = new ObjectOuter();
+        $dummy->setInner(new ObjectInner());
+
+        $obj = $normalizer->denormalize(['inner_foo' => 'foo'], ObjectOuter::class, 'json', [
+            'object_to_populate' => $dummy,
+            'groups' => 'read',
+        ]);
+
+        $expectedInner = new ObjectInner();
+        $expectedInner->foo = 'foo';
+        $expected = new ObjectOuter();
+        $expected->setInner($expectedInner);
 
         $this->assertEquals($expected, $obj);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54983
| License       | MIT

Caused by #52917.

The `ObjectNormalizer::isAllowedAttribute()` method doesn't work with property paths, this is an attempt to fix the problem.