### PR TITLE
[DependencyInjection] Add `#[WhenNot]` attribute

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `#[WhenNot]` attribute to prevent service from being registered in a specific environment
+
 7.1
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Attribute/WhenNot.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/WhenNot.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to tell under which environment this class should NOT be registered as a service.
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
+class WhenNot
+{
+    public function __construct(
+        public string $env,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/BadAttributes/WhenNotWhenFoo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/BadAttributes/WhenNotWhenFoo.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\BadAttributes;
+
+use Symfony\Component\DependencyInjection\Attribute\WhenNot;
+use Symfony\Component\DependencyInjection\Attribute\When;
+
+#[When(env: 'dev')]
+#[WhenNot(env: 'test')]
+class WhenNotWhenFoo
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/NotFoo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/NotFoo.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
+
+use Symfony\Component\DependencyInjection\Attribute\WhenNot;
+
+#[NeverInProduction]
+#[WhenNot(env: 'dev')]
+class NotFoo
+{
+    public function __construct($bar = null, ?iterable $foo = null, ?object $baz = null)
+    {
+    }
+
+    public function setFoo(self $foo)
+    {
+    }
+}
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
+class NeverInProduction extends WhenNot
+{
+    public function __construct()
+    {
+        parent::__construct('prod');
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
@@ -16,6 +16,9 @@ services:
 
         shared: false
         configurator: c
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\NotFoo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\NotFoo
+        public: true
     foo:
         class: App\FooService
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/not_when_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/not_when_env.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Attribute\WhenNot;
+
+return #[WhenNot(env: 'prod')] function () {
+    throw new RuntimeException('This code should not be run.');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.expected.yml
@@ -16,6 +16,19 @@ services:
             message: '%service_id%'
         arguments: [1]
         factory: f
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\NotFoo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\NotFoo
+        public: true
+        tags:
+            - foo
+            - baz
+        deprecated:
+            package: vendor/package
+            version: '1.1'
+            message: '%service_id%'
+        lazy: true
+        arguments: [1]
+        factory: f
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.php
@@ -10,7 +10,7 @@ return function (ContainerConfigurator $c) {
     $di->load(Prototype::class.'\\', '../Prototype')
         ->public()
         ->autoconfigure()
-        ->exclude('../Prototype/{OtherDir,BadClasses,SinglyImplementedInterface,StaticConstructor}')
+        ->exclude('../Prototype/{OtherDir,BadClasses,BadAttributes,SinglyImplementedInterface,StaticConstructor}')
         ->factory('f')
         ->deprecate('vendor/package', '1.1', '%service_id%')
         ->args([0])

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
@@ -16,6 +16,19 @@ services:
             message: '%service_id%'
         arguments: [1]
         factory: f
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\NotFoo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\NotFoo
+        public: true
+        tags:
+            - foo
+            - baz
+        deprecated:
+            package: vendor/package
+            version: '1.1'
+            message: '%service_id%'
+        lazy: true
+        arguments: [1]
+        factory: f
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.php
@@ -10,7 +10,7 @@ return function (ContainerConfigurator $c) {
     $di->load(Prototype::class.'\\', '../Prototype')
         ->public()
         ->autoconfigure()
-        ->exclude(['../Prototype/OtherDir', '../Prototype/BadClasses', '../Prototype/SinglyImplementedInterface', '../Prototype/StaticConstructor'])
+        ->exclude(['../Prototype/OtherDir', '../Prototype/BadClasses', '../Prototype/BadAttributes', '../Prototype/SinglyImplementedInterface', '../Prototype/StaticConstructor'])
         ->factory('f')
         ->deprecate('vendor/package', '1.1', '%service_id%')
         ->args([0])

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/when_not_when_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/when_not_when_env.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Attribute\WhenNot;
+use Symfony\Component\DependencyInjection\Attribute\When;
+
+return #[When(env: 'dev')] #[WhenNot(env: 'prod')] function () {
+    throw new RuntimeException('This code should not be run.');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
-      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" exclude="../Prototype/{OtherDir,BadClasses,SinglyImplementedInterface,StaticConstructor}" />
+      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" exclude="../Prototype/{OtherDir,BadClasses,BadAttributes,SinglyImplementedInterface,StaticConstructor}" />
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_array.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_array.xml
@@ -4,6 +4,7 @@
       <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*">
           <exclude>../Prototype/OtherDir</exclude>
           <exclude>../Prototype/BadClasses</exclude>
+          <exclude>../Prototype/BadAttributes</exclude>
           <exclude>../Prototype/SinglyImplementedInterface</exclude>
           <exclude>../Prototype/StaticConstructor</exclude>
       </prototype>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_array_with_space_node.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_array_with_space_node.xml
@@ -4,6 +4,7 @@
       <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*">
           <exclude>../Prototype/OtherDir</exclude>
           <exclude>../Prototype/BadClasses</exclude>
+          <exclude>../Prototype/BadAttributes</exclude>
           <exclude>../Prototype/SinglyImplementedInterface</exclude>
           <exclude>../Prototype/StaticConstructor</exclude>
           <exclude> </exclude>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype.yml
@@ -1,4 +1,4 @@
 services:
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\:
         resource: ../Prototype
-        exclude: '../Prototype/{OtherDir,BadClasses,SinglyImplementedInterface,StaticConstructor}'
+        exclude: '../Prototype/{OtherDir,BadClasses,BadAttributes,SinglyImplementedInterface,StaticConstructor}'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
@@ -224,6 +225,29 @@ class PhpFileLoaderTest extends TestCase
         $loader = new PhpFileLoader($container, new FileLocator(), 'dev', new ConfigBuilderGenerator(sys_get_temp_dir()));
 
         $loader->load($fixtures.'/config/when_env.php');
+    }
+
+    public function testNotWhenEnv()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator(), 'prod', new ConfigBuilderGenerator(sys_get_temp_dir()));
+
+        $loader->load($fixtures.'/config/not_when_env.php');
+    }
+
+    public function testUsingBothWhenAndNotWhenEnv()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator(), 'prod', new ConfigBuilderGenerator(sys_get_temp_dir()));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Using both #[When] and #[WhenNot] attributes on the same target is not allowed.');
+
+        $loader->load($fixtures.'/config/when_not_when_env.php');
     }
 
     public function testServiceWithServiceLocatorArgument()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -779,7 +779,7 @@ class XmlFileLoaderTest extends TestCase
 
         $ids = array_keys(array_filter($container->getDefinitions(), fn ($def) => !$def->hasTag('container.excluded')));
         sort($ids);
-        $this->assertSame([Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
+        $this->assertSame([Prototype\Foo::class, Prototype\NotFoo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
         $resources = array_map('strval', $container->getResources());
 
@@ -795,6 +795,7 @@ class XmlFileLoaderTest extends TestCase
             [
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'OtherDir') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'BadClasses') => true,
+                str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'BadAttributes') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'SinglyImplementedInterface') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'StaticConstructor') => true,
             ]
@@ -815,7 +816,7 @@ class XmlFileLoaderTest extends TestCase
 
         $ids = array_keys(array_filter($container->getDefinitions(), fn ($def) => !$def->hasTag('container.excluded')));
         sort($ids);
-        $this->assertSame([Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
+        $this->assertSame([Prototype\Foo::class, Prototype\NotFoo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
         $resources = array_map('strval', $container->getResources());
 
@@ -830,6 +831,7 @@ class XmlFileLoaderTest extends TestCase
             false,
             [
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'BadClasses') => true,
+                str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'BadAttributes') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'OtherDir') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'SinglyImplementedInterface') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'StaticConstructor') => true,

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -551,7 +551,7 @@ class YamlFileLoaderTest extends TestCase
 
         $ids = array_keys(array_filter($container->getDefinitions(), fn ($def) => !$def->hasTag('container.excluded')));
         sort($ids);
-        $this->assertSame([Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
+        $this->assertSame([Prototype\Foo::class, Prototype\NotFoo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
         $resources = array_map('strval', $container->getResources());
 
@@ -565,6 +565,7 @@ class YamlFileLoaderTest extends TestCase
             true,
             false, [
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'BadClasses') => true,
+                str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'BadAttributes') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'OtherDir') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'SinglyImplementedInterface') => true,
                 str_replace(\DIRECTORY_SEPARATOR, '/', $prototypeRealPath.\DIRECTORY_SEPARATOR.'StaticConstructor') => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

When dealing with many environment and concrete+test implementations of many services, it can be tricky/verbose to repeat `#[When]` for each and every existing env. By using `#[NotWhen]`, it becomes handy to deal with different implementations of a service across different env:

```php
// ConcreteService.php
#[WhenNot(env: 'test')]
class ConcreteService implements MyServiceInterface
{
    public function call()
    {
        dump("I'm a concrete service!");
    }
}

// TestService.php
#[When(env: 'test')]
class TestService implements MyServiceInterface
{
    public function call()
    {
        dump("I'm a test service!");
    }
}

// MyCommand.php
class MyCommand extends Command
{
    public function __construct(private MyServiceInterface $service)
    {
        parent::__construct();
    }

    // ...
}
```

It also eases the creation of a new env: no more need to go across all `#[When]` occurrences to update service definitions. 

You cannot use When and NotWhen at the same time:

```php
#[WhenNot(env: 'dev')]
#[When(env: 'test')]
class TestService implements MyServiceInterface
{
    public function call()
    {
        dump("I'm a test service!");
    }
}

// Throws a LogicException: The "App\Service\TestService" class cannot have both #[When] and #[NotWhen] attributes.
```