### PR TITLE
[VarExporter] Fix LazyProxyTrait skippedProperties injection

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -28,16 +28,16 @@ trait LazyProxyTrait
      * @param \Closure():object $initializer Returns the proxied object
      * @param static|null       $instance
      */
-    public static function createLazyProxy(\Closure $initializer, ?object $instance = null): static
+    public static function createLazyProxy(\Closure $initializer, ?object $instance = null, ?array $skippedProperties = null): static
     {
         if (self::class !== $class = $instance ? $instance::class : static::class) {
-            $skippedProperties = ["\0".self::class."\0lazyObjectState" => true];
+            $skippedProperties["\0".self::class."\0lazyObjectState"] = true;
         } elseif (\defined($class.'::LAZY_OBJECT_PROPERTY_SCOPES')) {
             Hydrator::$propertyScopes[$class] ??= $class::LAZY_OBJECT_PROPERTY_SCOPES;
         }
 
         $instance ??= (Registry::$classReflectors[$class] ??= new \ReflectionClass($class))->newInstanceWithoutConstructor();
-        $instance->lazyObjectState = new LazyObjectState($initializer);
+        $instance->lazyObjectState = new LazyObjectState($initializer, $skippedProperties ??= []);
 
         foreach (Registry::$classResetters[$class] ??= Registry::getClassResetters($class) as $reset) {
             $reset($instance, $skippedProperties ??= []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Using Foundry 2.0, the proxy system seems to fail with Symfony 7.1: https://github.com/zenstruck/foundry/pull/622

In Foundry proxy, a custom `$_autoRefresh` property should be skipped, but LazyProxyTrait does not allow to send `skippedProperties` (contrary to LazyGhostTrait, maybe a missing?). This PR aims to fix this missing argument in LazyProxyTrait::createLazyProxy method.

Note: targeting 6.4 as LazyProxyTrait has been introduced in 6.2