### PR TITLE
[Config] Add generic return type to DefinitionConfigurator::rootNode

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -17,6 +17,8 @@ use Symfony\Component\Config\Definition\NodeInterface;
  * This is the entry class for building a config tree.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @template T of 'array'|'scalar'|'variable'|'float'|'int'|'boolean'|'enum'
  */
 class TreeBuilder implements NodeParentInterface
 {
@@ -30,6 +32,9 @@ class TreeBuilder implements NodeParentInterface
      */
     protected $root;
 
+    /**
+     * @psalm-param T $type
+     */
     public function __construct(string $name, string $type = 'array', ?NodeBuilder $builder = null)
     {
         $builder ??= new NodeBuilder();
@@ -38,6 +43,7 @@ class TreeBuilder implements NodeParentInterface
 
     /**
      * @return NodeDefinition|ArrayNodeDefinition The root node (as an ArrayNodeDefinition when the type is 'array')
+     * @psalm-return (T is 'array' ? ArrayNodeDefinition : NodeDefinition)
      */
     public function getRootNode(): NodeDefinition|ArrayNodeDefinition
     {

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -43,6 +43,7 @@ class TreeBuilder implements NodeParentInterface
 
     /**
      * @return NodeDefinition|ArrayNodeDefinition The root node (as an ArrayNodeDefinition when the type is 'array')
+     *
      * @psalm-return (T is 'array' ? ArrayNodeDefinition : NodeDefinition)
      */
     public function getRootNode(): NodeDefinition|ArrayNodeDefinition

--- a/src/Symfony/Component/Config/Definition/ConfigurableInterface.php
+++ b/src/Symfony/Component/Config/Definition/ConfigurableInterface.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Config\Definition;
 
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 
 /**
@@ -22,7 +21,7 @@ interface ConfigurableInterface
     /**
      * Generates the configuration tree builder.
      *
-     * @psalm-param DefinitionConfigurator<ArrayNodeDefinition> $definition
+     * @psalm-param DefinitionConfigurator<'array'> $definition
      */
     public function configure(DefinitionConfigurator $definition): void;
 }

--- a/src/Symfony/Component/Config/Definition/ConfigurableInterface.php
+++ b/src/Symfony/Component/Config/Definition/ConfigurableInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Config\Definition;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 
 /**
@@ -20,6 +21,8 @@ interface ConfigurableInterface
 {
     /**
      * Generates the configuration tree builder.
+     *
+     * @psalm-param DefinitionConfigurator<ArrayNodeDefinition> $definition
      */
     public function configure(DefinitionConfigurator $definition): void;
 }

--- a/src/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.php
+++ b/src/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.php
@@ -19,11 +19,12 @@ use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  *
- * @template T of NodeDefinition
+ * @template T of 'array'|'scalar'|'variable'|'float'|'int'|'boolean'|'enum'
  */
 class DefinitionConfigurator
 {
     public function __construct(
+        /** @psalm-var TreeBuilder<T> */
         private TreeBuilder $treeBuilder,
         private DefinitionFileLoader $loader,
         private string $path,
@@ -38,11 +39,10 @@ class DefinitionConfigurator
     }
 
     /**
-     * @psalm-return T
+     * @psalm-return (T is 'array' ? ArrayNodeDefinition : NodeDefinition)
      */
     public function rootNode(): NodeDefinition|ArrayNodeDefinition
     {
-        /** @psalm-var T */
         return $this->treeBuilder->getRootNode();
     }
 

--- a/src/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.php
+++ b/src/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.php
@@ -18,6 +18,8 @@ use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
+ *
+ * @template T of NodeDefinition
  */
 class DefinitionConfigurator
 {
@@ -35,8 +37,12 @@ class DefinitionConfigurator
         $this->loader->import($resource, $type, $ignoreErrors, $this->file);
     }
 
+    /**
+     * @psalm-return T
+     */
     public function rootNode(): NodeDefinition|ArrayNodeDefinition
     {
+        /** @psalm-var T */
         return $this->treeBuilder->getRootNode();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #57102 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This PR adds a generic return type to `DefinitionConfigurator::rootNode` and implements it as `ArrayNodeDefinition` within `ConfigurableInterface`

This resolves the issue described in the linked issue where SA tools don't currently understand that `DefinitionConfigurator::rootNode` will always return an `ArrayNodeDefinition` in this context.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
