### PR TITLE
[Yaml] Fix parsing nested mappings in sequences

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -386,11 +386,33 @@ class Inline
                     // the value can be an array if a reference has been resolved to an array var
                     if (\is_string($value) && !$isQuoted && str_contains($value, ': ')) {
                         // embedded mapping?
-                        try {
-                            $pos = 0;
-                            $value = self::parseMapping('{'.$value.'}', $flags, $pos, $references);
-                        } catch (\InvalidArgumentException) {
-                            // no, it's not
+                        $j = $i;
+                        $mappingValue = $value;
+                        $mappingException = null;
+                        do {
+                            try {
+                                $pos = 0;
+                                $value = self::parseMapping('{'.$mappingValue.'}', $flags, $pos, $references);
+                                $i = $j;
+                                $mappingException = null;
+                                break;
+                            } catch (ParseException $exception) {
+                                $mappingException = $exception;
+                                if ($j >= $len) {
+                                    break;
+                                }
+
+                                $mappingValue .= $sequence[$j++];
+                                if ($j >= $len) {
+                                    break;
+                                }
+
+                                $mappingValue .= self::parseScalar($sequence, $flags, [',', ']'], $j, null === $tag, $references);
+                            }
+                        } while ($j < $len);
+
+                        if ($mappingException) {
+                            throw $mappingException;
                         }
                     }
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -203,6 +203,14 @@ class InlineTest extends TestCase
         Inline::parse('{ foo: bar } bar');
     }
 
+    public function testParseEmbeddedMappingWithDuplicateKeysShouldThrowException()
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessageMatches('/Duplicate key "bar" detected/');
+
+        Inline::parse('[ foo: { bar: 1, bar: 2 } ]');
+    }
+
     public function testParseInvalidTaggedSequenceShouldThrowException()
     {
         $this->expectException(ParseException::class);
@@ -399,6 +407,10 @@ class InlineTest extends TestCase
             ['[foo, bar: { foo: bar }]', ['foo', '1' => ['bar' => ['foo' => 'bar']]]],
             ['[foo, \'@foo.baz\', { \'%foo%\': \'foo is %foo%\', bar: \'%foo%\' }, true, \'@service_container\']', ['foo', '@foo.baz', ['%foo%' => 'foo is %foo%', 'bar' => '%foo%'], true, '@service_container']],
 
+            ['[ foo: { bar: [ \'foobar\', 12 ] } ]', [['foo' => ['bar' => ['foobar', 12]]]]],
+            ['[ foo: { bar: \'foobar\', baz: false } ]', [['foo' => ['bar' => 'foobar', 'baz' => false]]]],
+            ['[ foo: { bar: [ \'foobar\', 12 ], baz: true } ]', [['foo' => ['bar' => ['foobar', 12], 'baz' => true]]]],
+
             // Binary string not utf8-compliant but starting with and utf8-equivalent "&" character
             ['{ uid: !!binary Ju0Yh+uqSXOagJZFTlUt8g== }', ['uid' => hex2bin('26ed1887ebaa49739a8096454e552df2')]],
         ];
@@ -482,6 +494,10 @@ class InlineTest extends TestCase
             ['[foo, [[], {}]]', ['foo', [[], new \stdClass()]]],
             ['[foo, [[{}, {}], {}]]', ['foo', [[new \stdClass(), new \stdClass()], new \stdClass()]]],
             ['[foo, {bar: {}}]', ['foo', '1' => (object) ['bar' => new \stdClass()]]],
+
+            ['[ foo: { bar: [ \'foobar\', 12 ] } ]', [(object) ['foo' => (object) ['bar' => ['foobar', 12]]]]],
+            ['[ foo: { bar: \'foobar\', baz: false } ]', [(object) ['foo' => (object) ['bar' => 'foobar', 'baz' => false]]]],
+            ['[ foo: { bar: [ \'foobar\', 12 ], baz: true } ]', [(object) ['foo' => (object) ['bar' => ['foobar', 12], 'baz' => true]]]],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, the YAML parser fails when a sequence contains a mapping not enclosed in `{}` whose value is a mapping or sequence: `[key: mapping-or-sequence]`.