### PR TITLE
[AssetMapper] Surround brittle test teardown with `try/catch`

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
 use Symfony\Component\AssetMapper\ImportMap\RemotePackageStorage;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 class RemotePackageStorageTest extends TestCase
@@ -32,7 +33,11 @@ class RemotePackageStorageTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->filesystem->remove(self::$writableRoot);
+        try {
+            $this->filesystem->remove(self::$writableRoot);
+        } catch (IOException) {
+            // no-op
+        }
     }
 
     public function testGetStorageDir()

--- a/src/Symfony/Component/AssetMapper/Tests/Path/LocalPublicAssetsFilesystemTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Path/LocalPublicAssetsFilesystemTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\AssetMapper\Tests\Path;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\AssetMapper\Path\LocalPublicAssetsFilesystem;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 class LocalPublicAssetsFilesystemTest extends TestCase
@@ -30,7 +31,11 @@ class LocalPublicAssetsFilesystemTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->filesystem->remove(self::$writableRoot);
+        try {
+            $this->filesystem->remove(self::$writableRoot);
+        } catch (IOException) {
+            // no-op
+        }
     }
 
     public function testWrite()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix AppVeyor
| License       | MIT

AppVeyor [fails regularly](https://ci.appveyor.com/project/fabpot/symfony/builds/49973140) when tearing down `RemotePackageStorageTest`. I think it is acceptable to surround it with a `try/catch`, because everything will be erased in AppVeyor once the test suite is ran.