### PR TITLE
Release v7.1.1

### DIFF
--- a/CHANGELOG-7.1.md
+++ b/CHANGELOG-7.1.md
@@ -7,6 +7,21 @@ in 7.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.1.0...v7.1.1
 
+* 7.1.1 (2024-06-04)
+
+ * bug #57110 [PhpUnitBridge] Fix error handler triggered outside of tests (HypeMC)
+ * bug #57305 [Validator] do not modify a constraint during validation to not leak its context (xabbuh)
+ * bug #57297 [FrameworkBundle] not registered definitions must not be modified (xabbuh)
+ * bug #57234 [String] Fix Inflector for 'hardware' (podhy)
+ * bug #57224 [Mime] Use streams instead of loading raw message generator into memory (bytestream)
+ * bug #57284 [Mime] Fix TextPart using an unknown File (fabpot)
+ * bug #57282 [Scheduler] Throw an exception when no dispatcher has been passed to a Schedule (fabpot)
+ * bug #57276 Fix autoload configs to avoid warnings when building optimized autoloaders (Seldaek)
+ * bug #57275 Fix autoload configs to avoid warnings when building optimized autoloaders (Seldaek)
+ * bug #57263 [SecurityBundle] Fix `container.build_hash` parameter binding (alexandre-daubois)
+ * bug #57197 [Serializer] Fix denormalizing a collection of union types (HypeMC)
+ * bug #57188 [DoctrineBridge] Fix `UniqueEntityValidator` with proxy object (HypeMC)
+
 * 7.1.0 (2024-05-31)
 
  * bug #57248 [DoctrineBridge] Revert deprecating by-{id} mapping of entities (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.1.1-DEV';
+    public const VERSION = '7.1.1';
     public const VERSION_ID = 70101;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 1;
     public const RELEASE_VERSION = 1;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2025';
     public const END_OF_LIFE = '01/2025';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.1.0...v7.1.1)

 * bug #57110 [PhpUnitBridge] Fix error handler triggered outside of tests (@HypeMC)
 * bug #57305 [Validator] do not modify a constraint during validation to not leak its context (@xabbuh)
 * bug #57297 [FrameworkBundle] not registered definitions must not be modified (@xabbuh)
 * bug #57234 [String] Fix Inflector for 'hardware' (@podhy)
 * bug #57224 [Mime] Use streams instead of loading raw message generator into memory (@bytestream)
 * bug #57284 [Mime] Fix TextPart using an unknown File (@fabpot)
 * bug #57282 [Scheduler] Throw an exception when no dispatcher has been passed to a Schedule (@fabpot)
 * bug #57276 Fix autoload configs to avoid warnings when building optimized autoloaders (@Seldaek)
 * bug #57275 Fix autoload configs to avoid warnings when building optimized autoloaders (@Seldaek)
 * bug #57263 [SecurityBundle] Fix `container.build_hash` parameter binding (@alexandre-daubois)
 * bug #57197 [Serializer] Fix denormalizing a collection of union types (@HypeMC)
 * bug #57188 [DoctrineBridge] Fix `UniqueEntityValidator` with proxy object (@HypeMC)
