### PR TITLE
Remove extra space after full stop.

### DIFF
--- a/src/Symfony/Component/Finder/Comparator/NumberComparator.php
+++ b/src/Symfony/Component/Finder/Comparator/NumberComparator.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Finder\Comparator;
  * magnitudes.
  *
  * The target value may use magnitudes of kilobytes (k, ki),
- * megabytes (m, mi), or gigabytes (g, gi).  Those suffixed
+ * megabytes (m, mi), or gigabytes (g, gi). Those suffixed
  * with an i use the appropriate 2**n version in accordance with the
  * IEC standard: http://physics.nist.gov/cuu/Units/binary.html
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Simply removes an extra space in the comment section.