### PR TITLE
[Cache] Don't use LazyProxyTrait in redis proxies

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Cache\Traits;
 
 use Symfony\Component\VarExporter\LazyObjectInterface;
-use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Contracts\Service\ResetInterface;
 
 // Help opcache.preload discover always-needed symbols
@@ -25,1204 +24,1202 @@ class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
  */
 class Redis5Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 {
-    use LazyProxyTrait {
+    use RedisProxyTrait {
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
-
     public function __construct()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        $this->initializeLazyObject()->__construct(...\func_get_args());
     }
 
     public function _prefix($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix(...\func_get_args());
+        return $this->initializeLazyObject()->_prefix(...\func_get_args());
     }
 
     public function _serialize($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize(...\func_get_args());
+        return $this->initializeLazyObject()->_serialize(...\func_get_args());
     }
 
     public function _unserialize($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize(...\func_get_args());
+        return $this->initializeLazyObject()->_unserialize(...\func_get_args());
     }
 
     public function _pack($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack(...\func_get_args());
+        return $this->initializeLazyObject()->_pack(...\func_get_args());
     }
 
     public function _unpack($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack(...\func_get_args());
+        return $this->initializeLazyObject()->_unpack(...\func_get_args());
     }
 
     public function _compress($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress(...\func_get_args());
+        return $this->initializeLazyObject()->_compress(...\func_get_args());
     }
 
     public function _uncompress($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress(...\func_get_args());
+        return $this->initializeLazyObject()->_uncompress(...\func_get_args());
     }
 
     public function acl($subcmd, ...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl(...\func_get_args());
+        return $this->initializeLazyObject()->acl(...\func_get_args());
     }
 
     public function append($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append(...\func_get_args());
+        return $this->initializeLazyObject()->append(...\func_get_args());
     }
 
     public function auth(#[\SensitiveParameter] $auth)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->auth(...\func_get_args());
+        return $this->initializeLazyObject()->auth(...\func_get_args());
     }
 
     public function bgSave()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgSave(...\func_get_args());
+        return $this->initializeLazyObject()->bgSave(...\func_get_args());
     }
 
     public function bgrewriteaof()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof(...\func_get_args());
+        return $this->initializeLazyObject()->bgrewriteaof(...\func_get_args());
     }
 
     public function bitcount($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount(...\func_get_args());
+        return $this->initializeLazyObject()->bitcount(...\func_get_args());
     }
 
     public function bitop($operation, $ret_key, $key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop(...\func_get_args());
+        return $this->initializeLazyObject()->bitop(...\func_get_args());
     }
 
     public function bitpos($key, $bit, $start = null, $end = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos(...\func_get_args());
+        return $this->initializeLazyObject()->bitpos(...\func_get_args());
     }
 
     public function blPop($key, $timeout_or_key, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blPop(...\func_get_args());
+        return $this->initializeLazyObject()->blPop(...\func_get_args());
     }
 
     public function brPop($key, $timeout_or_key, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brPop(...\func_get_args());
+        return $this->initializeLazyObject()->brPop(...\func_get_args());
     }
 
     public function brpoplpush($src, $dst, $timeout)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->brpoplpush(...\func_get_args());
     }
 
     public function bzPopMax($key, $timeout_or_key, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzPopMax(...\func_get_args());
+        return $this->initializeLazyObject()->bzPopMax(...\func_get_args());
     }
 
     public function bzPopMin($key, $timeout_or_key, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzPopMin(...\func_get_args());
+        return $this->initializeLazyObject()->bzPopMin(...\func_get_args());
     }
 
     public function clearLastError()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearLastError(...\func_get_args());
+        return $this->initializeLazyObject()->clearLastError(...\func_get_args());
     }
 
     public function client($cmd, ...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client(...\func_get_args());
+        return $this->initializeLazyObject()->client(...\func_get_args());
     }
 
     public function close()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close(...\func_get_args());
+        return $this->initializeLazyObject()->close(...\func_get_args());
     }
 
     public function command(...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command(...\func_get_args());
+        return $this->initializeLazyObject()->command(...\func_get_args());
     }
 
     public function config($cmd, $key, $value = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config(...\func_get_args());
+        return $this->initializeLazyObject()->config(...\func_get_args());
     }
 
     public function connect($host, $port = null, $timeout = null, $retry_interval = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->connect(...\func_get_args());
+        return $this->initializeLazyObject()->connect(...\func_get_args());
     }
 
     public function dbSize()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbSize(...\func_get_args());
+        return $this->initializeLazyObject()->dbSize(...\func_get_args());
     }
 
     public function debug($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->debug(...\func_get_args());
+        return $this->initializeLazyObject()->debug(...\func_get_args());
     }
 
     public function decr($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr(...\func_get_args());
+        return $this->initializeLazyObject()->decr(...\func_get_args());
     }
 
     public function decrBy($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrBy(...\func_get_args());
+        return $this->initializeLazyObject()->decrBy(...\func_get_args());
     }
 
     public function del($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del(...\func_get_args());
+        return $this->initializeLazyObject()->del(...\func_get_args());
     }
 
     public function discard()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard(...\func_get_args());
+        return $this->initializeLazyObject()->discard(...\func_get_args());
     }
 
     public function dump($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump(...\func_get_args());
+        return $this->initializeLazyObject()->dump(...\func_get_args());
     }
 
     public function echo($msg)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo(...\func_get_args());
+        return $this->initializeLazyObject()->echo(...\func_get_args());
     }
 
     public function eval($script, $args = null, $num_keys = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval(...\func_get_args());
+        return $this->initializeLazyObject()->eval(...\func_get_args());
     }
 
     public function evalsha($script_sha, $args = null, $num_keys = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha(...\func_get_args());
+        return $this->initializeLazyObject()->evalsha(...\func_get_args());
     }
 
     public function exec()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec(...\func_get_args());
+        return $this->initializeLazyObject()->exec(...\func_get_args());
     }
 
     public function exists($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists(...\func_get_args());
+        return $this->initializeLazyObject()->exists(...\func_get_args());
     }
 
     public function expire($key, $timeout)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire(...\func_get_args());
+        return $this->initializeLazyObject()->expire(...\func_get_args());
     }
 
     public function expireAt($key, $timestamp)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireAt(...\func_get_args());
+        return $this->initializeLazyObject()->expireAt(...\func_get_args());
     }
 
     public function flushAll($async = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushAll(...\func_get_args());
+        return $this->initializeLazyObject()->flushAll(...\func_get_args());
     }
 
     public function flushDB($async = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushDB(...\func_get_args());
+        return $this->initializeLazyObject()->flushDB(...\func_get_args());
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd(...\func_get_args());
+        return $this->initializeLazyObject()->geoadd(...\func_get_args());
     }
 
     public function geodist($key, $src, $dst, $unit = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist(...\func_get_args());
+        return $this->initializeLazyObject()->geodist(...\func_get_args());
     }
 
     public function geohash($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash(...\func_get_args());
+        return $this->initializeLazyObject()->geohash(...\func_get_args());
     }
 
     public function geopos($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos(...\func_get_args());
+        return $this->initializeLazyObject()->geopos(...\func_get_args());
     }
 
     public function georadius($key, $lng, $lan, $radius, $unit, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius(...\func_get_args());
+        return $this->initializeLazyObject()->georadius(...\func_get_args());
     }
 
     public function georadius_ro($key, $lng, $lan, $radius, $unit, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadius_ro(...\func_get_args());
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember(...\func_get_args());
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember_ro(...\func_get_args());
     }
 
     public function get($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get(...\func_get_args());
+        return $this->initializeLazyObject()->get(...\func_get_args());
     }
 
     public function getAuth()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getAuth(...\func_get_args());
+        return $this->initializeLazyObject()->getAuth(...\func_get_args());
     }
 
     public function getBit($key, $offset)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getBit(...\func_get_args());
+        return $this->initializeLazyObject()->getBit(...\func_get_args());
     }
 
     public function getDBNum()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getDBNum(...\func_get_args());
+        return $this->initializeLazyObject()->getDBNum(...\func_get_args());
     }
 
     public function getHost()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getHost(...\func_get_args());
+        return $this->initializeLazyObject()->getHost(...\func_get_args());
     }
 
     public function getLastError()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getLastError(...\func_get_args());
+        return $this->initializeLazyObject()->getLastError(...\func_get_args());
     }
 
     public function getMode()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getMode(...\func_get_args());
+        return $this->initializeLazyObject()->getMode(...\func_get_args());
     }
 
     public function getOption($option)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getOption(...\func_get_args());
+        return $this->initializeLazyObject()->getOption(...\func_get_args());
     }
 
     public function getPersistentID()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPersistentID(...\func_get_args());
+        return $this->initializeLazyObject()->getPersistentID(...\func_get_args());
     }
 
     public function getPort()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPort(...\func_get_args());
+        return $this->initializeLazyObject()->getPort(...\func_get_args());
     }
 
     public function getRange($key, $start, $end)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getRange(...\func_get_args());
+        return $this->initializeLazyObject()->getRange(...\func_get_args());
     }
 
     public function getReadTimeout()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getReadTimeout(...\func_get_args());
+        return $this->initializeLazyObject()->getReadTimeout(...\func_get_args());
     }
 
     public function getSet($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getSet(...\func_get_args());
+        return $this->initializeLazyObject()->getSet(...\func_get_args());
     }
 
     public function getTimeout()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getTimeout(...\func_get_args());
+        return $this->initializeLazyObject()->getTimeout(...\func_get_args());
     }
 
     public function hDel($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hDel(...\func_get_args());
+        return $this->initializeLazyObject()->hDel(...\func_get_args());
     }
 
     public function hExists($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hExists(...\func_get_args());
+        return $this->initializeLazyObject()->hExists(...\func_get_args());
     }
 
     public function hGet($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hGet(...\func_get_args());
+        return $this->initializeLazyObject()->hGet(...\func_get_args());
     }
 
     public function hGetAll($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hGetAll(...\func_get_args());
+        return $this->initializeLazyObject()->hGetAll(...\func_get_args());
     }
 
     public function hIncrBy($key, $member, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hIncrBy(...\func_get_args());
+        return $this->initializeLazyObject()->hIncrBy(...\func_get_args());
     }
 
     public function hIncrByFloat($key, $member, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hIncrByFloat(...\func_get_args());
+        return $this->initializeLazyObject()->hIncrByFloat(...\func_get_args());
     }
 
     public function hKeys($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hKeys(...\func_get_args());
+        return $this->initializeLazyObject()->hKeys(...\func_get_args());
     }
 
     public function hLen($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hLen(...\func_get_args());
+        return $this->initializeLazyObject()->hLen(...\func_get_args());
     }
 
     public function hMget($key, $keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hMget(...\func_get_args());
+        return $this->initializeLazyObject()->hMget(...\func_get_args());
     }
 
     public function hMset($key, $pairs)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hMset(...\func_get_args());
+        return $this->initializeLazyObject()->hMset(...\func_get_args());
     }
 
     public function hSet($key, $member, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSet(...\func_get_args());
+        return $this->initializeLazyObject()->hSet(...\func_get_args());
     }
 
     public function hSetNx($key, $member, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSetNx(...\func_get_args());
+        return $this->initializeLazyObject()->hSetNx(...\func_get_args());
     }
 
     public function hStrLen($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hStrLen(...\func_get_args());
+        return $this->initializeLazyObject()->hStrLen(...\func_get_args());
     }
 
     public function hVals($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hVals(...\func_get_args());
+        return $this->initializeLazyObject()->hVals(...\func_get_args());
     }
 
     public function hscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->hscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function incr($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr(...\func_get_args());
+        return $this->initializeLazyObject()->incr(...\func_get_args());
     }
 
     public function incrBy($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrBy(...\func_get_args());
+        return $this->initializeLazyObject()->incrBy(...\func_get_args());
     }
 
     public function incrByFloat($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrByFloat(...\func_get_args());
+        return $this->initializeLazyObject()->incrByFloat(...\func_get_args());
     }
 
     public function info($option = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info(...\func_get_args());
+        return $this->initializeLazyObject()->info(...\func_get_args());
     }
 
     public function isConnected()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->isConnected(...\func_get_args());
+        return $this->initializeLazyObject()->isConnected(...\func_get_args());
     }
 
     public function keys($pattern)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys(...\func_get_args());
+        return $this->initializeLazyObject()->keys(...\func_get_args());
     }
 
     public function lInsert($key, $position, $pivot, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lInsert(...\func_get_args());
+        return $this->initializeLazyObject()->lInsert(...\func_get_args());
     }
 
     public function lLen($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lLen(...\func_get_args());
+        return $this->initializeLazyObject()->lLen(...\func_get_args());
     }
 
     public function lPop($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPop(...\func_get_args());
+        return $this->initializeLazyObject()->lPop(...\func_get_args());
     }
 
     public function lPush($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPush(...\func_get_args());
+        return $this->initializeLazyObject()->lPush(...\func_get_args());
     }
 
     public function lPushx($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPushx(...\func_get_args());
+        return $this->initializeLazyObject()->lPushx(...\func_get_args());
     }
 
     public function lSet($key, $index, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lSet(...\func_get_args());
+        return $this->initializeLazyObject()->lSet(...\func_get_args());
     }
 
     public function lastSave()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastSave(...\func_get_args());
+        return $this->initializeLazyObject()->lastSave(...\func_get_args());
     }
 
     public function lindex($key, $index)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex(...\func_get_args());
+        return $this->initializeLazyObject()->lindex(...\func_get_args());
     }
 
     public function lrange($key, $start, $end)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange(...\func_get_args());
+        return $this->initializeLazyObject()->lrange(...\func_get_args());
     }
 
     public function lrem($key, $value, $count)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem(...\func_get_args());
+        return $this->initializeLazyObject()->lrem(...\func_get_args());
     }
 
     public function ltrim($key, $start, $stop)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim(...\func_get_args());
+        return $this->initializeLazyObject()->ltrim(...\func_get_args());
     }
 
     public function mget($keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget(...\func_get_args());
+        return $this->initializeLazyObject()->mget(...\func_get_args());
     }
 
     public function migrate($host, $port, $key, $db, $timeout, $copy = null, $replace = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->migrate(...\func_get_args());
+        return $this->initializeLazyObject()->migrate(...\func_get_args());
     }
 
     public function move($key, $dbindex)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->move(...\func_get_args());
+        return $this->initializeLazyObject()->move(...\func_get_args());
     }
 
     public function mset($pairs)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset(...\func_get_args());
+        return $this->initializeLazyObject()->mset(...\func_get_args());
     }
 
     public function msetnx($pairs)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx(...\func_get_args());
+        return $this->initializeLazyObject()->msetnx(...\func_get_args());
     }
 
     public function multi($mode = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi(...\func_get_args());
+        return $this->initializeLazyObject()->multi(...\func_get_args());
     }
 
     public function object($field, $key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object(...\func_get_args());
+        return $this->initializeLazyObject()->object(...\func_get_args());
     }
 
     public function pconnect($host, $port = null, $timeout = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pconnect(...\func_get_args());
+        return $this->initializeLazyObject()->pconnect(...\func_get_args());
     }
 
     public function persist($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist(...\func_get_args());
+        return $this->initializeLazyObject()->persist(...\func_get_args());
     }
 
     public function pexpire($key, $timestamp)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire(...\func_get_args());
+        return $this->initializeLazyObject()->pexpire(...\func_get_args());
     }
 
     public function pexpireAt($key, $timestamp)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireAt(...\func_get_args());
+        return $this->initializeLazyObject()->pexpireAt(...\func_get_args());
     }
 
     public function pfadd($key, $elements)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd(...\func_get_args());
+        return $this->initializeLazyObject()->pfadd(...\func_get_args());
     }
 
     public function pfcount($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount(...\func_get_args());
+        return $this->initializeLazyObject()->pfcount(...\func_get_args());
     }
 
     public function pfmerge($dstkey, $keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge(...\func_get_args());
+        return $this->initializeLazyObject()->pfmerge(...\func_get_args());
     }
 
     public function ping()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping(...\func_get_args());
+        return $this->initializeLazyObject()->ping(...\func_get_args());
     }
 
     public function pipeline()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pipeline(...\func_get_args());
+        return $this->initializeLazyObject()->pipeline(...\func_get_args());
     }
 
     public function psetex($key, $expire, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex(...\func_get_args());
+        return $this->initializeLazyObject()->psetex(...\func_get_args());
     }
 
     public function psubscribe($patterns, $callback)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->psubscribe(...\func_get_args());
     }
 
     public function pttl($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl(...\func_get_args());
+        return $this->initializeLazyObject()->pttl(...\func_get_args());
     }
 
     public function publish($channel, $message)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish(...\func_get_args());
+        return $this->initializeLazyObject()->publish(...\func_get_args());
     }
 
     public function pubsub($cmd, ...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub(...\func_get_args());
+        return $this->initializeLazyObject()->pubsub(...\func_get_args());
     }
 
     public function punsubscribe($pattern, ...$other_patterns)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->punsubscribe(...\func_get_args());
     }
 
     public function rPop($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPop(...\func_get_args());
+        return $this->initializeLazyObject()->rPop(...\func_get_args());
     }
 
     public function rPush($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPush(...\func_get_args());
+        return $this->initializeLazyObject()->rPush(...\func_get_args());
     }
 
     public function rPushx($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPushx(...\func_get_args());
+        return $this->initializeLazyObject()->rPushx(...\func_get_args());
     }
 
     public function randomKey()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomKey(...\func_get_args());
+        return $this->initializeLazyObject()->randomKey(...\func_get_args());
     }
 
     public function rawcommand($cmd, ...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawcommand(...\func_get_args());
+        return $this->initializeLazyObject()->rawcommand(...\func_get_args());
     }
 
     public function rename($key, $newkey)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename(...\func_get_args());
+        return $this->initializeLazyObject()->rename(...\func_get_args());
     }
 
     public function renameNx($key, $newkey)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renameNx(...\func_get_args());
+        return $this->initializeLazyObject()->renameNx(...\func_get_args());
     }
 
     public function restore($ttl, $key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore(...\func_get_args());
+        return $this->initializeLazyObject()->restore(...\func_get_args());
     }
 
     public function role()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role(...\func_get_args());
+        return $this->initializeLazyObject()->role(...\func_get_args());
     }
 
     public function rpoplpush($src, $dst)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->rpoplpush(...\func_get_args());
     }
 
     public function sAdd($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sAdd(...\func_get_args());
+        return $this->initializeLazyObject()->sAdd(...\func_get_args());
     }
 
     public function sAddArray($key, $options)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sAddArray(...\func_get_args());
+        return $this->initializeLazyObject()->sAddArray(...\func_get_args());
     }
 
     public function sDiff($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sDiff(...\func_get_args());
+        return $this->initializeLazyObject()->sDiff(...\func_get_args());
     }
 
     public function sDiffStore($dst, $key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sDiffStore(...\func_get_args());
+        return $this->initializeLazyObject()->sDiffStore(...\func_get_args());
     }
 
     public function sInter($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sInter(...\func_get_args());
+        return $this->initializeLazyObject()->sInter(...\func_get_args());
     }
 
     public function sInterStore($dst, $key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sInterStore(...\func_get_args());
+        return $this->initializeLazyObject()->sInterStore(...\func_get_args());
     }
 
     public function sMembers($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMembers(...\func_get_args());
+        return $this->initializeLazyObject()->sMembers(...\func_get_args());
     }
 
     public function sMisMember($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMisMember(...\func_get_args());
+        return $this->initializeLazyObject()->sMisMember(...\func_get_args());
     }
 
     public function sMove($src, $dst, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMove(...\func_get_args());
+        return $this->initializeLazyObject()->sMove(...\func_get_args());
     }
 
     public function sPop($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sPop(...\func_get_args());
+        return $this->initializeLazyObject()->sPop(...\func_get_args());
     }
 
     public function sRandMember($key, $count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sRandMember(...\func_get_args());
+        return $this->initializeLazyObject()->sRandMember(...\func_get_args());
     }
 
     public function sUnion($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sUnion(...\func_get_args());
+        return $this->initializeLazyObject()->sUnion(...\func_get_args());
     }
 
     public function sUnionStore($dst, $key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sUnionStore(...\func_get_args());
+        return $this->initializeLazyObject()->sUnionStore(...\func_get_args());
     }
 
     public function save()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save(...\func_get_args());
+        return $this->initializeLazyObject()->save(...\func_get_args());
     }
 
     public function scan(&$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($i_iterator, ...\array_slice(\func_get_args(), 1));
+        return $this->initializeLazyObject()->scan($i_iterator, ...\array_slice(\func_get_args(), 1));
     }
 
     public function scard($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard(...\func_get_args());
+        return $this->initializeLazyObject()->scard(...\func_get_args());
     }
 
     public function script($cmd, ...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script(...\func_get_args());
+        return $this->initializeLazyObject()->script(...\func_get_args());
     }
 
     public function select($dbindex)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->select(...\func_get_args());
+        return $this->initializeLazyObject()->select(...\func_get_args());
     }
 
     public function set($key, $value, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set(...\func_get_args());
+        return $this->initializeLazyObject()->set(...\func_get_args());
     }
 
     public function setBit($key, $offset, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setBit(...\func_get_args());
+        return $this->initializeLazyObject()->setBit(...\func_get_args());
     }
 
     public function setOption($option, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setOption(...\func_get_args());
+        return $this->initializeLazyObject()->setOption(...\func_get_args());
     }
 
     public function setRange($key, $offset, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setRange(...\func_get_args());
+        return $this->initializeLazyObject()->setRange(...\func_get_args());
     }
 
     public function setex($key, $expire, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex(...\func_get_args());
+        return $this->initializeLazyObject()->setex(...\func_get_args());
     }
 
     public function setnx($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx(...\func_get_args());
+        return $this->initializeLazyObject()->setnx(...\func_get_args());
     }
 
     public function sismember($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember(...\func_get_args());
+        return $this->initializeLazyObject()->sismember(...\func_get_args());
     }
 
     public function slaveof($host = null, $port = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slaveof(...\func_get_args());
+        return $this->initializeLazyObject()->slaveof(...\func_get_args());
     }
 
     public function slowlog($arg, $option = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog(...\func_get_args());
+        return $this->initializeLazyObject()->slowlog(...\func_get_args());
     }
 
     public function sort($key, $options = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort(...\func_get_args());
+        return $this->initializeLazyObject()->sort(...\func_get_args());
     }
 
     public function sortAsc($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortAsc(...\func_get_args());
+        return $this->initializeLazyObject()->sortAsc(...\func_get_args());
     }
 
     public function sortAscAlpha($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortAscAlpha(...\func_get_args());
+        return $this->initializeLazyObject()->sortAscAlpha(...\func_get_args());
     }
 
     public function sortDesc($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortDesc(...\func_get_args());
+        return $this->initializeLazyObject()->sortDesc(...\func_get_args());
     }
 
     public function sortDescAlpha($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortDescAlpha(...\func_get_args());
+        return $this->initializeLazyObject()->sortDescAlpha(...\func_get_args());
     }
 
     public function srem($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem(...\func_get_args());
+        return $this->initializeLazyObject()->srem(...\func_get_args());
     }
 
     public function sscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->sscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function strlen($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen(...\func_get_args());
+        return $this->initializeLazyObject()->strlen(...\func_get_args());
     }
 
     public function subscribe($channels, $callback)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe(...\func_get_args());
+        return $this->initializeLazyObject()->subscribe(...\func_get_args());
     }
 
     public function swapdb($srcdb, $dstdb)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->swapdb(...\func_get_args());
+        return $this->initializeLazyObject()->swapdb(...\func_get_args());
     }
 
     public function time()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time(...\func_get_args());
+        return $this->initializeLazyObject()->time(...\func_get_args());
     }
 
     public function ttl($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl(...\func_get_args());
+        return $this->initializeLazyObject()->ttl(...\func_get_args());
     }
 
     public function type($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type(...\func_get_args());
+        return $this->initializeLazyObject()->type(...\func_get_args());
     }
 
     public function unlink($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink(...\func_get_args());
+        return $this->initializeLazyObject()->unlink(...\func_get_args());
     }
 
     public function unsubscribe($channel, ...$other_channels)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->unsubscribe(...\func_get_args());
     }
 
     public function unwatch()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch(...\func_get_args());
+        return $this->initializeLazyObject()->unwatch(...\func_get_args());
     }
 
     public function wait($numslaves, $timeout)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->wait(...\func_get_args());
+        return $this->initializeLazyObject()->wait(...\func_get_args());
     }
 
     public function watch($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch(...\func_get_args());
+        return $this->initializeLazyObject()->watch(...\func_get_args());
     }
 
     public function xack($str_key, $str_group, $arr_ids)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack(...\func_get_args());
+        return $this->initializeLazyObject()->xack(...\func_get_args());
     }
 
     public function xadd($str_key, $str_id, $arr_fields, $i_maxlen = null, $boo_approximate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd(...\func_get_args());
+        return $this->initializeLazyObject()->xadd(...\func_get_args());
     }
 
     public function xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim(...\func_get_args());
+        return $this->initializeLazyObject()->xclaim(...\func_get_args());
     }
 
     public function xdel($str_key, $arr_ids)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel(...\func_get_args());
+        return $this->initializeLazyObject()->xdel(...\func_get_args());
     }
 
     public function xgroup($str_operation, $str_key = null, $str_arg1 = null, $str_arg2 = null, $str_arg3 = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xgroup(...\func_get_args());
     }
 
     public function xinfo($str_cmd, $str_key = null, $str_group = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo(...\func_get_args());
+        return $this->initializeLazyObject()->xinfo(...\func_get_args());
     }
 
     public function xlen($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen(...\func_get_args());
+        return $this->initializeLazyObject()->xlen(...\func_get_args());
     }
 
     public function xpending($str_key, $str_group, $str_start = null, $str_end = null, $i_count = null, $str_consumer = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending(...\func_get_args());
+        return $this->initializeLazyObject()->xpending(...\func_get_args());
     }
 
     public function xrange($str_key, $str_start, $str_end, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrange(...\func_get_args());
     }
 
     public function xread($arr_streams, $i_count = null, $i_block = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread(...\func_get_args());
+        return $this->initializeLazyObject()->xread(...\func_get_args());
     }
 
     public function xreadgroup($str_group, $str_consumer, $arr_streams, $i_count = null, $i_block = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xreadgroup(...\func_get_args());
     }
 
     public function xrevrange($str_key, $str_start, $str_end, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrevrange(...\func_get_args());
     }
 
     public function xtrim($str_key, $i_maxlen, $boo_approximate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim(...\func_get_args());
+        return $this->initializeLazyObject()->xtrim(...\func_get_args());
     }
 
     public function zAdd($key, $score, $value, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zAdd(...\func_get_args());
+        return $this->initializeLazyObject()->zAdd(...\func_get_args());
     }
 
     public function zCard($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zCard(...\func_get_args());
+        return $this->initializeLazyObject()->zCard(...\func_get_args());
     }
 
     public function zCount($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zCount(...\func_get_args());
+        return $this->initializeLazyObject()->zCount(...\func_get_args());
     }
 
     public function zIncrBy($key, $value, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zIncrBy(...\func_get_args());
+        return $this->initializeLazyObject()->zIncrBy(...\func_get_args());
     }
 
     public function zLexCount($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zLexCount(...\func_get_args());
+        return $this->initializeLazyObject()->zLexCount(...\func_get_args());
     }
 
     public function zPopMax($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zPopMax(...\func_get_args());
+        return $this->initializeLazyObject()->zPopMax(...\func_get_args());
     }
 
     public function zPopMin($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zPopMin(...\func_get_args());
+        return $this->initializeLazyObject()->zPopMin(...\func_get_args());
     }
 
     public function zRange($key, $start, $end, $scores = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRange(...\func_get_args());
+        return $this->initializeLazyObject()->zRange(...\func_get_args());
     }
 
     public function zRangeByLex($key, $min, $max, $offset = null, $limit = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRangeByLex(...\func_get_args());
+        return $this->initializeLazyObject()->zRangeByLex(...\func_get_args());
     }
 
     public function zRangeByScore($key, $start, $end, $options = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRangeByScore(...\func_get_args());
+        return $this->initializeLazyObject()->zRangeByScore(...\func_get_args());
     }
 
     public function zRank($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRank(...\func_get_args());
+        return $this->initializeLazyObject()->zRank(...\func_get_args());
     }
 
     public function zRem($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRem(...\func_get_args());
+        return $this->initializeLazyObject()->zRem(...\func_get_args());
     }
 
     public function zRemRangeByLex($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByLex(...\func_get_args());
+        return $this->initializeLazyObject()->zRemRangeByLex(...\func_get_args());
     }
 
     public function zRemRangeByRank($key, $start, $end)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByRank(...\func_get_args());
+        return $this->initializeLazyObject()->zRemRangeByRank(...\func_get_args());
     }
 
     public function zRemRangeByScore($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByScore(...\func_get_args());
+        return $this->initializeLazyObject()->zRemRangeByScore(...\func_get_args());
     }
 
     public function zRevRange($key, $start, $end, $scores = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRange(...\func_get_args());
+        return $this->initializeLazyObject()->zRevRange(...\func_get_args());
     }
 
     public function zRevRangeByLex($key, $min, $max, $offset = null, $limit = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRangeByLex(...\func_get_args());
+        return $this->initializeLazyObject()->zRevRangeByLex(...\func_get_args());
     }
 
     public function zRevRangeByScore($key, $start, $end, $options = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRangeByScore(...\func_get_args());
+        return $this->initializeLazyObject()->zRevRangeByScore(...\func_get_args());
     }
 
     public function zRevRank($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRank(...\func_get_args());
+        return $this->initializeLazyObject()->zRevRank(...\func_get_args());
     }
 
     public function zScore($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zScore(...\func_get_args());
+        return $this->initializeLazyObject()->zScore(...\func_get_args());
     }
 
     public function zinterstore($key, $keys, $weights = null, $aggregate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore(...\func_get_args());
+        return $this->initializeLazyObject()->zinterstore(...\func_get_args());
     }
 
     public function zscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->zscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function zunionstore($key, $keys, $weights = null, $aggregate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore(...\func_get_args());
+        return $this->initializeLazyObject()->zunionstore(...\func_get_args());
     }
 
     public function delete($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->delete(...\func_get_args());
+        return $this->initializeLazyObject()->delete(...\func_get_args());
     }
 
     public function evaluate($script, $args = null, $num_keys = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evaluate(...\func_get_args());
+        return $this->initializeLazyObject()->evaluate(...\func_get_args());
     }
 
     public function evaluateSha($script_sha, $args = null, $num_keys = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evaluateSha(...\func_get_args());
+        return $this->initializeLazyObject()->evaluateSha(...\func_get_args());
     }
 
     public function getKeys($pattern)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getKeys(...\func_get_args());
+        return $this->initializeLazyObject()->getKeys(...\func_get_args());
     }
 
     public function getMultiple($keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getMultiple(...\func_get_args());
+        return $this->initializeLazyObject()->getMultiple(...\func_get_args());
     }
 
     public function lGet($key, $index)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lGet(...\func_get_args());
+        return $this->initializeLazyObject()->lGet(...\func_get_args());
     }
 
     public function lGetRange($key, $start, $end)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lGetRange(...\func_get_args());
+        return $this->initializeLazyObject()->lGetRange(...\func_get_args());
     }
 
     public function lRemove($key, $value, $count)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lRemove(...\func_get_args());
+        return $this->initializeLazyObject()->lRemove(...\func_get_args());
     }
 
     public function lSize($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lSize(...\func_get_args());
+        return $this->initializeLazyObject()->lSize(...\func_get_args());
     }
 
     public function listTrim($key, $start, $stop)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->listTrim(...\func_get_args());
+        return $this->initializeLazyObject()->listTrim(...\func_get_args());
     }
 
     public function open($host, $port = null, $timeout = null, $retry_interval = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->open(...\func_get_args());
+        return $this->initializeLazyObject()->open(...\func_get_args());
     }
 
     public function popen($host, $port = null, $timeout = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->popen(...\func_get_args());
+        return $this->initializeLazyObject()->popen(...\func_get_args());
     }
 
     public function renameKey($key, $newkey)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renameKey(...\func_get_args());
+        return $this->initializeLazyObject()->renameKey(...\func_get_args());
     }
 
     public function sContains($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sContains(...\func_get_args());
+        return $this->initializeLazyObject()->sContains(...\func_get_args());
     }
 
     public function sGetMembers($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sGetMembers(...\func_get_args());
+        return $this->initializeLazyObject()->sGetMembers(...\func_get_args());
     }
 
     public function sRemove($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sRemove(...\func_get_args());
+        return $this->initializeLazyObject()->sRemove(...\func_get_args());
     }
 
     public function sSize($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sSize(...\func_get_args());
+        return $this->initializeLazyObject()->sSize(...\func_get_args());
     }
 
     public function sendEcho($msg)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sendEcho(...\func_get_args());
+        return $this->initializeLazyObject()->sendEcho(...\func_get_args());
     }
 
     public function setTimeout($key, $timeout)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setTimeout(...\func_get_args());
+        return $this->initializeLazyObject()->setTimeout(...\func_get_args());
     }
 
     public function substr($key, $start, $end)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->substr(...\func_get_args());
+        return $this->initializeLazyObject()->substr(...\func_get_args());
     }
 
     public function zDelete($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zDelete(...\func_get_args());
+        return $this->initializeLazyObject()->zDelete(...\func_get_args());
     }
 
     public function zDeleteRangeByRank($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zDeleteRangeByRank(...\func_get_args());
+        return $this->initializeLazyObject()->zDeleteRangeByRank(...\func_get_args());
     }
 
     public function zDeleteRangeByScore($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zDeleteRangeByScore(...\func_get_args());
+        return $this->initializeLazyObject()->zDeleteRangeByScore(...\func_get_args());
     }
 
     public function zInter($key, $keys, $weights = null, $aggregate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zInter(...\func_get_args());
+        return $this->initializeLazyObject()->zInter(...\func_get_args());
     }
 
     public function zRemove($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemove(...\func_get_args());
+        return $this->initializeLazyObject()->zRemove(...\func_get_args());
     }
 
     public function zRemoveRangeByScore($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemoveRangeByScore(...\func_get_args());
+        return $this->initializeLazyObject()->zRemoveRangeByScore(...\func_get_args());
     }
 
     public function zReverseRange($key, $start, $end, $scores = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zReverseRange(...\func_get_args());
+        return $this->initializeLazyObject()->zReverseRange(...\func_get_args());
     }
 
     public function zSize($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zSize(...\func_get_args());
+        return $this->initializeLazyObject()->zSize(...\func_get_args());
     }
 
     public function zUnion($key, $keys, $weights = null, $aggregate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zUnion(...\func_get_args());
+        return $this->initializeLazyObject()->zUnion(...\func_get_args());
     }
 }

--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Cache\Traits;
 
 use Symfony\Component\VarExporter\LazyObjectInterface;
-use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Contracts\Service\ResetInterface;
 
 // Help opcache.preload discover always-needed symbols
@@ -25,1269 +24,1267 @@ class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
  */
 class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 {
-    use LazyProxyTrait {
+    use RedisProxyTrait {
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
-
     public function __construct($options = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        $this->initializeLazyObject()->__construct(...\func_get_args());
     }
 
     public function _compress($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress(...\func_get_args());
+        return $this->initializeLazyObject()->_compress(...\func_get_args());
     }
 
     public function _uncompress($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress(...\func_get_args());
+        return $this->initializeLazyObject()->_uncompress(...\func_get_args());
     }
 
     public function _prefix($key): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix(...\func_get_args());
+        return $this->initializeLazyObject()->_prefix(...\func_get_args());
     }
 
     public function _serialize($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize(...\func_get_args());
+        return $this->initializeLazyObject()->_serialize(...\func_get_args());
     }
 
     public function _unserialize($value): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize(...\func_get_args());
+        return $this->initializeLazyObject()->_unserialize(...\func_get_args());
     }
 
     public function _pack($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack(...\func_get_args());
+        return $this->initializeLazyObject()->_pack(...\func_get_args());
     }
 
     public function _unpack($value): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack(...\func_get_args());
+        return $this->initializeLazyObject()->_unpack(...\func_get_args());
     }
 
     public function acl($subcmd, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl(...\func_get_args());
+        return $this->initializeLazyObject()->acl(...\func_get_args());
     }
 
     public function append($key, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append(...\func_get_args());
+        return $this->initializeLazyObject()->append(...\func_get_args());
     }
 
     public function auth(#[\SensitiveParameter] $credentials): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->auth(...\func_get_args());
+        return $this->initializeLazyObject()->auth(...\func_get_args());
     }
 
     public function bgSave(): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgSave(...\func_get_args());
+        return $this->initializeLazyObject()->bgSave(...\func_get_args());
     }
 
     public function bgrewriteaof(): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof(...\func_get_args());
+        return $this->initializeLazyObject()->bgrewriteaof(...\func_get_args());
     }
 
     public function bitcount($key, $start = 0, $end = -1, $bybit = false): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount(...\func_get_args());
+        return $this->initializeLazyObject()->bitcount(...\func_get_args());
     }
 
     public function bitop($operation, $deskey, $srckey, ...$other_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop(...\func_get_args());
+        return $this->initializeLazyObject()->bitop(...\func_get_args());
     }
 
     public function bitpos($key, $bit, $start = 0, $end = -1, $bybit = false): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos(...\func_get_args());
+        return $this->initializeLazyObject()->bitpos(...\func_get_args());
     }
 
     public function blPop($key_or_keys, $timeout_or_key, ...$extra_args): \Redis|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blPop(...\func_get_args());
+        return $this->initializeLazyObject()->blPop(...\func_get_args());
     }
 
     public function brPop($key_or_keys, $timeout_or_key, ...$extra_args): \Redis|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brPop(...\func_get_args());
+        return $this->initializeLazyObject()->brPop(...\func_get_args());
     }
 
     public function brpoplpush($src, $dst, $timeout): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->brpoplpush(...\func_get_args());
     }
 
     public function bzPopMax($key, $timeout_or_key, ...$extra_args): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzPopMax(...\func_get_args());
+        return $this->initializeLazyObject()->bzPopMax(...\func_get_args());
     }
 
     public function bzPopMin($key, $timeout_or_key, ...$extra_args): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzPopMin(...\func_get_args());
+        return $this->initializeLazyObject()->bzPopMin(...\func_get_args());
     }
 
     public function bzmpop($timeout, $keys, $from, $count = 1): \Redis|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzmpop(...\func_get_args());
+        return $this->initializeLazyObject()->bzmpop(...\func_get_args());
     }
 
     public function zmpop($keys, $from, $count = 1): \Redis|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zmpop(...\func_get_args());
+        return $this->initializeLazyObject()->zmpop(...\func_get_args());
     }
 
     public function blmpop($timeout, $keys, $from, $count = 1): \Redis|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmpop(...\func_get_args());
+        return $this->initializeLazyObject()->blmpop(...\func_get_args());
     }
 
     public function lmpop($keys, $from, $count = 1): \Redis|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmpop(...\func_get_args());
+        return $this->initializeLazyObject()->lmpop(...\func_get_args());
     }
 
     public function clearLastError(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearLastError(...\func_get_args());
+        return $this->initializeLazyObject()->clearLastError(...\func_get_args());
     }
 
     public function client($opt, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client(...\func_get_args());
+        return $this->initializeLazyObject()->client(...\func_get_args());
     }
 
     public function close(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close(...\func_get_args());
+        return $this->initializeLazyObject()->close(...\func_get_args());
     }
 
     public function command($opt = null, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command(...\func_get_args());
+        return $this->initializeLazyObject()->command(...\func_get_args());
     }
 
     public function config($operation, $key_or_settings = null, $value = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config(...\func_get_args());
+        return $this->initializeLazyObject()->config(...\func_get_args());
     }
 
     public function connect($host, $port = 6379, $timeout = 0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0, $context = null): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->connect(...\func_get_args());
+        return $this->initializeLazyObject()->connect(...\func_get_args());
     }
 
     public function copy($src, $dst, $options = null): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->copy(...\func_get_args());
+        return $this->initializeLazyObject()->copy(...\func_get_args());
     }
 
     public function dbSize(): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbSize(...\func_get_args());
+        return $this->initializeLazyObject()->dbSize(...\func_get_args());
     }
 
     public function debug($key): \Redis|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->debug(...\func_get_args());
+        return $this->initializeLazyObject()->debug(...\func_get_args());
     }
 
     public function decr($key, $by = 1): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr(...\func_get_args());
+        return $this->initializeLazyObject()->decr(...\func_get_args());
     }
 
     public function decrBy($key, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrBy(...\func_get_args());
+        return $this->initializeLazyObject()->decrBy(...\func_get_args());
     }
 
     public function del($key, ...$other_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del(...\func_get_args());
+        return $this->initializeLazyObject()->del(...\func_get_args());
     }
 
     public function delete($key, ...$other_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->delete(...\func_get_args());
+        return $this->initializeLazyObject()->delete(...\func_get_args());
     }
 
     public function discard(): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard(...\func_get_args());
+        return $this->initializeLazyObject()->discard(...\func_get_args());
     }
 
     public function dump($key): \Redis|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump(...\func_get_args());
+        return $this->initializeLazyObject()->dump(...\func_get_args());
     }
 
     public function echo($str): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo(...\func_get_args());
+        return $this->initializeLazyObject()->echo(...\func_get_args());
     }
 
     public function eval($script, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval(...\func_get_args());
+        return $this->initializeLazyObject()->eval(...\func_get_args());
     }
 
     public function eval_ro($script_sha, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval_ro(...\func_get_args());
+        return $this->initializeLazyObject()->eval_ro(...\func_get_args());
     }
 
     public function evalsha($sha1, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha(...\func_get_args());
+        return $this->initializeLazyObject()->evalsha(...\func_get_args());
     }
 
     public function evalsha_ro($sha1, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha_ro(...\func_get_args());
+        return $this->initializeLazyObject()->evalsha_ro(...\func_get_args());
     }
 
     public function exec(): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec(...\func_get_args());
+        return $this->initializeLazyObject()->exec(...\func_get_args());
     }
 
     public function exists($key, ...$other_keys): \Redis|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists(...\func_get_args());
+        return $this->initializeLazyObject()->exists(...\func_get_args());
     }
 
     public function expire($key, $timeout, $mode = null): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire(...\func_get_args());
+        return $this->initializeLazyObject()->expire(...\func_get_args());
     }
 
     public function expireAt($key, $timestamp, $mode = null): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireAt(...\func_get_args());
+        return $this->initializeLazyObject()->expireAt(...\func_get_args());
     }
 
     public function failover($to = null, $abort = false, $timeout = 0): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->failover(...\func_get_args());
+        return $this->initializeLazyObject()->failover(...\func_get_args());
     }
 
     public function expiretime($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expiretime(...\func_get_args());
+        return $this->initializeLazyObject()->expiretime(...\func_get_args());
     }
 
     public function pexpiretime($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpiretime(...\func_get_args());
+        return $this->initializeLazyObject()->pexpiretime(...\func_get_args());
     }
 
     public function fcall($fn, $keys = [], $args = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->fcall(...\func_get_args());
+        return $this->initializeLazyObject()->fcall(...\func_get_args());
     }
 
     public function fcall_ro($fn, $keys = [], $args = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->fcall_ro(...\func_get_args());
+        return $this->initializeLazyObject()->fcall_ro(...\func_get_args());
     }
 
     public function flushAll($sync = null): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushAll(...\func_get_args());
+        return $this->initializeLazyObject()->flushAll(...\func_get_args());
     }
 
     public function flushDB($sync = null): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushDB(...\func_get_args());
+        return $this->initializeLazyObject()->flushDB(...\func_get_args());
     }
 
     public function function($operation, ...$args): \Redis|array|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->function(...\func_get_args());
+        return $this->initializeLazyObject()->function(...\func_get_args());
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples_and_options): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd(...\func_get_args());
+        return $this->initializeLazyObject()->geoadd(...\func_get_args());
     }
 
     public function geodist($key, $src, $dst, $unit = null): \Redis|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist(...\func_get_args());
+        return $this->initializeLazyObject()->geodist(...\func_get_args());
     }
 
     public function geohash($key, $member, ...$other_members): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash(...\func_get_args());
+        return $this->initializeLazyObject()->geohash(...\func_get_args());
     }
 
     public function geopos($key, $member, ...$other_members): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos(...\func_get_args());
+        return $this->initializeLazyObject()->geopos(...\func_get_args());
     }
 
     public function georadius($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius(...\func_get_args());
+        return $this->initializeLazyObject()->georadius(...\func_get_args());
     }
 
     public function georadius_ro($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadius_ro(...\func_get_args());
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember(...\func_get_args());
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember_ro(...\func_get_args());
     }
 
     public function geosearch($key, $position, $shape, $unit, $options = []): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearch(...\func_get_args());
+        return $this->initializeLazyObject()->geosearch(...\func_get_args());
     }
 
     public function geosearchstore($dst, $src, $position, $shape, $unit, $options = []): \Redis|array|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearchstore(...\func_get_args());
+        return $this->initializeLazyObject()->geosearchstore(...\func_get_args());
     }
 
     public function get($key): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get(...\func_get_args());
+        return $this->initializeLazyObject()->get(...\func_get_args());
     }
 
     public function getAuth(): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getAuth(...\func_get_args());
+        return $this->initializeLazyObject()->getAuth(...\func_get_args());
     }
 
     public function getBit($key, $idx): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getBit(...\func_get_args());
+        return $this->initializeLazyObject()->getBit(...\func_get_args());
     }
 
     public function getEx($key, $options = []): \Redis|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getEx(...\func_get_args());
+        return $this->initializeLazyObject()->getEx(...\func_get_args());
     }
 
     public function getDBNum(): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getDBNum(...\func_get_args());
+        return $this->initializeLazyObject()->getDBNum(...\func_get_args());
     }
 
     public function getDel($key): \Redis|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getDel(...\func_get_args());
+        return $this->initializeLazyObject()->getDel(...\func_get_args());
     }
 
     public function getHost(): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getHost(...\func_get_args());
+        return $this->initializeLazyObject()->getHost(...\func_get_args());
     }
 
     public function getLastError(): ?string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getLastError(...\func_get_args());
+        return $this->initializeLazyObject()->getLastError(...\func_get_args());
     }
 
     public function getMode(): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getMode(...\func_get_args());
+        return $this->initializeLazyObject()->getMode(...\func_get_args());
     }
 
     public function getOption($option): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getOption(...\func_get_args());
+        return $this->initializeLazyObject()->getOption(...\func_get_args());
     }
 
     public function getPersistentID(): ?string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPersistentID(...\func_get_args());
+        return $this->initializeLazyObject()->getPersistentID(...\func_get_args());
     }
 
     public function getPort(): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPort(...\func_get_args());
+        return $this->initializeLazyObject()->getPort(...\func_get_args());
     }
 
     public function getRange($key, $start, $end): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getRange(...\func_get_args());
+        return $this->initializeLazyObject()->getRange(...\func_get_args());
     }
 
     public function lcs($key1, $key2, $options = null): \Redis|array|false|int|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lcs(...\func_get_args());
+        return $this->initializeLazyObject()->lcs(...\func_get_args());
     }
 
     public function getReadTimeout(): float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getReadTimeout(...\func_get_args());
+        return $this->initializeLazyObject()->getReadTimeout(...\func_get_args());
     }
 
     public function getset($key, $value): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getset(...\func_get_args());
+        return $this->initializeLazyObject()->getset(...\func_get_args());
     }
 
     public function getTimeout(): false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getTimeout(...\func_get_args());
+        return $this->initializeLazyObject()->getTimeout(...\func_get_args());
     }
 
     public function getTransferredBytes(): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getTransferredBytes(...\func_get_args());
+        return $this->initializeLazyObject()->getTransferredBytes(...\func_get_args());
     }
 
     public function clearTransferredBytes(): void
     {
-        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearTransferredBytes(...\func_get_args());
+        $this->initializeLazyObject()->clearTransferredBytes(...\func_get_args());
     }
 
     public function hDel($key, $field, ...$other_fields): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hDel(...\func_get_args());
+        return $this->initializeLazyObject()->hDel(...\func_get_args());
     }
 
     public function hExists($key, $field): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hExists(...\func_get_args());
+        return $this->initializeLazyObject()->hExists(...\func_get_args());
     }
 
     public function hGet($key, $member): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hGet(...\func_get_args());
+        return $this->initializeLazyObject()->hGet(...\func_get_args());
     }
 
     public function hGetAll($key): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hGetAll(...\func_get_args());
+        return $this->initializeLazyObject()->hGetAll(...\func_get_args());
     }
 
     public function hIncrBy($key, $field, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hIncrBy(...\func_get_args());
+        return $this->initializeLazyObject()->hIncrBy(...\func_get_args());
     }
 
     public function hIncrByFloat($key, $field, $value): \Redis|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hIncrByFloat(...\func_get_args());
+        return $this->initializeLazyObject()->hIncrByFloat(...\func_get_args());
     }
 
     public function hKeys($key): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hKeys(...\func_get_args());
+        return $this->initializeLazyObject()->hKeys(...\func_get_args());
     }
 
     public function hLen($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hLen(...\func_get_args());
+        return $this->initializeLazyObject()->hLen(...\func_get_args());
     }
 
     public function hMget($key, $fields): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hMget(...\func_get_args());
+        return $this->initializeLazyObject()->hMget(...\func_get_args());
     }
 
     public function hMset($key, $fieldvals): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hMset(...\func_get_args());
+        return $this->initializeLazyObject()->hMset(...\func_get_args());
     }
 
     public function hRandField($key, $options = null): \Redis|array|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hRandField(...\func_get_args());
+        return $this->initializeLazyObject()->hRandField(...\func_get_args());
     }
 
     public function hSet($key, $member, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSet(...\func_get_args());
+        return $this->initializeLazyObject()->hSet(...\func_get_args());
     }
 
     public function hSetNx($key, $field, $value): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSetNx(...\func_get_args());
+        return $this->initializeLazyObject()->hSetNx(...\func_get_args());
     }
 
     public function hStrLen($key, $field): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hStrLen(...\func_get_args());
+        return $this->initializeLazyObject()->hStrLen(...\func_get_args());
     }
 
     public function hVals($key): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hVals(...\func_get_args());
+        return $this->initializeLazyObject()->hVals(...\func_get_args());
     }
 
     public function hscan($key, &$iterator, $pattern = null, $count = 0): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function incr($key, $by = 1): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr(...\func_get_args());
+        return $this->initializeLazyObject()->incr(...\func_get_args());
     }
 
     public function incrBy($key, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrBy(...\func_get_args());
+        return $this->initializeLazyObject()->incrBy(...\func_get_args());
     }
 
     public function incrByFloat($key, $value): \Redis|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrByFloat(...\func_get_args());
+        return $this->initializeLazyObject()->incrByFloat(...\func_get_args());
     }
 
     public function info(...$sections): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info(...\func_get_args());
+        return $this->initializeLazyObject()->info(...\func_get_args());
     }
 
     public function isConnected(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->isConnected(...\func_get_args());
+        return $this->initializeLazyObject()->isConnected(...\func_get_args());
     }
 
     public function keys($pattern)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys(...\func_get_args());
+        return $this->initializeLazyObject()->keys(...\func_get_args());
     }
 
     public function lInsert($key, $pos, $pivot, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lInsert(...\func_get_args());
+        return $this->initializeLazyObject()->lInsert(...\func_get_args());
     }
 
     public function lLen($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lLen(...\func_get_args());
+        return $this->initializeLazyObject()->lLen(...\func_get_args());
     }
 
     public function lMove($src, $dst, $wherefrom, $whereto): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lMove(...\func_get_args());
+        return $this->initializeLazyObject()->lMove(...\func_get_args());
     }
 
     public function blmove($src, $dst, $wherefrom, $whereto, $timeout): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmove(...\func_get_args());
+        return $this->initializeLazyObject()->blmove(...\func_get_args());
     }
 
     public function lPop($key, $count = 0): \Redis|array|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPop(...\func_get_args());
+        return $this->initializeLazyObject()->lPop(...\func_get_args());
     }
 
     public function lPos($key, $value, $options = null): \Redis|array|bool|int|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPos(...\func_get_args());
+        return $this->initializeLazyObject()->lPos(...\func_get_args());
     }
 
     public function lPush($key, ...$elements): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPush(...\func_get_args());
+        return $this->initializeLazyObject()->lPush(...\func_get_args());
     }
 
     public function rPush($key, ...$elements): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPush(...\func_get_args());
+        return $this->initializeLazyObject()->rPush(...\func_get_args());
     }
 
     public function lPushx($key, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPushx(...\func_get_args());
+        return $this->initializeLazyObject()->lPushx(...\func_get_args());
     }
 
     public function rPushx($key, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPushx(...\func_get_args());
+        return $this->initializeLazyObject()->rPushx(...\func_get_args());
     }
 
     public function lSet($key, $index, $value): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lSet(...\func_get_args());
+        return $this->initializeLazyObject()->lSet(...\func_get_args());
     }
 
     public function lastSave(): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastSave(...\func_get_args());
+        return $this->initializeLazyObject()->lastSave(...\func_get_args());
     }
 
     public function lindex($key, $index): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex(...\func_get_args());
+        return $this->initializeLazyObject()->lindex(...\func_get_args());
     }
 
     public function lrange($key, $start, $end): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange(...\func_get_args());
+        return $this->initializeLazyObject()->lrange(...\func_get_args());
     }
 
     public function lrem($key, $value, $count = 0): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem(...\func_get_args());
+        return $this->initializeLazyObject()->lrem(...\func_get_args());
     }
 
     public function ltrim($key, $start, $end): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim(...\func_get_args());
+        return $this->initializeLazyObject()->ltrim(...\func_get_args());
     }
 
     public function mget($keys): \Redis|array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget(...\func_get_args());
+        return $this->initializeLazyObject()->mget(...\func_get_args());
     }
 
     public function migrate($host, $port, $key, $dstdb, $timeout, $copy = false, $replace = false, #[\SensitiveParameter] $credentials = null): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->migrate(...\func_get_args());
+        return $this->initializeLazyObject()->migrate(...\func_get_args());
     }
 
     public function move($key, $index): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->move(...\func_get_args());
+        return $this->initializeLazyObject()->move(...\func_get_args());
     }
 
     public function mset($key_values): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset(...\func_get_args());
+        return $this->initializeLazyObject()->mset(...\func_get_args());
     }
 
     public function msetnx($key_values): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx(...\func_get_args());
+        return $this->initializeLazyObject()->msetnx(...\func_get_args());
     }
 
     public function multi($value = \Redis::MULTI): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi(...\func_get_args());
+        return $this->initializeLazyObject()->multi(...\func_get_args());
     }
 
     public function object($subcommand, $key): \Redis|false|int|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object(...\func_get_args());
+        return $this->initializeLazyObject()->object(...\func_get_args());
     }
 
     public function open($host, $port = 6379, $timeout = 0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0, $context = null): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->open(...\func_get_args());
+        return $this->initializeLazyObject()->open(...\func_get_args());
     }
 
     public function pconnect($host, $port = 6379, $timeout = 0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0, $context = null): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pconnect(...\func_get_args());
+        return $this->initializeLazyObject()->pconnect(...\func_get_args());
     }
 
     public function persist($key): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist(...\func_get_args());
+        return $this->initializeLazyObject()->persist(...\func_get_args());
     }
 
     public function pexpire($key, $timeout, $mode = null): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire(...\func_get_args());
+        return $this->initializeLazyObject()->pexpire(...\func_get_args());
     }
 
     public function pexpireAt($key, $timestamp, $mode = null): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireAt(...\func_get_args());
+        return $this->initializeLazyObject()->pexpireAt(...\func_get_args());
     }
 
     public function pfadd($key, $elements): \Redis|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd(...\func_get_args());
+        return $this->initializeLazyObject()->pfadd(...\func_get_args());
     }
 
     public function pfcount($key_or_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount(...\func_get_args());
+        return $this->initializeLazyObject()->pfcount(...\func_get_args());
     }
 
     public function pfmerge($dst, $srckeys): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge(...\func_get_args());
+        return $this->initializeLazyObject()->pfmerge(...\func_get_args());
     }
 
     public function ping($message = null): \Redis|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping(...\func_get_args());
+        return $this->initializeLazyObject()->ping(...\func_get_args());
     }
 
     public function pipeline(): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pipeline(...\func_get_args());
+        return $this->initializeLazyObject()->pipeline(...\func_get_args());
     }
 
     public function popen($host, $port = 6379, $timeout = 0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0, $context = null): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->popen(...\func_get_args());
+        return $this->initializeLazyObject()->popen(...\func_get_args());
     }
 
     public function psetex($key, $expire, $value): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex(...\func_get_args());
+        return $this->initializeLazyObject()->psetex(...\func_get_args());
     }
 
     public function psubscribe($patterns, $cb): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->psubscribe(...\func_get_args());
     }
 
     public function pttl($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl(...\func_get_args());
+        return $this->initializeLazyObject()->pttl(...\func_get_args());
     }
 
     public function publish($channel, $message): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish(...\func_get_args());
+        return $this->initializeLazyObject()->publish(...\func_get_args());
     }
 
     public function pubsub($command, $arg = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub(...\func_get_args());
+        return $this->initializeLazyObject()->pubsub(...\func_get_args());
     }
 
     public function punsubscribe($patterns): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->punsubscribe(...\func_get_args());
     }
 
     public function rPop($key, $count = 0): \Redis|array|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPop(...\func_get_args());
+        return $this->initializeLazyObject()->rPop(...\func_get_args());
     }
 
     public function randomKey(): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomKey(...\func_get_args());
+        return $this->initializeLazyObject()->randomKey(...\func_get_args());
     }
 
     public function rawcommand($command, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawcommand(...\func_get_args());
+        return $this->initializeLazyObject()->rawcommand(...\func_get_args());
     }
 
     public function rename($old_name, $new_name): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename(...\func_get_args());
+        return $this->initializeLazyObject()->rename(...\func_get_args());
     }
 
     public function renameNx($key_src, $key_dst): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renameNx(...\func_get_args());
+        return $this->initializeLazyObject()->renameNx(...\func_get_args());
     }
 
     public function restore($key, $ttl, $value, $options = null): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore(...\func_get_args());
+        return $this->initializeLazyObject()->restore(...\func_get_args());
     }
 
     public function role(): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role(...\func_get_args());
+        return $this->initializeLazyObject()->role(...\func_get_args());
     }
 
     public function rpoplpush($srckey, $dstkey): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->rpoplpush(...\func_get_args());
     }
 
     public function sAdd($key, $value, ...$other_values): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sAdd(...\func_get_args());
+        return $this->initializeLazyObject()->sAdd(...\func_get_args());
     }
 
     public function sAddArray($key, $values): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sAddArray(...\func_get_args());
+        return $this->initializeLazyObject()->sAddArray(...\func_get_args());
     }
 
     public function sDiff($key, ...$other_keys): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sDiff(...\func_get_args());
+        return $this->initializeLazyObject()->sDiff(...\func_get_args());
     }
 
     public function sDiffStore($dst, $key, ...$other_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sDiffStore(...\func_get_args());
+        return $this->initializeLazyObject()->sDiffStore(...\func_get_args());
     }
 
     public function sInter($key, ...$other_keys): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sInter(...\func_get_args());
+        return $this->initializeLazyObject()->sInter(...\func_get_args());
     }
 
     public function sintercard($keys, $limit = -1): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sintercard(...\func_get_args());
+        return $this->initializeLazyObject()->sintercard(...\func_get_args());
     }
 
     public function sInterStore($key, ...$other_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sInterStore(...\func_get_args());
+        return $this->initializeLazyObject()->sInterStore(...\func_get_args());
     }
 
     public function sMembers($key): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMembers(...\func_get_args());
+        return $this->initializeLazyObject()->sMembers(...\func_get_args());
     }
 
     public function sMisMember($key, $member, ...$other_members): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMisMember(...\func_get_args());
+        return $this->initializeLazyObject()->sMisMember(...\func_get_args());
     }
 
     public function sMove($src, $dst, $value): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMove(...\func_get_args());
+        return $this->initializeLazyObject()->sMove(...\func_get_args());
     }
 
     public function sPop($key, $count = 0): \Redis|array|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sPop(...\func_get_args());
+        return $this->initializeLazyObject()->sPop(...\func_get_args());
     }
 
     public function sRandMember($key, $count = 0): \Redis|array|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sRandMember(...\func_get_args());
+        return $this->initializeLazyObject()->sRandMember(...\func_get_args());
     }
 
     public function sUnion($key, ...$other_keys): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sUnion(...\func_get_args());
+        return $this->initializeLazyObject()->sUnion(...\func_get_args());
     }
 
     public function sUnionStore($dst, $key, ...$other_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sUnionStore(...\func_get_args());
+        return $this->initializeLazyObject()->sUnionStore(...\func_get_args());
     }
 
     public function save(): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save(...\func_get_args());
+        return $this->initializeLazyObject()->save(...\func_get_args());
     }
 
     public function scan(&$iterator, $pattern = null, $count = 0, $type = null): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, ...\array_slice(\func_get_args(), 1));
+        return $this->initializeLazyObject()->scan($iterator, ...\array_slice(\func_get_args(), 1));
     }
 
     public function scard($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard(...\func_get_args());
+        return $this->initializeLazyObject()->scard(...\func_get_args());
     }
 
     public function script($command, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script(...\func_get_args());
+        return $this->initializeLazyObject()->script(...\func_get_args());
     }
 
     public function select($db): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->select(...\func_get_args());
+        return $this->initializeLazyObject()->select(...\func_get_args());
     }
 
     public function set($key, $value, $options = null): \Redis|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set(...\func_get_args());
+        return $this->initializeLazyObject()->set(...\func_get_args());
     }
 
     public function setBit($key, $idx, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setBit(...\func_get_args());
+        return $this->initializeLazyObject()->setBit(...\func_get_args());
     }
 
     public function setRange($key, $index, $value): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setRange(...\func_get_args());
+        return $this->initializeLazyObject()->setRange(...\func_get_args());
     }
 
     public function setOption($option, $value): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setOption(...\func_get_args());
+        return $this->initializeLazyObject()->setOption(...\func_get_args());
     }
 
     public function setex($key, $expire, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex(...\func_get_args());
+        return $this->initializeLazyObject()->setex(...\func_get_args());
     }
 
     public function setnx($key, $value): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx(...\func_get_args());
+        return $this->initializeLazyObject()->setnx(...\func_get_args());
     }
 
     public function sismember($key, $value): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember(...\func_get_args());
+        return $this->initializeLazyObject()->sismember(...\func_get_args());
     }
 
     public function slaveof($host = null, $port = 6379): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slaveof(...\func_get_args());
+        return $this->initializeLazyObject()->slaveof(...\func_get_args());
     }
 
     public function replicaof($host = null, $port = 6379): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->replicaof(...\func_get_args());
+        return $this->initializeLazyObject()->replicaof(...\func_get_args());
     }
 
     public function touch($key_or_array, ...$more_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->touch(...\func_get_args());
+        return $this->initializeLazyObject()->touch(...\func_get_args());
     }
 
     public function slowlog($operation, $length = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog(...\func_get_args());
+        return $this->initializeLazyObject()->slowlog(...\func_get_args());
     }
 
     public function sort($key, $options = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort(...\func_get_args());
+        return $this->initializeLazyObject()->sort(...\func_get_args());
     }
 
     public function sort_ro($key, $options = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort_ro(...\func_get_args());
+        return $this->initializeLazyObject()->sort_ro(...\func_get_args());
     }
 
     public function sortAsc($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortAsc(...\func_get_args());
+        return $this->initializeLazyObject()->sortAsc(...\func_get_args());
     }
 
     public function sortAscAlpha($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortAscAlpha(...\func_get_args());
+        return $this->initializeLazyObject()->sortAscAlpha(...\func_get_args());
     }
 
     public function sortDesc($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortDesc(...\func_get_args());
+        return $this->initializeLazyObject()->sortDesc(...\func_get_args());
     }
 
     public function sortDescAlpha($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortDescAlpha(...\func_get_args());
+        return $this->initializeLazyObject()->sortDescAlpha(...\func_get_args());
     }
 
     public function srem($key, $value, ...$other_values): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem(...\func_get_args());
+        return $this->initializeLazyObject()->srem(...\func_get_args());
     }
 
     public function sscan($key, &$iterator, $pattern = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function ssubscribe($channels, $cb): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ssubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->ssubscribe(...\func_get_args());
     }
 
     public function strlen($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen(...\func_get_args());
+        return $this->initializeLazyObject()->strlen(...\func_get_args());
     }
 
     public function subscribe($channels, $cb): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe(...\func_get_args());
+        return $this->initializeLazyObject()->subscribe(...\func_get_args());
     }
 
     public function sunsubscribe($channels): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->sunsubscribe(...\func_get_args());
     }
 
     public function swapdb($src, $dst): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->swapdb(...\func_get_args());
+        return $this->initializeLazyObject()->swapdb(...\func_get_args());
     }
 
     public function time(): \Redis|array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time(...\func_get_args());
+        return $this->initializeLazyObject()->time(...\func_get_args());
     }
 
     public function ttl($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl(...\func_get_args());
+        return $this->initializeLazyObject()->ttl(...\func_get_args());
     }
 
     public function type($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type(...\func_get_args());
+        return $this->initializeLazyObject()->type(...\func_get_args());
     }
 
     public function unlink($key, ...$other_keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink(...\func_get_args());
+        return $this->initializeLazyObject()->unlink(...\func_get_args());
     }
 
     public function unsubscribe($channels): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->unsubscribe(...\func_get_args());
     }
 
     public function unwatch(): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch(...\func_get_args());
+        return $this->initializeLazyObject()->unwatch(...\func_get_args());
     }
 
     public function watch($key, ...$other_keys): \Redis|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch(...\func_get_args());
+        return $this->initializeLazyObject()->watch(...\func_get_args());
     }
 
     public function wait($numreplicas, $timeout): false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->wait(...\func_get_args());
+        return $this->initializeLazyObject()->wait(...\func_get_args());
     }
 
     public function xack($key, $group, $ids): false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack(...\func_get_args());
+        return $this->initializeLazyObject()->xack(...\func_get_args());
     }
 
     public function xadd($key, $id, $values, $maxlen = 0, $approx = false, $nomkstream = false): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd(...\func_get_args());
+        return $this->initializeLazyObject()->xadd(...\func_get_args());
     }
 
     public function xautoclaim($key, $group, $consumer, $min_idle, $start, $count = -1, $justid = false): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xautoclaim(...\func_get_args());
+        return $this->initializeLazyObject()->xautoclaim(...\func_get_args());
     }
 
     public function xclaim($key, $group, $consumer, $min_idle, $ids, $options): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim(...\func_get_args());
+        return $this->initializeLazyObject()->xclaim(...\func_get_args());
     }
 
     public function xdel($key, $ids): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel(...\func_get_args());
+        return $this->initializeLazyObject()->xdel(...\func_get_args());
     }
 
     public function xgroup($operation, $key = null, $group = null, $id_or_consumer = null, $mkstream = false, $entries_read = -2): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xgroup(...\func_get_args());
     }
 
     public function xinfo($operation, $arg1 = null, $arg2 = null, $count = -1): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo(...\func_get_args());
+        return $this->initializeLazyObject()->xinfo(...\func_get_args());
     }
 
     public function xlen($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen(...\func_get_args());
+        return $this->initializeLazyObject()->xlen(...\func_get_args());
     }
 
     public function xpending($key, $group, $start = null, $end = null, $count = -1, $consumer = null): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending(...\func_get_args());
+        return $this->initializeLazyObject()->xpending(...\func_get_args());
     }
 
     public function xrange($key, $start, $end, $count = -1): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrange(...\func_get_args());
     }
 
     public function xread($streams, $count = -1, $block = -1): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread(...\func_get_args());
+        return $this->initializeLazyObject()->xread(...\func_get_args());
     }
 
     public function xreadgroup($group, $consumer, $streams, $count = 1, $block = 1): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xreadgroup(...\func_get_args());
     }
 
     public function xrevrange($key, $end, $start, $count = -1): \Redis|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrevrange(...\func_get_args());
     }
 
     public function xtrim($key, $threshold, $approx = false, $minid = false, $limit = -1): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim(...\func_get_args());
+        return $this->initializeLazyObject()->xtrim(...\func_get_args());
     }
 
     public function zAdd($key, $score_or_options, ...$more_scores_and_mems): \Redis|false|float|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zAdd(...\func_get_args());
+        return $this->initializeLazyObject()->zAdd(...\func_get_args());
     }
 
     public function zCard($key): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zCard(...\func_get_args());
+        return $this->initializeLazyObject()->zCard(...\func_get_args());
     }
 
     public function zCount($key, $start, $end): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zCount(...\func_get_args());
+        return $this->initializeLazyObject()->zCount(...\func_get_args());
     }
 
     public function zIncrBy($key, $value, $member): \Redis|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zIncrBy(...\func_get_args());
+        return $this->initializeLazyObject()->zIncrBy(...\func_get_args());
     }
 
     public function zLexCount($key, $min, $max): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zLexCount(...\func_get_args());
+        return $this->initializeLazyObject()->zLexCount(...\func_get_args());
     }
 
     public function zMscore($key, $member, ...$other_members): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zMscore(...\func_get_args());
+        return $this->initializeLazyObject()->zMscore(...\func_get_args());
     }
 
     public function zPopMax($key, $count = null): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zPopMax(...\func_get_args());
+        return $this->initializeLazyObject()->zPopMax(...\func_get_args());
     }
 
     public function zPopMin($key, $count = null): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zPopMin(...\func_get_args());
+        return $this->initializeLazyObject()->zPopMin(...\func_get_args());
     }
 
     public function zRange($key, $start, $end, $options = null): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRange(...\func_get_args());
+        return $this->initializeLazyObject()->zRange(...\func_get_args());
     }
 
     public function zRangeByLex($key, $min, $max, $offset = -1, $count = -1): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRangeByLex(...\func_get_args());
+        return $this->initializeLazyObject()->zRangeByLex(...\func_get_args());
     }
 
     public function zRangeByScore($key, $start, $end, $options = []): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRangeByScore(...\func_get_args());
+        return $this->initializeLazyObject()->zRangeByScore(...\func_get_args());
     }
 
     public function zrangestore($dstkey, $srckey, $start, $end, $options = null): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangestore(...\func_get_args());
+        return $this->initializeLazyObject()->zrangestore(...\func_get_args());
     }
 
     public function zRandMember($key, $options = null): \Redis|array|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRandMember(...\func_get_args());
+        return $this->initializeLazyObject()->zRandMember(...\func_get_args());
     }
 
     public function zRank($key, $member): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRank(...\func_get_args());
+        return $this->initializeLazyObject()->zRank(...\func_get_args());
     }
 
     public function zRem($key, $member, ...$other_members): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRem(...\func_get_args());
+        return $this->initializeLazyObject()->zRem(...\func_get_args());
     }
 
     public function zRemRangeByLex($key, $min, $max): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByLex(...\func_get_args());
+        return $this->initializeLazyObject()->zRemRangeByLex(...\func_get_args());
     }
 
     public function zRemRangeByRank($key, $start, $end): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByRank(...\func_get_args());
+        return $this->initializeLazyObject()->zRemRangeByRank(...\func_get_args());
     }
 
     public function zRemRangeByScore($key, $start, $end): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByScore(...\func_get_args());
+        return $this->initializeLazyObject()->zRemRangeByScore(...\func_get_args());
     }
 
     public function zRevRange($key, $start, $end, $scores = null): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRange(...\func_get_args());
+        return $this->initializeLazyObject()->zRevRange(...\func_get_args());
     }
 
     public function zRevRangeByLex($key, $max, $min, $offset = -1, $count = -1): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRangeByLex(...\func_get_args());
+        return $this->initializeLazyObject()->zRevRangeByLex(...\func_get_args());
     }
 
     public function zRevRangeByScore($key, $max, $min, $options = []): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRangeByScore(...\func_get_args());
+        return $this->initializeLazyObject()->zRevRangeByScore(...\func_get_args());
     }
 
     public function zRevRank($key, $member): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRank(...\func_get_args());
+        return $this->initializeLazyObject()->zRevRank(...\func_get_args());
     }
 
     public function zScore($key, $member): \Redis|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zScore(...\func_get_args());
+        return $this->initializeLazyObject()->zScore(...\func_get_args());
     }
 
     public function zdiff($keys, $options = null): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiff(...\func_get_args());
+        return $this->initializeLazyObject()->zdiff(...\func_get_args());
     }
 
     public function zdiffstore($dst, $keys): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiffstore(...\func_get_args());
+        return $this->initializeLazyObject()->zdiffstore(...\func_get_args());
     }
 
     public function zinter($keys, $weights = null, $options = null): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinter(...\func_get_args());
+        return $this->initializeLazyObject()->zinter(...\func_get_args());
     }
 
     public function zintercard($keys, $limit = -1): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zintercard(...\func_get_args());
+        return $this->initializeLazyObject()->zintercard(...\func_get_args());
     }
 
     public function zinterstore($dst, $keys, $weights = null, $aggregate = null): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore(...\func_get_args());
+        return $this->initializeLazyObject()->zinterstore(...\func_get_args());
     }
 
     public function zscan($key, &$iterator, $pattern = null, $count = 0): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function zunion($keys, $weights = null, $options = null): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunion(...\func_get_args());
+        return $this->initializeLazyObject()->zunion(...\func_get_args());
     }
 
     public function zunionstore($dst, $keys, $weights = null, $aggregate = null): \Redis|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore(...\func_get_args());
+        return $this->initializeLazyObject()->zunionstore(...\func_get_args());
     }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Cache\Traits;
 
 use Symfony\Component\VarExporter\LazyObjectInterface;
-use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Contracts\Service\ResetInterface;
 
 // Help opcache.preload discover always-needed symbols
@@ -25,959 +24,957 @@ class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
  */
 class RedisCluster5Proxy extends \RedisCluster implements ResetInterface, LazyObjectInterface
 {
-    use LazyProxyTrait {
+    use RedisProxyTrait {
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
-
     public function __construct($name, $seeds = null, $timeout = null, $read_timeout = null, $persistent = null, #[\SensitiveParameter] $auth = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        $this->initializeLazyObject()->__construct(...\func_get_args());
     }
 
     public function _masters()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_masters(...\func_get_args());
+        return $this->initializeLazyObject()->_masters(...\func_get_args());
     }
 
     public function _prefix($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix(...\func_get_args());
+        return $this->initializeLazyObject()->_prefix(...\func_get_args());
     }
 
     public function _redir()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_redir(...\func_get_args());
+        return $this->initializeLazyObject()->_redir(...\func_get_args());
     }
 
     public function _serialize($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize(...\func_get_args());
+        return $this->initializeLazyObject()->_serialize(...\func_get_args());
     }
 
     public function _unserialize($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize(...\func_get_args());
+        return $this->initializeLazyObject()->_unserialize(...\func_get_args());
     }
 
     public function _compress($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress(...\func_get_args());
+        return $this->initializeLazyObject()->_compress(...\func_get_args());
     }
 
     public function _uncompress($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress(...\func_get_args());
+        return $this->initializeLazyObject()->_uncompress(...\func_get_args());
     }
 
     public function _pack($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack(...\func_get_args());
+        return $this->initializeLazyObject()->_pack(...\func_get_args());
     }
 
     public function _unpack($value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack(...\func_get_args());
+        return $this->initializeLazyObject()->_unpack(...\func_get_args());
     }
 
     public function acl($key_or_address, $subcmd, ...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl(...\func_get_args());
+        return $this->initializeLazyObject()->acl(...\func_get_args());
     }
 
     public function append($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append(...\func_get_args());
+        return $this->initializeLazyObject()->append(...\func_get_args());
     }
 
     public function bgrewriteaof($key_or_address)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof(...\func_get_args());
+        return $this->initializeLazyObject()->bgrewriteaof(...\func_get_args());
     }
 
     public function bgsave($key_or_address)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgsave(...\func_get_args());
+        return $this->initializeLazyObject()->bgsave(...\func_get_args());
     }
 
     public function bitcount($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount(...\func_get_args());
+        return $this->initializeLazyObject()->bitcount(...\func_get_args());
     }
 
     public function bitop($operation, $ret_key, $key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop(...\func_get_args());
+        return $this->initializeLazyObject()->bitop(...\func_get_args());
     }
 
     public function bitpos($key, $bit, $start = null, $end = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos(...\func_get_args());
+        return $this->initializeLazyObject()->bitpos(...\func_get_args());
     }
 
     public function blpop($key, $timeout_or_key, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blpop(...\func_get_args());
+        return $this->initializeLazyObject()->blpop(...\func_get_args());
     }
 
     public function brpop($key, $timeout_or_key, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpop(...\func_get_args());
+        return $this->initializeLazyObject()->brpop(...\func_get_args());
     }
 
     public function brpoplpush($src, $dst, $timeout)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->brpoplpush(...\func_get_args());
     }
 
     public function clearlasterror()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearlasterror(...\func_get_args());
+        return $this->initializeLazyObject()->clearlasterror(...\func_get_args());
     }
 
     public function bzpopmax($key, $timeout_or_key, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmax(...\func_get_args());
+        return $this->initializeLazyObject()->bzpopmax(...\func_get_args());
     }
 
     public function bzpopmin($key, $timeout_or_key, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmin(...\func_get_args());
+        return $this->initializeLazyObject()->bzpopmin(...\func_get_args());
     }
 
     public function client($key_or_address, $arg = null, ...$other_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client(...\func_get_args());
+        return $this->initializeLazyObject()->client(...\func_get_args());
     }
 
     public function close()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close(...\func_get_args());
+        return $this->initializeLazyObject()->close(...\func_get_args());
     }
 
     public function cluster($key_or_address, $arg = null, ...$other_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->cluster(...\func_get_args());
+        return $this->initializeLazyObject()->cluster(...\func_get_args());
     }
 
     public function command(...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command(...\func_get_args());
+        return $this->initializeLazyObject()->command(...\func_get_args());
     }
 
     public function config($key_or_address, $arg = null, ...$other_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config(...\func_get_args());
+        return $this->initializeLazyObject()->config(...\func_get_args());
     }
 
     public function dbsize($key_or_address)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbsize(...\func_get_args());
+        return $this->initializeLazyObject()->dbsize(...\func_get_args());
     }
 
     public function decr($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr(...\func_get_args());
+        return $this->initializeLazyObject()->decr(...\func_get_args());
     }
 
     public function decrby($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrby(...\func_get_args());
+        return $this->initializeLazyObject()->decrby(...\func_get_args());
     }
 
     public function del($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del(...\func_get_args());
+        return $this->initializeLazyObject()->del(...\func_get_args());
     }
 
     public function discard()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard(...\func_get_args());
+        return $this->initializeLazyObject()->discard(...\func_get_args());
     }
 
     public function dump($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump(...\func_get_args());
+        return $this->initializeLazyObject()->dump(...\func_get_args());
     }
 
     public function echo($msg)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo(...\func_get_args());
+        return $this->initializeLazyObject()->echo(...\func_get_args());
     }
 
     public function eval($script, $args = null, $num_keys = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval(...\func_get_args());
+        return $this->initializeLazyObject()->eval(...\func_get_args());
     }
 
     public function evalsha($script_sha, $args = null, $num_keys = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha(...\func_get_args());
+        return $this->initializeLazyObject()->evalsha(...\func_get_args());
     }
 
     public function exec()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec(...\func_get_args());
+        return $this->initializeLazyObject()->exec(...\func_get_args());
     }
 
     public function exists($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists(...\func_get_args());
+        return $this->initializeLazyObject()->exists(...\func_get_args());
     }
 
     public function expire($key, $timeout)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire(...\func_get_args());
+        return $this->initializeLazyObject()->expire(...\func_get_args());
     }
 
     public function expireat($key, $timestamp)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireat(...\func_get_args());
+        return $this->initializeLazyObject()->expireat(...\func_get_args());
     }
 
     public function flushall($key_or_address, $async = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushall(...\func_get_args());
+        return $this->initializeLazyObject()->flushall(...\func_get_args());
     }
 
     public function flushdb($key_or_address, $async = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushdb(...\func_get_args());
+        return $this->initializeLazyObject()->flushdb(...\func_get_args());
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd(...\func_get_args());
+        return $this->initializeLazyObject()->geoadd(...\func_get_args());
     }
 
     public function geodist($key, $src, $dst, $unit = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist(...\func_get_args());
+        return $this->initializeLazyObject()->geodist(...\func_get_args());
     }
 
     public function geohash($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash(...\func_get_args());
+        return $this->initializeLazyObject()->geohash(...\func_get_args());
     }
 
     public function geopos($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos(...\func_get_args());
+        return $this->initializeLazyObject()->geopos(...\func_get_args());
     }
 
     public function georadius($key, $lng, $lan, $radius, $unit, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius(...\func_get_args());
+        return $this->initializeLazyObject()->georadius(...\func_get_args());
     }
 
     public function georadius_ro($key, $lng, $lan, $radius, $unit, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadius_ro(...\func_get_args());
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember(...\func_get_args());
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember_ro(...\func_get_args());
     }
 
     public function get($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get(...\func_get_args());
+        return $this->initializeLazyObject()->get(...\func_get_args());
     }
 
     public function getbit($key, $offset)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getbit(...\func_get_args());
+        return $this->initializeLazyObject()->getbit(...\func_get_args());
     }
 
     public function getlasterror()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getlasterror(...\func_get_args());
+        return $this->initializeLazyObject()->getlasterror(...\func_get_args());
     }
 
     public function getmode()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getmode(...\func_get_args());
+        return $this->initializeLazyObject()->getmode(...\func_get_args());
     }
 
     public function getoption($option)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getoption(...\func_get_args());
+        return $this->initializeLazyObject()->getoption(...\func_get_args());
     }
 
     public function getrange($key, $start, $end)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getrange(...\func_get_args());
+        return $this->initializeLazyObject()->getrange(...\func_get_args());
     }
 
     public function getset($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getset(...\func_get_args());
+        return $this->initializeLazyObject()->getset(...\func_get_args());
     }
 
     public function hdel($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hdel(...\func_get_args());
+        return $this->initializeLazyObject()->hdel(...\func_get_args());
     }
 
     public function hexists($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hexists(...\func_get_args());
+        return $this->initializeLazyObject()->hexists(...\func_get_args());
     }
 
     public function hget($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hget(...\func_get_args());
+        return $this->initializeLazyObject()->hget(...\func_get_args());
     }
 
     public function hgetall($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hgetall(...\func_get_args());
+        return $this->initializeLazyObject()->hgetall(...\func_get_args());
     }
 
     public function hincrby($key, $member, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrby(...\func_get_args());
+        return $this->initializeLazyObject()->hincrby(...\func_get_args());
     }
 
     public function hincrbyfloat($key, $member, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrbyfloat(...\func_get_args());
+        return $this->initializeLazyObject()->hincrbyfloat(...\func_get_args());
     }
 
     public function hkeys($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hkeys(...\func_get_args());
+        return $this->initializeLazyObject()->hkeys(...\func_get_args());
     }
 
     public function hlen($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hlen(...\func_get_args());
+        return $this->initializeLazyObject()->hlen(...\func_get_args());
     }
 
     public function hmget($key, $keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmget(...\func_get_args());
+        return $this->initializeLazyObject()->hmget(...\func_get_args());
     }
 
     public function hmset($key, $pairs)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmset(...\func_get_args());
+        return $this->initializeLazyObject()->hmset(...\func_get_args());
     }
 
     public function hscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->hscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function hset($key, $member, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hset(...\func_get_args());
+        return $this->initializeLazyObject()->hset(...\func_get_args());
     }
 
     public function hsetnx($key, $member, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hsetnx(...\func_get_args());
+        return $this->initializeLazyObject()->hsetnx(...\func_get_args());
     }
 
     public function hstrlen($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hstrlen(...\func_get_args());
+        return $this->initializeLazyObject()->hstrlen(...\func_get_args());
     }
 
     public function hvals($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hvals(...\func_get_args());
+        return $this->initializeLazyObject()->hvals(...\func_get_args());
     }
 
     public function incr($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr(...\func_get_args());
+        return $this->initializeLazyObject()->incr(...\func_get_args());
     }
 
     public function incrby($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrby(...\func_get_args());
+        return $this->initializeLazyObject()->incrby(...\func_get_args());
     }
 
     public function incrbyfloat($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrbyfloat(...\func_get_args());
+        return $this->initializeLazyObject()->incrbyfloat(...\func_get_args());
     }
 
     public function info($key_or_address, $option = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info(...\func_get_args());
+        return $this->initializeLazyObject()->info(...\func_get_args());
     }
 
     public function keys($pattern)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys(...\func_get_args());
+        return $this->initializeLazyObject()->keys(...\func_get_args());
     }
 
     public function lastsave($key_or_address)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastsave(...\func_get_args());
+        return $this->initializeLazyObject()->lastsave(...\func_get_args());
     }
 
     public function lget($key, $index)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lget(...\func_get_args());
+        return $this->initializeLazyObject()->lget(...\func_get_args());
     }
 
     public function lindex($key, $index)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex(...\func_get_args());
+        return $this->initializeLazyObject()->lindex(...\func_get_args());
     }
 
     public function linsert($key, $position, $pivot, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->linsert(...\func_get_args());
+        return $this->initializeLazyObject()->linsert(...\func_get_args());
     }
 
     public function llen($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->llen(...\func_get_args());
+        return $this->initializeLazyObject()->llen(...\func_get_args());
     }
 
     public function lpop($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpop(...\func_get_args());
+        return $this->initializeLazyObject()->lpop(...\func_get_args());
     }
 
     public function lpush($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpush(...\func_get_args());
+        return $this->initializeLazyObject()->lpush(...\func_get_args());
     }
 
     public function lpushx($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpushx(...\func_get_args());
+        return $this->initializeLazyObject()->lpushx(...\func_get_args());
     }
 
     public function lrange($key, $start, $end)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange(...\func_get_args());
+        return $this->initializeLazyObject()->lrange(...\func_get_args());
     }
 
     public function lrem($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem(...\func_get_args());
+        return $this->initializeLazyObject()->lrem(...\func_get_args());
     }
 
     public function lset($key, $index, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lset(...\func_get_args());
+        return $this->initializeLazyObject()->lset(...\func_get_args());
     }
 
     public function ltrim($key, $start, $stop)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim(...\func_get_args());
+        return $this->initializeLazyObject()->ltrim(...\func_get_args());
     }
 
     public function mget($keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget(...\func_get_args());
+        return $this->initializeLazyObject()->mget(...\func_get_args());
     }
 
     public function mset($pairs)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset(...\func_get_args());
+        return $this->initializeLazyObject()->mset(...\func_get_args());
     }
 
     public function msetnx($pairs)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx(...\func_get_args());
+        return $this->initializeLazyObject()->msetnx(...\func_get_args());
     }
 
     public function multi()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi(...\func_get_args());
+        return $this->initializeLazyObject()->multi(...\func_get_args());
     }
 
     public function object($field, $key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object(...\func_get_args());
+        return $this->initializeLazyObject()->object(...\func_get_args());
     }
 
     public function persist($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist(...\func_get_args());
+        return $this->initializeLazyObject()->persist(...\func_get_args());
     }
 
     public function pexpire($key, $timestamp)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire(...\func_get_args());
+        return $this->initializeLazyObject()->pexpire(...\func_get_args());
     }
 
     public function pexpireat($key, $timestamp)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireat(...\func_get_args());
+        return $this->initializeLazyObject()->pexpireat(...\func_get_args());
     }
 
     public function pfadd($key, $elements)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd(...\func_get_args());
+        return $this->initializeLazyObject()->pfadd(...\func_get_args());
     }
 
     public function pfcount($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount(...\func_get_args());
+        return $this->initializeLazyObject()->pfcount(...\func_get_args());
     }
 
     public function pfmerge($dstkey, $keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge(...\func_get_args());
+        return $this->initializeLazyObject()->pfmerge(...\func_get_args());
     }
 
     public function ping($key_or_address)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping(...\func_get_args());
+        return $this->initializeLazyObject()->ping(...\func_get_args());
     }
 
     public function psetex($key, $expire, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex(...\func_get_args());
+        return $this->initializeLazyObject()->psetex(...\func_get_args());
     }
 
     public function psubscribe($patterns, $callback)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->psubscribe(...\func_get_args());
     }
 
     public function pttl($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl(...\func_get_args());
+        return $this->initializeLazyObject()->pttl(...\func_get_args());
     }
 
     public function publish($channel, $message)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish(...\func_get_args());
+        return $this->initializeLazyObject()->publish(...\func_get_args());
     }
 
     public function pubsub($key_or_address, $arg = null, ...$other_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub(...\func_get_args());
+        return $this->initializeLazyObject()->pubsub(...\func_get_args());
     }
 
     public function punsubscribe($pattern, ...$other_patterns)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->punsubscribe(...\func_get_args());
     }
 
     public function randomkey($key_or_address)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomkey(...\func_get_args());
+        return $this->initializeLazyObject()->randomkey(...\func_get_args());
     }
 
     public function rawcommand($cmd, ...$args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawcommand(...\func_get_args());
+        return $this->initializeLazyObject()->rawcommand(...\func_get_args());
     }
 
     public function rename($key, $newkey)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename(...\func_get_args());
+        return $this->initializeLazyObject()->rename(...\func_get_args());
     }
 
     public function renamenx($key, $newkey)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renamenx(...\func_get_args());
+        return $this->initializeLazyObject()->renamenx(...\func_get_args());
     }
 
     public function restore($ttl, $key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore(...\func_get_args());
+        return $this->initializeLazyObject()->restore(...\func_get_args());
     }
 
     public function role()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role(...\func_get_args());
+        return $this->initializeLazyObject()->role(...\func_get_args());
     }
 
     public function rpop($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpop(...\func_get_args());
+        return $this->initializeLazyObject()->rpop(...\func_get_args());
     }
 
     public function rpoplpush($src, $dst)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->rpoplpush(...\func_get_args());
     }
 
     public function rpush($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpush(...\func_get_args());
+        return $this->initializeLazyObject()->rpush(...\func_get_args());
     }
 
     public function rpushx($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpushx(...\func_get_args());
+        return $this->initializeLazyObject()->rpushx(...\func_get_args());
     }
 
     public function sadd($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sadd(...\func_get_args());
+        return $this->initializeLazyObject()->sadd(...\func_get_args());
     }
 
     public function saddarray($key, $options)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->saddarray(...\func_get_args());
+        return $this->initializeLazyObject()->saddarray(...\func_get_args());
     }
 
     public function save($key_or_address)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save(...\func_get_args());
+        return $this->initializeLazyObject()->save(...\func_get_args());
     }
 
     public function scan(&$i_iterator, $str_node, $str_pattern = null, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($i_iterator, ...\array_slice(\func_get_args(), 1));
+        return $this->initializeLazyObject()->scan($i_iterator, ...\array_slice(\func_get_args(), 1));
     }
 
     public function scard($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard(...\func_get_args());
+        return $this->initializeLazyObject()->scard(...\func_get_args());
     }
 
     public function script($key_or_address, $arg = null, ...$other_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script(...\func_get_args());
+        return $this->initializeLazyObject()->script(...\func_get_args());
     }
 
     public function sdiff($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiff(...\func_get_args());
+        return $this->initializeLazyObject()->sdiff(...\func_get_args());
     }
 
     public function sdiffstore($dst, $key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiffstore(...\func_get_args());
+        return $this->initializeLazyObject()->sdiffstore(...\func_get_args());
     }
 
     public function set($key, $value, $opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set(...\func_get_args());
+        return $this->initializeLazyObject()->set(...\func_get_args());
     }
 
     public function setbit($key, $offset, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setbit(...\func_get_args());
+        return $this->initializeLazyObject()->setbit(...\func_get_args());
     }
 
     public function setex($key, $expire, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex(...\func_get_args());
+        return $this->initializeLazyObject()->setex(...\func_get_args());
     }
 
     public function setnx($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx(...\func_get_args());
+        return $this->initializeLazyObject()->setnx(...\func_get_args());
     }
 
     public function setoption($option, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setoption(...\func_get_args());
+        return $this->initializeLazyObject()->setoption(...\func_get_args());
     }
 
     public function setrange($key, $offset, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setrange(...\func_get_args());
+        return $this->initializeLazyObject()->setrange(...\func_get_args());
     }
 
     public function sinter($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinter(...\func_get_args());
+        return $this->initializeLazyObject()->sinter(...\func_get_args());
     }
 
     public function sinterstore($dst, $key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinterstore(...\func_get_args());
+        return $this->initializeLazyObject()->sinterstore(...\func_get_args());
     }
 
     public function sismember($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember(...\func_get_args());
+        return $this->initializeLazyObject()->sismember(...\func_get_args());
     }
 
     public function slowlog($key_or_address, $arg = null, ...$other_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog(...\func_get_args());
+        return $this->initializeLazyObject()->slowlog(...\func_get_args());
     }
 
     public function smembers($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smembers(...\func_get_args());
+        return $this->initializeLazyObject()->smembers(...\func_get_args());
     }
 
     public function smove($src, $dst, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smove(...\func_get_args());
+        return $this->initializeLazyObject()->smove(...\func_get_args());
     }
 
     public function sort($key, $options = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort(...\func_get_args());
+        return $this->initializeLazyObject()->sort(...\func_get_args());
     }
 
     public function spop($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->spop(...\func_get_args());
+        return $this->initializeLazyObject()->spop(...\func_get_args());
     }
 
     public function srandmember($key, $count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srandmember(...\func_get_args());
+        return $this->initializeLazyObject()->srandmember(...\func_get_args());
     }
 
     public function srem($key, $value)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem(...\func_get_args());
+        return $this->initializeLazyObject()->srem(...\func_get_args());
     }
 
     public function sscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->sscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function strlen($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen(...\func_get_args());
+        return $this->initializeLazyObject()->strlen(...\func_get_args());
     }
 
     public function subscribe($channels, $callback)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe(...\func_get_args());
+        return $this->initializeLazyObject()->subscribe(...\func_get_args());
     }
 
     public function sunion($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunion(...\func_get_args());
+        return $this->initializeLazyObject()->sunion(...\func_get_args());
     }
 
     public function sunionstore($dst, $key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunionstore(...\func_get_args());
+        return $this->initializeLazyObject()->sunionstore(...\func_get_args());
     }
 
     public function time()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time(...\func_get_args());
+        return $this->initializeLazyObject()->time(...\func_get_args());
     }
 
     public function ttl($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl(...\func_get_args());
+        return $this->initializeLazyObject()->ttl(...\func_get_args());
     }
 
     public function type($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type(...\func_get_args());
+        return $this->initializeLazyObject()->type(...\func_get_args());
     }
 
     public function unsubscribe($channel, ...$other_channels)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->unsubscribe(...\func_get_args());
     }
 
     public function unlink($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink(...\func_get_args());
+        return $this->initializeLazyObject()->unlink(...\func_get_args());
     }
 
     public function unwatch()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch(...\func_get_args());
+        return $this->initializeLazyObject()->unwatch(...\func_get_args());
     }
 
     public function watch($key, ...$other_keys)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch(...\func_get_args());
+        return $this->initializeLazyObject()->watch(...\func_get_args());
     }
 
     public function xack($str_key, $str_group, $arr_ids)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack(...\func_get_args());
+        return $this->initializeLazyObject()->xack(...\func_get_args());
     }
 
     public function xadd($str_key, $str_id, $arr_fields, $i_maxlen = null, $boo_approximate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd(...\func_get_args());
+        return $this->initializeLazyObject()->xadd(...\func_get_args());
     }
 
     public function xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim(...\func_get_args());
+        return $this->initializeLazyObject()->xclaim(...\func_get_args());
     }
 
     public function xdel($str_key, $arr_ids)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel(...\func_get_args());
+        return $this->initializeLazyObject()->xdel(...\func_get_args());
     }
 
     public function xgroup($str_operation, $str_key = null, $str_arg1 = null, $str_arg2 = null, $str_arg3 = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xgroup(...\func_get_args());
     }
 
     public function xinfo($str_cmd, $str_key = null, $str_group = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo(...\func_get_args());
+        return $this->initializeLazyObject()->xinfo(...\func_get_args());
     }
 
     public function xlen($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen(...\func_get_args());
+        return $this->initializeLazyObject()->xlen(...\func_get_args());
     }
 
     public function xpending($str_key, $str_group, $str_start = null, $str_end = null, $i_count = null, $str_consumer = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending(...\func_get_args());
+        return $this->initializeLazyObject()->xpending(...\func_get_args());
     }
 
     public function xrange($str_key, $str_start, $str_end, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrange(...\func_get_args());
     }
 
     public function xread($arr_streams, $i_count = null, $i_block = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread(...\func_get_args());
+        return $this->initializeLazyObject()->xread(...\func_get_args());
     }
 
     public function xreadgroup($str_group, $str_consumer, $arr_streams, $i_count = null, $i_block = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xreadgroup(...\func_get_args());
     }
 
     public function xrevrange($str_key, $str_start, $str_end, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrevrange(...\func_get_args());
     }
 
     public function xtrim($str_key, $i_maxlen, $boo_approximate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim(...\func_get_args());
+        return $this->initializeLazyObject()->xtrim(...\func_get_args());
     }
 
     public function zadd($key, $score, $value, ...$extra_args)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zadd(...\func_get_args());
+        return $this->initializeLazyObject()->zadd(...\func_get_args());
     }
 
     public function zcard($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcard(...\func_get_args());
+        return $this->initializeLazyObject()->zcard(...\func_get_args());
     }
 
     public function zcount($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcount(...\func_get_args());
+        return $this->initializeLazyObject()->zcount(...\func_get_args());
     }
 
     public function zincrby($key, $value, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zincrby(...\func_get_args());
+        return $this->initializeLazyObject()->zincrby(...\func_get_args());
     }
 
     public function zinterstore($key, $keys, $weights = null, $aggregate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore(...\func_get_args());
+        return $this->initializeLazyObject()->zinterstore(...\func_get_args());
     }
 
     public function zlexcount($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zlexcount(...\func_get_args());
+        return $this->initializeLazyObject()->zlexcount(...\func_get_args());
     }
 
     public function zpopmax($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmax(...\func_get_args());
+        return $this->initializeLazyObject()->zpopmax(...\func_get_args());
     }
 
     public function zpopmin($key)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmin(...\func_get_args());
+        return $this->initializeLazyObject()->zpopmin(...\func_get_args());
     }
 
     public function zrange($key, $start, $end, $scores = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrange(...\func_get_args());
+        return $this->initializeLazyObject()->zrange(...\func_get_args());
     }
 
     public function zrangebylex($key, $min, $max, $offset = null, $limit = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zrangebylex(...\func_get_args());
     }
 
     public function zrangebyscore($key, $start, $end, $options = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zrangebyscore(...\func_get_args());
     }
 
     public function zrank($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrank(...\func_get_args());
+        return $this->initializeLazyObject()->zrank(...\func_get_args());
     }
 
     public function zrem($key, $member, ...$other_members)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrem(...\func_get_args());
+        return $this->initializeLazyObject()->zrem(...\func_get_args());
     }
 
     public function zremrangebylex($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebylex(...\func_get_args());
     }
 
     public function zremrangebyrank($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyrank(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebyrank(...\func_get_args());
     }
 
     public function zremrangebyscore($key, $min, $max)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebyscore(...\func_get_args());
     }
 
     public function zrevrange($key, $start, $end, $scores = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrange(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrange(...\func_get_args());
     }
 
     public function zrevrangebylex($key, $min, $max, $offset = null, $limit = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrangebylex(...\func_get_args());
     }
 
     public function zrevrangebyscore($key, $start, $end, $options = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrangebyscore(...\func_get_args());
     }
 
     public function zrevrank($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrank(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrank(...\func_get_args());
     }
 
     public function zscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->zscan($str_key, $i_iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function zscore($key, $member)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscore(...\func_get_args());
+        return $this->initializeLazyObject()->zscore(...\func_get_args());
     }
 
     public function zunionstore($key, $keys, $weights = null, $aggregate = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore(...\func_get_args());
+        return $this->initializeLazyObject()->zunionstore(...\func_get_args());
     }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Cache\Traits;
 
 use Symfony\Component\VarExporter\LazyObjectInterface;
-use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Contracts\Service\ResetInterface;
 
 // Help opcache.preload discover always-needed symbols
@@ -25,1119 +24,1117 @@ class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
  */
 class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyObjectInterface
 {
-    use LazyProxyTrait {
+    use RedisProxyTrait {
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
-
     public function __construct($name, $seeds = null, $timeout = 0, $read_timeout = 0, $persistent = false, #[\SensitiveParameter] $auth = null, $context = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        $this->initializeLazyObject()->__construct(...\func_get_args());
     }
 
     public function _compress($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress(...\func_get_args());
+        return $this->initializeLazyObject()->_compress(...\func_get_args());
     }
 
     public function _uncompress($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress(...\func_get_args());
+        return $this->initializeLazyObject()->_uncompress(...\func_get_args());
     }
 
     public function _serialize($value): bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize(...\func_get_args());
+        return $this->initializeLazyObject()->_serialize(...\func_get_args());
     }
 
     public function _unserialize($value): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize(...\func_get_args());
+        return $this->initializeLazyObject()->_unserialize(...\func_get_args());
     }
 
     public function _pack($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack(...\func_get_args());
+        return $this->initializeLazyObject()->_pack(...\func_get_args());
     }
 
     public function _unpack($value): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack(...\func_get_args());
+        return $this->initializeLazyObject()->_unpack(...\func_get_args());
     }
 
     public function _prefix($key): bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix(...\func_get_args());
+        return $this->initializeLazyObject()->_prefix(...\func_get_args());
     }
 
     public function _masters(): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_masters(...\func_get_args());
+        return $this->initializeLazyObject()->_masters(...\func_get_args());
     }
 
     public function _redir(): ?string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_redir(...\func_get_args());
+        return $this->initializeLazyObject()->_redir(...\func_get_args());
     }
 
     public function acl($key_or_address, $subcmd, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl(...\func_get_args());
+        return $this->initializeLazyObject()->acl(...\func_get_args());
     }
 
     public function append($key, $value): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append(...\func_get_args());
+        return $this->initializeLazyObject()->append(...\func_get_args());
     }
 
     public function bgrewriteaof($key_or_address): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof(...\func_get_args());
+        return $this->initializeLazyObject()->bgrewriteaof(...\func_get_args());
     }
 
     public function bgsave($key_or_address): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgsave(...\func_get_args());
+        return $this->initializeLazyObject()->bgsave(...\func_get_args());
     }
 
     public function bitcount($key, $start = 0, $end = -1, $bybit = false): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount(...\func_get_args());
+        return $this->initializeLazyObject()->bitcount(...\func_get_args());
     }
 
     public function bitop($operation, $deskey, $srckey, ...$otherkeys): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop(...\func_get_args());
+        return $this->initializeLazyObject()->bitop(...\func_get_args());
     }
 
     public function bitpos($key, $bit, $start = 0, $end = -1, $bybit = false): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos(...\func_get_args());
+        return $this->initializeLazyObject()->bitpos(...\func_get_args());
     }
 
     public function blpop($key, $timeout_or_key, ...$extra_args): \RedisCluster|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blpop(...\func_get_args());
+        return $this->initializeLazyObject()->blpop(...\func_get_args());
     }
 
     public function brpop($key, $timeout_or_key, ...$extra_args): \RedisCluster|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpop(...\func_get_args());
+        return $this->initializeLazyObject()->brpop(...\func_get_args());
     }
 
     public function brpoplpush($srckey, $deskey, $timeout): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->brpoplpush(...\func_get_args());
     }
 
     public function lmove($src, $dst, $wherefrom, $whereto): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmove(...\func_get_args());
+        return $this->initializeLazyObject()->lmove(...\func_get_args());
     }
 
     public function blmove($src, $dst, $wherefrom, $whereto, $timeout): \Redis|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmove(...\func_get_args());
+        return $this->initializeLazyObject()->blmove(...\func_get_args());
     }
 
     public function bzpopmax($key, $timeout_or_key, ...$extra_args): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmax(...\func_get_args());
+        return $this->initializeLazyObject()->bzpopmax(...\func_get_args());
     }
 
     public function bzpopmin($key, $timeout_or_key, ...$extra_args): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmin(...\func_get_args());
+        return $this->initializeLazyObject()->bzpopmin(...\func_get_args());
     }
 
     public function bzmpop($timeout, $keys, $from, $count = 1): \RedisCluster|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzmpop(...\func_get_args());
+        return $this->initializeLazyObject()->bzmpop(...\func_get_args());
     }
 
     public function zmpop($keys, $from, $count = 1): \RedisCluster|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zmpop(...\func_get_args());
+        return $this->initializeLazyObject()->zmpop(...\func_get_args());
     }
 
     public function blmpop($timeout, $keys, $from, $count = 1): \RedisCluster|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmpop(...\func_get_args());
+        return $this->initializeLazyObject()->blmpop(...\func_get_args());
     }
 
     public function lmpop($keys, $from, $count = 1): \RedisCluster|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmpop(...\func_get_args());
+        return $this->initializeLazyObject()->lmpop(...\func_get_args());
     }
 
     public function clearlasterror(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearlasterror(...\func_get_args());
+        return $this->initializeLazyObject()->clearlasterror(...\func_get_args());
     }
 
     public function client($key_or_address, $subcommand, $arg = null): array|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client(...\func_get_args());
+        return $this->initializeLazyObject()->client(...\func_get_args());
     }
 
     public function close(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close(...\func_get_args());
+        return $this->initializeLazyObject()->close(...\func_get_args());
     }
 
     public function cluster($key_or_address, $command, ...$extra_args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->cluster(...\func_get_args());
+        return $this->initializeLazyObject()->cluster(...\func_get_args());
     }
 
     public function command(...$extra_args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command(...\func_get_args());
+        return $this->initializeLazyObject()->command(...\func_get_args());
     }
 
     public function config($key_or_address, $subcommand, ...$extra_args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config(...\func_get_args());
+        return $this->initializeLazyObject()->config(...\func_get_args());
     }
 
     public function dbsize($key_or_address): \RedisCluster|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbsize(...\func_get_args());
+        return $this->initializeLazyObject()->dbsize(...\func_get_args());
     }
 
     public function copy($src, $dst, $options = null): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->copy(...\func_get_args());
+        return $this->initializeLazyObject()->copy(...\func_get_args());
     }
 
     public function decr($key, $by = 1): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr(...\func_get_args());
+        return $this->initializeLazyObject()->decr(...\func_get_args());
     }
 
     public function decrby($key, $value): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrby(...\func_get_args());
+        return $this->initializeLazyObject()->decrby(...\func_get_args());
     }
 
     public function decrbyfloat($key, $value): float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrbyfloat(...\func_get_args());
+        return $this->initializeLazyObject()->decrbyfloat(...\func_get_args());
     }
 
     public function del($key, ...$other_keys): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del(...\func_get_args());
+        return $this->initializeLazyObject()->del(...\func_get_args());
     }
 
     public function discard(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard(...\func_get_args());
+        return $this->initializeLazyObject()->discard(...\func_get_args());
     }
 
     public function dump($key): \RedisCluster|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump(...\func_get_args());
+        return $this->initializeLazyObject()->dump(...\func_get_args());
     }
 
     public function echo($key_or_address, $msg): \RedisCluster|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo(...\func_get_args());
+        return $this->initializeLazyObject()->echo(...\func_get_args());
     }
 
     public function eval($script, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval(...\func_get_args());
+        return $this->initializeLazyObject()->eval(...\func_get_args());
     }
 
     public function eval_ro($script, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval_ro(...\func_get_args());
+        return $this->initializeLazyObject()->eval_ro(...\func_get_args());
     }
 
     public function evalsha($script_sha, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha(...\func_get_args());
+        return $this->initializeLazyObject()->evalsha(...\func_get_args());
     }
 
     public function evalsha_ro($script_sha, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha_ro(...\func_get_args());
+        return $this->initializeLazyObject()->evalsha_ro(...\func_get_args());
     }
 
     public function exec(): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec(...\func_get_args());
+        return $this->initializeLazyObject()->exec(...\func_get_args());
     }
 
     public function exists($key, ...$other_keys): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists(...\func_get_args());
+        return $this->initializeLazyObject()->exists(...\func_get_args());
     }
 
     public function touch($key, ...$other_keys): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->touch(...\func_get_args());
+        return $this->initializeLazyObject()->touch(...\func_get_args());
     }
 
     public function expire($key, $timeout, $mode = null): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire(...\func_get_args());
+        return $this->initializeLazyObject()->expire(...\func_get_args());
     }
 
     public function expireat($key, $timestamp, $mode = null): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireat(...\func_get_args());
+        return $this->initializeLazyObject()->expireat(...\func_get_args());
     }
 
     public function expiretime($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expiretime(...\func_get_args());
+        return $this->initializeLazyObject()->expiretime(...\func_get_args());
     }
 
     public function pexpiretime($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpiretime(...\func_get_args());
+        return $this->initializeLazyObject()->pexpiretime(...\func_get_args());
     }
 
     public function flushall($key_or_address, $async = false): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushall(...\func_get_args());
+        return $this->initializeLazyObject()->flushall(...\func_get_args());
     }
 
     public function flushdb($key_or_address, $async = false): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushdb(...\func_get_args());
+        return $this->initializeLazyObject()->flushdb(...\func_get_args());
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples_and_options): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd(...\func_get_args());
+        return $this->initializeLazyObject()->geoadd(...\func_get_args());
     }
 
     public function geodist($key, $src, $dest, $unit = null): \RedisCluster|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist(...\func_get_args());
+        return $this->initializeLazyObject()->geodist(...\func_get_args());
     }
 
     public function geohash($key, $member, ...$other_members): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash(...\func_get_args());
+        return $this->initializeLazyObject()->geohash(...\func_get_args());
     }
 
     public function geopos($key, $member, ...$other_members): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos(...\func_get_args());
+        return $this->initializeLazyObject()->geopos(...\func_get_args());
     }
 
     public function georadius($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius(...\func_get_args());
+        return $this->initializeLazyObject()->georadius(...\func_get_args());
     }
 
     public function georadius_ro($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadius_ro(...\func_get_args());
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember(...\func_get_args());
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember_ro(...\func_get_args());
     }
 
     public function geosearch($key, $position, $shape, $unit, $options = []): \RedisCluster|array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearch(...\func_get_args());
+        return $this->initializeLazyObject()->geosearch(...\func_get_args());
     }
 
     public function geosearchstore($dst, $src, $position, $shape, $unit, $options = []): \RedisCluster|array|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearchstore(...\func_get_args());
+        return $this->initializeLazyObject()->geosearchstore(...\func_get_args());
     }
 
     public function get($key): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get(...\func_get_args());
+        return $this->initializeLazyObject()->get(...\func_get_args());
     }
 
     public function getbit($key, $value): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getbit(...\func_get_args());
+        return $this->initializeLazyObject()->getbit(...\func_get_args());
     }
 
     public function getlasterror(): ?string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getlasterror(...\func_get_args());
+        return $this->initializeLazyObject()->getlasterror(...\func_get_args());
     }
 
     public function getmode(): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getmode(...\func_get_args());
+        return $this->initializeLazyObject()->getmode(...\func_get_args());
     }
 
     public function getoption($option): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getoption(...\func_get_args());
+        return $this->initializeLazyObject()->getoption(...\func_get_args());
     }
 
     public function getrange($key, $start, $end): \RedisCluster|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getrange(...\func_get_args());
+        return $this->initializeLazyObject()->getrange(...\func_get_args());
     }
 
     public function lcs($key1, $key2, $options = null): \RedisCluster|array|false|int|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lcs(...\func_get_args());
+        return $this->initializeLazyObject()->lcs(...\func_get_args());
     }
 
     public function getset($key, $value): \RedisCluster|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getset(...\func_get_args());
+        return $this->initializeLazyObject()->getset(...\func_get_args());
     }
 
     public function gettransferredbytes(): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->gettransferredbytes(...\func_get_args());
+        return $this->initializeLazyObject()->gettransferredbytes(...\func_get_args());
     }
 
     public function cleartransferredbytes(): void
     {
-        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->cleartransferredbytes(...\func_get_args());
+        $this->initializeLazyObject()->cleartransferredbytes(...\func_get_args());
     }
 
     public function hdel($key, $member, ...$other_members): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hdel(...\func_get_args());
+        return $this->initializeLazyObject()->hdel(...\func_get_args());
     }
 
     public function hexists($key, $member): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hexists(...\func_get_args());
+        return $this->initializeLazyObject()->hexists(...\func_get_args());
     }
 
     public function hget($key, $member): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hget(...\func_get_args());
+        return $this->initializeLazyObject()->hget(...\func_get_args());
     }
 
     public function hgetall($key): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hgetall(...\func_get_args());
+        return $this->initializeLazyObject()->hgetall(...\func_get_args());
     }
 
     public function hincrby($key, $member, $value): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrby(...\func_get_args());
+        return $this->initializeLazyObject()->hincrby(...\func_get_args());
     }
 
     public function hincrbyfloat($key, $member, $value): \RedisCluster|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrbyfloat(...\func_get_args());
+        return $this->initializeLazyObject()->hincrbyfloat(...\func_get_args());
     }
 
     public function hkeys($key): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hkeys(...\func_get_args());
+        return $this->initializeLazyObject()->hkeys(...\func_get_args());
     }
 
     public function hlen($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hlen(...\func_get_args());
+        return $this->initializeLazyObject()->hlen(...\func_get_args());
     }
 
     public function hmget($key, $keys): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmget(...\func_get_args());
+        return $this->initializeLazyObject()->hmget(...\func_get_args());
     }
 
     public function hmset($key, $key_values): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmset(...\func_get_args());
+        return $this->initializeLazyObject()->hmset(...\func_get_args());
     }
 
     public function hscan($key, &$iterator, $pattern = null, $count = 0): array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function hrandfield($key, $options = null): \RedisCluster|array|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hrandfield(...\func_get_args());
+        return $this->initializeLazyObject()->hrandfield(...\func_get_args());
     }
 
     public function hset($key, $member, $value): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hset(...\func_get_args());
+        return $this->initializeLazyObject()->hset(...\func_get_args());
     }
 
     public function hsetnx($key, $member, $value): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hsetnx(...\func_get_args());
+        return $this->initializeLazyObject()->hsetnx(...\func_get_args());
     }
 
     public function hstrlen($key, $field): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hstrlen(...\func_get_args());
+        return $this->initializeLazyObject()->hstrlen(...\func_get_args());
     }
 
     public function hvals($key): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hvals(...\func_get_args());
+        return $this->initializeLazyObject()->hvals(...\func_get_args());
     }
 
     public function incr($key, $by = 1): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr(...\func_get_args());
+        return $this->initializeLazyObject()->incr(...\func_get_args());
     }
 
     public function incrby($key, $value): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrby(...\func_get_args());
+        return $this->initializeLazyObject()->incrby(...\func_get_args());
     }
 
     public function incrbyfloat($key, $value): \RedisCluster|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrbyfloat(...\func_get_args());
+        return $this->initializeLazyObject()->incrbyfloat(...\func_get_args());
     }
 
     public function info($key_or_address, ...$sections): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info(...\func_get_args());
+        return $this->initializeLazyObject()->info(...\func_get_args());
     }
 
     public function keys($pattern): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys(...\func_get_args());
+        return $this->initializeLazyObject()->keys(...\func_get_args());
     }
 
     public function lastsave($key_or_address): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastsave(...\func_get_args());
+        return $this->initializeLazyObject()->lastsave(...\func_get_args());
     }
 
     public function lget($key, $index): \RedisCluster|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lget(...\func_get_args());
+        return $this->initializeLazyObject()->lget(...\func_get_args());
     }
 
     public function lindex($key, $index): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex(...\func_get_args());
+        return $this->initializeLazyObject()->lindex(...\func_get_args());
     }
 
     public function linsert($key, $pos, $pivot, $value): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->linsert(...\func_get_args());
+        return $this->initializeLazyObject()->linsert(...\func_get_args());
     }
 
     public function llen($key): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->llen(...\func_get_args());
+        return $this->initializeLazyObject()->llen(...\func_get_args());
     }
 
     public function lpop($key, $count = 0): \RedisCluster|array|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpop(...\func_get_args());
+        return $this->initializeLazyObject()->lpop(...\func_get_args());
     }
 
     public function lpos($key, $value, $options = null): \Redis|array|bool|int|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpos(...\func_get_args());
+        return $this->initializeLazyObject()->lpos(...\func_get_args());
     }
 
     public function lpush($key, $value, ...$other_values): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpush(...\func_get_args());
+        return $this->initializeLazyObject()->lpush(...\func_get_args());
     }
 
     public function lpushx($key, $value): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpushx(...\func_get_args());
+        return $this->initializeLazyObject()->lpushx(...\func_get_args());
     }
 
     public function lrange($key, $start, $end): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange(...\func_get_args());
+        return $this->initializeLazyObject()->lrange(...\func_get_args());
     }
 
     public function lrem($key, $value, $count = 0): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem(...\func_get_args());
+        return $this->initializeLazyObject()->lrem(...\func_get_args());
     }
 
     public function lset($key, $index, $value): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lset(...\func_get_args());
+        return $this->initializeLazyObject()->lset(...\func_get_args());
     }
 
     public function ltrim($key, $start, $end): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim(...\func_get_args());
+        return $this->initializeLazyObject()->ltrim(...\func_get_args());
     }
 
     public function mget($keys): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget(...\func_get_args());
+        return $this->initializeLazyObject()->mget(...\func_get_args());
     }
 
     public function mset($key_values): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset(...\func_get_args());
+        return $this->initializeLazyObject()->mset(...\func_get_args());
     }
 
     public function msetnx($key_values): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx(...\func_get_args());
+        return $this->initializeLazyObject()->msetnx(...\func_get_args());
     }
 
     public function multi($value = \Redis::MULTI): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi(...\func_get_args());
+        return $this->initializeLazyObject()->multi(...\func_get_args());
     }
 
     public function object($subcommand, $key): \RedisCluster|false|int|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object(...\func_get_args());
+        return $this->initializeLazyObject()->object(...\func_get_args());
     }
 
     public function persist($key): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist(...\func_get_args());
+        return $this->initializeLazyObject()->persist(...\func_get_args());
     }
 
     public function pexpire($key, $timeout, $mode = null): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire(...\func_get_args());
+        return $this->initializeLazyObject()->pexpire(...\func_get_args());
     }
 
     public function pexpireat($key, $timestamp, $mode = null): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireat(...\func_get_args());
+        return $this->initializeLazyObject()->pexpireat(...\func_get_args());
     }
 
     public function pfadd($key, $elements): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd(...\func_get_args());
+        return $this->initializeLazyObject()->pfadd(...\func_get_args());
     }
 
     public function pfcount($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount(...\func_get_args());
+        return $this->initializeLazyObject()->pfcount(...\func_get_args());
     }
 
     public function pfmerge($key, $keys): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge(...\func_get_args());
+        return $this->initializeLazyObject()->pfmerge(...\func_get_args());
     }
 
     public function ping($key_or_address, $message = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping(...\func_get_args());
+        return $this->initializeLazyObject()->ping(...\func_get_args());
     }
 
     public function psetex($key, $timeout, $value): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex(...\func_get_args());
+        return $this->initializeLazyObject()->psetex(...\func_get_args());
     }
 
     public function psubscribe($patterns, $callback): void
     {
-        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe(...\func_get_args());
+        $this->initializeLazyObject()->psubscribe(...\func_get_args());
     }
 
     public function pttl($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl(...\func_get_args());
+        return $this->initializeLazyObject()->pttl(...\func_get_args());
     }
 
     public function publish($channel, $message): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish(...\func_get_args());
+        return $this->initializeLazyObject()->publish(...\func_get_args());
     }
 
     public function pubsub($key_or_address, ...$values): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub(...\func_get_args());
+        return $this->initializeLazyObject()->pubsub(...\func_get_args());
     }
 
     public function punsubscribe($pattern, ...$other_patterns): array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->punsubscribe(...\func_get_args());
     }
 
     public function randomkey($key_or_address): \RedisCluster|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomkey(...\func_get_args());
+        return $this->initializeLazyObject()->randomkey(...\func_get_args());
     }
 
     public function rawcommand($key_or_address, $command, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawcommand(...\func_get_args());
+        return $this->initializeLazyObject()->rawcommand(...\func_get_args());
     }
 
     public function rename($key_src, $key_dst): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename(...\func_get_args());
+        return $this->initializeLazyObject()->rename(...\func_get_args());
     }
 
     public function renamenx($key, $newkey): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renamenx(...\func_get_args());
+        return $this->initializeLazyObject()->renamenx(...\func_get_args());
     }
 
     public function restore($key, $timeout, $value, $options = null): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore(...\func_get_args());
+        return $this->initializeLazyObject()->restore(...\func_get_args());
     }
 
     public function role($key_or_address): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role(...\func_get_args());
+        return $this->initializeLazyObject()->role(...\func_get_args());
     }
 
     public function rpop($key, $count = 0): \RedisCluster|array|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpop(...\func_get_args());
+        return $this->initializeLazyObject()->rpop(...\func_get_args());
     }
 
     public function rpoplpush($src, $dst): \RedisCluster|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->rpoplpush(...\func_get_args());
     }
 
     public function rpush($key, ...$elements): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpush(...\func_get_args());
+        return $this->initializeLazyObject()->rpush(...\func_get_args());
     }
 
     public function rpushx($key, $value): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpushx(...\func_get_args());
+        return $this->initializeLazyObject()->rpushx(...\func_get_args());
     }
 
     public function sadd($key, $value, ...$other_values): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sadd(...\func_get_args());
+        return $this->initializeLazyObject()->sadd(...\func_get_args());
     }
 
     public function saddarray($key, $values): \RedisCluster|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->saddarray(...\func_get_args());
+        return $this->initializeLazyObject()->saddarray(...\func_get_args());
     }
 
     public function save($key_or_address): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save(...\func_get_args());
+        return $this->initializeLazyObject()->save(...\func_get_args());
     }
 
     public function scan(&$iterator, $key_or_address, $pattern = null, $count = 0): array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, ...\array_slice(\func_get_args(), 1));
+        return $this->initializeLazyObject()->scan($iterator, ...\array_slice(\func_get_args(), 1));
     }
 
     public function scard($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard(...\func_get_args());
+        return $this->initializeLazyObject()->scard(...\func_get_args());
     }
 
     public function script($key_or_address, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script(...\func_get_args());
+        return $this->initializeLazyObject()->script(...\func_get_args());
     }
 
     public function sdiff($key, ...$other_keys): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiff(...\func_get_args());
+        return $this->initializeLazyObject()->sdiff(...\func_get_args());
     }
 
     public function sdiffstore($dst, $key, ...$other_keys): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiffstore(...\func_get_args());
+        return $this->initializeLazyObject()->sdiffstore(...\func_get_args());
     }
 
     public function set($key, $value, $options = null): \RedisCluster|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set(...\func_get_args());
+        return $this->initializeLazyObject()->set(...\func_get_args());
     }
 
     public function setbit($key, $offset, $onoff): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setbit(...\func_get_args());
+        return $this->initializeLazyObject()->setbit(...\func_get_args());
     }
 
     public function setex($key, $expire, $value): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex(...\func_get_args());
+        return $this->initializeLazyObject()->setex(...\func_get_args());
     }
 
     public function setnx($key, $value): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx(...\func_get_args());
+        return $this->initializeLazyObject()->setnx(...\func_get_args());
     }
 
     public function setoption($option, $value): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setoption(...\func_get_args());
+        return $this->initializeLazyObject()->setoption(...\func_get_args());
     }
 
     public function setrange($key, $offset, $value): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setrange(...\func_get_args());
+        return $this->initializeLazyObject()->setrange(...\func_get_args());
     }
 
     public function sinter($key, ...$other_keys): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinter(...\func_get_args());
+        return $this->initializeLazyObject()->sinter(...\func_get_args());
     }
 
     public function sintercard($keys, $limit = -1): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sintercard(...\func_get_args());
+        return $this->initializeLazyObject()->sintercard(...\func_get_args());
     }
 
     public function sinterstore($key, ...$other_keys): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinterstore(...\func_get_args());
+        return $this->initializeLazyObject()->sinterstore(...\func_get_args());
     }
 
     public function sismember($key, $value): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember(...\func_get_args());
+        return $this->initializeLazyObject()->sismember(...\func_get_args());
     }
 
     public function smismember($key, $member, ...$other_members): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smismember(...\func_get_args());
+        return $this->initializeLazyObject()->smismember(...\func_get_args());
     }
 
     public function slowlog($key_or_address, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog(...\func_get_args());
+        return $this->initializeLazyObject()->slowlog(...\func_get_args());
     }
 
     public function smembers($key): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smembers(...\func_get_args());
+        return $this->initializeLazyObject()->smembers(...\func_get_args());
     }
 
     public function smove($src, $dst, $member): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smove(...\func_get_args());
+        return $this->initializeLazyObject()->smove(...\func_get_args());
     }
 
     public function sort($key, $options = null): \RedisCluster|array|bool|int|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort(...\func_get_args());
+        return $this->initializeLazyObject()->sort(...\func_get_args());
     }
 
     public function sort_ro($key, $options = null): \RedisCluster|array|bool|int|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort_ro(...\func_get_args());
+        return $this->initializeLazyObject()->sort_ro(...\func_get_args());
     }
 
     public function spop($key, $count = 0): \RedisCluster|array|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->spop(...\func_get_args());
+        return $this->initializeLazyObject()->spop(...\func_get_args());
     }
 
     public function srandmember($key, $count = 0): \RedisCluster|array|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srandmember(...\func_get_args());
+        return $this->initializeLazyObject()->srandmember(...\func_get_args());
     }
 
     public function srem($key, $value, ...$other_values): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem(...\func_get_args());
+        return $this->initializeLazyObject()->srem(...\func_get_args());
     }
 
     public function sscan($key, &$iterator, $pattern = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function strlen($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen(...\func_get_args());
+        return $this->initializeLazyObject()->strlen(...\func_get_args());
     }
 
     public function subscribe($channels, $cb): void
     {
-        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe(...\func_get_args());
+        $this->initializeLazyObject()->subscribe(...\func_get_args());
     }
 
     public function sunion($key, ...$other_keys): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunion(...\func_get_args());
+        return $this->initializeLazyObject()->sunion(...\func_get_args());
     }
 
     public function sunionstore($dst, $key, ...$other_keys): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunionstore(...\func_get_args());
+        return $this->initializeLazyObject()->sunionstore(...\func_get_args());
     }
 
     public function time($key_or_address): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time(...\func_get_args());
+        return $this->initializeLazyObject()->time(...\func_get_args());
     }
 
     public function ttl($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl(...\func_get_args());
+        return $this->initializeLazyObject()->ttl(...\func_get_args());
     }
 
     public function type($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type(...\func_get_args());
+        return $this->initializeLazyObject()->type(...\func_get_args());
     }
 
     public function unsubscribe($channels): array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->unsubscribe(...\func_get_args());
     }
 
     public function unlink($key, ...$other_keys): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink(...\func_get_args());
+        return $this->initializeLazyObject()->unlink(...\func_get_args());
     }
 
     public function unwatch(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch(...\func_get_args());
+        return $this->initializeLazyObject()->unwatch(...\func_get_args());
     }
 
     public function watch($key, ...$other_keys): \RedisCluster|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch(...\func_get_args());
+        return $this->initializeLazyObject()->watch(...\func_get_args());
     }
 
     public function xack($key, $group, $ids): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack(...\func_get_args());
+        return $this->initializeLazyObject()->xack(...\func_get_args());
     }
 
     public function xadd($key, $id, $values, $maxlen = 0, $approx = false): \RedisCluster|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd(...\func_get_args());
+        return $this->initializeLazyObject()->xadd(...\func_get_args());
     }
 
     public function xclaim($key, $group, $consumer, $min_iddle, $ids, $options): \RedisCluster|array|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim(...\func_get_args());
+        return $this->initializeLazyObject()->xclaim(...\func_get_args());
     }
 
     public function xdel($key, $ids): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel(...\func_get_args());
+        return $this->initializeLazyObject()->xdel(...\func_get_args());
     }
 
     public function xgroup($operation, $key = null, $group = null, $id_or_consumer = null, $mkstream = false, $entries_read = -2): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xgroup(...\func_get_args());
     }
 
     public function xautoclaim($key, $group, $consumer, $min_idle, $start, $count = -1, $justid = false): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xautoclaim(...\func_get_args());
+        return $this->initializeLazyObject()->xautoclaim(...\func_get_args());
     }
 
     public function xinfo($operation, $arg1 = null, $arg2 = null, $count = -1): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo(...\func_get_args());
+        return $this->initializeLazyObject()->xinfo(...\func_get_args());
     }
 
     public function xlen($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen(...\func_get_args());
+        return $this->initializeLazyObject()->xlen(...\func_get_args());
     }
 
     public function xpending($key, $group, $start = null, $end = null, $count = -1, $consumer = null): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending(...\func_get_args());
+        return $this->initializeLazyObject()->xpending(...\func_get_args());
     }
 
     public function xrange($key, $start, $end, $count = -1): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrange(...\func_get_args());
     }
 
     public function xread($streams, $count = -1, $block = -1): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread(...\func_get_args());
+        return $this->initializeLazyObject()->xread(...\func_get_args());
     }
 
     public function xreadgroup($group, $consumer, $streams, $count = 1, $block = 1): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xreadgroup(...\func_get_args());
     }
 
     public function xrevrange($key, $start, $end, $count = -1): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrevrange(...\func_get_args());
     }
 
     public function xtrim($key, $maxlen, $approx = false, $minid = false, $limit = -1): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim(...\func_get_args());
+        return $this->initializeLazyObject()->xtrim(...\func_get_args());
     }
 
     public function zadd($key, $score_or_options, ...$more_scores_and_mems): \RedisCluster|false|float|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zadd(...\func_get_args());
+        return $this->initializeLazyObject()->zadd(...\func_get_args());
     }
 
     public function zcard($key): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcard(...\func_get_args());
+        return $this->initializeLazyObject()->zcard(...\func_get_args());
     }
 
     public function zcount($key, $start, $end): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcount(...\func_get_args());
+        return $this->initializeLazyObject()->zcount(...\func_get_args());
     }
 
     public function zincrby($key, $value, $member): \RedisCluster|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zincrby(...\func_get_args());
+        return $this->initializeLazyObject()->zincrby(...\func_get_args());
     }
 
     public function zinterstore($dst, $keys, $weights = null, $aggregate = null): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore(...\func_get_args());
+        return $this->initializeLazyObject()->zinterstore(...\func_get_args());
     }
 
     public function zintercard($keys, $limit = -1): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zintercard(...\func_get_args());
+        return $this->initializeLazyObject()->zintercard(...\func_get_args());
     }
 
     public function zlexcount($key, $min, $max): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zlexcount(...\func_get_args());
+        return $this->initializeLazyObject()->zlexcount(...\func_get_args());
     }
 
     public function zpopmax($key, $value = null): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmax(...\func_get_args());
+        return $this->initializeLazyObject()->zpopmax(...\func_get_args());
     }
 
     public function zpopmin($key, $value = null): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmin(...\func_get_args());
+        return $this->initializeLazyObject()->zpopmin(...\func_get_args());
     }
 
     public function zrange($key, $start, $end, $options = null): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrange(...\func_get_args());
+        return $this->initializeLazyObject()->zrange(...\func_get_args());
     }
 
     public function zrangestore($dstkey, $srckey, $start, $end, $options = null): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangestore(...\func_get_args());
+        return $this->initializeLazyObject()->zrangestore(...\func_get_args());
     }
 
     public function zrandmember($key, $options = null): \RedisCluster|array|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrandmember(...\func_get_args());
+        return $this->initializeLazyObject()->zrandmember(...\func_get_args());
     }
 
     public function zrangebylex($key, $min, $max, $offset = -1, $count = -1): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zrangebylex(...\func_get_args());
     }
 
     public function zrangebyscore($key, $start, $end, $options = []): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zrangebyscore(...\func_get_args());
     }
 
     public function zrank($key, $member): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrank(...\func_get_args());
+        return $this->initializeLazyObject()->zrank(...\func_get_args());
     }
 
     public function zrem($key, $value, ...$other_values): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrem(...\func_get_args());
+        return $this->initializeLazyObject()->zrem(...\func_get_args());
     }
 
     public function zremrangebylex($key, $min, $max): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebylex(...\func_get_args());
     }
 
     public function zremrangebyrank($key, $min, $max): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyrank(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebyrank(...\func_get_args());
     }
 
     public function zremrangebyscore($key, $min, $max): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebyscore(...\func_get_args());
     }
 
     public function zrevrange($key, $min, $max, $options = null): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrange(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrange(...\func_get_args());
     }
 
     public function zrevrangebylex($key, $min, $max, $options = null): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrangebylex(...\func_get_args());
     }
 
     public function zrevrangebyscore($key, $min, $max, $options = null): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrangebyscore(...\func_get_args());
     }
 
     public function zrevrank($key, $member): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrank(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrank(...\func_get_args());
     }
 
     public function zscan($key, &$iterator, $pattern = null, $count = 0): \RedisCluster|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function zscore($key, $member): \RedisCluster|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscore(...\func_get_args());
+        return $this->initializeLazyObject()->zscore(...\func_get_args());
     }
 
     public function zmscore($key, $member, ...$other_members): \Redis|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zmscore(...\func_get_args());
+        return $this->initializeLazyObject()->zmscore(...\func_get_args());
     }
 
     public function zunionstore($dst, $keys, $weights = null, $aggregate = null): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore(...\func_get_args());
+        return $this->initializeLazyObject()->zunionstore(...\func_get_args());
     }
 
     public function zinter($keys, $weights = null, $options = null): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinter(...\func_get_args());
+        return $this->initializeLazyObject()->zinter(...\func_get_args());
     }
 
     public function zdiffstore($dst, $keys): \RedisCluster|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiffstore(...\func_get_args());
+        return $this->initializeLazyObject()->zdiffstore(...\func_get_args());
     }
 
     public function zunion($keys, $weights = null, $options = null): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunion(...\func_get_args());
+        return $this->initializeLazyObject()->zunion(...\func_get_args());
     }
 
     public function zdiff($keys, $options = null): \RedisCluster|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiff(...\func_get_args());
+        return $this->initializeLazyObject()->zdiff(...\func_get_args());
     }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisProxyTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisProxyTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+trait RedisProxyTrait
+{
+    private \Closure $initializer;
+    private ?parent $realInstance = null;
+
+    public static function createLazyProxy(\Closure $initializer, ?self $instance = null): static
+    {
+        $instance ??= (new \ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $instance->realInstance = null;
+        $instance->initializer = $initializer;
+
+        return $instance;
+    }
+
+    public function isLazyObjectInitialized(bool $partial = false): bool
+    {
+        return isset($this->realInstance);
+    }
+
+    public function initializeLazyObject(): object
+    {
+        return $this->realInstance ??= ($this->initializer)();
+    }
+
+    public function resetLazyObject(): bool
+    {
+        $this->realInstance = null;
+
+        return true;
+    }
+
+    public function __destruct()
+    {
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RelayProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RelayProxy.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Cache\Traits;
 
 use Symfony\Component\VarExporter\LazyObjectInterface;
-use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Contracts\Service\ResetInterface;
 
 // Help opcache.preload discover always-needed symbols
@@ -25,1299 +24,1297 @@ class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
  */
 class RelayProxy extends \Relay\Relay implements ResetInterface, LazyObjectInterface
 {
-    use LazyProxyTrait {
+    use RedisProxyTrait {
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
-
     public function __construct($host = null, $port = 6379, $connect_timeout = 0.0, $command_timeout = 0.0, #[\SensitiveParameter] $context = [], $database = 0)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        $this->initializeLazyObject()->__construct(...\func_get_args());
     }
 
     public function connect($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, #[\SensitiveParameter] $context = [], $database = 0): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->connect(...\func_get_args());
+        return $this->initializeLazyObject()->connect(...\func_get_args());
     }
 
     public function pconnect($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, #[\SensitiveParameter] $context = [], $database = 0): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pconnect(...\func_get_args());
+        return $this->initializeLazyObject()->pconnect(...\func_get_args());
     }
 
     public function close(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close(...\func_get_args());
+        return $this->initializeLazyObject()->close(...\func_get_args());
     }
 
     public function pclose(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pclose(...\func_get_args());
+        return $this->initializeLazyObject()->pclose(...\func_get_args());
     }
 
     public function listen($callback): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->listen(...\func_get_args());
+        return $this->initializeLazyObject()->listen(...\func_get_args());
     }
 
     public function onFlushed($callback): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->onFlushed(...\func_get_args());
+        return $this->initializeLazyObject()->onFlushed(...\func_get_args());
     }
 
     public function onInvalidated($callback, $pattern = null): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->onInvalidated(...\func_get_args());
+        return $this->initializeLazyObject()->onInvalidated(...\func_get_args());
     }
 
     public function dispatchEvents(): false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dispatchEvents(...\func_get_args());
+        return $this->initializeLazyObject()->dispatchEvents(...\func_get_args());
     }
 
     public function getOption($option): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getOption(...\func_get_args());
+        return $this->initializeLazyObject()->getOption(...\func_get_args());
     }
 
     public function option($option, $value = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->option(...\func_get_args());
+        return $this->initializeLazyObject()->option(...\func_get_args());
     }
 
     public function setOption($option, $value): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setOption(...\func_get_args());
+        return $this->initializeLazyObject()->setOption(...\func_get_args());
     }
 
     public function addIgnorePatterns(...$pattern): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->addIgnorePatterns(...\func_get_args());
+        return $this->initializeLazyObject()->addIgnorePatterns(...\func_get_args());
     }
 
     public function addAllowPatterns(...$pattern): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->addAllowPatterns(...\func_get_args());
+        return $this->initializeLazyObject()->addAllowPatterns(...\func_get_args());
     }
 
     public function getTimeout(): false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getTimeout(...\func_get_args());
+        return $this->initializeLazyObject()->getTimeout(...\func_get_args());
     }
 
     public function timeout(): false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->timeout(...\func_get_args());
+        return $this->initializeLazyObject()->timeout(...\func_get_args());
     }
 
     public function getReadTimeout(): false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getReadTimeout(...\func_get_args());
+        return $this->initializeLazyObject()->getReadTimeout(...\func_get_args());
     }
 
     public function readTimeout(): false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->readTimeout(...\func_get_args());
+        return $this->initializeLazyObject()->readTimeout(...\func_get_args());
     }
 
     public function getBytes(): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getBytes(...\func_get_args());
+        return $this->initializeLazyObject()->getBytes(...\func_get_args());
     }
 
     public function bytes(): array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bytes(...\func_get_args());
+        return $this->initializeLazyObject()->bytes(...\func_get_args());
     }
 
     public function getHost(): false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getHost(...\func_get_args());
+        return $this->initializeLazyObject()->getHost(...\func_get_args());
     }
 
     public function isConnected(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->isConnected(...\func_get_args());
+        return $this->initializeLazyObject()->isConnected(...\func_get_args());
     }
 
     public function getPort(): false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPort(...\func_get_args());
+        return $this->initializeLazyObject()->getPort(...\func_get_args());
     }
 
     public function getAuth(): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getAuth(...\func_get_args());
+        return $this->initializeLazyObject()->getAuth(...\func_get_args());
     }
 
     public function getDbNum(): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getDbNum(...\func_get_args());
+        return $this->initializeLazyObject()->getDbNum(...\func_get_args());
     }
 
     public function _serialize($value): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize(...\func_get_args());
+        return $this->initializeLazyObject()->_serialize(...\func_get_args());
     }
 
     public function _unserialize($value): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize(...\func_get_args());
+        return $this->initializeLazyObject()->_unserialize(...\func_get_args());
     }
 
     public function _compress($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress(...\func_get_args());
+        return $this->initializeLazyObject()->_compress(...\func_get_args());
     }
 
     public function _uncompress($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress(...\func_get_args());
+        return $this->initializeLazyObject()->_uncompress(...\func_get_args());
     }
 
     public function _pack($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack(...\func_get_args());
+        return $this->initializeLazyObject()->_pack(...\func_get_args());
     }
 
     public function _unpack($value): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack(...\func_get_args());
+        return $this->initializeLazyObject()->_unpack(...\func_get_args());
     }
 
     public function _prefix($value): string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix(...\func_get_args());
+        return $this->initializeLazyObject()->_prefix(...\func_get_args());
     }
 
     public function getLastError(): ?string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getLastError(...\func_get_args());
+        return $this->initializeLazyObject()->getLastError(...\func_get_args());
     }
 
     public function clearLastError(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearLastError(...\func_get_args());
+        return $this->initializeLazyObject()->clearLastError(...\func_get_args());
     }
 
     public function endpointId(): false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->endpointId(...\func_get_args());
+        return $this->initializeLazyObject()->endpointId(...\func_get_args());
     }
 
     public function getPersistentID(): false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPersistentID(...\func_get_args());
+        return $this->initializeLazyObject()->getPersistentID(...\func_get_args());
     }
 
     public function socketId(): false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->socketId(...\func_get_args());
+        return $this->initializeLazyObject()->socketId(...\func_get_args());
     }
 
     public function rawCommand($cmd, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawCommand(...\func_get_args());
+        return $this->initializeLazyObject()->rawCommand(...\func_get_args());
     }
 
     public function select($db): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->select(...\func_get_args());
+        return $this->initializeLazyObject()->select(...\func_get_args());
     }
 
     public function auth(#[\SensitiveParameter] $auth): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->auth(...\func_get_args());
+        return $this->initializeLazyObject()->auth(...\func_get_args());
     }
 
     public function info(...$sections): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info(...\func_get_args());
+        return $this->initializeLazyObject()->info(...\func_get_args());
     }
 
     public function flushdb($sync = null): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushdb(...\func_get_args());
+        return $this->initializeLazyObject()->flushdb(...\func_get_args());
     }
 
     public function flushall($sync = null): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushall(...\func_get_args());
+        return $this->initializeLazyObject()->flushall(...\func_get_args());
     }
 
     public function fcall($name, $keys = [], $argv = [], $handler = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->fcall(...\func_get_args());
+        return $this->initializeLazyObject()->fcall(...\func_get_args());
     }
 
     public function fcall_ro($name, $keys = [], $argv = [], $handler = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->fcall_ro(...\func_get_args());
+        return $this->initializeLazyObject()->fcall_ro(...\func_get_args());
     }
 
     public function function($op, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->function(...\func_get_args());
+        return $this->initializeLazyObject()->function(...\func_get_args());
     }
 
     public function dbsize(): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbsize(...\func_get_args());
+        return $this->initializeLazyObject()->dbsize(...\func_get_args());
     }
 
     public function dump($key): \Relay\Relay|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump(...\func_get_args());
+        return $this->initializeLazyObject()->dump(...\func_get_args());
     }
 
     public function replicaof($host = null, $port = 0): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->replicaof(...\func_get_args());
+        return $this->initializeLazyObject()->replicaof(...\func_get_args());
     }
 
     public function waitaof($numlocal, $numremote, $timeout): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->waitaof(...\func_get_args());
+        return $this->initializeLazyObject()->waitaof(...\func_get_args());
     }
 
     public function restore($key, $ttl, $value, $options = null): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore(...\func_get_args());
+        return $this->initializeLazyObject()->restore(...\func_get_args());
     }
 
     public function migrate($host, $port, $key, $dstdb, $timeout, $copy = false, $replace = false, #[\SensitiveParameter] $credentials = null): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->migrate(...\func_get_args());
+        return $this->initializeLazyObject()->migrate(...\func_get_args());
     }
 
     public function copy($src, $dst, $options = null): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->copy(...\func_get_args());
+        return $this->initializeLazyObject()->copy(...\func_get_args());
     }
 
     public function echo($arg): \Relay\Relay|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo(...\func_get_args());
+        return $this->initializeLazyObject()->echo(...\func_get_args());
     }
 
     public function ping($arg = null): \Relay\Relay|bool|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping(...\func_get_args());
+        return $this->initializeLazyObject()->ping(...\func_get_args());
     }
 
     public function idleTime(): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->idleTime(...\func_get_args());
+        return $this->initializeLazyObject()->idleTime(...\func_get_args());
     }
 
     public function randomkey(): \Relay\Relay|bool|null|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomkey(...\func_get_args());
+        return $this->initializeLazyObject()->randomkey(...\func_get_args());
     }
 
     public function time(): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time(...\func_get_args());
+        return $this->initializeLazyObject()->time(...\func_get_args());
     }
 
     public function bgrewriteaof(): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof(...\func_get_args());
+        return $this->initializeLazyObject()->bgrewriteaof(...\func_get_args());
     }
 
     public function lastsave(): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastsave(...\func_get_args());
+        return $this->initializeLazyObject()->lastsave(...\func_get_args());
     }
 
     public function lcs($key1, $key2, $options = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lcs(...\func_get_args());
+        return $this->initializeLazyObject()->lcs(...\func_get_args());
     }
 
     public function bgsave($schedule = false): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgsave(...\func_get_args());
+        return $this->initializeLazyObject()->bgsave(...\func_get_args());
     }
 
     public function save(): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save(...\func_get_args());
+        return $this->initializeLazyObject()->save(...\func_get_args());
     }
 
     public function role(): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role(...\func_get_args());
+        return $this->initializeLazyObject()->role(...\func_get_args());
     }
 
     public function ttl($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl(...\func_get_args());
+        return $this->initializeLazyObject()->ttl(...\func_get_args());
     }
 
     public function pttl($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl(...\func_get_args());
+        return $this->initializeLazyObject()->pttl(...\func_get_args());
     }
 
     public function exists(...$keys): \Relay\Relay|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists(...\func_get_args());
+        return $this->initializeLazyObject()->exists(...\func_get_args());
     }
 
     public function eval($script, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval(...\func_get_args());
+        return $this->initializeLazyObject()->eval(...\func_get_args());
     }
 
     public function eval_ro($script, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval_ro(...\func_get_args());
+        return $this->initializeLazyObject()->eval_ro(...\func_get_args());
     }
 
     public function evalsha($sha, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha(...\func_get_args());
+        return $this->initializeLazyObject()->evalsha(...\func_get_args());
     }
 
     public function evalsha_ro($sha, $args = [], $num_keys = 0): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha_ro(...\func_get_args());
+        return $this->initializeLazyObject()->evalsha_ro(...\func_get_args());
     }
 
     public function client($operation, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client(...\func_get_args());
+        return $this->initializeLazyObject()->client(...\func_get_args());
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples_and_options): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd(...\func_get_args());
+        return $this->initializeLazyObject()->geoadd(...\func_get_args());
     }
 
     public function geodist($key, $src, $dst, $unit = null): \Relay\Relay|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist(...\func_get_args());
+        return $this->initializeLazyObject()->geodist(...\func_get_args());
     }
 
     public function geohash($key, $member, ...$other_members): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash(...\func_get_args());
+        return $this->initializeLazyObject()->geohash(...\func_get_args());
     }
 
     public function georadius($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius(...\func_get_args());
+        return $this->initializeLazyObject()->georadius(...\func_get_args());
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember(...\func_get_args());
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadiusbymember_ro(...\func_get_args());
     }
 
     public function georadius_ro($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro(...\func_get_args());
+        return $this->initializeLazyObject()->georadius_ro(...\func_get_args());
     }
 
     public function geosearch($key, $position, $shape, $unit, $options = []): \Relay\Relay|array
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearch(...\func_get_args());
+        return $this->initializeLazyObject()->geosearch(...\func_get_args());
     }
 
     public function geosearchstore($dst, $src, $position, $shape, $unit, $options = []): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearchstore(...\func_get_args());
+        return $this->initializeLazyObject()->geosearchstore(...\func_get_args());
     }
 
     public function get($key): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get(...\func_get_args());
+        return $this->initializeLazyObject()->get(...\func_get_args());
     }
 
     public function getset($key, $value): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getset(...\func_get_args());
+        return $this->initializeLazyObject()->getset(...\func_get_args());
     }
 
     public function getrange($key, $start, $end): \Relay\Relay|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getrange(...\func_get_args());
+        return $this->initializeLazyObject()->getrange(...\func_get_args());
     }
 
     public function setrange($key, $start, $value): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setrange(...\func_get_args());
+        return $this->initializeLazyObject()->setrange(...\func_get_args());
     }
 
     public function getbit($key, $pos): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getbit(...\func_get_args());
+        return $this->initializeLazyObject()->getbit(...\func_get_args());
     }
 
     public function bitcount($key, $start = 0, $end = -1, $by_bit = false): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount(...\func_get_args());
+        return $this->initializeLazyObject()->bitcount(...\func_get_args());
     }
 
     public function bitfield($key, ...$args): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitfield(...\func_get_args());
+        return $this->initializeLazyObject()->bitfield(...\func_get_args());
     }
 
     public function config($operation, $key = null, $value = null): \Relay\Relay|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config(...\func_get_args());
+        return $this->initializeLazyObject()->config(...\func_get_args());
     }
 
     public function command(...$args): \Relay\Relay|array|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command(...\func_get_args());
+        return $this->initializeLazyObject()->command(...\func_get_args());
     }
 
     public function bitop($operation, $dstkey, $srckey, ...$other_keys): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop(...\func_get_args());
+        return $this->initializeLazyObject()->bitop(...\func_get_args());
     }
 
     public function bitpos($key, $bit, $start = null, $end = null, $bybit = false): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos(...\func_get_args());
+        return $this->initializeLazyObject()->bitpos(...\func_get_args());
     }
 
     public function setbit($key, $pos, $val): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setbit(...\func_get_args());
+        return $this->initializeLazyObject()->setbit(...\func_get_args());
     }
 
     public function acl($cmd, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl(...\func_get_args());
+        return $this->initializeLazyObject()->acl(...\func_get_args());
     }
 
     public function append($key, $value): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append(...\func_get_args());
+        return $this->initializeLazyObject()->append(...\func_get_args());
     }
 
     public function set($key, $value, $options = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set(...\func_get_args());
+        return $this->initializeLazyObject()->set(...\func_get_args());
     }
 
     public function getex($key, $options = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getex(...\func_get_args());
+        return $this->initializeLazyObject()->getex(...\func_get_args());
     }
 
     public function getdel($key): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getdel(...\func_get_args());
+        return $this->initializeLazyObject()->getdel(...\func_get_args());
     }
 
     public function setex($key, $seconds, $value): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex(...\func_get_args());
+        return $this->initializeLazyObject()->setex(...\func_get_args());
     }
 
     public function pfadd($key, $elements): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd(...\func_get_args());
+        return $this->initializeLazyObject()->pfadd(...\func_get_args());
     }
 
     public function pfcount($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount(...\func_get_args());
+        return $this->initializeLazyObject()->pfcount(...\func_get_args());
     }
 
     public function pfmerge($dst, $srckeys): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge(...\func_get_args());
+        return $this->initializeLazyObject()->pfmerge(...\func_get_args());
     }
 
     public function psetex($key, $milliseconds, $value): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex(...\func_get_args());
+        return $this->initializeLazyObject()->psetex(...\func_get_args());
     }
 
     public function publish($channel, $message): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish(...\func_get_args());
+        return $this->initializeLazyObject()->publish(...\func_get_args());
     }
 
     public function pubsub($operation, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub(...\func_get_args());
+        return $this->initializeLazyObject()->pubsub(...\func_get_args());
     }
 
     public function spublish($channel, $message): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->spublish(...\func_get_args());
+        return $this->initializeLazyObject()->spublish(...\func_get_args());
     }
 
     public function setnx($key, $value): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx(...\func_get_args());
+        return $this->initializeLazyObject()->setnx(...\func_get_args());
     }
 
     public function mget($keys): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget(...\func_get_args());
+        return $this->initializeLazyObject()->mget(...\func_get_args());
     }
 
     public function move($key, $db): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->move(...\func_get_args());
+        return $this->initializeLazyObject()->move(...\func_get_args());
     }
 
     public function mset($kvals): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset(...\func_get_args());
+        return $this->initializeLazyObject()->mset(...\func_get_args());
     }
 
     public function msetnx($kvals): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx(...\func_get_args());
+        return $this->initializeLazyObject()->msetnx(...\func_get_args());
     }
 
     public function rename($key, $newkey): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename(...\func_get_args());
+        return $this->initializeLazyObject()->rename(...\func_get_args());
     }
 
     public function renamenx($key, $newkey): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renamenx(...\func_get_args());
+        return $this->initializeLazyObject()->renamenx(...\func_get_args());
     }
 
     public function del(...$keys): \Relay\Relay|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del(...\func_get_args());
+        return $this->initializeLazyObject()->del(...\func_get_args());
     }
 
     public function unlink(...$keys): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink(...\func_get_args());
+        return $this->initializeLazyObject()->unlink(...\func_get_args());
     }
 
     public function expire($key, $seconds, $mode = null): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire(...\func_get_args());
+        return $this->initializeLazyObject()->expire(...\func_get_args());
     }
 
     public function pexpire($key, $milliseconds): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire(...\func_get_args());
+        return $this->initializeLazyObject()->pexpire(...\func_get_args());
     }
 
     public function expireat($key, $timestamp): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireat(...\func_get_args());
+        return $this->initializeLazyObject()->expireat(...\func_get_args());
     }
 
     public function expiretime($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expiretime(...\func_get_args());
+        return $this->initializeLazyObject()->expiretime(...\func_get_args());
     }
 
     public function pexpireat($key, $timestamp_ms): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireat(...\func_get_args());
+        return $this->initializeLazyObject()->pexpireat(...\func_get_args());
     }
 
     public function pexpiretime($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpiretime(...\func_get_args());
+        return $this->initializeLazyObject()->pexpiretime(...\func_get_args());
     }
 
     public function persist($key): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist(...\func_get_args());
+        return $this->initializeLazyObject()->persist(...\func_get_args());
     }
 
     public function type($key): \Relay\Relay|bool|int|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type(...\func_get_args());
+        return $this->initializeLazyObject()->type(...\func_get_args());
     }
 
     public function lmove($srckey, $dstkey, $srcpos, $dstpos): \Relay\Relay|false|null|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmove(...\func_get_args());
+        return $this->initializeLazyObject()->lmove(...\func_get_args());
     }
 
     public function blmove($srckey, $dstkey, $srcpos, $dstpos, $timeout): \Relay\Relay|false|null|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmove(...\func_get_args());
+        return $this->initializeLazyObject()->blmove(...\func_get_args());
     }
 
     public function lrange($key, $start, $stop): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange(...\func_get_args());
+        return $this->initializeLazyObject()->lrange(...\func_get_args());
     }
 
     public function lpush($key, $mem, ...$mems): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpush(...\func_get_args());
+        return $this->initializeLazyObject()->lpush(...\func_get_args());
     }
 
     public function rpush($key, $mem, ...$mems): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpush(...\func_get_args());
+        return $this->initializeLazyObject()->rpush(...\func_get_args());
     }
 
     public function lpushx($key, $mem, ...$mems): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpushx(...\func_get_args());
+        return $this->initializeLazyObject()->lpushx(...\func_get_args());
     }
 
     public function rpushx($key, $mem, ...$mems): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpushx(...\func_get_args());
+        return $this->initializeLazyObject()->rpushx(...\func_get_args());
     }
 
     public function lset($key, $index, $mem): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lset(...\func_get_args());
+        return $this->initializeLazyObject()->lset(...\func_get_args());
     }
 
     public function lpop($key, $count = 1): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpop(...\func_get_args());
+        return $this->initializeLazyObject()->lpop(...\func_get_args());
     }
 
     public function lpos($key, $value, $options = null): \Relay\Relay|array|false|int|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpos(...\func_get_args());
+        return $this->initializeLazyObject()->lpos(...\func_get_args());
     }
 
     public function rpop($key, $count = 1): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpop(...\func_get_args());
+        return $this->initializeLazyObject()->rpop(...\func_get_args());
     }
 
     public function rpoplpush($source, $dest): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->rpoplpush(...\func_get_args());
     }
 
     public function brpoplpush($source, $dest, $timeout): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush(...\func_get_args());
+        return $this->initializeLazyObject()->brpoplpush(...\func_get_args());
     }
 
     public function blpop($key, $timeout_or_key, ...$extra_args): \Relay\Relay|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blpop(...\func_get_args());
+        return $this->initializeLazyObject()->blpop(...\func_get_args());
     }
 
     public function blmpop($timeout, $keys, $from, $count = 1): \Relay\Relay|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmpop(...\func_get_args());
+        return $this->initializeLazyObject()->blmpop(...\func_get_args());
     }
 
     public function bzmpop($timeout, $keys, $from, $count = 1): \Relay\Relay|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzmpop(...\func_get_args());
+        return $this->initializeLazyObject()->bzmpop(...\func_get_args());
     }
 
     public function lmpop($keys, $from, $count = 1): \Relay\Relay|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmpop(...\func_get_args());
+        return $this->initializeLazyObject()->lmpop(...\func_get_args());
     }
 
     public function zmpop($keys, $from, $count = 1): \Relay\Relay|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zmpop(...\func_get_args());
+        return $this->initializeLazyObject()->zmpop(...\func_get_args());
     }
 
     public function brpop($key, $timeout_or_key, ...$extra_args): \Relay\Relay|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpop(...\func_get_args());
+        return $this->initializeLazyObject()->brpop(...\func_get_args());
     }
 
     public function bzpopmax($key, $timeout_or_key, ...$extra_args): \Relay\Relay|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmax(...\func_get_args());
+        return $this->initializeLazyObject()->bzpopmax(...\func_get_args());
     }
 
     public function bzpopmin($key, $timeout_or_key, ...$extra_args): \Relay\Relay|array|false|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmin(...\func_get_args());
+        return $this->initializeLazyObject()->bzpopmin(...\func_get_args());
     }
 
     public function object($op, $key): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object(...\func_get_args());
+        return $this->initializeLazyObject()->object(...\func_get_args());
     }
 
     public function geopos($key, ...$members): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos(...\func_get_args());
+        return $this->initializeLazyObject()->geopos(...\func_get_args());
     }
 
     public function lrem($key, $mem, $count = 0): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem(...\func_get_args());
+        return $this->initializeLazyObject()->lrem(...\func_get_args());
     }
 
     public function lindex($key, $index): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex(...\func_get_args());
+        return $this->initializeLazyObject()->lindex(...\func_get_args());
     }
 
     public function linsert($key, $op, $pivot, $element): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->linsert(...\func_get_args());
+        return $this->initializeLazyObject()->linsert(...\func_get_args());
     }
 
     public function ltrim($key, $start, $end): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim(...\func_get_args());
+        return $this->initializeLazyObject()->ltrim(...\func_get_args());
     }
 
     public function hget($hash, $member): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hget(...\func_get_args());
+        return $this->initializeLazyObject()->hget(...\func_get_args());
     }
 
     public function hstrlen($hash, $member): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hstrlen(...\func_get_args());
+        return $this->initializeLazyObject()->hstrlen(...\func_get_args());
     }
 
     public function hgetall($hash): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hgetall(...\func_get_args());
+        return $this->initializeLazyObject()->hgetall(...\func_get_args());
     }
 
     public function hkeys($hash): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hkeys(...\func_get_args());
+        return $this->initializeLazyObject()->hkeys(...\func_get_args());
     }
 
     public function hvals($hash): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hvals(...\func_get_args());
+        return $this->initializeLazyObject()->hvals(...\func_get_args());
     }
 
     public function hmget($hash, $members): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmget(...\func_get_args());
+        return $this->initializeLazyObject()->hmget(...\func_get_args());
     }
 
     public function hrandfield($hash, $options = null): \Relay\Relay|array|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hrandfield(...\func_get_args());
+        return $this->initializeLazyObject()->hrandfield(...\func_get_args());
     }
 
     public function hmset($hash, $members): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmset(...\func_get_args());
+        return $this->initializeLazyObject()->hmset(...\func_get_args());
     }
 
     public function hexists($hash, $member): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hexists(...\func_get_args());
+        return $this->initializeLazyObject()->hexists(...\func_get_args());
     }
 
     public function hsetnx($hash, $member, $value): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hsetnx(...\func_get_args());
+        return $this->initializeLazyObject()->hsetnx(...\func_get_args());
     }
 
     public function hset($key, $mem, $val, ...$kvals): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hset(...\func_get_args());
+        return $this->initializeLazyObject()->hset(...\func_get_args());
     }
 
     public function hdel($key, $mem, ...$mems): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hdel(...\func_get_args());
+        return $this->initializeLazyObject()->hdel(...\func_get_args());
     }
 
     public function hincrby($key, $mem, $value): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrby(...\func_get_args());
+        return $this->initializeLazyObject()->hincrby(...\func_get_args());
     }
 
     public function hincrbyfloat($key, $mem, $value): \Relay\Relay|bool|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrbyfloat(...\func_get_args());
+        return $this->initializeLazyObject()->hincrbyfloat(...\func_get_args());
     }
 
     public function incr($key, $by = 1): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr(...\func_get_args());
+        return $this->initializeLazyObject()->incr(...\func_get_args());
     }
 
     public function decr($key, $by = 1): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr(...\func_get_args());
+        return $this->initializeLazyObject()->decr(...\func_get_args());
     }
 
     public function incrby($key, $value): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrby(...\func_get_args());
+        return $this->initializeLazyObject()->incrby(...\func_get_args());
     }
 
     public function decrby($key, $value): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrby(...\func_get_args());
+        return $this->initializeLazyObject()->decrby(...\func_get_args());
     }
 
     public function incrbyfloat($key, $value): \Relay\Relay|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrbyfloat(...\func_get_args());
+        return $this->initializeLazyObject()->incrbyfloat(...\func_get_args());
     }
 
     public function sdiff($key, ...$other_keys): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiff(...\func_get_args());
+        return $this->initializeLazyObject()->sdiff(...\func_get_args());
     }
 
     public function sdiffstore($key, ...$other_keys): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiffstore(...\func_get_args());
+        return $this->initializeLazyObject()->sdiffstore(...\func_get_args());
     }
 
     public function sinter($key, ...$other_keys): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinter(...\func_get_args());
+        return $this->initializeLazyObject()->sinter(...\func_get_args());
     }
 
     public function sintercard($keys, $limit = -1): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sintercard(...\func_get_args());
+        return $this->initializeLazyObject()->sintercard(...\func_get_args());
     }
 
     public function sinterstore($key, ...$other_keys): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinterstore(...\func_get_args());
+        return $this->initializeLazyObject()->sinterstore(...\func_get_args());
     }
 
     public function sunion($key, ...$other_keys): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunion(...\func_get_args());
+        return $this->initializeLazyObject()->sunion(...\func_get_args());
     }
 
     public function sunionstore($key, ...$other_keys): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunionstore(...\func_get_args());
+        return $this->initializeLazyObject()->sunionstore(...\func_get_args());
     }
 
     public function subscribe($channels, $callback): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe(...\func_get_args());
+        return $this->initializeLazyObject()->subscribe(...\func_get_args());
     }
 
     public function unsubscribe($channels = []): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->unsubscribe(...\func_get_args());
     }
 
     public function psubscribe($patterns, $callback): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->psubscribe(...\func_get_args());
     }
 
     public function punsubscribe($patterns = []): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->punsubscribe(...\func_get_args());
     }
 
     public function ssubscribe($channels, $callback): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ssubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->ssubscribe(...\func_get_args());
     }
 
     public function sunsubscribe($channels = []): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunsubscribe(...\func_get_args());
+        return $this->initializeLazyObject()->sunsubscribe(...\func_get_args());
     }
 
     public function touch($key_or_array, ...$more_keys): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->touch(...\func_get_args());
+        return $this->initializeLazyObject()->touch(...\func_get_args());
     }
 
     public function pipeline(): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pipeline(...\func_get_args());
+        return $this->initializeLazyObject()->pipeline(...\func_get_args());
     }
 
     public function multi($mode = 0): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi(...\func_get_args());
+        return $this->initializeLazyObject()->multi(...\func_get_args());
     }
 
     public function exec(): \Relay\Relay|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec(...\func_get_args());
+        return $this->initializeLazyObject()->exec(...\func_get_args());
     }
 
     public function wait($replicas, $timeout): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->wait(...\func_get_args());
+        return $this->initializeLazyObject()->wait(...\func_get_args());
     }
 
     public function watch($key, ...$other_keys): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch(...\func_get_args());
+        return $this->initializeLazyObject()->watch(...\func_get_args());
     }
 
     public function unwatch(): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch(...\func_get_args());
+        return $this->initializeLazyObject()->unwatch(...\func_get_args());
     }
 
     public function discard(): bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard(...\func_get_args());
+        return $this->initializeLazyObject()->discard(...\func_get_args());
     }
 
     public function getMode($masked = false): int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getMode(...\func_get_args());
+        return $this->initializeLazyObject()->getMode(...\func_get_args());
     }
 
     public function clearBytes(): void
     {
-        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearBytes(...\func_get_args());
+        $this->initializeLazyObject()->clearBytes(...\func_get_args());
     }
 
     public function scan(&$iterator, $match = null, $count = 0, $type = null): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, ...\array_slice(\func_get_args(), 1));
+        return $this->initializeLazyObject()->scan($iterator, ...\array_slice(\func_get_args(), 1));
     }
 
     public function hscan($key, &$iterator, $match = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->hscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function sscan($key, &$iterator, $match = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->sscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function zscan($key, &$iterator, $match = null, $count = 0): array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
+        return $this->initializeLazyObject()->zscan($key, $iterator, ...\array_slice(\func_get_args(), 2));
     }
 
     public function keys($pattern): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys(...\func_get_args());
+        return $this->initializeLazyObject()->keys(...\func_get_args());
     }
 
     public function slowlog($operation, ...$extra_args): \Relay\Relay|array|bool|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog(...\func_get_args());
+        return $this->initializeLazyObject()->slowlog(...\func_get_args());
     }
 
     public function smembers($set): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smembers(...\func_get_args());
+        return $this->initializeLazyObject()->smembers(...\func_get_args());
     }
 
     public function sismember($set, $member): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember(...\func_get_args());
+        return $this->initializeLazyObject()->sismember(...\func_get_args());
     }
 
     public function smismember($set, ...$members): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smismember(...\func_get_args());
+        return $this->initializeLazyObject()->smismember(...\func_get_args());
     }
 
     public function srem($set, $member, ...$members): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem(...\func_get_args());
+        return $this->initializeLazyObject()->srem(...\func_get_args());
     }
 
     public function sadd($set, $member, ...$members): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sadd(...\func_get_args());
+        return $this->initializeLazyObject()->sadd(...\func_get_args());
     }
 
     public function sort($key, $options = []): \Relay\Relay|array|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort(...\func_get_args());
+        return $this->initializeLazyObject()->sort(...\func_get_args());
     }
 
     public function sort_ro($key, $options = []): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort_ro(...\func_get_args());
+        return $this->initializeLazyObject()->sort_ro(...\func_get_args());
     }
 
     public function smove($srcset, $dstset, $member): \Relay\Relay|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smove(...\func_get_args());
+        return $this->initializeLazyObject()->smove(...\func_get_args());
     }
 
     public function spop($set, $count = 1): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->spop(...\func_get_args());
+        return $this->initializeLazyObject()->spop(...\func_get_args());
     }
 
     public function srandmember($set, $count = 1): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srandmember(...\func_get_args());
+        return $this->initializeLazyObject()->srandmember(...\func_get_args());
     }
 
     public function scard($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard(...\func_get_args());
+        return $this->initializeLazyObject()->scard(...\func_get_args());
     }
 
     public function script($command, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script(...\func_get_args());
+        return $this->initializeLazyObject()->script(...\func_get_args());
     }
 
     public function strlen($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen(...\func_get_args());
+        return $this->initializeLazyObject()->strlen(...\func_get_args());
     }
 
     public function hlen($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hlen(...\func_get_args());
+        return $this->initializeLazyObject()->hlen(...\func_get_args());
     }
 
     public function llen($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->llen(...\func_get_args());
+        return $this->initializeLazyObject()->llen(...\func_get_args());
     }
 
     public function xack($key, $group, $ids): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack(...\func_get_args());
+        return $this->initializeLazyObject()->xack(...\func_get_args());
     }
 
     public function xadd($key, $id, $values, $maxlen = 0, $approx = false, $nomkstream = false): \Relay\Relay|false|string
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd(...\func_get_args());
+        return $this->initializeLazyObject()->xadd(...\func_get_args());
     }
 
     public function xclaim($key, $group, $consumer, $min_idle, $ids, $options): \Relay\Relay|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim(...\func_get_args());
+        return $this->initializeLazyObject()->xclaim(...\func_get_args());
     }
 
     public function xautoclaim($key, $group, $consumer, $min_idle, $start, $count = -1, $justid = false): \Relay\Relay|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xautoclaim(...\func_get_args());
+        return $this->initializeLazyObject()->xautoclaim(...\func_get_args());
     }
 
     public function xlen($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen(...\func_get_args());
+        return $this->initializeLazyObject()->xlen(...\func_get_args());
     }
 
     public function xgroup($operation, $key = null, $group = null, $id_or_consumer = null, $mkstream = false, $entries_read = -2): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xgroup(...\func_get_args());
     }
 
     public function xdel($key, $ids): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel(...\func_get_args());
+        return $this->initializeLazyObject()->xdel(...\func_get_args());
     }
 
     public function xinfo($operation, $arg1 = null, $arg2 = null, $count = -1): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo(...\func_get_args());
+        return $this->initializeLazyObject()->xinfo(...\func_get_args());
     }
 
     public function xpending($key, $group, $start = null, $end = null, $count = -1, $consumer = null, $idle = 0): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending(...\func_get_args());
+        return $this->initializeLazyObject()->xpending(...\func_get_args());
     }
 
     public function xrange($key, $start, $end, $count = -1): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrange(...\func_get_args());
     }
 
     public function xrevrange($key, $end, $start, $count = -1): \Relay\Relay|array|bool
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange(...\func_get_args());
+        return $this->initializeLazyObject()->xrevrange(...\func_get_args());
     }
 
     public function xread($streams, $count = -1, $block = -1): \Relay\Relay|array|bool|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread(...\func_get_args());
+        return $this->initializeLazyObject()->xread(...\func_get_args());
     }
 
     public function xreadgroup($group, $consumer, $streams, $count = 1, $block = 1): \Relay\Relay|array|bool|null
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup(...\func_get_args());
+        return $this->initializeLazyObject()->xreadgroup(...\func_get_args());
     }
 
     public function xtrim($key, $threshold, $approx = false, $minid = false, $limit = -1): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim(...\func_get_args());
+        return $this->initializeLazyObject()->xtrim(...\func_get_args());
     }
 
     public function zadd($key, ...$args): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zadd(...\func_get_args());
+        return $this->initializeLazyObject()->zadd(...\func_get_args());
     }
 
     public function zrandmember($key, $options = null): mixed
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrandmember(...\func_get_args());
+        return $this->initializeLazyObject()->zrandmember(...\func_get_args());
     }
 
     public function zrange($key, $start, $end, $options = null): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrange(...\func_get_args());
+        return $this->initializeLazyObject()->zrange(...\func_get_args());
     }
 
     public function zrevrange($key, $start, $end, $options = null): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrange(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrange(...\func_get_args());
     }
 
     public function zrangebyscore($key, $start, $end, $options = null): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zrangebyscore(...\func_get_args());
     }
 
     public function zrevrangebyscore($key, $start, $end, $options = null): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrangebyscore(...\func_get_args());
     }
 
     public function zrangestore($dst, $src, $start, $end, $options = null): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangestore(...\func_get_args());
+        return $this->initializeLazyObject()->zrangestore(...\func_get_args());
     }
 
     public function zrangebylex($key, $min, $max, $offset = -1, $count = -1): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zrangebylex(...\func_get_args());
     }
 
     public function zrevrangebylex($key, $max, $min, $offset = -1, $count = -1): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrangebylex(...\func_get_args());
     }
 
     public function zrank($key, $rank, $withscore = false): \Relay\Relay|array|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrank(...\func_get_args());
+        return $this->initializeLazyObject()->zrank(...\func_get_args());
     }
 
     public function zrevrank($key, $rank, $withscore = false): \Relay\Relay|array|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrank(...\func_get_args());
+        return $this->initializeLazyObject()->zrevrank(...\func_get_args());
     }
 
     public function zrem($key, ...$args): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrem(...\func_get_args());
+        return $this->initializeLazyObject()->zrem(...\func_get_args());
     }
 
     public function zremrangebylex($key, $min, $max): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebylex(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebylex(...\func_get_args());
     }
 
     public function zremrangebyrank($key, $start, $end): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyrank(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebyrank(...\func_get_args());
     }
 
     public function zremrangebyscore($key, $min, $max): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyscore(...\func_get_args());
+        return $this->initializeLazyObject()->zremrangebyscore(...\func_get_args());
     }
 
     public function zcard($key): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcard(...\func_get_args());
+        return $this->initializeLazyObject()->zcard(...\func_get_args());
     }
 
     public function zcount($key, $min, $max): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcount(...\func_get_args());
+        return $this->initializeLazyObject()->zcount(...\func_get_args());
     }
 
     public function zdiff($keys, $options = null): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiff(...\func_get_args());
+        return $this->initializeLazyObject()->zdiff(...\func_get_args());
     }
 
     public function zdiffstore($dst, $keys): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiffstore(...\func_get_args());
+        return $this->initializeLazyObject()->zdiffstore(...\func_get_args());
     }
 
     public function zincrby($key, $score, $mem): \Relay\Relay|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zincrby(...\func_get_args());
+        return $this->initializeLazyObject()->zincrby(...\func_get_args());
     }
 
     public function zlexcount($key, $min, $max): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zlexcount(...\func_get_args());
+        return $this->initializeLazyObject()->zlexcount(...\func_get_args());
     }
 
     public function zmscore($key, ...$mems): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zmscore(...\func_get_args());
+        return $this->initializeLazyObject()->zmscore(...\func_get_args());
     }
 
     public function zscore($key, $member): \Relay\Relay|false|float
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscore(...\func_get_args());
+        return $this->initializeLazyObject()->zscore(...\func_get_args());
     }
 
     public function zinter($keys, $weights = null, $options = null): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinter(...\func_get_args());
+        return $this->initializeLazyObject()->zinter(...\func_get_args());
     }
 
     public function zintercard($keys, $limit = -1): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zintercard(...\func_get_args());
+        return $this->initializeLazyObject()->zintercard(...\func_get_args());
     }
 
     public function zinterstore($dst, $keys, $weights = null, $options = null): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore(...\func_get_args());
+        return $this->initializeLazyObject()->zinterstore(...\func_get_args());
     }
 
     public function zunion($keys, $weights = null, $options = null): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunion(...\func_get_args());
+        return $this->initializeLazyObject()->zunion(...\func_get_args());
     }
 
     public function zunionstore($dst, $keys, $weights = null, $options = null): \Relay\Relay|false|int
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore(...\func_get_args());
+        return $this->initializeLazyObject()->zunionstore(...\func_get_args());
     }
 
     public function zpopmin($key, $count = 1): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmin(...\func_get_args());
+        return $this->initializeLazyObject()->zpopmin(...\func_get_args());
     }
 
     public function zpopmax($key, $count = 1): \Relay\Relay|array|false
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmax(...\func_get_args());
+        return $this->initializeLazyObject()->zpopmax(...\func_get_args());
     }
 
     public function _getKeys()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_getKeys(...\func_get_args());
+        return $this->initializeLazyObject()->_getKeys(...\func_get_args());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Making things a bit simpler.
Forwarding dynamic properties to the real instance is the only benefit of using LazyProxyTrait here, and this has no use cases.