### PR TITLE
Fix autoload configs to avoid warnings when building optimized autoloaders

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -176,7 +176,8 @@
             "Symfony\\Bridge\\ProxyManager\\": "src/Symfony/Bridge/ProxyManager/",
             "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
             "Symfony\\Bundle\\": "src/Symfony/Bundle/",
-            "Symfony\\Component\\": "src/Symfony/Component/"
+            "Symfony\\Component\\": "src/Symfony/Component/",
+            "Symfony\\Runtime\\Symfony\\Component\\": "src/Symfony/Component/Runtime/Internal/"
         },
         "files": [
             "src/Symfony/Component/String/Resources/functions.php"
@@ -185,7 +186,8 @@
             "src/Symfony/Component/Intl/Resources/stubs"
         ],
         "exclude-from-classmap": [
-            "**/Tests/"
+            "**/Tests/",
+            "**/bin/"
         ]
     },
     "autoload-dev": {

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -34,7 +34,8 @@
         "files": [ "bootstrap.php" ],
         "psr-4": { "Symfony\\Bridge\\PhpUnit\\": "" },
         "exclude-from-classmap": [
-            "/Tests/"
+            "/Tests/",
+            "/bin/"
         ]
     },
     "bin": [

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -72,7 +72,8 @@
     "autoload": {
         "psr-4": { "Symfony\\Component\\Validator\\": "" },
         "exclude-from-classmap": [
-            "/Tests/"
+            "/Tests/",
+            "/Resources/bin/"
         ]
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

The next composer release next week (you can try `composer dump -o` with snapshots right now) warns a bit more about classes which do not match the psr-4 rules they are found in.. Symfony has quite a few false positives there because the rules are using `""` as path for all individual components so all files of the component are scanned by default. I already made sure Composer excludes the vendor dir by default now, and this fixes the rest of the errors I noticed.