### PR TITLE
[Validator] fix IBAN validator fails if IBAN contains non-breaking space

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -179,8 +179,8 @@ class IbanValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        // Remove spaces and convert to uppercase
-        $canonicalized = str_replace(' ', '', strtoupper($value));
+        // Remove spaces (regular, non-breaking, and narrow non-breaking) and convert to uppercase
+        $canonicalized = str_replace([' ', "\xc2\xa0", "\xe2\x80\xaf"], '', strtoupper($value));
 
         // The IBAN must contain only digits and characters...
         if (!ctype_alnum($canonicalized)) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -77,6 +77,8 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
             ['FO97 5432 0388 8999 44'], // Faroe Islands
             ['FI21 1234 5600 0007 85'], // Finland
             ['FR14 2004 1010 0505 0001 3M02 606'], // France
+            ["FR14\xc2\xa02004\xc2\xa01010\xc2\xa00505\xc2\xa00001\xc2\xa03M02\xc2\xa0606"], // France with non-breaking spaces
+            ["FR14\xe2\x80\xaf2004\xe2\x80\xaf1010\xe2\x80\xaf0505\xe2\x80\xaf0001\xe2\x80\xaf3M02\xe2\x80\xaf606"], // France with narrow non-breaking spaces
             ['GE29 NB00 0000 0101 9049 17'], // Georgia
             ['DE89 3704 0044 0532 0130 00'], // Germany
             ['GI75 NWBK 0000 0000 7099 453'], // Gibraltar


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57364
| License       | MIT

Hello,
It's my first contribution to Symfony and I am really happy to be able to participate in the project.

After analyzing the class \Symfony\Component\Validator\Constraints\IbanValidator, I think the solution proposed in the issue is the right one.
