### PR TITLE
[Security] Display authenticators in the profiler even if they are all skipped

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 
 /**
  * @author Timo Bakx <timobakx@gmail.com>
@@ -210,7 +211,7 @@ EOF
         $io->table(
             ['Classname'],
             array_map(
-                fn ($authenticator) => [$authenticator::class],
+                fn ($authenticator) => [($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)::class],
                 $authenticators
             )
         );

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -58,6 +58,7 @@ use Symfony\Component\Security\Core\User\ChainUserChecker;
 use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Flex\Command\InstallRecipesCommand;
@@ -635,6 +636,15 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                         $listeners[] = new Reference($firewallListenerId);
                     }
                 }
+            }
+        }
+
+        if ($container->hasDefinition('debug.security.firewall')) {
+            foreach ($authenticationProviders as $authenticatorId) {
+                $container->register('debug.'.$authenticatorId, TraceableAuthenticator::class)
+                    ->setDecoratedService($authenticatorId)
+                    ->setArguments([new Reference('debug.'.$authenticatorId.'.inner')])
+                ;
             }
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -360,7 +360,7 @@
 
                                 <tr>
                                     <td class="font-normal">{{ profiler_dump(authenticator.stub) }}</td>
-                                    <td class="no-wrap">{{ source('@WebProfiler/Icon/' ~ (authenticator.supports ? 'yes' : 'no') ~ '.svg') }}</td>
+                                    <td class="no-wrap">{{ source('@WebProfiler/Icon/' ~ (authenticator.supports is same as (false) ? 'no' : 'yes') ~ '.svg') }}</td>
                                     <td class="no-wrap">{{ authenticator.authenticated is not null ? source('@WebProfiler/Icon/' ~ (authenticator.authenticated ? 'yes' : 'no') ~ '.svg') : '' }}</td>
                                     <td class="no-wrap">{{ authenticator.duration is null ? '(none)' : '%0.2f ms'|format(authenticator.duration * 1000) }}</td>
                                     <td class="font-normal">{{ authenticator.passport ? profiler_dump(authenticator.passport) : '(none)' }}</td>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
 use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
@@ -99,7 +100,7 @@ class TraceableFirewallListenerTest extends TestCase
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $dispatcher = new EventDispatcher();
         $authenticatorManager = new AuthenticatorManager(
-            [$notSupportingAuthenticator, $supportingAuthenticator],
+            [new TraceableAuthenticator($notSupportingAuthenticator), new TraceableAuthenticator($supportingAuthenticator)],
             $tokenStorage,
             $dispatcher,
             'main'

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -108,12 +108,12 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             }
         }
 
+        $request->attributes->set('_security_skipped_authenticators', $skippedAuthenticators);
+        $request->attributes->set('_security_authenticators', $authenticators);
+
         if (!$authenticators) {
             return false;
         }
-
-        $request->attributes->set('_security_authenticators', $authenticators);
-        $request->attributes->set('_security_skipped_authenticators', $skippedAuthenticators);
 
         return $lazy ? null : true;
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Http\Firewall\AbstractListener;
 use Symfony\Component\Security\Http\Firewall\AuthenticatorManagerListener;
-use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -25,50 +24,38 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 final class TraceableAuthenticatorManagerListener extends AbstractListener implements ResetInterface
 {
-    private array $authenticatorsInfo = [];
-    private bool $hasVardumper;
+    private array $authenticators = [];
 
-    public function __construct(
-        private AuthenticatorManagerListener $authenticationManagerListener,
-    ) {
-        $this->hasVardumper = class_exists(ClassStub::class);
+    public function __construct(private AuthenticatorManagerListener $authenticationManagerListener)
+    {
     }
 
     public function supports(Request $request): ?bool
     {
-        return $this->authenticationManagerListener->supports($request);
+        $supports = $this->authenticationManagerListener->supports($request);
+
+        foreach($request->attributes->get('_security_skipped_authenticators') as $authenticator) {
+            $this->authenticators[] = $authenticator instanceof TraceableAuthenticator
+                ? $authenticator
+                : new TraceableAuthenticator($authenticator)
+            ;
+        }
+
+        $supportedAuthenticators = [];
+        foreach ($request->attributes->get('_security_authenticators') as $authenticator) {
+            $this->authenticators[] = $supportedAuthenticators[] = $authenticator instanceof TraceableAuthenticator
+                ? $authenticator :
+                new TraceableAuthenticator($authenticator)
+            ;
+        }
+        $request->attributes->set('_security_authenticators', $supportedAuthenticators);
+
+        return $supports;
     }
 
     public function authenticate(RequestEvent $event): void
     {
-        $request = $event->getRequest();
-
-        if (!$authenticators = $request->attributes->get('_security_authenticators')) {
-            return;
-        }
-
-        foreach ($request->attributes->get('_security_skipped_authenticators') as $skippedAuthenticator) {
-            $this->authenticatorsInfo[] = [
-                'supports' => false,
-                'stub' => $this->hasVardumper ? new ClassStub($skippedAuthenticator::class) : $skippedAuthenticator::class,
-                'passport' => null,
-                'duration' => 0,
-                'authenticated' => null,
-                'badges' => [],
-            ];
-        }
-
-        foreach ($authenticators as $key => $authenticator) {
-            $authenticators[$key] = new TraceableAuthenticator($authenticator);
-        }
-
-        $request->attributes->set('_security_authenticators', $authenticators);
-
         $this->authenticationManagerListener->authenticate($event);
-
-        foreach ($authenticators as $authenticator) {
-            $this->authenticatorsInfo[] = $authenticator->getInfo();
-        }
     }
 
     public function getAuthenticatorManagerListener(): AuthenticatorManagerListener
@@ -78,11 +65,14 @@ final class TraceableAuthenticatorManagerListener extends AbstractListener imple
 
     public function getAuthenticatorsInfo(): array
     {
-        return $this->authenticatorsInfo;
+        return array_map(
+            static fn (TraceableAuthenticator $authenticator) => $authenticator->getInfo(),
+            $this->authenticators
+        );
     }
 
     public function reset(): void
     {
-        $this->authenticatorsInfo = [];
+        $this->authenticators = [];
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
@@ -26,6 +26,11 @@ class TraceableAuthenticatorTest extends TestCase
         $passport = new SelfValidatingPassport(new UserBadge('robin', function () {}));
 
         $authenticator = $this->createMock(AuthenticatorInterface::class);
+        $authenticator->expects($this->once())
+            ->method('supports')
+            ->with($request)
+            ->willReturn(true);
+
         $authenticator
             ->expects($this->once())
             ->method('authenticate')
@@ -33,15 +38,23 @@ class TraceableAuthenticatorTest extends TestCase
             ->willReturn($passport);
 
         $traceable = new TraceableAuthenticator($authenticator);
+        $this->assertTrue($traceable->supports($request));
         $this->assertSame($passport, $traceable->authenticate($request));
         $this->assertSame($passport, $traceable->getInfo()['passport']);
     }
 
     public function testGetInfoWithoutAuth()
     {
+        $request = new Request();
+
         $authenticator = $this->createMock(AuthenticatorInterface::class);
+        $authenticator->expects($this->once())
+            ->method('supports')
+            ->with($request)
+            ->willReturn(false);
 
         $traceable = new TraceableAuthenticator($authenticator);
+        $this->assertFalse($traceable->supports($request));
         $this->assertNull($traceable->getInfo()['passport']);
         $this->assertIsArray($traceable->getInfo()['badges']);
         $this->assertSame([], $traceable->getInfo()['badges']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Currently if no authenticator supports the request, the `_security_skipped_authenticators` request attribute is not set which (among others) results in an empty list in the profiler’s security panel’s authenticators tab:

![](https://github.com/symfony/symfony/assets/1898254/37f63661-ad21-4945-b05a-396f4781b88f)

It makes more sense to display them all as not supported:

![](https://github.com/symfony/symfony/assets/1898254/ca7241c8-92f1-47f7-bdea-96fce6daf910)