### PR TITLE
[DependencyInjection] Fix regression in ordering service locators by priority

### DIFF
--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -53,7 +53,7 @@ final class CompletionInput extends ArgvInput
      * Create an input based on an COMP_WORDS token list.
      *
      * @param string[] $tokens       the set of split tokens (e.g. COMP_WORDS or argv)
-     * @param          $currentIndex the index of the cursor (e.g. COMP_CWORD)
+     * @param int      $currentIndex the index of the cursor (e.g. COMP_CWORD)
      */
     public static function fromTokens(array $tokens, int $currentIndex): self
     {

--- a/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
@@ -133,4 +133,19 @@ class CompletionInputTest extends TestCase
         yield ['bin/console cache:clear "multi word string"', ['bin/console', 'cache:clear', '"multi word string"']];
         yield ['bin/console cache:clear \'multi word string\'', ['bin/console', 'cache:clear', '\'multi word string\'']];
     }
+
+    public function testToString()
+    {
+        $input = CompletionInput::fromTokens(['foo', 'bar', 'baz'], 0);
+        $this->assertSame('foo| bar baz', (string) $input);
+
+        $input = CompletionInput::fromTokens(['foo', 'bar', 'baz'], 1);
+        $this->assertSame('foo bar| baz', (string) $input);
+
+        $input = CompletionInput::fromTokens(['foo', 'bar', 'baz'], 2);
+        $this->assertSame('foo bar baz|', (string) $input);
+
+        $input = CompletionInput::fromTokens(['foo', 'bar', 'baz'], 11);
+        $this->assertSame('foo bar baz |', (string) $input);
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
@@ -131,7 +131,6 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
 
             $services[$k] = new ServiceClosureArgument($v);
         }
-        ksort($services);
 
         return $services;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -623,7 +623,7 @@ class IntegrationTest extends TestCase
         // We need to check priority of instances in the factories
         $factories = (new \ReflectionClass($locator))->getProperty('factories');
 
-        self::assertSame([BarTagClass::class, FooTagClass::class], array_keys($factories->getValue($locator)));
+        self::assertSame([FooTagClass::class, BarTagClass::class], array_keys($factories->getValue($locator)));
     }
 
     public function testTaggedLocatorWithDefaultIndexMethodAndWithDefaultPriorityMethodConfiguredViaAttribute()
@@ -652,7 +652,7 @@ class IntegrationTest extends TestCase
         // We need to check priority of instances in the factories
         $factories = (new \ReflectionClass($locator))->getProperty('factories');
 
-        self::assertSame(['bar_tag_class', 'foo_tag_class'], array_keys($factories->getValue($locator)));
+        self::assertSame(['foo_tag_class', 'bar_tag_class'], array_keys($factories->getValue($locator)));
         self::assertSame($container->get(BarTagClass::class), $locator->get('bar_tag_class'));
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -462,7 +462,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowired', [new Autowire(service: 'service.id')])),
             'autowired.nullable' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'autowired.nullable', [new Autowire(service: 'service.id')])),
             'autowired.parameter' => new ServiceClosureArgument('foobar'),
-            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.oO4rxCy.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
+            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.0tSxobl.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'target', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -214,7 +214,7 @@ class ServiceLocatorTagPassTest extends TestCase
         $locator = $container->getDefinition($locator);
         $factories = $locator->getArguments()[0];
 
-        static::assertSame(['service-1', 'service-2'], array_keys($factories));
+        static::assertSame(['service-2', 'service-1'], array_keys($factories));
     }
 
     public function testBindingsAreProcessed()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -43,9 +43,9 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.2hyyc9y' => true,
-            '.service_locator.KGUGnmw' => true,
-            '.service_locator.KGUGnmw.foo_service' => true,
+            '.service_locator.0H1ht0q' => true,
+            '.service_locator.0H1ht0q.foo_service' => true,
+            '.service_locator.tfSHZa1' => true,
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => true,
         ];
     }
@@ -68,14 +68,14 @@ class ProjectServiceContainer extends Container
     protected static function getFooServiceService($container)
     {
         return $container->services['foo_service'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber((new \Symfony\Component\DependencyInjection\Argument\ServiceLocator($container->getService ??= $container->getService(...), [
-            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => ['privates', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition', 'getCustomDefinitionService', false],
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber' => ['services', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber', 'getTestServiceSubscriberService', false],
+            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => ['privates', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition', 'getCustomDefinitionService', false],
             'bar' => ['services', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber', 'getTestServiceSubscriberService', false],
             'baz' => ['privates', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition', 'getCustomDefinitionService', false],
             'late_alias' => ['services', 'late_alias', 'getLateAliasService', false],
         ], [
-            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition',
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber',
+            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition',
             'bar' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition',
             'baz' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition',
             'late_alias' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestDefinition1',

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -171,17 +171,17 @@ class FilesystemTest extends FilesystemTestCase
         }
 
         $finder = new PhpExecutableFinder();
-        $process = new Process(array_merge([$finder->find(false)], $finder->findArguments(), ['-dopcache.enable=0', '-dvariables_order=EGPCS', '-S', 'localhost:8057']));
+        $process = new Process(array_merge([$finder->find(false)], $finder->findArguments(), ['-dopcache.enable=0', '-dvariables_order=EGPCS', '-S', 'localhost:8857']));
         $process->setWorkingDirectory(__DIR__.'/Fixtures/web');
 
         $process->start();
 
         do {
             usleep(50000);
-        } while (!@fopen('http://localhost:8057', 'r'));
+        } while (!@fopen('http://localhost:8857', 'r'));
 
         try {
-            $sourceFilePath = 'http://localhost:8057/logo_symfony_header.png';
+            $sourceFilePath = 'http://localhost:8857/logo_symfony_header.png';
             $targetFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_target_file';
             file_put_contents($targetFilePath, 'TARGET FILE');
             $this->filesystem->copy($sourceFilePath, $targetFilePath, false);

--- a/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
@@ -143,15 +143,15 @@ class DataPartTest extends TestCase
         }
 
         $finder = new PhpExecutableFinder();
-        $process = new Process(array_merge([$finder->find(false)], $finder->findArguments(), ['-dopcache.enable=0', '-dvariables_order=EGPCS', '-S', 'localhost:8057']));
+        $process = new Process(array_merge([$finder->find(false)], $finder->findArguments(), ['-dopcache.enable=0', '-dvariables_order=EGPCS', '-S', 'localhost:8856']));
         $process->setWorkingDirectory(__DIR__.'/../Fixtures/web');
         $process->start();
 
         try {
             do {
                 usleep(50000);
-            } while (!@fopen('http://localhost:8057', 'r'));
-            $p = DataPart::fromPath($file = 'http://localhost:8057/logo_symfony_header.png');
+            } while (!@fopen('http://localhost:8856', 'r'));
+            $p = DataPart::fromPath($file = 'http://localhost:8856/logo_symfony_header.png');
             $content = file_get_contents($file);
             $this->assertEquals($content, $p->getBody());
             $maxLineLength = 76;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57344
| License       | MIT

Fixes a regression in Symfony 7.0 where service locators are no longer ordered by priority.

