### PR TITLE
[Validator] do not modify a constraint during validation to not leak its context

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CidrValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CidrValidator.php
@@ -71,11 +71,13 @@ class CidrValidator extends ConstraintValidator
             return;
         }
 
-        if (filter_var($ipAddress, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4) && $constraint->netmaskMax > 32) {
-            $constraint->netmaskMax = 32;
+        $netmaskMax = $constraint->netmaskMax;
+
+        if (filter_var($ipAddress, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4) && $netmaskMax > 32) {
+            $netmaskMax = 32;
         }
 
-        if ($netmask < $constraint->netmaskMin || $netmask > $constraint->netmaskMax) {
+        if ($netmask < $constraint->netmaskMin || $netmask > $netmaskMax) {
             $this->context
                 ->buildViolation($constraint->netmaskRangeViolationMessage)
                 ->setParameter('{{ min }}', $constraint->netmaskMin)

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
@@ -255,4 +255,17 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
             ['2001:0db8:85a3:0000:0000:8a2e:0370:7334/13', Ip::V4],
         ];
     }
+
+    public function testDoesNotModifyContextBetweenValidations()
+    {
+        $constraint = new Cidr();
+
+        $this->validator->validate('1.2.3.4/28', $constraint);
+
+        $this->assertNoViolation();
+
+        $this->validator->validate('::1/64', $constraint);
+
+        $this->assertNoViolation();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57301
| License       | MIT