### PR TITLE
[Console] Allow to override the command used to execute the application during autocompletion

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Allow to override the command used to execute the application during autocompletion
+
 7.1
 ---
 

--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -18,7 +18,8 @@ _sf_{{ COMMAND_NAME }}() {
 
     # Use newline as only separator to allow space in completion values
     IFS=$'\n'
-    local sf_cmd="${COMP_WORDS[0]}"
+    # _SF_CMD allows Symfony CLI to tell us to use a different command to run the console
+    local sf_cmd="${_SF_CMD:-${COMP_WORDS[0]}}"
 
     # for an alias, get the real script behind it
     sf_cmd_type=$(type -t $sf_cmd)

--- a/src/Symfony/Component/Console/Resources/completion.fish
+++ b/src/Symfony/Component/Console/Resources/completion.fish
@@ -9,7 +9,18 @@ function _sf_{{ COMMAND_NAME }}
     set sf_cmd (commandline -o)
     set c (count (commandline -oc))
 
-    set completecmd "$sf_cmd[1]" "_complete" "--no-interaction" "-sfish" "-a{{ VERSION }}"
+    # _SF_CMD allows Symfony CLI to tell us to use a different command to run the console
+    if set -q _SF_CMD; and test -n _SF_CMD
+      for i in $_SF_CMD
+          if [ $i != "" ]
+              set completecmd $completecmd "$i"
+          end
+      end
+    else
+      set completecmd $completecmd $sf_cmd[1]
+    end
+
+    set completecmd $completecmd "_complete" "--no-interaction" "-sfish" "-a{{ VERSION }}"
 
     for i in $sf_cmd
         if [ $i != "" ]

--- a/src/Symfony/Component/Console/Resources/completion.zsh
+++ b/src/Symfony/Component/Console/Resources/completion.zsh
@@ -33,7 +33,8 @@ _sf_{{ COMMAND_NAME }}() {
     fi
 
     # Prepare the command to obtain completions
-    requestComp="${words[0]} ${words[1]} _complete --no-interaction -szsh -a{{ VERSION }} -c$((CURRENT-1))" i=""
+    # _SF_CMD allows Symfony CLI to tell us to use a different command to run the console
+    requestComp="${words[0]} ${_SF_CMD:-${words[1]}} _complete --no-interaction -szsh -a{{ VERSION }} -c$((CURRENT-1))" i=""
     for w in ${words[@]}; do
         w=$(printf -- '%b' "$w")
         # remove quotes from typed values


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Relates to https://github.com/symfony-cli/console/pull/11

When running Symfony CLI autocompletion, we will forward `symfony console` autocompletion to the application autocompletion shell helper.
But we need to be allowed to define how to run the console for two reasons:
1. Ensure the console autocompletion uses `symfony console` under the hood to ensure the proper environment is used (PHP versions, extensions, etc)
2. Make sure the autocompletion is able to run properly (otherwise the autocompletion magics will make it think the binary to run is only `console` instead of `bin/console`)