### PR TITLE
[DependencyInjection] Fix phpdoc for $calls in class Autoconfigure

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -21,7 +21,7 @@ class Autoconfigure
 {
     /**
      * @param array<array-key, array<array-key, mixed>>|string[]|null $tags         The tags to add to the service
-     * @param array<string, array<array-key, mixed>>|null             $calls        The calls to be made when instantiating the service
+     * @param array<array<mixed>>|null                                $calls        The calls to be made when instantiating the service
      * @param array<string, mixed>|null                               $bind         The bindings to declare for the service
      * @param bool|string|null                                        $lazy         Whether the service is lazy-loaded
      * @param bool|null                                               $public       Whether to declare the service as public


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | yes
| New feature?  |no 
| Deprecations? |no 
| Issues        | None
| License       | MIT

PHPDoc for $call in class Autoconfigure should be `array<array-key, array<array-key, mixed>>|null`
As usage is:

````
calls: [
        ['method' => 'setEntityManager', 'arguments' => ['@doctrine.orm.entity_manager']]
    ]
````

