### PR TITLE
[DoctrineBridge] Improve deprecation when mapping by `{id}`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -157,7 +157,7 @@ final class EntityValueResolver implements ValueResolverInterface
             return $id ?? ($options->stripNull ? false : null);
         }
         if ($request->attributes->has('id')) {
-            trigger_deprecation('symfony/doctrine-bridge', '7.1', 'Relying on auto-mapping for Doctrine entities is deprecated for argument $%s of "%s": declare the mapping using either the #[MapEntity] attribute or mapped route parameters.', $argument->getName(), method_exists($argument, 'getControllerName') ? $argument->getControllerName() : 'n/a');
+            trigger_deprecation('symfony/doctrine-bridge', '7.1', 'Relying on parameter "{id}" in route definitions is deprecated for Doctrine entities, use "{%s}" instead for controller "%s".', $argument->getName(), method_exists($argument, 'getControllerName') ? $argument->getControllerName() : 'n/a');
 
             return $request->attributes->get('id') ?? ($options->stripNull ? false : null);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follows https://github.com/symfony/symfony/pull/54455#issuecomment-2124506437

While the suggestion there is to remove the deprecation altogether, I think we'd better keep it so that we move people to a code that is always mapping explicit. Mapping by exact argument name is supported since the introduction of the entity-value-resolver so its very possible to upgrade existing code while still supporting previous versions of Symfony.

/cc @kevinpapst