### PR TITLE
[FrameworkBundle] Fix setting default context for certain normalizers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1859,18 +1859,20 @@ class FrameworkExtension extends Extension
         }
 
         $arguments = $container->getDefinition('serializer.normalizer.object')->getArguments();
-        $context = [];
+        $context = $arguments[6] ?? $defaultContext;
 
         if (isset($config['circular_reference_handler']) && $config['circular_reference_handler']) {
-            $context += ($arguments[6] ?? $defaultContext) + ['circular_reference_handler' => new Reference($config['circular_reference_handler'])];
+            $context += ['circular_reference_handler' => new Reference($config['circular_reference_handler'])];
             $container->getDefinition('serializer.normalizer.object')->setArgument(5, null);
         }
 
         if ($config['max_depth_handler'] ?? false) {
-            $context += ($arguments[6] ?? $defaultContext) + ['max_depth_handler' => new Reference($config['max_depth_handler'])];
+            $context += ['max_depth_handler' => new Reference($config['max_depth_handler'])];
         }
 
         $container->getDefinition('serializer.normalizer.object')->setArgument(6, $context);
+
+        $container->getDefinition('serializer.normalizer.property')->setArgument(5, $defaultContext);
     }
 
     private function registerPropertyInfoConfiguration(ContainerBuilder $container, PhpFileLoader $loader)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -139,7 +139,6 @@ return static function (ContainerConfigurator $container) {
                 service('property_info')->ignoreOnInvalid(),
                 service('serializer.mapping.class_discriminator_resolver')->ignoreOnInvalid(),
                 null,
-                [],
             ])
 
         ->alias(PropertyNormalizer::class, 'serializer.normalizer.property')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
@@ -52,7 +52,7 @@ abstract class AbstractWebTestCase extends BaseWebTestCase
 
     protected static function createKernel(array $options = []): KernelInterface
     {
-        $class = self::getKernelClass();
+        $class = static::getKernelClass();
 
         if (!isset($options['test_case'])) {
             throw new \InvalidArgumentException('The option "test_case" must be set.');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\app\AppKernel;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -33,39 +37,55 @@ class SerializerTest extends AbstractWebTestCase
         $this->assertEquals($expected, $result);
     }
 
-    /**
-     * @dataProvider provideNormalizersAndEncodersWithDefaultContextOption
-     */
-    public function testNormalizersAndEncodersUseDefaultContextConfigOption(string $normalizerId)
+    public function testNormalizersAndEncodersUseDefaultContextConfigOption()
     {
-        static::bootKernel(['test_case' => 'Serializer']);
+        /** @var SerializerKernel $kernel */
+        $kernel = static::bootKernel(['test_case' => 'Serializer', 'root_config' => 'default_context.yaml']);
 
-        $normalizer = static::getContainer()->get($normalizerId);
+        foreach ($kernel->normalizersAndEncoders as $normalizerOrEncoderId) {
+            $normalizerOrEncoder = static::getContainer()->get($normalizerOrEncoderId);
 
-        $reflectionObject = new \ReflectionObject($normalizer);
-        $property = $reflectionObject->getProperty('defaultContext');
-        $property->setAccessible(true);
+            $reflectionObject = new \ReflectionObject($normalizerOrEncoder);
+            $property = $reflectionObject->getProperty('defaultContext');
+            $property->setAccessible(true);
 
-        $defaultContext = $property->getValue($normalizer);
+            $defaultContext = $property->getValue($normalizerOrEncoder);
 
-        self::assertArrayHasKey('fake_context_option', $defaultContext);
-        self::assertEquals('foo', $defaultContext['fake_context_option']);
+            self::assertArrayHasKey('fake_context_option', $defaultContext);
+            self::assertEquals('foo', $defaultContext['fake_context_option']);
+        }
     }
 
-    public static function provideNormalizersAndEncodersWithDefaultContextOption(): array
+    protected static function getKernelClass(): string
     {
-        return [
-            ['serializer.normalizer.constraint_violation_list.alias'],
-            ['serializer.normalizer.dateinterval.alias'],
-            ['serializer.normalizer.datetime.alias'],
-            ['serializer.normalizer.json_serializable.alias'],
-            ['serializer.normalizer.problem.alias'],
-            ['serializer.normalizer.uid.alias'],
-            ['serializer.normalizer.object.alias'],
-            ['serializer.encoder.xml.alias'],
-            ['serializer.encoder.yaml.alias'],
-            ['serializer.encoder.csv.alias'],
-        ];
+        return SerializerKernel::class;
+    }
+}
+
+class SerializerKernel extends AppKernel implements CompilerPassInterface
+{
+    public $normalizersAndEncoders = [
+        'serializer.normalizer.property.alias', // Special case as this normalizer isn't tagged
+    ];
+
+    public function process(ContainerBuilder $container)
+    {
+        $services = array_merge(
+            $container->findTaggedServiceIds('serializer.normalizer'),
+            $container->findTaggedServiceIds('serializer.encoder')
+        );
+        foreach ($services as $serviceId => $attributes) {
+            $class = $container->getDefinition($serviceId)->getClass();
+            if (null === $reflectionConstructor = (new \ReflectionClass($class))->getConstructor()) {
+                continue;
+            }
+            foreach ($reflectionConstructor->getParameters() as $reflectionParam) {
+                if ('array $defaultContext' === $reflectionParam->getType()->getName().' $'.$reflectionParam->getName()) {
+                    $this->normalizersAndEncoders[] = $serviceId.'.alias';
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -49,6 +49,11 @@ class AppKernel extends Kernel implements ExtensionInterface, ConfigurationInter
         parent::__construct($environment, $debug);
     }
 
+    protected function getContainerClass(): string
+    {
+        return parent::getContainerClass().substr(md5($this->rootConfig), -16);
+    }
+
     public function registerBundles(): iterable
     {
         if (!file_exists($filename = $this->getProjectDir().'/'.$this->testCase.'/bundles.php')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
@@ -8,56 +8,11 @@ framework:
         max_depth_handler: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serializer\MaxDepthHandler
         default_context:
             enable_max_depth: true
-            fake_context_option: foo
     property_info: { enabled: true }
 
 services:
     serializer.alias:
         alias: serializer
-        public: true
-
-    serializer.normalizer.constraint_violation_list.alias:
-        alias: serializer.normalizer.constraint_violation_list
-        public: true
-
-    serializer.normalizer.dateinterval.alias:
-        alias: serializer.normalizer.dateinterval
-        public: true
-
-    serializer.normalizer.datetime.alias:
-        alias: serializer.normalizer.datetime
-        public: true
-
-    serializer.normalizer.json_serializable.alias:
-        alias: serializer.normalizer.json_serializable
-        public: true
-
-    serializer.normalizer.problem.alias:
-        alias: serializer.normalizer.problem
-        public: true
-
-    serializer.normalizer.uid.alias:
-        alias: serializer.normalizer.uid
-        public: true
-
-    serializer.normalizer.property.alias:
-        alias: serializer.normalizer.property
-        public: true
-
-    serializer.normalizer.object.alias:
-        alias: serializer.normalizer.object
-        public: true
-
-    serializer.encoder.xml.alias:
-        alias: serializer.encoder.xml
-        public: true
-
-    serializer.encoder.yaml.alias:
-        alias: serializer.encoder.yaml
-        public: true
-
-    serializer.encoder.csv.alias:
-        alias: serializer.encoder.csv
         public: true
 
     Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serializer\CircularReferenceHandler: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/default_context.yaml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/default_context.yaml
@@ -1,0 +1,59 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    serializer:
+        enabled: true
+        circular_reference_handler: ~ # This must be null
+        max_depth_handler: ~ # This must be null
+        default_context:
+            fake_context_option: foo
+
+services:
+    serializer.normalizer.constraint_violation_list.alias:
+        alias: serializer.normalizer.constraint_violation_list
+        public: true
+
+    serializer.normalizer.dateinterval.alias:
+        alias: serializer.normalizer.dateinterval
+        public: true
+
+    serializer.normalizer.datetime.alias:
+        alias: serializer.normalizer.datetime
+        public: true
+
+    serializer.normalizer.json_serializable.alias:
+        alias: serializer.normalizer.json_serializable
+        public: true
+
+    serializer.normalizer.object.alias:
+        alias: serializer.normalizer.object
+        public: true
+
+    serializer.normalizer.problem.alias:
+        alias: serializer.normalizer.problem
+        public: true
+
+    serializer.normalizer.property.alias:
+        alias: serializer.normalizer.property
+        public: true
+
+    serializer.normalizer.uid.alias:
+        alias: serializer.normalizer.uid
+        public: true
+
+    serializer.encoder.csv.alias:
+        alias: serializer.encoder.csv
+        public: true
+
+    serializer.encoder.json.alias:
+        alias: serializer.encoder.json
+        public: true
+
+    serializer.encoder.xml.alias:
+        alias: serializer.encoder.xml
+        public: true
+
+    serializer.encoder.yaml.alias:
+        alias: serializer.encoder.yaml
+        public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #56875, fix #57316
| License       | MIT

Caused by #54791. The main problem is that `$context` defaults to `[]` instead of `$defaultContext`. There's a test to check this, but it didn't work when `circular_reference_handler` or `max_depth_handler` were not `null`.

I also found an issue with `serializer.normalizer.property`. Since it’s not tagged with `serializer.normalizer`, which, to my understanding, is intentional, it would never have the default context bound to it.