### PR TITLE
[Notifier] Fix thread key in GoogleChat bridge

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
@@ -96,16 +96,22 @@ final class GoogleChatTransport extends AbstractTransport
 
         $threadKey = $opts->getThreadKey() ?: $this->threadKey;
 
-        $options = $opts->toArray();
         $url = sprintf('https://%s/v1/spaces/%s/messages?key=%s&token=%s%s',
             $this->getEndpoint(),
             $this->space,
             urlencode($this->accessKey),
             urlencode($this->accessToken),
-            $threadKey ? '&threadKey='.urlencode($threadKey) : ''
+            $threadKey ? '&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD' : ''
         );
+
+        $body = array_filter($opts->toArray());
+
+        if ($threadKey) {
+            $body['thread']['threadKey'] = $threadKey;
+        }
+
         $response = $this->client->request('POST', $url, [
-            'json' => array_filter($options),
+            'json' => $body,
         ]);
 
         try {

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
@@ -116,11 +116,11 @@ final class GoogleChatTransportTest extends TransportTestCase
             ->method('getContent')
             ->willReturn('{"name":"spaces/My-Space/messages/abcdefg.hijklmno"}');
 
-        $expectedBody = json_encode(['text' => $message]);
+        $expectedBody = json_encode(['text' => $message, 'thread' => ['threadKey' => 'My-Thread']]);
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://chat.googleapis.com/v1/spaces/My-Space/messages?key=theAccessKey&token=theAccessToken%3D&threadKey=My-Thread', $url);
+            $this->assertSame('https://chat.googleapis.com/v1/spaces/My-Space/messages?key=theAccessKey&token=theAccessToken%3D&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD', $url);
             $this->assertSame($expectedBody, $options['body']);
 
             return $response;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57323
| License       | MIT

Hello,

Google Chat API [has deprecated](https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/create#query-parameters) the use of `threadKey` query parameter in favor of `thread.threadKey` in request's body.

In order for the thread key value to not be ignored, a [new query parameter `messageReplyOption`](https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/create#messagereplyoption) has been added which controls the way the key is handled.
I chose **not to expose** the values used by this new parameter as I wanted to focus this PR on the actual fix.
To do so, I've forced the value of `messageReplyOption` to `REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` which replicates the original behavior of this bridge.