### PR TITLE
[Serializer] avoid calling undefined built-in is_*() functions

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -773,11 +773,24 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     return (float) $data;
                 }
 
-                if ((TypeIdentifier::FALSE === $typeIdentifier && false === $data) || (TypeIdentifier::TRUE === $typeIdentifier && true === $data)) {
-                    return $data;
-                }
+                $dataMatchesExpectedType = match ($typeIdentifier) {
+                    TypeIdentifier::ARRAY => \is_array($data),
+                    TypeIdentifier::BOOL => \is_bool($data),
+                    TypeIdentifier::CALLABLE => \is_callable($data),
+                    TypeIdentifier::FALSE => false === $data,
+                    TypeIdentifier::FLOAT => \is_float($data),
+                    TypeIdentifier::INT => \is_int($data),
+                    TypeIdentifier::ITERABLE => is_iterable($data),
+                    TypeIdentifier::MIXED => true,
+                    TypeIdentifier::NULL => null === $data,
+                    TypeIdentifier::OBJECT => \is_object($data),
+                    TypeIdentifier::RESOURCE => \is_resource($data),
+                    TypeIdentifier::STRING => \is_string($data),
+                    TypeIdentifier::TRUE => true === $data,
+                    default => false,
+                };
 
-                if (('is_'.$typeIdentifier->value)($data)) {
+                if ($dataMatchesExpectedType) {
                     return $data;
                 }
             } catch (NotNormalizableValueException|InvalidArgumentException $e) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1132,7 +1132,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeCollectionOfScalarTypesPropertyWithPhpDocExtractor()
     {
-        $normalizer = new AbstractObjectNormalizerWithMetadataAndPhpDocExtractor();
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
         $data = [
             'type' => 'foo',
             'values' => [
@@ -1150,7 +1150,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeCollectionOfUnionTypesPropertyWithPhpDocExtractor()
     {
-        $normalizer = new AbstractObjectNormalizerWithMetadataAndPhpDocExtractor();
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
         $data = [
             'values1' => [
                 'foo' => 'foo',
@@ -1165,6 +1165,15 @@ class AbstractObjectNormalizerTest extends TestCase
         $expected->values2 = $data['values2'];
 
         $this->assertEquals($expected, $normalizer->denormalize($data, UnionCollectionDocBlockDummy::class));
+    }
+
+    public function testDenormalizeMixedProperty()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+        $expected = new MixedPropertyDummy();
+        $expected->foo = 'bar';
+
+        $this->assertEquals($expected, $normalizer->denormalize(['foo' => 'bar'], MixedPropertyDummy::class));
     }
 }
 
@@ -1266,6 +1275,11 @@ class SnakeCaseNestedDummy
 {
     #[SerializedPath('[one][two_three]')]
     public $fooBar;
+}
+
+class MixedPropertyDummy
+{
+    public mixed $foo;
 }
 
 #[DiscriminatorMap(typeProperty: 'type', mapping: [
@@ -1612,11 +1626,11 @@ class UnionCollectionDocBlockDummy
     public array $values2;
 }
 
-class AbstractObjectNormalizerWithMetadataAndPhpDocExtractor extends AbstractObjectNormalizer
+class AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors extends AbstractObjectNormalizer
 {
     public function __construct()
     {
-        parent::__construct(new ClassMetadataFactory(new AttributeLoader()), null, new PropertyInfoExtractor([], [new PhpDocExtractor()]));
+        parent::__construct(new ClassMetadataFactory(new AttributeLoader()), null, new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]));
     }
 
     protected function extractAttributes(object $object, ?string $format = null, array $context = []): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57314
| License       | MIT