### PR TITLE
[Console] Improve `AsCommand` DX for simple arguments and options

### DIFF
--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Console\Attribute;
 
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+
 /**
  * Service tag to autoconfigure commands.
  */
@@ -18,16 +21,18 @@ namespace Symfony\Component\Console\Attribute;
 class AsCommand
 {
     /**
-     * @param string      $name        The name of the command, used when calling it (i.e. "cache:clear")
-     * @param string|null $description The description of the command, displayed with the help page
-     * @param string[]    $aliases     The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
-     * @param bool        $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
+     * @param string                                             $name        The name of the command, used when calling it (i.e. "cache:clear")
+     * @param string|null                                        $description The description of the command, displayed with the help page
+     * @param string[]                                           $aliases     The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
+     * @param bool                                               $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
+     * @param array<InputArgument|InputArgument>|InputDefinition $definition  The list of argument and option instances
      */
     public function __construct(
         public string $name,
         public ?string $description = null,
         array $aliases = [],
         bool $hidden = false,
+        public array|InputDefinition $definition = [],
     ) {
         if (!$hidden && !$aliases) {
             return;

--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Attribute;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Service tag to autoconfigure commands.
@@ -21,18 +22,18 @@ use Symfony\Component\Console\Input\InputDefinition;
 class AsCommand
 {
     /**
-     * @param string                                             $name        The name of the command, used when calling it (i.e. "cache:clear")
-     * @param string|null                                        $description The description of the command, displayed with the help page
-     * @param string[]                                           $aliases     The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
-     * @param bool                                               $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
-     * @param array<InputArgument|InputArgument>|InputDefinition $definition  The list of argument and option instances
+     * @param string                                           $name            The name of the command, used when calling it (i.e. "cache:clear")
+     * @param string|null                                      $description     The description of the command, displayed with the help page
+     * @param string[]                                         $aliases         The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
+     * @param bool                                             $hidden          If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
+     * @param array<InputArgument|InputOption>|InputDefinition $inputDefinition The list of argument and option instances
      */
     public function __construct(
         public string $name,
         public ?string $description = null,
         array $aliases = [],
         bool $hidden = false,
-        public array|InputDefinition $definition = [],
+        public array|InputDefinition $inputDefinition = [],
     ) {
         if (!$hidden && !$aliases) {
             return;

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add the `definition` option to configure arguments and options in the `AsCommand` attribute
+
 7.1
 ---
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.2
 ---
 
- * Add the `definition` option to configure arguments and options in the `AsCommand` attribute
+ * Add the `inputDefinition` option to configure arguments and options in the `AsCommand` attribute
 
 7.1
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -100,6 +100,10 @@ class Command
             $this->setDescription(static::getDefaultDescription() ?? '');
         }
 
+        if ($attribute = (new \ReflectionClass(static::class))->getAttributes(AsCommand::class)) {
+            $this->setDefinition($attribute[0]->newInstance()->definition);
+        }
+
         $this->configure();
     }
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -101,7 +101,7 @@ class Command
         }
 
         if ($attribute = (new \ReflectionClass(static::class))->getAttributes(AsCommand::class)) {
-            $this->setDefinition($attribute[0]->newInstance()->definition);
+            $this->setDefinition($attribute[0]->newInstance()->inputDefinition);
         }
 
         $this->configure();

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -474,6 +474,18 @@ class CommandTest extends TestCase
         $this->assertTrue($command->getDefinition()->hasArgument('target'));
         $this->assertTrue($command->getDefinition()->hasOption('symlink'));
     }
+
+    public function testCommandWithDefinitionObjectAttribute()
+    {
+        $this->assertSame('my:command:with-definition-object', CommandWithDefinitionObject::getDefaultName());
+
+        $command = new CommandWithDefinitionObject();
+
+        $this->assertSame('my:command:with-definition-object', $command->getName());
+
+        $this->assertTrue($command->getDefinition()->hasArgument('target'));
+        $this->assertTrue($command->getDefinition()->hasOption('symlink'));
+    }
 }
 
 // In order to get an unbound closure, we should create it outside a class
@@ -505,11 +517,21 @@ class MyAnnotatedCommand extends Command
 
 #[AsCommand(
     name: 'my:command:with-definition',
-    definition: [
+    inputDefinition: [
         new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', null),
         new InputOption('symlink', null, InputOption::VALUE_NONE),
     ]
 )]
 class CommandWithDefinition extends Command
+{
+}
+#[AsCommand(
+    name: 'my:command:with-definition-object',
+    inputDefinition: new InputDefinition([
+        new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', null),
+        new InputOption('symlink', null, InputOption::VALUE_NONE),
+    ])
+)]
+class CommandWithDefinitionObject extends Command
 {
 }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -462,6 +462,18 @@ class CommandTest extends TestCase
 
         $this->assertEquals('foo2', $property->getValue($apl));
     }
+
+    public function testCommandWithDefinitionAttribute()
+    {
+        $this->assertSame('my:command:with-definition', CommandWithDefinition::getDefaultName());
+
+        $command = new CommandWithDefinition();
+
+        $this->assertSame('my:command:with-definition', $command->getName());
+
+        $this->assertTrue($command->getDefinition()->hasArgument('target'));
+        $this->assertTrue($command->getDefinition()->hasOption('symlink'));
+    }
 }
 
 // In order to get an unbound closure, we should create it outside a class
@@ -489,4 +501,15 @@ class MyAnnotatedCommand extends Command
     protected static $defaultName = 'i-shall-be-ignored';
 
     protected static $defaultDescription = 'This description should be ignored.';
+}
+
+#[AsCommand(
+    name: 'my:command:with-definition',
+    definition: [
+        new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', null),
+        new InputOption('symlink', null, InputOption::VALUE_NONE),
+    ]
+)]
+class CommandWithDefinition extends Command
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I really like to use `AsCommand` attribute to configure command name and description. 
For most of my commands I only have one or two arguments/options.

Instead implementing `configure` method, what do you think to allow argument/inputs declarations inside the attribute ?

(IMO, I can be more focus on execute method because command configuration it's done at one place)

**Before this PR**

```php
#[AsCommand(
    name: 'app:foobar',
    description: 'Add a short description for your command',
)]
class FoobarCommandBefore extends Command
{
    protected function configure(): void
    {
        $this
            ->addArgument('folder', InputArgument::REQUIRED, 'Argument description')
            ->addOption('symlink', null, InputOption::VALUE_NONE, 'Option description')
        ;
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        // ...
    }
}
```

**After this PR**

```php
#[AsCommand(
    name: 'app:foobar',
    description: 'Add a short description for your command',
    inputDefinition: [
        new InputArgument('folder', InputArgument::REQUIRED, 'Argument description'),
        new InputOption('symlink', null, InputOption::VALUE_NONE, 'Option description'),
    ],
)]
class FoobarCommand extends Command
{
    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        // ...
    }
}
```

(You can, of course, continue to use `configure` method )