### PR TITLE
[Messenger] Allow to skip message in `FailedMessagesRetryCommand`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `#[AsMessage]` attribute with `$transport` parameter for message routing
  * Add `--format` option to the `messenger:stats` command
  * Add `getRetryDelay()` method to `RecoverableExceptionInterface`
+ * Add `skip` option to `messenger:failed:retry` command when run interactively to skip message and requeue it
 
 7.1
 ---

--- a/src/Symfony/Component/Messenger/Event/WorkerMessageSkipEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerMessageSkipEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+/**
+ * Dispatched when a message was skip.
+ *
+ * The event name is the class name.
+ */
+final class WorkerMessageSkipEvent extends AbstractWorkerMessageEvent
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #50936 
| License       | MIT

When retrying message with the command messenger:failed:retry, we have two options:
- Retry : (It will be consumed and re-added to failed queue if it re-fail)
- Delete

But sometimes we have no clue if we can retry it or not but I know that we don't want to delete it yet. In that case we need to stop the command and go id by id. The interactive command is lost. The command should provide a way to skip a message to continue with the rest of the failed message.
