### PR TITLE
[String] Fix Inflector for 'hardware'

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -399,6 +399,9 @@ final class EnglishInflector implements InflectorInterface
 
         // aircraft
         'tfarcria',
+
+        // hardware
+        'erawdrah',
     ];
 
     /**

--- a/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
@@ -302,6 +302,7 @@ class EnglishInflectorTest extends TestCase
             ['icon', 'icons'],
             ['hippocampus', 'hippocampi'],
             ['campus', 'campuses'],
+            ['hardware', 'hardware'],
 
             // test casing: if the first letter was uppercase, it should remain so
             ['Man', 'Men'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Hello,
this PR fixes problem when inflecting `hardware` word into `hardwares`. This word should not be inflected.

Please make someone review because I'm not 100% sure if this is the right way how to fix it.

Thank you.

Btw: older versions are also affected and it should be possible to merge it there