### PR TITLE
[SecurityBundle] Fix `container.build_hash` parameter binding

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface;
 use Symfony\Component\Lock\LockInterface;
@@ -76,7 +77,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface
             $container->register($config['limiter'] = 'security.login_throttling.'.$firewallName.'.limiter', DefaultLoginRateLimiter::class)
                 ->addArgument(new Reference('limiter.'.$globalId))
                 ->addArgument(new Reference('limiter.'.$localId))
-                ->addArgument('%container.build_hash%')
+                ->addArgument(new Parameter('container.build_hash'))
             ;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57257
| License       | MIT

Happened to us as well when trying to upgrade to 7.1, this PR fixes the param binding.

Before:

<img width="617" alt="Capture d’écran 2024-05-31 à 14 53 37" src="https://github.com/symfony/symfony/assets/2144837/5e703f83-4c24-4aa3-834d-515691c75e21">

After:

<img width="617" alt="Capture d’écran 2024-05-31 à 14 52 56" src="https://github.com/symfony/symfony/assets/2144837/020c04c5-b7ad-4f5d-a6f4-85a0b09b9908">
