### PR TITLE
[SecurityBundle] Adds space in `FirewallTrait`s error message

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallAwareTrait.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallAwareTrait.php
@@ -41,7 +41,7 @@ trait FirewallAwareTrait
         if (!$this->locator->has($firewallName)) {
             $message = 'No '.$serviceIdentifier.' found for this firewall.';
             if (\defined(static::class.'::FIREWALL_OPTION')) {
-                $message .= sprintf('Did you forget to add a "'.static::FIREWALL_OPTION.'" key under your "%s" firewall?', $firewallName);
+                $message .= sprintf(' Did you forget to add a "'.static::FIREWALL_OPTION.'" key under your "%s" firewall?', $firewallName);
             }
 
             throw new \LogicException($message);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | 
| License       | MIT

I just hit that error while debugging my application. I wondered why it was written like this:

```
[...] found for this firewall.Did you forget to add a [...]
```

Note that missing whitespace after dot.

I'm sorry for being picky, but it hurt my eyes :see_no_evil: 