### PR TITLE
[Security] Display authenticators laziness and exception in the profiler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -340,10 +340,12 @@
                             <tr>
                                 <th>Authenticator</th>
                                 <th>Supports</th>
+                                <th>Lazy</th>
                                 <th>Authenticated</th>
                                 <th>Duration</th>
                                 <th>Passport</th>
                                 <th>Badges</th>
+                                <th>Exception</th>
                             </tr>
                             </thead>
 
@@ -361,7 +363,8 @@
                                 <tr>
                                     <td class="font-normal">{{ profiler_dump(authenticator.stub) }}</td>
                                     <td class="no-wrap">{{ source('@WebProfiler/Icon/' ~ (authenticator.supports ? 'yes' : 'no') ~ '.svg') }}</td>
-                                    <td class="no-wrap">{{ authenticator.authenticated is not null ? source('@WebProfiler/Icon/' ~ (authenticator.authenticated ? 'yes' : 'no') ~ '.svg') : '' }}</td>
+                                    <td class="no-wrap">{{ authenticator.lazy is not null ? source('@WebProfiler/Icon/' ~ (authenticator.lazy ? 'yes' : 'no') ~ '.svg') }}</td>
+                                    <td class="no-wrap">{{ authenticator.authenticated is not null ? source('@WebProfiler/Icon/' ~ (authenticator.authenticated ? 'yes' : 'no') ~ '.svg') }}</td>
                                     <td class="no-wrap">{{ authenticator.duration is null ? '(none)' : '%0.2f ms'|format(authenticator.duration * 1000) }}</td>
                                     <td class="font-normal">{{ authenticator.passport ? profiler_dump(authenticator.passport) : '(none)' }}</td>
                                     <td class="font-normal">
@@ -373,6 +376,7 @@
                                             (none)
                                         {% endfor %}
                                     </td>
+                                    <td class="font-normal">{{ authenticator.exception ? profiler_dump(authenticator.exception) : '(none)' }}</td>
                                 </tr>
 
                                 {% if loop.last %}

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
@@ -55,6 +55,8 @@ final class TraceableAuthenticatorManagerListener extends AbstractListener imple
                 'duration' => 0,
                 'authenticated' => null,
                 'badges' => [],
+                'lazy' => null,
+                'exception' => null,
             ];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix parts of #36668
| License       | MIT

This PR adds two pieces of information to each authenticator displayed in the profiler: its laziness (computed from the return of its `supports` call) and an eventual `AuthenticationException` thrown while executing it.

As you can see in the screenshot below (set the profiler’s width to the window’s for the occasion), there may be a better way to display the exception.

![](https://github.com/symfony/symfony/assets/1898254/c51f5c3d-4a6e-4885-8618-bf699e7ca2c7)
