### PR TITLE
[ErrorHandler] Fix rendered exception code highlighting on PHP 8.3

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -129,12 +129,10 @@ final class CodeExtension extends AbstractExtension
             if (\PHP_VERSION_ID >= 80300) {
                 // remove main pre/code tags
                 $code = preg_replace('#^<pre.*?>\s*<code.*?>(.*)</code>\s*</pre>#s', '\\1', $code);
-                // split multiline code tags
-                $code = preg_replace_callback('#<code ([^>]++)>((?:[^<]*+\\n)++[^<]*+)</code>#', function ($m) {
-                    return "<code $m[1]>".str_replace("\n", "</code>\n<code $m[1]>", $m[2]).'</code>';
+                // split multiline span tags
+                $code = preg_replace_callback('#<span ([^>]++)>((?:[^<\\n]*+\\n)++[^<]*+)</span>#', function ($m) {
+                    return "<span $m[1]>".str_replace("\n", "</span>\n<span $m[1]>", $m[2]).'</span>';
                 }, $code);
-                // Convert spaces to html entities to preserve indentation when rendered
-                $code = str_replace(' ', '&nbsp;', $code);
                 $content = explode("\n", $code);
             } else {
                 // remove main code/span tags

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -274,12 +274,10 @@ class HtmlErrorRenderer implements ErrorRendererInterface
             if (\PHP_VERSION_ID >= 80300) {
                 // remove main pre/code tags
                 $code = preg_replace('#^<pre.*?>\s*<code.*?>(.*)</code>\s*</pre>#s', '\\1', $code);
-                // split multiline code tags
-                $code = preg_replace_callback('#<code ([^>]++)>((?:[^<]*+\\n)++[^<]*+)</code>#', function ($m) {
-                    return "<code $m[1]>".str_replace("\n", "</code>\n<code $m[1]>", $m[2]).'</code>';
+                // split multiline span tags
+                $code = preg_replace_callback('#<span ([^>]++)>((?:[^<\\n]*+\\n)++[^<]*+)</span>#', function ($m) {
+                    return "<span $m[1]>".str_replace("\n", "</span>\n<span $m[1]>", $m[2]).'</span>';
                 }, $code);
-                // Convert spaces to html entities to preserve indentation when rendered
-                $code = str_replace(' ', '&nbsp;', $code);
                 $content = explode("\n", $code);
             } else {
                 // remove main code/span tags

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -242,7 +242,7 @@ header .container { display: flex; justify-content: space-between; }
 .trace-code li { color: #969896; margin: 0; padding-left: 10px; float: left; width: 100%; }
 .trace-code li + li { margin-top: 5px; }
 .trace-code li.selected { background: var(--trace-selected-background); margin-top: 2px; }
-.trace-code li code { color: var(--base-6); white-space: nowrap; }
+.trace-code li code { color: var(--base-6); white-space: pre; }
 
 .trace-as-text .stacktrace { line-height: 1.8; margin: 0 0 15px; white-space: pre-wrap; }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57354
| License       | MIT

https://github.com/symfony/symfony/pull/51586 made some mistakes when fixing the use of `highlight_file()` for PHP 8.3:
- It assumed that the inner `<span>` were changed to `<code>`
- It did not properly adjust the pattern for `\n` when splitting the highlighting across multiple lines
- It replaced all spaces with `&nbsp`, including those inside tags, breaking the highlighting entirely

The first two are easy to fix.

The latter one not so much without CSS adjustments. But just changing `white-space: nowrap` to `white-space: pre` would remove the need for that. I'm a bit worried about side effects though and I'm not sure if `CodeExtension` uses separate styling somewhere, but I can't find anything problematic at least.

A test would be a bit cumbersome to add for this, so unless very much preferred I'd rather not spend the time on it.
But at least in manual tests this resolved all the highlighting issues.