### PR TITLE
[HttpFoundation] A more precise comment for HeaderUtils::split method.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderUtils.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderUtils.php
@@ -34,7 +34,7 @@ class HeaderUtils
      * Example:
      *
      *     HeaderUtils::split('da, en-gb;q=0.8', ',;')
-     *     // => ['da'], ['en-gb', 'q=0.8']]
+     *     # returns [['da'], ['en-gb', 'q=0.8']]
      *
      * @param string $separators List of characters to split on, ordered by
      *                           precedence, e.g. ',', ';=', or ',;='


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch? | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no


Hi everybody :)

# Information


The current comment for HeaderUtils::split() contains an Unpaired symbol

The line below to be more precise

```
// => ['da'], ['en-gb', 'q=0.8']] 
```

`Unpaired symbol: '[' seems to be missing` 

Maybe something like the one below

```
Will return: [['da'], ['en-gb', 'q=0.8']]
```


