### PR TITLE
[Mime] Use streams instead of loading raw message generator into memory

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -18,7 +18,8 @@ use Symfony\Component\Mime\Exception\LogicException;
  */
 class RawMessage
 {
-    private iterable|string $message;
+    /** @var iterable|string|resource */
+    private $message;
     private bool $isGeneratorClosed;
 
     public function __construct(iterable|string $message)
@@ -26,10 +27,21 @@ class RawMessage
         $this->message = $message;
     }
 
+    public function __destruct()
+    {
+        if (\is_resource($this->message)) {
+            fclose($this->message);
+        }
+    }
+
     public function toString(): string
     {
         if (\is_string($this->message)) {
             return $this->message;
+        }
+
+        if (\is_resource($this->message)) {
+            return stream_get_contents($this->message, -1, 0);
         }
 
         $message = '';
@@ -53,10 +65,19 @@ class RawMessage
             return;
         }
 
+        if (\is_resource($this->message)) {
+            rewind($this->message);
+            while ($line = fgets($this->message)) {
+                yield $line;
+            }
+
+            return;
+        }
+
         if ($this->message instanceof \Generator) {
-            $message = '';
+            $message = fopen('php://temp', 'w+');
             foreach ($this->message as $chunk) {
-                $message .= $chunk;
+                fwrite($message, $chunk);
                 yield $chunk;
             }
             $this->isGeneratorClosed = !$this->message->valid();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51764
| License       | MIT

Generators can only be used once and so the previous iteration of the code loaded the contents of the generator into memory. That results in OOM errors when sending large e-mails. 

This PR changes the behaviour so that the generator contents are loaded into a `php://temp` stream. By default 2MB is stored in memory and the rest is written to temporary files to prevent OOM issues.