### PR TITLE
[AssetMapper] fix npm version constraint conversion

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapVersionChecker.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapVersionChecker.php
@@ -137,7 +137,7 @@ class ImportMapVersionChecker
             if (str_contains($segment, '-') && !preg_match('/-(alpha|beta|rc)\./', $segment)) {
                 // This is a range
                 [$start, $end] = explode('-', $segment);
-                $processedSegments[] = '>='.self::cleanVersionSegment(trim($start)).' <='.self::cleanVersionSegment(trim($end));
+                $processedSegments[] = self::cleanVersionSegment(trim($start)).' - '.self::cleanVersionSegment(trim($end));
             } elseif (preg_match('/^~(\d+\.\d+)$/', $segment, $matches)) {
                 // Handle the tilde when only major.minor specified
                 $baseVersion = $matches[1];

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapVersionCheckerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapVersionCheckerTest.php
@@ -261,6 +261,26 @@ class ImportMapVersionCheckerTest extends TestCase
                 new PackageVersionProblem('foo', 'bar', 'some/repo', '1.5.0'),
             ],
         ];
+
+        yield 'single with range constraint but no problem' => [
+            [
+                self::createRemoteEntry('foo', version: '1.0'),
+                self::createRemoteEntry('bar', version: '2.0.3'),
+            ],
+            [
+                'foo' => ['bar'],
+                'bar' => [],
+            ],
+            [
+                [
+                    'url' => '/foo/1.0',
+                    'response' => [
+                        'dependencies' => ['bar' => '1.11 - 2'],
+                    ],
+                ],
+            ],
+            [],
+        ];
     }
 
     /**
@@ -297,22 +317,22 @@ class ImportMapVersionCheckerTest extends TestCase
         // Hyphen Ranges
         yield 'hyphen range simple' => [
             '1.0.0 - 2.0.0',
-            '>=1.0.0 <=2.0.0',
+            '1.0.0 - 2.0.0',
         ];
 
         yield 'hyphen range with v prefix' => [
             'v1.0.0 - 2.0.0',
-            '>=1.0.0 <=2.0.0',
+            '1.0.0 - 2.0.0',
         ];
 
         yield 'hyphen range without patch' => [
             '1.0 - 2.0',
-            '>=1.0 <=2.0',
+            '1.0 - 2.0',
         ];
 
         yield 'hyphen range with no spaces' => [
             '1.0-v2.0',
-            '>=1.0 <=2.0',
+            '1.0 - 2.0',
         ];
 
         // .x Wildcards
@@ -386,7 +406,7 @@ class ImportMapVersionCheckerTest extends TestCase
 
         yield 'multiple constraints with space and or operator' => [
             '1.2.7 || 1.2.9- v2.0.0',
-            '1.2.7 || >=1.2.9 <=2.0.0',
+            '1.2.7 || 1.2.9 - 2.0.0',
         ];
 
         yield 'tilde constraint with patch version no change' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54610
| License       | MIT

This PR fixes semver conversion when requiring or updating packages. 
```
[warning] datatables.net-scroller-bs5 requires datatables.net-bs5@1.11 - 2 but version 2.0.3 is installed.
```

Ranges are now converted to `1.11 - 2` instead of  `>=1.11 <=2`.

See #54610