### PR TITLE
[ErrorHandler] Prevent an empty IF block statement.

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -291,14 +291,24 @@ class DebugClassLoader
         try {
             if ($this->isFinder && !isset($this->loaded[$class])) {
                 $this->loaded[$class] = true;
-                if (!$file = $this->classLoader[0]->findFile($class) ?: '') {
-                    // no-op
-                } elseif (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($file)) {
-                    include $file;
+                
+                $file = '';
 
-                    return;
-                } elseif (false === include $file) {
-                    return;
+                if (isset($this->classLoader[0]) &&
+                    is_object($this->classLoader[0]) &&
+                    method_exists($this->classLoader[0], 'findFile')
+                ) {
+                    $file = $this->classLoader[0]->findFile($class) ?: '';
+                }
+
+                if ($file) {
+                    if (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($file)) {
+                        include $file;
+
+                        return;
+                    } elseif (false === include $file) {
+                        return;
+                    }
                 }
             } else {
                 ($this->classLoader)($class);

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -301,14 +301,16 @@ class DebugClassLoader
                     $file = $this->classLoader[0]->findFile($class) ?: '';
                 }
 
-                if (!empty($file)) {
-                    if (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($file)) {
-                        include $file;
+                if (empty($file)) {
+                    return;
+                }
 
-                        return;
-                    } elseif (false === include $file) {
-                        return;
-                    }
+                if (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($file)) {
+                    include $file;
+
+                    return;
+                } elseif (false === include $file) {
+                    return;
                 }
             } else {
                 ($this->classLoader)($class);

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -301,7 +301,7 @@ class DebugClassLoader
                     $file = $this->classLoader[0]->findFile($class) ?: '';
                 }
 
-                if ($file) {
+                if (!empty($file)) {
                     if (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($file)) {
                         include $file;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | No
| New feature?  | No
| Deprecations? | No
| License       | MIT

# Information

It's not something urgent, but according to standard, can we avoid  IF statement, with an empty body?

For example 

```
if (!$file = $this->classLoader[0]->findFile($class) ?: '') {
    / / no-op
}
``` 

Maybe something like this, with robust check?

```
$file = '';

if (isset($this->classLoader[0]) &&
    is_object($this->classLoader[0]) &&
    method_exists($this->classLoader[0], 'findFile')
) {
    $file = $this->classLoader[0]->findFile($class) ?: '';
}

if (empty($file)) {
    return;
}

if (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($file)) {
    include $file;

    return;
} elseif (false === include $file) {
    return;
}
```

Right now, We have this

```
if (!$file = $this->classLoader[0]->findFile($class) ?: '') {
    // no-op
} elseif (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($file)) {
    include $file;

    return;
} elseif (false === include $file) {
    return;
}
```