### PR TITLE
[PropertyInfo] Skip extractors that do not implement `getType`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -90,6 +90,12 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     private function extract(iterable $extractors, string $method, array $arguments): mixed
     {
         foreach ($extractors as $extractor) {
+            if (!method_exists($extractor, $method)) {
+                trigger_deprecation('symfony/property-info', '7.1', 'Not implementing the "%s()" method in class "%s" is deprecated."', $method, $extractor::class);
+
+                continue;
+            }
+
             if (null !== $value = $extractor->{$method}(...$arguments)) {
                 return $value;
             }

--- a/src/Symfony/Component/PropertyInfo/Tests/AbstractPropertyInfoExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/AbstractPropertyInfoExtractorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyExtractor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyLegacyExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NullExtractor;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
@@ -57,7 +58,10 @@ class AbstractPropertyInfoExtractorTest extends TestCase
 
     public function testGetType()
     {
-        $this->assertEquals(Type::int(), $this->propertyInfo->getType('Foo', 'bar', []));
+        $extractors = [new NullExtractor(), new DummyLegacyExtractor(), new DummyExtractor()];
+        $propertyInfo = new PropertyInfoExtractor($extractors, $extractors, $extractors, $extractors, $extractors);
+
+        $this->assertEquals(Type::int(), $propertyInfo->getType('Foo', 'bar', []));
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyLegacyExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyLegacyExtractor.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+use Symfony\Component\PropertyInfo\Extractor\ConstructorArgumentTypeExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\PropertyInfo\Type as LegacyType;
+use Symfony\Component\TypeInfo\Type;
+
+class DummyLegacyExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, ConstructorArgumentTypeExtractorInterface
+{
+    public function getShortDescription($class, $property, array $context = []): ?string
+    {
+        return 'short';
+    }
+
+    public function getLongDescription($class, $property, array $context = []): ?string
+    {
+        return 'long';
+    }
+
+    public function getTypes($class, $property, array $context = []): ?array
+    {
+        return [new LegacyType(LegacyType::BUILTIN_TYPE_INT)];
+    }
+
+    public function getTypesFromConstructor(string $class, string $property): ?array
+    {
+        return [new LegacyType(LegacyType::BUILTIN_TYPE_STRING)];
+    }
+
+    public function getTypeFromConstructor(string $class, string $property): ?Type
+    {
+        return Type::string();
+    }
+
+    public function isReadable($class, $property, array $context = []): ?bool
+    {
+        return true;
+    }
+
+    public function isWritable($class, $property, array $context = []): ?bool
+    {
+        return true;
+    }
+
+    public function getProperties($class, array $context = []): ?array
+    {
+        return ['a', 'b'];
+    }
+
+    public function isInitializable(string $class, string $property, array $context = []): ?bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #57360
| License       | MIT