### PR TITLE
[Form] Allow specifying `CollectionType`'s "prototype_name" as `callable`

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.2
 ---
 
- * Allow specifying `prototype_name` option of `CollectionType` as a `callable` (resolved value stored as `resolved_prototype_name` config attribute)
+ * Allow specifying `prototype_name` option of `CollectionType` as a `callable`
 
 7.1
 ---

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Allow specifying `prototype_name` option of `CollectionType` as a `callable` (resolved value stored as `resolved_prototype_name` config attribute)
+
 7.1
 ---
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -25,17 +25,20 @@ class CollectionType extends AbstractType
     {
         $resizePrototypeOptions = null;
         if ($options['allow_add'] && $options['prototype']) {
+            $prototypeName = \is_callable($options['prototype_name']) ? $options['prototype_name']($options) : $options['prototype_name'];
+            $builder->setAttribute('resolved_prototype_name', $prototypeName);
+
             $resizePrototypeOptions = array_replace($options['entry_options'], $options['prototype_options']);
             $prototypeOptions = array_replace([
                 'required' => $options['required'],
-                'label' => $options['prototype_name'].'label__',
+                'label' => $prototypeName.'label__',
             ], $resizePrototypeOptions);
 
             if (null !== $options['prototype_data']) {
                 $prototypeOptions['data'] = $options['prototype_data'];
             }
 
-            $prototype = $builder->create($options['prototype_name'], $options['entry_type'], $prototypeOptions);
+            $prototype = $builder->create($prototypeName, $options['entry_type'], $prototypeOptions);
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 
@@ -121,6 +124,7 @@ class CollectionType extends AbstractType
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);
 
         $resolver->setAllowedTypes('delete_empty', ['bool', 'callable']);
+        $resolver->setAllowedTypes('prototype_name', ['string', 'callable']);
         $resolver->setAllowedTypes('prototype_options', 'array');
         $resolver->setAllowedTypes('keep_as_list', ['bool']);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Nesting `CollectionType`s which utilize prototypes requires diligently defining `prototype_name` manually  to avoid collisions of the default value (`__name__`). This has been a pain point since I started using prototypes and I've long wished to be able to dynamically specify the placeholder. I added the `callable` type to the allowed types for `prototype_name` and call it once at the beginning of `buildForm()` to resolve the actual (string) value, and then store that in a `FormConfig` `resolved_prototype_name` attribute in case it needs to be accessed later.

In my application code I extend `CollectionType` (via `getExtendedTypes()`), set the default `prototype_name` option value to a function that generates a placeholder name containing random hex characters, and in `buildView()` inject that placeholder (retrieved via the `FormConfig` attribute) into an HTML attribute for use by the front-end JS code. This provides a set-and-forget solution where I can happily nest as many prototyped forms as I need without concerning myself with the placeholders.

Example implementation of a `CollectionType` extension that generates random placeholders:
```php
class CollectionTypeExtension
    extends AbstractTypeExtension
{
    private ?Randomizer $randomizer = null;
    private array $usedPrototypeNames = [];

    public static function getExtendedTypes(): iterable
    {
        return [CollectionType::class];
    }

    public function configureOptions(
        OptionsResolver $resolver,
    ): void
    {
        $resolver->setDefaults([
            'prototype_name_random_bytes' => 3,
            'prototype_name' => function (array $options): string {
                do {
                    $value = \sprintf(
                        '_:%s:_',
                        \bin2hex(
                            ($this->randomizer ??= new Randomizer(new Xoshiro256StarStar()))
                                ->getBytes($options['prototype_name_random_bytes'])
                        ),
                    );
                } while (isset($this->usedPrototypeNames[$value]));

                $this->usedPrototypeNames[$value] = true;

                return $value;
            },
        ]);
    }

    public function buildView(
        FormView $view,
        FormInterface $form,
        array $options,
    ): void
    {
        if (
            $options['prototype']
            && !isset($view->vars['attr']['data-prototype-name'])
            && $form->getConfig()->hasAttribute('resolved_prototype_name')
        ) {
            $view->vars['attr']['data-prototype-name'] = $form->getConfig()->getAttribute('resolved_prototype_name');
        }
    }
}

```