### PR TITLE
[DependencyInjection] Fix handling of repeated `#[Autoconfigure]` attributes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -448,8 +448,9 @@ class YamlFileLoader extends FileLoader
             return $return ? $alias : $this->container->setAlias($id, $alias);
         }
 
+        $changes = [];
         if (null !== $definition) {
-            // no-op
+            $changes = $definition->getChanges();
         } elseif ($this->isLoadingInstanceof) {
             $definition = new ChildDefinition('');
         } elseif (isset($service['parent'])) {
@@ -472,7 +473,7 @@ class YamlFileLoader extends FileLoader
             $definition->setAutoconfigured($defaults['autoconfigure']);
         }
 
-        $definition->setChanges([]);
+        $definition->setChanges($changes);
 
         if (isset($service['class'])) {
             $definition->setClass($service['class']);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAutoconfigureAttributesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAutoconfigureAttributesPassTest.php
@@ -19,6 +19,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureAttributed;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeated;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedBindings;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedCalls;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedOverwrite;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedProperties;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedTag;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists;
 
 /**
@@ -75,6 +81,99 @@ class RegisterAutoconfigureAttributesPassTest extends TestCase
             ->addTag(AutoconfiguredInterface::class, ['foo' => 123])
         ;
         $this->assertEquals([AutoconfiguredInterface::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfiguredRepeated()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureRepeated::class)
+            ->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setLazy(true)
+            ->setPublic(true)
+            ->setShared(false);
+
+        $this->assertEquals([AutoconfigureRepeated::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfiguredRepeatedOverwrite()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureRepeatedOverwrite::class)
+            ->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setLazy(true)
+            ->setPublic(false)
+            ->setShared(true);
+
+        $this->assertEquals([AutoconfigureRepeatedOverwrite::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfiguredRepeatedTag()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureRepeatedTag::class)
+            ->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->addTag('foo', ['priority' => 2])
+            ->addTag('bar');
+
+        $this->assertEquals([AutoconfigureRepeatedTag::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfiguredRepeatedCalls()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureRepeatedCalls::class)
+            ->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->addMethodCall('setBar', ['arg2'])
+            ->addMethodCall('setFoo', ['arg1']);
+
+        $this->assertEquals([AutoconfigureRepeatedCalls::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfiguredRepeatedBindingsOverwrite()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureRepeatedBindings::class)
+            ->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setBindings(['$arg' => new BoundArgument('bar', false, BoundArgument::INSTANCEOF_BINDING, realpath(__DIR__.'/../Fixtures/AutoconfigureRepeatedBindings.php'))]);
+
+        $this->assertEquals([AutoconfigureRepeatedBindings::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfiguredRepeatedPropertiesOverwrite()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureRepeatedProperties::class)
+            ->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setProperties([
+                '$foo' => 'bar',
+                '$bar' => 'baz',
+            ]);
+
+        $this->assertEquals([AutoconfigureRepeatedProperties::class => $expected], $container->getAutoconfiguredInstanceof());
     }
 
     public function testMissingParent()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeated.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeated.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(public: true, shared: false)]
+#[Autoconfigure(lazy: true)]
+class AutoconfigureRepeated
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedBindings.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedBindings.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(bind: ['$arg' => 'foo'])]
+#[Autoconfigure(bind: ['$arg' => 'bar'])]
+class AutoconfigureRepeatedBindings
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedCalls.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedCalls.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(calls: [['setBar', ['arg2']]])]
+#[Autoconfigure(calls: [['setFoo', ['arg1']]])]
+class AutoconfigureRepeatedCalls
+{
+    public function setFoo(string $arg)
+    {
+    }
+
+    public function setBar(string $arg)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedOverwrite.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedOverwrite.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(public: true, shared: false)]
+#[Autoconfigure(lazy: true, shared: true, public: false)]
+class AutoconfigureRepeatedOverwrite
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedProperties.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedProperties.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(properties: ['$replaced' => 'to be replaced', '$bar' => 'existing to be replaced'])]
+#[Autoconfigure(properties: ['$foo' => 'bar', '$bar' => 'baz'])]
+class AutoconfigureRepeatedProperties
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedTag.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureRepeatedTag.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('foo', ['priority' => 2])]
+#[AutoconfigureTag('bar')]
+class AutoconfigureRepeatedTag
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #56841
| License       | MIT

When repeating `#[Autoconfigure]`, arguments from all attributes are now used. If an option is defined multiple times in repeated attributes, the last attribute defined will sets value.