### PR TITLE
[VarDumper] Fix generator dump on PHP 8.4

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -83,13 +83,13 @@ class ReflectionCaster
         // Cannot create ReflectionGenerator based on a terminated Generator
         try {
             $reflectionGenerator = new \ReflectionGenerator($c);
+
+            return self::castReflectionGenerator($reflectionGenerator, $a, $stub, $isNested);
         } catch (\Exception $e) {
             $a[Caster::PREFIX_VIRTUAL.'closed'] = true;
 
             return $a;
         }
-
-        return self::castReflectionGenerator($reflectionGenerator, $a, $stub, $isNested);
     }
 
     public static function castType(\ReflectionType $c, array $a, Stub $stub, bool $isNested)

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -500,7 +500,10 @@ EOTXT
         );
     }
 
-    public function testGenerator()
+    /**
+     * @requires PHP < 8.4
+     */
+    public function testGeneratorPriorTo84()
     {
         if (\extension_loaded('xdebug')) {
             $this->markTestSkipped('xdebug is active');
@@ -566,6 +569,85 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 Generator {
+  closed: true
+}
+EODUMP;
+        $this->assertDumpMatchesFormat($expectedDump, $generator);
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testGenerator()
+    {
+        if (\extension_loaded('xdebug')) {
+            $this->markTestSkipped('xdebug is active');
+        }
+
+        $generator = new GeneratorDemo();
+        $generator = $generator->baz();
+
+        $expectedDump = <<<'EODUMP'
+Generator {
+  function: "Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::baz"
+  this: Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo { …}
+  %s: {
+    %sGeneratorDemo.php:14 {
+      Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo->baz()
+      › {
+      ›     yield from bar();
+      › }
+    }
+    Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo->baz() {}
+%A}
+  closed: false
+}
+EODUMP;
+
+        $this->assertDumpMatchesFormat($expectedDump, $generator);
+
+        foreach ($generator as $v) {
+            break;
+        }
+
+        $expectedDump = <<<'EODUMP'
+array:2 [
+  0 => ReflectionGenerator {
+    this: Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo { …}
+    %s: {
+      %s%eTests%eFixtures%eGeneratorDemo.php:%d {
+        Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo()
+%A      ›     yield 1;
+%A    }
+      %s%eTests%eFixtures%eGeneratorDemo.php:20 { …}
+      %s%eTests%eFixtures%eGeneratorDemo.php:14 { …}
+%A  }
+    closed: false
+  }
+  1 => Generator {
+    function: "Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo"
+    %s: {
+      %s%eTests%eFixtures%eGeneratorDemo.php:%d {
+        Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo()
+        ›     yield 1;
+        › }
+        › 
+      }
+%A  }
+    closed: false
+  }
+]
+EODUMP;
+
+        $r = new \ReflectionGenerator($generator);
+        $this->assertDumpMatchesFormat($expectedDump, [$r, $r->getExecutingGenerator()]);
+
+        foreach ($generator as $v) {
+        }
+
+        $expectedDump = <<<'EODUMP'
+Generator {
+  function: "Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::baz"
   closed: true
 }
 EODUMP;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

From PHP 8.4, generators dump contains the generating function: https://github.com/php/php-src/pull/14167.

Also, creating a ReflectionGenerator on a closed generator is now permitted, which explains the update in `ReflectionCaster` to catch anything that may happen in `castReflectionGenerator()`.