### PR TITLE
[Process] Regression: Error output-handling is affecting Drupal core development

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -309,12 +309,7 @@ class Process implements \IteratorAggregate
         $env += '\\' === \DIRECTORY_SEPARATOR ? array_diff_ukey($this->getDefaultEnv(), $env, 'strcasecmp') : $this->getDefaultEnv();
 
         if (\is_array($commandline = $this->commandline)) {
-            $commandline = implode(' ', array_map($this->escapeArgument(...), $commandline));
-
-            if ('\\' !== \DIRECTORY_SEPARATOR) {
-                // exec is mandatory to deal with sending a signal to the process
-                $commandline = 'exec '.$commandline;
-            }
+            $commandline = array_values(array_map(strval(...), $commandline));
         } else {
             $commandline = $this->replacePlaceholders($commandline, $env);
         }
@@ -324,6 +319,11 @@ class Process implements \IteratorAggregate
         } elseif ($this->isSigchildEnabled()) {
             // last exit code is output on the fourth pipe and caught to work around --enable-sigchild
             $descriptors[3] = ['pipe', 'w'];
+
+            if (\is_array($commandline)) {
+                // exec is mandatory to deal with sending a signal to the process
+                $commandline = 'exec '.$this->buildShellCommandline($commandline);
+            }
 
             // See https://unix.stackexchange.com/questions/71205/background-process-pipe-input
             $commandline = '{ ('.$commandline.') <&3 3<&- 3>/dev/null & } 3<&0;';

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -422,6 +422,17 @@ class ProcessTest extends TestCase
         $this->assertEquals(3, preg_match_all('/ERROR/', $p->getErrorOutput(), $matches));
     }
 
+    public function testErrorOutputRegression()
+    {
+        $p = new Process(['invalid_command']);
+
+        $p->run();
+
+        var_dump($p->getErrorOutput());
+
+        $this->assertMatchesRegularExpression('/^.*invalid_command.*(\r\n|\r|\n)$/', $p->getErrorOutput());
+    }
+
     public function testFlushErrorOutput()
     {
         $p = $this->getProcessForCode('$n = 0; while ($n < 3) { file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }');


### PR DESCRIPTION
| Q | A
| -- | ---
| Branch? | 7.1
| Bug fix? | yes
| New feature? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

<!--
Additionally (see https://symfony.com/releases):
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

**tl;dr**: Since https://github.com/symfony/symfony/pull/52409, `\Symfony\Component\Process\Process` no longer captures error output when attempting to run a non-existent command on Linux--behavior Drupal core was relying on. The regression was first released in [v7.1.0-BETA1](https://github.com/symfony/symfony/releases/tag/v7.1.0-BETA1) and persists into `7.2`.

### Details

https://github.com/symfony/symfony/pull/52409 changed how the commandline is passed to `proc_open()`, apparently triggering a bug in PHP (https://github.com/php/php-src/issues/12589) whereby invoking a non-existent command on Linux no longer provides any error output. That's important behavior for a major error condition. Hence my surprise when I discovered that it was a known issue before the PR was merged--that it was explicitly called out and that tests were simply updated to avoid it.

As a consequence of the change, tests started failing on Drupal core component [Composer Stager](https://github.com/php-tuf/composer-stager). This has caused a ripple effect and taken me away from other Drupal core work. I would _really_ like to see it fixed quickly.

### Steps to Reproduce

This PR **demonstrates** the problem. It does not yet fix it. (Since the regression was part of a performance enhancement, not a functional change, perhaps it wouldn't be out of the question to just revert it, if necessary.) This begins by temporarily reverting the regression and adding a test that we can see passing on CI<sup>[1]</sup>. Then it puts the regression back in place so we can see it failing.

This...
```php
$p = new Process(['invalid_command']);
$p->run();
var_dump($p->getErrorOutput());
```

🟢 Used to print this on Linux:
```
string(45) "sh: line 0: exec: invalid_command: not found
"
```

🔴 Now it prints this:
```
string(0) ""
```

### To-do
- [ ] Fix the regression
- [ ] Ensure adequate test coverage
- [ ] Update `src/**/CHANGELOG.md` files

---

<sup>[1]</sup> Well, not very obviously, I guess, since a bunch of tests were already failing.