### PR TITLE
[Security] Change to `BadCredentialsException` when empty username / password

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
@@ -130,7 +131,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
         $credentials['username'] = trim($credentials['username']);
 
         if ('' === $credentials['username']) {
-            throw new BadRequestHttpException(sprintf('The key "%s" must be a non-empty string.', $this->options['username_parameter']));
+            throw new BadCredentialsException(sprintf('The key "%s" must be a non-empty string.', $this->options['username_parameter']));
         }
 
         $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $credentials['username']);
@@ -140,7 +141,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
         }
 
         if ('' === (string) $credentials['password']) {
-            throw new BadRequestHttpException(sprintf('The key "%s" must be a non-empty string.', $this->options['password_parameter']));
+            throw new BadCredentialsException(sprintf('The key "%s" must be a non-empty string.', $this->options['password_parameter']));
         }
 
         if (!\is_string($credentials['csrf_token'] ?? '') && (!\is_object($credentials['csrf_token']) || !method_exists($credentials['csrf_token'], '__toString'))) {

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -44,7 +44,7 @@ class FormLoginAuthenticatorTest extends TestCase
 
     public function testHandleWhenUsernameEmpty()
     {
-        $this->expectException(BadRequestHttpException::class);
+        $this->expectException(BadCredentialsException::class);
         $this->expectExceptionMessage('The key "_username" must be a non-empty string.');
 
         $request = Request::create('/login_check', 'POST', ['_username' => '', '_password' => 's$cr$t']);
@@ -56,7 +56,7 @@ class FormLoginAuthenticatorTest extends TestCase
 
     public function testHandleWhenPasswordEmpty()
     {
-        $this->expectException(BadRequestHttpException::class);
+        $this->expectException(BadCredentialsException::class);
         $this->expectExceptionMessage('The key "_password" must be a non-empty string.');
 
         $request = Request::create('/login_check', 'POST', ['_username' => 'foo', '_password' => '']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      |no
| New feature?  |no 
| Deprecations? |no
| Issues        | Fix https://github.com/symfony/symfony/pull/53851#issuecomment-2162636985
| License       | MIT

~Tests will likely fail since they are running flipped.~
