### PR TITLE
[TwigBridge] Add pluralize and singularize Twig filters

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `pluralize` Twig filter
+ * Add `singularize` Twig filter
+
 7.1
 ---
 

--- a/src/Symfony/Bridge/Twig/Extension/StringExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/StringExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * Twig extension for the string helper.
+ *
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ */
+final class StringExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('pluralize', [StringRuntime::class, 'pluralize'], ['is_safe' => ['html']]),
+            new TwigFilter('singularize', [StringRuntime::class, 'singularize'], ['is_safe' => ['html']]),
+        ];
+    }
+}

--- a/src/Symfony/Bridge/Twig/Extension/StringRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/StringRuntime.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\String\Inflector\EnglishInflector;
+use Symfony\Component\String\Inflector\FrenchInflector;
+use Symfony\Component\String\Inflector\InflectorInterface;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ */
+final class StringRuntime implements RuntimeExtensionInterface
+{
+    private FrenchInflector $frenchInflector;
+    private EnglishInflector $englishInflector;
+
+    public function pluralize($value, string $lang, bool $singleResult = false): array|string
+    {
+        return match (true) {
+            $singleResult => $this->getInflector($lang)->pluralize($value)[0],
+            default => $this->getInflector($lang)->pluralize($value),
+        };
+    }
+
+    public function singularize($value, string $lang, bool $singleResult = false): array|string
+    {
+        return match (true) {
+            $singleResult => $this->getInflector($lang)->singularize($value)[0],
+            default => $this->getInflector($lang)->singularize($value),
+        };
+    }
+
+    private function getInflector(string $lang): InflectorInterface
+    {
+        return match ($lang) {
+            'fr' => $this->frenchInflector ?? $this->frenchInflector = new FrenchInflector(),
+            'en' => $this->englishInflector ?? $this->englishInflector = new EnglishInflector(),
+            default => throw new \InvalidArgumentException(sprintf('Language "%s" is not supported.', $lang)),
+        };
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StringExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StringExtensionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\StringRuntime;
+
+class StringExtensionTest extends TestCase
+{
+    /**
+     * @testWith [["partitions"], "fr", false, "partition"]
+     *           ["partitions", "fr", true, "partition"]
+     *           [["persons", "people"], "en", false, "person"]
+     *           ["persons", "en", true, "person"]
+     */
+    public function testPluralize(array|string $expected, string $lang, bool $singleResult, string $value)
+    {
+        $extensionRuntime = new StringRuntime();
+        $this->assertSame($expected, $extensionRuntime->pluralize($value, $lang, $singleResult));
+    }
+
+    /**
+     * @testWith [["partition"], "fr", false, "partitions"]
+     *           ["partition", "fr", true, "partitions"]
+     *           [["person"], "en", false, "persons"]
+     *           ["person", "en", true, "persons"]
+     *           [["person"], "en", false, "people"]
+     *           ["person", "en", true, "people"]
+     */
+    public function testSingularize(array|string $expected, string $lang, bool $singleResult, string $value)
+    {
+        $extensionRuntime = new StringRuntime();
+        $this->assertSame($expected, $extensionRuntime->singularize($value, $lang, $singleResult));
+    }
+
+    /**
+     * @testWith [["partitions"], "it", false, "partition"]
+     *           [["partitions"], "it", true, "partition"]
+     */
+    public function testPluralizeInvalidLang(array|string $expected, string $lang, bool $singleResult, string $value)
+    {
+        $extensionRuntime = new StringRuntime();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Language "it" is not supported.');
+        $this->assertSame($expected, $extensionRuntime->pluralize($value, $lang, $singleResult));
+    }
+
+    /**
+     * @testWith [["partition"], "it", false, "partitions"]
+     *           [["partition"], "it", true, "partitions"]
+     */
+    public function testSingularizeInvalidLang(array|string $expected, string $lang, bool $singleResult, string $value)
+    {
+        $extensionRuntime = new StringRuntime();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Language "it" is not supported.');
+        $this->assertSame($expected, $extensionRuntime->singularize($value, $lang, $singleResult));
+    }
+}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -46,6 +46,7 @@
         "symfony/security-http": "^6.4|^7.0",
         "symfony/serializer": "^6.4.3|^7.0.3",
         "symfony/stopwatch": "^6.4|^7.0",
+        "symfony/string": "^7.2",
         "symfony/console": "^6.4|^7.0",
         "symfony/expression-language": "^6.4|^7.0",
         "symfony/web-link": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This PR adds `pluralize` and `singularize` Twig filters. It uses the String component, especially `EnglishInflector` and `FrenchInflector`.

Examples:

```php
{{ 'person'|pluralize('en') }} // ['persons', 'people']
{{ 'person'|pluralize('en', true) }} // persons


{{ 'personne'|pluralize('fr') }} // ['personnes']
{{ 'personne'|pluralize('fr', true) }} // personnes


{{ 'persons'|singluarize('en') }} // ['person']
{{ 'persons'|singluarize('en', true) }} // person
{{ 'people'|singluarize('en', true) }} // person

{{ 'personnes'|singluarize('fr') }} // ['personne']
{{ 'personnes'|singluarize('fr', true) }} // personne


{{ 'persona'|pluralize('it', true) }} // \InvalidArgumentException('Language "it" is not supported.')
{{ 'persone'|singluarize('it', true) }} // \InvalidArgumentException('Language "it" is not supported.')
```
