### PR TITLE
[Validator] fix cssColor HSLA test dataProvider

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
@@ -396,7 +396,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @dataProvider getInvalidHSL
+     * @dataProvider getInvalidHSLA
      */
     public function testInvalidHSLA($cssColor)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix cssColor HSLA test dataProvider
| License       | MIT

`testInvalidHSLA`  refers to a wrong dataProvider method
