### PR TITLE
[AssetMapper] Fix AssetMapper commands need http_client service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -197,7 +197,7 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('asset_mapper.importmap.resolver', JsDelivrEsmResolver::class)
-            ->args([service('http_client')])
+            ->args([service('http_client')->nullOnInvalid()])
 
         ->set('asset_mapper.importmap.renderer', ImportMapRenderer::class)
             ->args([
@@ -212,12 +212,12 @@ return static function (ContainerConfigurator $container) {
         ->set('asset_mapper.importmap.auditor', ImportMapAuditor::class)
         ->args([
             service('asset_mapper.importmap.config_reader'),
-            service('http_client'),
+            service('http_client')->nullOnInvalid(),
         ])
         ->set('asset_mapper.importmap.update_checker', ImportMapUpdateChecker::class)
         ->args([
             service('asset_mapper.importmap.config_reader'),
-            service('http_client'),
+            service('http_client')->nullOnInvalid(),
         ])
 
         ->set('asset_mapper.importmap.command.require', ImportMapRequireCommand::class)

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapUpdateChecker.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapUpdateChecker.php
@@ -11,16 +11,20 @@
 
 namespace Symfony\Component\AssetMapper\ImportMap;
 
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ImportMapUpdateChecker
 {
     private const URL_PACKAGE_METADATA = 'https://registry.npmjs.org/%s';
 
+    private readonly HttpClientInterface $httpClient;
+
     public function __construct(
         private readonly ImportMapConfigReader $importMapConfigReader,
-        private readonly HttpClientInterface $httpClient,
+        ?HttpClientInterface $httpClient = null,
     ) {
+        $this->httpClient = $httpClient ?? HttpClient::create();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #57073 
| License       | MIT

Alternative solution to #57219 
