### PR TITLE
[DependencyInjection] Fix ternary in `AutowireCallable` attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireCallable.php
@@ -42,7 +42,7 @@ class AutowireCallable extends Autowire
 
     public function buildDefinition(mixed $value, ?string $type, \ReflectionParameter $parameter): Definition
     {
-        return (new Definition($type = \is_string($this->lazy) ? $this->lazy : ($type ?: 'Closure')))
+        return (new Definition($type = \is_array($this->lazy) ? current($this->lazy) : ($type ?: 'Closure')))
             ->setFactory(['Closure', 'fromCallable'])
             ->setArguments([\is_array($value) ? $value + [1 => '__invoke'] : $value])
             ->setLazy($this->lazy || 'Closure' !== $type && 'callable' !== (string) $parameter->getType());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Although `AutowireCallable` construct is 
```php
    public function __construct(
        ...
        bool|string $lazy = false,
    ) {
```
It call `Autowire::__construct(..., lazy: $lazy);`

And in this class construct is 

```php
    public function __construct(
        ...
        bool|string|array $lazy = false,
    ) {
        if ($this->lazy = \is_string($lazy) ? [$lazy] : $lazy) {}
    }
```

So `$this->lazy` is always `bool|array` and ternary always false