### PR TITLE
[HttpKernel] Remove `@internal` flag and add `@final` to `ServicesResetter`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Remove `@internal` flag and add `@final` to `ServicesResetter`
+
 7.1
 ---
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\Service\ResetInterface;
  * @author Alexander M. Turek <me@derrabus.de>
  * @author Nicolas Grekas <p@tchwork.com>
  *
- * @internal
+ * @final since Symfony 7.2
  */
 class ServicesResetter implements ResetInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

I used this class for ages! I moved many of my internal "hack" to symfony (messenger, etc)
But there are still a lot of use cases where we could need this class:

* Custom worker that does not use messenger
* import/export command that process a lot of rows (doctrine/dbal leak by default, even in prod env)
* etc

---

Anyway, I used this class, and I never noticed it was internal. And today, I showed this class to @pyrech
and its IDE displayed the class in strikethrough! (vscode does not do that...)

So I think it's time to open this class.
