### PR TITLE
[HttpKernel][Security] Fix accessing session for stateless request

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -66,7 +66,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $sessionMetadata = [];
         $sessionAttributes = [];
         $flashes = [];
-        if ($request->hasSession()) {
+        if (!$request->attributes->getBoolean('_stateless') && $request->hasSession()) {
             $session = $request->getSession();
             if ($session->isStarted()) {
                 $sessionMetadata['Created'] = date(\DATE_RFC822, $session->getMetadataBag()->getCreated());

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -97,7 +97,7 @@ class ProfilerListener implements EventSubscriberInterface
             return;
         }
 
-        $session = $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
+        $session = !$request->attributes->getBoolean('_stateless') && $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
 
         if ($session instanceof Session) {
             $usageIndexValue = $usageIndexReference = &$session->getUsageIndex();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
@@ -40,8 +40,8 @@ class ProfilerListenerTest extends TestCase
             ->willReturn($profile);
 
         $kernel = $this->createMock(HttpKernelInterface::class);
-        $mainRequest = $this->createMock(Request::class);
-        $subRequest = $this->createMock(Request::class);
+        $mainRequest = new Request();
+        $subRequest = new Request();
         $response = $this->createMock(Response::class);
 
         $requestStack = new RequestStack();

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -95,7 +95,7 @@ class ContextListener extends AbstractListener
         }
 
         $request = $event->getRequest();
-        $session = $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
+        $session = !$request->attributes->getBoolean('_stateless') && $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
 
         $request->attributes->set('_security_firewall_run', $this->sessionKey);
 


### PR DESCRIPTION
|Q|A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? |no
| Issues        | Fix #...
| License       | MIT

I'm getting some `Session was used while the request was declared stateless.` warning on my project.

When throwing an error in the `getSession` method, I found 3 places where the getSession were used without any check about the stateless state of the request.