### PR TITLE
[DoctrineBridge] Fix `UniqueEntityValidator` with proxy object

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdWithPrivateNameEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdWithPrivateNameEntity.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+class SingleIntIdWithPrivateNameEntity
+{
+    public function __construct(
+        #[Id, Column(type: 'integer')]
+        protected int $id,
+
+        #[Column(type: 'string', nullable: true)]
+        private ?string $name,
+    ) {
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -287,7 +287,9 @@ class UniqueEntityValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException(sprintf('The field "%s" is not a property of class "%s".', $fieldName, $objectClass));
             }
 
-            $fieldValues[$entityFieldName] = $this->getPropertyValue($objectClass, $fieldName, $object);
+            $fieldValues[$entityFieldName] = $isValueEntity && $object instanceof ($class->getName())
+                ? $class->reflFields[$fieldName]->getValue($object)
+                : $this->getPropertyValue($objectClass, $fieldName, $object);
         }
 
         return $fieldValues;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57075
| License       | MIT

Before #38662, `$fieldValue = $class->reflFields[$fieldName]->getValue($entity);` was used to get the value of a property, so it makes sense to keep using it when the object is an entity.