### PR TITLE
[Notifier] [Slack] Add README examples about button block element and emoji/verbatim options

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/README.md
@@ -74,6 +74,46 @@ $chatMessage->options($slackOptions);
 $chatter->send($chatMessage);
 ```
 
+Alternatively, a single button can be added to a section using the `accessory()` method and the `SlackButtonBlockElement` class.
+
+```php
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackButtonBlockElement;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackDividerBlock;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
+use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('Contribute To Symfony');
+
+$slackOptions = (new SlackOptions())
+    ->block((new SlackSectionBlock())
+        ->text('Symfony Framework')
+        ->accessory(
+            new SlackButtonBlockElement(
+                'Report bugs',
+                'https://symfony.com/doc/current/contributing/code/bugs.html',
+                'danger'
+            )
+        )
+    )
+    ->block(new SlackDividerBlock())
+    ->block((new SlackSectionBlock())
+        ->text('Symfony Documentation')
+        ->accessory(
+            new SlackButtonBlockElement(
+                'Improve Documentation',
+                'https://symfony.com/doc/current/contributing/documentation/standards.html',
+                'primary'
+            )
+        )
+    );
+
+// Add the custom options to the chat message and send the message
+$chatMessage->options($slackOptions);
+
+$chatter->send($chatMessage);
+```
+
 Adding Fields and Values to a Message
 -------------------------------------
 
@@ -103,6 +143,34 @@ $chatMessage->options($options);
 
 $chatter->send($chatMessage);
 ```
+
+Define text objects properties
+------------------------------
+
+[Text objects properties](https://api.slack.com/reference/block-kit/composition-objects#text) can be set on any `text()` or `field()` method :
+
+```php
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
+use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('Slack Notifier');
+
+$options = (new SlackOptions())
+    ->block(
+        (new SlackSectionBlock())
+            ->field('My **Markdown** content with clickable URL : symfony.com') // Markdown content (default)
+            ->field('*Plain text content*', markdown: false) // Plain text content
+            ->field('Not clickable URL : symfony.com', verbatim: true) // Only for markdown content
+            ->field('Thumbs up emoji code is :thumbsup: ', emoji: false) // Only for plain text content
+    );
+
+// Add the custom options to the chat message and send the message
+$chatMessage->options($options);
+
+$chatter->send($chatMessage);
+```
+
 
 Adding a Header to a Message
 ----------------------------


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony-docs/issues/19929
| License       | MIT

This PR is just a followup of my previously merged PR https://github.com/symfony/symfony/pull/54737.
Following the merge, [an issue was created about documentation](https://github.com/symfony/symfony-docs/issues/19929), but each Notifier Bridge documentation is directly in README of each bridge so here it is :)