### PR TITLE
[HttpKernel] MapQueryString/MapRequestPayload do not skip validation when empty request is sent

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
@@ -23,11 +23,11 @@ class ApiAttributesTest extends AbstractWebTestCase
     /**
      * @dataProvider mapQueryStringProvider
      */
-    public function testMapQueryString(array $query, string $expectedResponse, int $expectedStatusCode)
+    public function testMapQueryString(string $uri, array $query, string $expectedResponse, int $expectedStatusCode)
     {
         $client = self::createClient(['test_case' => 'ApiAttributesTest']);
 
-        $client->request('GET', '/map-query-string.json', $query);
+        $client->request('GET', $uri, $query);
 
         $response = $client->getResponse();
         if ($expectedResponse) {
@@ -40,13 +40,15 @@ class ApiAttributesTest extends AbstractWebTestCase
 
     public static function mapQueryStringProvider(): iterable
     {
-        yield 'empty' => [
+        yield 'empty nullable query string' => [
+            'uri' => '/map-nullable-query-string.json',
             'query' => [],
             'expectedResponse' => '',
             'expectedStatusCode' => 204,
         ];
 
-        yield 'valid' => [
+        yield 'valid nullable query string' => [
+            'uri' => '/map-nullable-query-string.json',
             'query' => ['filter' => ['status' => 'approved', 'quantity' => '4']],
             'expectedResponse' => <<<'JSON'
                 {
@@ -59,7 +61,63 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 200,
         ];
 
-        yield 'invalid' => [
+        yield 'invalid nullable query string' => [
+            'uri' => '/map-nullable-query-string.json',
+            'query' => ['filter' => ['status' => 'approved', 'quantity' => '200']],
+            'expectedResponse' => <<<'JSON'
+                {
+                    "type": "https:\/\/symfony.com\/errors\/validation",
+                    "title": "Validation Failed",
+                    "status": 404,
+                    "detail": "filter.quantity: This value should be less than 10.",
+                    "violations": [
+                        {
+                            "propertyPath": "filter.quantity",
+                            "title": "This value should be less than 10.",
+                            "template": "This value should be less than {{ compared_value }}.",
+                            "parameters": {
+                                "{{ value }}": "200",
+                                "{{ compared_value }}": "10",
+                                "{{ compared_value_type }}": "int"
+                            },
+                            "type": "urn:uuid:079d7420-2d13-460c-8756-de810eeb37d2"
+                        }
+                    ]
+                }
+                JSON,
+            'expectedStatusCode' => 404,
+        ];
+
+        yield 'empty query string with default value' => [
+            'uri' => '/map-query-string-with-default-value.json',
+            'query' => [],
+            'expectedResponse' => <<<'JSON'
+                {
+                    "filter": {
+                        "status": "approved",
+                        "quantity": 5
+                    }
+                }
+                JSON,
+            'expectedStatusCode' => 200,
+        ];
+
+        yield 'valid query string with default value' => [
+            'uri' => '/map-query-string-with-default-value.json',
+            'query' => ['filter' => ['status' => 'approved', 'quantity' => '4']],
+            'expectedResponse' => <<<'JSON'
+                {
+                    "filter": {
+                        "status": "approved",
+                        "quantity": 4
+                    }
+                }
+                JSON,
+            'expectedStatusCode' => 200,
+        ];
+
+        yield 'invalid query string with default value' => [
+            'uri' => '/map-query-string-with-default-value.json',
             'query' => ['filter' => ['status' => 'approved', 'quantity' => '200']],
             'expectedResponse' => <<<'JSON'
                 {
@@ -89,7 +147,7 @@ class ApiAttributesTest extends AbstractWebTestCase
     /**
      * @dataProvider mapRequestPayloadProvider
      */
-    public function testMapRequestPayload(string $format, array $parameters, ?string $content, string $expectedResponse, int $expectedStatusCode)
+    public function testMapRequestPayload(string $uri, string $format, array $parameters, ?string $content, string $expectedResponse, int $expectedStatusCode)
     {
         $client = self::createClient(['test_case' => 'ApiAttributesTest']);
 
@@ -102,7 +160,7 @@ class ApiAttributesTest extends AbstractWebTestCase
 
         $client->request(
             'POST',
-            '/map-request-body.'.$format,
+            $uri,
             $parameters,
             [],
             ['HTTP_ACCEPT' => $acceptHeader, 'CONTENT_TYPE' => $acceptHeader],
@@ -123,7 +181,8 @@ class ApiAttributesTest extends AbstractWebTestCase
 
     public static function mapRequestPayloadProvider(): iterable
     {
-        yield 'empty' => [
+        yield 'empty nullable request' => [
+            'uri' => '/map-nullable-request-body.json',
             'format' => 'json',
             'parameters' => [],
             'content' => '',
@@ -131,7 +190,22 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 204,
         ];
 
-        yield 'valid json' => [
+        yield 'empty with default request value' => [
+            'uri' => '/map-request-body-with-default-value.json',
+            'format' => 'json',
+            'parameters' => [],
+            'content' => '',
+            'expectedResponse' => <<<'JSON'
+                {
+                    "comment": "Hello everyone!",
+                    "approved": false
+                }
+                JSON,
+            'expectedStatusCode' => 200,
+        ];
+
+        yield 'valid json with nullable request' => [
+            'uri' => '/map-nullable-request-body.json',
             'format' => 'json',
             'parameters' => [],
             'content' => <<<'JSON'
@@ -149,7 +223,27 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 200,
         ];
 
-        yield 'malformed json' => [
+        yield 'valid json with default request value' => [
+            'uri' => '/map-request-body-with-default-value.json',
+            'format' => 'json',
+            'parameters' => [],
+            'content' => <<<'JSON'
+                {
+                    "comment": "Hello everyone!",
+                    "approved": false
+                }
+                JSON,
+            'expectedResponse' => <<<'JSON'
+                {
+                    "comment": "Hello everyone!",
+                    "approved": false
+                }
+                JSON,
+            'expectedStatusCode' => 200,
+        ];
+
+        yield 'malformed json with nullable request' => [
+            'uri' => '/map-nullable-request-body.json',
             'format' => 'json',
             'parameters' => [],
             'content' => <<<'JSON'
@@ -169,7 +263,29 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 400,
         ];
 
-        yield 'unsupported format' => [
+        yield 'malformed json with default request value' => [
+            'uri' => '/map-request-body-with-default-value.json',
+            'format' => 'json',
+            'parameters' => [],
+            'content' => <<<'JSON'
+                {
+                    "comment": "Hello everyone!",
+                    "approved": false,
+                }
+                JSON,
+            'expectedResponse' => <<<'JSON'
+                {
+                    "type": "https:\/\/tools.ietf.org\/html\/rfc2616#section-10",
+                    "title": "An error occurred",
+                    "status": 400,
+                    "detail": "Bad Request"
+                }
+                JSON,
+            'expectedStatusCode' => 400,
+        ];
+
+        yield 'unsupported format with nullable request' => [
+            'uri' => '/map-nullable-request-body.dummy',
             'format' => 'dummy',
             'parameters' => [],
             'content' => 'Hello',
@@ -177,7 +293,17 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 415,
         ];
 
-        yield 'valid xml' => [
+        yield 'unsupported format with default request value' => [
+            'uri' => '/map-request-body-with-default-value.dummy',
+            'format' => 'dummy',
+            'parameters' => [],
+            'content' => 'Hello',
+            'expectedResponse' => '415 Unsupported Media Type',
+            'expectedStatusCode' => 415,
+        ];
+
+        yield 'valid xml with nullable request' => [
+            'uri' => '/map-nullable-request-body.xml',
             'format' => 'xml',
             'parameters' => [],
             'content' => <<<'XML'
@@ -195,7 +321,27 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 200,
         ];
 
-        yield 'invalid type' => [
+        yield 'valid xml with default request value' => [
+            'uri' => '/map-request-body-with-default-value.xml',
+            'format' => 'xml',
+            'parameters' => [],
+            'content' => <<<'XML'
+                <request>
+                    <comment>Hello everyone!</comment>
+                    <approved>true</approved>
+                </request>
+                XML,
+            'expectedResponse' => <<<'XML'
+                <response>
+                    <comment>Hello everyone!</comment>
+                    <approved>1</approved>
+                </response>
+                XML,
+            'expectedStatusCode' => 200,
+        ];
+
+        yield 'invalid type with nullable request' => [
+            'uri' => '/map-nullable-request-body.json',
             'format' => 'json',
             'parameters' => [],
             'content' => <<<'JSON'
@@ -225,7 +371,39 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 422,
         ];
 
-        yield 'validation error json' => [
+        yield 'invalid type with default request value' => [
+            'uri' => '/map-request-body-with-default-value.json',
+            'format' => 'json',
+            'parameters' => [],
+            'content' => <<<'JSON'
+                {
+                    "comment": "Hello everyone!",
+                    "approved": "string instead of bool"
+                }
+                JSON,
+            'expectedResponse' => <<<'JSON'
+                {
+                    "type": "https:\/\/symfony.com\/errors\/validation",
+                    "title": "Validation Failed",
+                    "status": 422,
+                    "detail": "approved: This value should be of type bool.",
+                    "violations": [
+                        {
+                            "propertyPath": "approved",
+                            "title": "This value should be of type bool.",
+                            "template": "This value should be of type {{ type }}.",
+                            "parameters": {
+                                "{{ type }}": "bool"
+                            }
+                        }
+                    ]
+                }
+                JSON,
+            'expectedStatusCode' => 422,
+        ];
+
+        yield 'validation error json with nullable request' => [
+            'uri' => '/map-nullable-request-body.json',
             'format' => 'json',
             'parameters' => [],
             'content' => <<<'JSON'
@@ -267,7 +445,51 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 422,
         ];
 
-        yield 'validation error xml' => [
+        yield 'validation error json with default request value' => [
+            'uri' => '/map-request-body-with-default-value.json',
+            'format' => 'json',
+            'parameters' => [],
+            'content' => <<<'JSON'
+                {
+                    "comment": "",
+                    "approved": true
+                }
+                JSON,
+            'expectedResponse' => <<<'JSON'
+                {
+                    "type": "https:\/\/symfony.com\/errors\/validation",
+                    "title": "Validation Failed",
+                    "status": 422,
+                    "detail": "comment: This value should not be blank.\ncomment: This value is too short. It should have 10 characters or more.",
+                    "violations": [
+                        {
+                            "propertyPath": "comment",
+                            "title": "This value should not be blank.",
+                            "template": "This value should not be blank.",
+                            "parameters": {
+                                "{{ value }}": "\"\""
+                            },
+                            "type": "urn:uuid:c1051bb4-d103-4f74-8988-acbcafc7fdc3"
+                        },
+                        {
+                            "propertyPath": "comment",
+                            "title": "This value is too short. It should have 10 characters or more.",
+                            "template": "This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.",
+                            "parameters": {
+                                "{{ value }}": "\"\"",
+                                "{{ limit }}": "10",
+                                "{{ value_length }}": "0"
+                            },
+                            "type": "urn:uuid:9ff3fdc4-b214-49db-8718-39c315e33d45"
+                        }
+                    ]
+                }
+                JSON,
+            'expectedStatusCode' => 422,
+        ];
+
+        yield 'validation error xml with nullable request' => [
+            'uri' => '/map-nullable-request-body.xml',
             'format' => 'xml',
             'parameters' => [],
             'content' => <<<'XML'
@@ -299,7 +521,41 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 422,
         ];
 
-        yield 'valid input' => [
+        yield 'validation error xml with default request value' => [
+            'uri' => '/map-request-body-with-default-value.xml',
+            'format' => 'xml',
+            'parameters' => [],
+            'content' => <<<'XML'
+                <request>
+                    <comment>H</comment>
+                    <approved>false</approved>
+                </request>
+                XML,
+            'expectedResponse' => <<<'XML'
+                <?xml version="1.0"?>
+                <response>
+                    <type>https://symfony.com/errors/validation</type>
+                    <title>Validation Failed</title>
+                    <status>422</status>
+                    <detail>comment: This value is too short. It should have 10 characters or more.</detail>
+                    <violations>
+                        <propertyPath>comment</propertyPath>
+                        <title>This value is too short. It should have 10 characters or more.</title>
+                        <template>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</template>
+                        <parameters>
+                            <item key="{{ value }}">"H"</item>
+                            <item key="{{ limit }}">10</item>
+                            <item key="{{ value_length }}">1</item>
+                        </parameters>
+                        <type>urn:uuid:9ff3fdc4-b214-49db-8718-39c315e33d45</type>
+                    </violations>
+                </response>
+                XML,
+            'expectedStatusCode' => 422,
+        ];
+
+        yield 'valid input with nullable request' => [
+            'uri' => '/map-nullable-request-body.json',
             'format' => 'json',
             'input' => ['comment' => 'Hello everyone!', 'approved' => '0'],
             'content' => null,
@@ -312,7 +568,60 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 200,
         ];
 
-        yield 'validation error input' => [
+        yield 'valid input with default request value' => [
+            'uri' => '/map-request-body-with-default-value.json',
+            'format' => 'json',
+            'input' => ['comment' => 'Hello everyone!', 'approved' => '0'],
+            'content' => null,
+            'expectedResponse' => <<<'JSON'
+                {
+                    "comment": "Hello everyone!",
+                    "approved": false
+                }
+                JSON,
+            'expectedStatusCode' => 200,
+        ];
+
+        yield 'validation error input with nullable request' => [
+            'uri' => '/map-nullable-request-body.json',
+            'format' => 'json',
+            'input' => ['comment' => '', 'approved' => '1'],
+            'content' => null,
+            'expectedResponse' => <<<'JSON'
+                {
+                    "type": "https:\/\/symfony.com\/errors\/validation",
+                    "title": "Validation Failed",
+                    "status": 422,
+                    "detail": "comment: This value should not be blank.\ncomment: This value is too short. It should have 10 characters or more.",
+                    "violations": [
+                        {
+                            "propertyPath": "comment",
+                            "title": "This value should not be blank.",
+                            "template": "This value should not be blank.",
+                            "parameters": {
+                                "{{ value }}": "\"\""
+                            },
+                            "type": "urn:uuid:c1051bb4-d103-4f74-8988-acbcafc7fdc3"
+                        },
+                        {
+                            "propertyPath": "comment",
+                            "title": "This value is too short. It should have 10 characters or more.",
+                            "template": "This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.",
+                            "parameters": {
+                                "{{ value }}": "\"\"",
+                                "{{ limit }}": "10",
+                                "{{ value_length }}": "0"
+                            },
+                            "type": "urn:uuid:9ff3fdc4-b214-49db-8718-39c315e33d45"
+                        }
+                    ]
+                }
+                JSON,
+            'expectedStatusCode' => 422,
+        ];
+
+        yield 'validation error input with default request value' => [
+            'uri' => '/map-request-body-with-default-value.json',
             'format' => 'json',
             'input' => ['comment' => '', 'approved' => '1'],
             'content' => null,
@@ -351,7 +660,7 @@ class ApiAttributesTest extends AbstractWebTestCase
     }
 }
 
-class WithMapQueryStringController
+class WithMapNullableQueryStringController
 {
     public function __invoke(#[MapQueryString] ?QueryString $query): Response
     {
@@ -365,7 +674,17 @@ class WithMapQueryStringController
     }
 }
 
-class WithMapRequestPayloadController
+class WithMapQueryStringWithDefaultValueController
+{
+    public function __invoke(#[MapQueryString] QueryString $query = new QueryString(new Filter('approved', 5))): Response
+    {
+        return new JsonResponse(
+            ['filter' => ['status' => $query->filter->status, 'quantity' => $query->filter->quantity]],
+        );
+    }
+}
+
+class WithMapNullableRequestPayloadController
 {
     public function __invoke(#[MapRequestPayload] ?RequestBody $body, Request $request): Response
     {
@@ -374,6 +693,25 @@ class WithMapRequestPayloadController
                 return new Response('', Response::HTTP_NO_CONTENT);
             }
 
+            return new JsonResponse(['comment' => $body->comment, 'approved' => $body->approved]);
+        }
+
+        return new Response(
+            <<<XML
+            <response>
+                <comment>{$body->comment}</comment>
+                <approved>{$body->approved}</approved>
+            </response>
+            XML
+        );
+    }
+}
+
+class WithMapRequestPayloadWithDefaultValueController
+{
+    public function __invoke(Request $request, #[MapRequestPayload] RequestBody $body = new RequestBody('Hello everyone!', false)): Response
+    {
+        if ('json' === $request->getPreferredFormat('json')) {
             return new JsonResponse(['comment' => $body->comment, 'approved' => $body->approved]);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/routing.yml
@@ -1,7 +1,15 @@
-map_query_string:
-    path: /map-query-string.{_format}
-    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapQueryStringController
+map_nullable_query_string:
+    path: /map-nullable-query-string.{_format}
+    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapNullableQueryStringController
 
-map_request_body:
-    path: /map-request-body.{_format}
-    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapRequestPayloadController
+map_query_string_with_default_value:
+    path: /map-query-string-with-default-value.{_format}
+    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapQueryStringWithDefaultValueController
+
+map_nullable_request_body:
+    path: /map-nullable-request-body.{_format}
+    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapNullableRequestPayloadController
+
+map_request_body_with_default_value:
+    path: /map-request-body-with-default-value.{_format}
+    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapRequestPayloadWithDefaultValueController

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -161,7 +161,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function mapQueryString(Request $request, string $type, MapQueryString $attribute): ?object
     {
-        if (!$data = $request->query->all()) {
+        if (!($data = $request->query->all()) && ($attribute->metadata->isNullable() || $attribute->metadata->hasDefaultValue())) {
             return null;
         }
 
@@ -182,7 +182,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             return $this->serializer->denormalize($data, $type, null, $attribute->serializationContext + self::CONTEXT_DENORMALIZE);
         }
 
-        if ('' === $data = $request->getContent()) {
+        if ('' === ($data = $request->getContent()) && ($attribute->metadata->isNullable() || $attribute->metadata->hasDefaultValue())) {
             return null;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -115,7 +115,7 @@ class RequestPayloadValueResolverTest extends TestCase
         $validator->expects($this->never())
             ->method('validate');
 
-        $resolver = new RequestPayloadValueResolver(new Serializer(), $validator);
+        $resolver = new RequestPayloadValueResolver(new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]), $validator);
 
         $argument = new ArgumentMetadata('valid', RequestPayload::class, false, false, null, true, [
             MapRequestPayload::class => new MapRequestPayload(),
@@ -137,9 +137,9 @@ class RequestPayloadValueResolverTest extends TestCase
         $validator->expects($this->never())
             ->method('validate');
 
-        $resolver = new RequestPayloadValueResolver(new Serializer(), $validator);
+        $resolver = new RequestPayloadValueResolver(new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]), $validator);
 
-        $argument = new ArgumentMetadata('valid', RequestPayload::class, false, false, null, true, [
+        $argument = new ArgumentMetadata('valid', QueryPayload::class, false, false, null, true, [
             MapQueryString::class => new MapQueryString(),
         ]);
         $request = Request::create('/', 'GET');
@@ -159,7 +159,7 @@ class RequestPayloadValueResolverTest extends TestCase
         $validator->expects($this->never())
             ->method('validate');
 
-        $resolver = new RequestPayloadValueResolver(new Serializer(), $validator);
+        $resolver = new RequestPayloadValueResolver(new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]), $validator);
 
         $argument = new ArgumentMetadata('valid', RequestPayload::class, false, false, null, false, [
             MapRequestPayload::class => new MapRequestPayload(),
@@ -174,7 +174,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
-            $this->assertSame(422, $e->getStatusCode());
+            $this->assertSame(400, $e->getStatusCode());
         }
     }
 
@@ -184,9 +184,9 @@ class RequestPayloadValueResolverTest extends TestCase
         $validator->expects($this->never())
             ->method('validate');
 
-        $resolver = new RequestPayloadValueResolver(new Serializer(), $validator);
+        $resolver = new RequestPayloadValueResolver(new Serializer([new ObjectNormalizer()]), $validator);
 
-        $argument = new ArgumentMetadata('valid', RequestPayload::class, false, false, null, false, [
+        $argument = new ArgumentMetadata('valid', QueryPayload::class, false, false, null, false, [
             MapQueryString::class => new MapQueryString(),
         ]);
         $request = Request::create('/', 'GET');
@@ -229,7 +229,7 @@ class RequestPayloadValueResolverTest extends TestCase
 
     public function testValidationNotPassed()
     {
-        $content = '{"price": 50, "title": ["not a string"]}';
+        $content = '{"price": 50.0, "title": ["not a string"]}';
         $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
 
         $validator = $this->createMock(ValidatorInterface::class);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 6.4|
| Bug fix?| yes |
| New feature?| no |
| Deprecations? | no |
| Issues | Fix #54617 |
| License |MIT |

MapQueryString/MapRequestPayload skips validation when empty request is sent
