### PR TITLE
[Cache] Add a note about the change in the default cache namespace generation to the upgrade guide

### DIFF
--- a/UPGRADE-7.1.md
+++ b/UPGRADE-7.1.md
@@ -45,6 +45,7 @@ Cache
 -----
 
  * Deprecate `CouchbaseBucketAdapter`, use `CouchbaseCollectionAdapter` with Couchbase 3 instead
+ * The algorithm for the default cache namespace changed from SHA256 to XXH128
 
 DependencyInjection
 -------------------

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate `CouchbaseBucketAdapter`, use `CouchbaseCollectionAdapter`
  * Add support for URL encoded characters in Couchbase DSN
  * Add support for using DSN with PDOAdapter
+ * The algorithm for the default cache namespace changed from SHA256 to XXH128
 
 7.0
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

After deploying the Symfony 7.1 upgrade for a client, we immediately noticed a high rate of cache misses for one of our heavily used controller actions.  Digging through the changes for the relevant upstream packages, it looks like this was introduced by way of #52948 and changing the algorithm used for the default cache namespaces when a `namespace` attribute isn't configured on the `cache.pool` service tag.

To my knowledge, there is no way to configure a namespace for cache pools using the `framework.cache` configuration, so through the framework configuration, there is no way to avoid hitting this issue without either manually building cache services or getting creative with a compiler pass that runs before the core `CachePoolPass`, so IMO it's best to call out the change in the upgrade guide.