### PR TITLE
Fix autoload configs to avoid warnings when building optimized autoloaders

### DIFF
--- a/src/Symfony/Component/Emoji/composer.json
+++ b/src/Symfony/Component/Emoji/composer.json
@@ -28,7 +28,8 @@
         "psr-4": { "Symfony\\Component\\Emoji\\": "" },
         "exclude-from-classmap": [
             "/Tests/",
-            "/Resources/data/"
+            "/Resources/data/",
+            "/Resources/bin/"
         ]
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
…aders

| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Same as #57275 but for 7.1 as the new Emoji component also needed a fix.