### PR TITLE
[Uid] Make `AbstractUid` implement `Ds\Hashable` if available

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Uid;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-abstract class AbstractUid implements \JsonSerializable, \Stringable
+abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableInterface
 {
     /**
      * The identifier in its canonic representation.
@@ -157,6 +157,11 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable
         }
 
         return $this->uid === $other->uid;
+    }
+
+    public function hash(): string
+    {
+        return $this->uid;
     }
 
     public function compare(self $other): int

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Make `AbstractUid` implement `Ds\Hashable` if available
+
 7.1
 ---
 

--- a/src/Symfony/Component/Uid/HashableInterface.php
+++ b/src/Symfony/Component/Uid/HashableInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+if (interface_exists(\Ds\Hashable::class)) {
+    /**
+     * @internal
+     */
+    interface HashableInterface extends \Ds\Hashable
+    {
+        public function hash(): string;
+    }
+} else {
+    /**
+     * @internal
+     */
+    interface HashableInterface
+    {
+        public function equals(mixed $other): bool;
+
+        public function hash(): string;
+    }
+}

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -248,6 +248,29 @@ class UuidTest extends TestCase
         yield [new \stdClass()];
     }
 
+    public function testHashable()
+    {
+        $uuid1 = new UuidV4(self::A_UUID_V4);
+        $uuid2 = new UuidV4(self::A_UUID_V4);
+
+        $this->assertSame($uuid1->hash(), $uuid2->hash());
+    }
+
+    /** @requires extension ds */
+    public function testDsCompatibility()
+    {
+        $uuid1 = new UuidV4(self::A_UUID_V4);
+        $uuid2 = new UuidV4(self::A_UUID_V4);
+
+        $set = new \Ds\Set();
+        $set->add($uuid1);
+        $set->add($uuid2);
+
+        $this->assertTrue($set->contains($uuid1));
+        $this->assertTrue($set->contains($uuid2));
+        $this->assertCount(1, $set);
+    }
+
     public function testCompare()
     {
         $uuids = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR makes UUIDs usable with the PHP DS extension's `Map` and `Set` classes. It's a new feature and shouldn't cause any BC breaks.

The `Map` and `Set` classes in the DS extension have extended support for objects implementing the `Ds\Hashable` interface (as keys in `Map` and values in `Set`). By default, values are made unique by testing for strict equality, which will consider two `Uuid` instances to be distinct even though they represent the same UUID; with this PR merged, `Uuid` instances would behave as expected with these classes.

The current implementation of `AbstractUid` already includes the `equals()` method defined in the interface; the PR adds the missing `hash()` method and a shim for the interface in case the extension isn't loaded. I've also added a test for the new `hash()` method, checking both the behaviour of the method itself and the correctness of that behaviour when used with the `Ds\Set` class (that part of the test only runs if the `ds` extension is loaded).

I've read through the contributing docs, but it's still my first time contributing to Symfony, I'm sure I've made mistakes - please don't be too harsh on me! :pray: :heart: