### PR TITLE
[DependencyInjection] Throw exception when the constructor is private

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -224,7 +224,7 @@ abstract class FileLoader extends BaseFileLoader
                 throw new InvalidArgumentException(sprintf('Expected to find class "%s" in file "%s" while importing services from resource "%s", but it was not found! Check the namespace prefix used with the resource.', $class, $path, $pattern));
             }
 
-            if (!$r->isInstantiable() && !is_null($r->getConstructor())) {
+            if (!$r->isInstantiable() && null !== $r->getConstructor()) {
                 throw new InvalidArgumentException(sprintf('Invalid service "%s": constructor of class "%s" must be public.', $class, $class));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -224,6 +224,10 @@ abstract class FileLoader extends BaseFileLoader
                 throw new InvalidArgumentException(sprintf('Expected to find class "%s" in file "%s" while importing services from resource "%s", but it was not found! Check the namespace prefix used with the resource.', $class, $path, $pattern));
             }
 
+            if (!$r->isInstantiable() && !is_null($r->getConstructor())) {
+                throw new InvalidArgumentException(sprintf('Invalid service "%s": constructor of class "%s" must be public.', $class, $class));
+            }
+
             if ($r->isInstantiable() || $r->isInterface()) {
                 $classes[$class] = null;
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructor/ClassWithPrivateConstructor.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructor/ClassWithPrivateConstructor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructor;
+
+class ClassWithPrivateConstructor
+{
+    private function __construct()
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -229,6 +229,17 @@ class FileLoaderTest extends TestCase
         $loader->registerClasses(new Definition(), 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\\', 'Prototype/Sub/*');
     }
 
+    public function testRegisterClassesWithPrivateConstructor()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructor\ClassWithPrivateConstructor": constructor of class "Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructor\ClassWithPrivateConstructor" must be public');
+
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        $loader->registerClasses(new Definition(), 'Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructor\\', 'PrivateConstructor/*');
+    }
+
     public function testRegisterClassesWithIncompatibleExclude()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Resolves developer confusion as seen here #53651
| License       | MIT

It makes no sense to include a class with a private constructor since it cant be instantiated unless that happens within a static method. Skipping such a class in not in my scope of solutions, since that would leave the developer in the dark, just like it happened in the mentioned issue.

No additional test failed when running phpunit and also added a new one.

Symfony already covers a class with private constructor, but the message only appears when manually registering the class.

_I hope I did everything okay this time, please review. Thank you!_