### PR TITLE
[AssetMapper] Skip test with `chmod` failing on Windows

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
@@ -43,6 +43,10 @@ class RemotePackageStorageTest extends TestCase
 
     public function testSaveThrowsWhenVendorDirectoryIsNotWritable()
     {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('chmod is not supported on Windows');
+        }
+
         $this->filesystem->mkdir($vendorDir = self::$writableRoot.'/assets/acme/vendor');
         $this->filesystem->chmod($vendorDir, 0555);
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -172,7 +172,7 @@ class Filesystem
                 }
             } elseif (is_dir($file)) {
                 if (!$isRecursive) {
-                    $tmpName = \dirname(realpath($file)).'/.'.strrev(strtr(base64_encode(random_bytes(2)), '/=', '-_'));
+                    $tmpName = \dirname(realpath($file)).'/.'.strrev(strtr(base64_encode(random_bytes(2)), '/=', '-.'));
 
                     if (file_exists($tmpName)) {
                         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

Test to check solution for #https://github.com/symfony/symfony/pull/57346

(cannot test on Windows elsewhere)
