### PR TITLE
[HttpFoundation] Recursively order query string keys in `Request::normalizeQueryString()`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `HeaderRequestMatcher`
  * Add support for `\SplTempFileObject` in `BinaryFileResponse`
  * Add `verbose` argument to response test constraints
+ * [BC BREAK] Query string key/value pairs are now recursively sorted in `Request::normalizeQueryString()`.
 
 7.0
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -595,7 +595,15 @@ class Request
         }
 
         $qs = HeaderUtils::parseQuery($qs);
-        ksort($qs);
+        $recursive_sort = function (&$array) use (&$recursive_sort) {
+            foreach ($array as &$v) {
+                if (is_array($v)) {
+                    $recursive_sort($v);
+                }
+            }
+            ksort($array);
+        };
+        $recursive_sort($qs);
 
         return http_build_query($qs, '', '&', \PHP_QUERY_RFC3986);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -826,9 +826,9 @@ class RequestTest extends TestCase
             // PHP also does not include them when building _GET.
             ['foo=bar&=a=b&=x=y', 'foo=bar', 'removes params with empty key'],
 
-            // Don't reorder nested query string keys
+            // Provide predictable ordering of nested query string keys.
             ['foo[]=Z&foo[]=A', 'foo%5B0%5D=Z&foo%5B1%5D=A', 'keeps order of values'],
-            ['foo[Z]=B&foo[A]=B', 'foo%5BZ%5D=B&foo%5BA%5D=B', 'keeps order of keys'],
+            ['foo[Z]=A&foo[A]=B', 'foo%5BA%5D=B&foo%5BZ%5D=A', 'nested keys are reordered but values are maintained'],
 
             ['utf8=✓', 'utf8=%E2%9C%93', 'encodes UTF-8'],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes, changelog updated
| Deprecations? | no
| License       | MIT

I'm not quite sure how to handle this proposal (particularly as it comes to BC implications) but opening an MR to at least start the discussion and get some guidance.

Over in Drupal I am working on [a bug](https://www.drupal.org/project/drupal/issues/3085360) where our cache is poisoned due to query parameters that are altered during our internal request handling. That bug is specific to Drupal's request and caching API, however the solution has me looking upstream with a potential improvement.

We need to add the request query parameters and the potentially altered set to the cache ID. To maximize cache hits (and also hedge against a bit of DDoS vectors, I think?) it's necessary to predictably order the query parameters, recursively. Symfony only sorts the top-level keys, and even has test coverage to ensure the ordering is limited to the top level.

I'm not sure there's any real benefit to this and the git log for the applicable test coverage dates to version 3.4 and I think is lumped in with "cleanup," so it's hard to know the motivation.

Technically speaking this would be a BC break because you get a differently-ordered query string out of the function, but it would work exactly the same. I know BC is important but it also seems like this might be a case where functional equivalence is fine?

It could also be that this just isn't important in Symfony's code and we can continue to address this directly in our code (as we will now, unless this merges fast) but I wanted to also raise this here.