### PR TITLE
[Serializer][Validator] Fix propertyPath in ConstraintViolationListNormalizer with MetadataAwareNameConverter

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -62,7 +62,11 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
         $violations = [];
         $messages = [];
         foreach ($object as $violation) {
-            $propertyPath = $this->nameConverter ? $this->nameConverter->normalize($violation->getPropertyPath(), null, $format, $context) : $violation->getPropertyPath();
+            $propertyPath = $violation->getPropertyPath();
+
+            if (null !== $this->nameConverter) {
+                $propertyPath = $this->normalizePropertyPath($propertyPath, \is_object($violation->getRoot()) ? \get_class($violation->getRoot()) : null, $format, $context);
+            }
 
             $violationEntry = [
                 'propertyPath' => $propertyPath,
@@ -106,6 +110,48 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
         }
 
         return $result + ['violations' => $violations];
+    }
+
+    private function normalizePropertyPath(string $propertyPath, ?string $class, ?string $format, array $context): string
+    {
+        if (!str_contains($propertyPath, '.')) {
+            return $this->nameConverter->normalize($propertyPath, $class, $format, $context);
+        }
+
+        $result = [];
+        $currentClass = $class;
+
+        foreach (explode('.', $propertyPath) as $segment) {
+            $subscript = '';
+            $propertyName = $segment;
+            if (false !== $bracketPos = strpos($segment, '[')) {
+                $propertyName = substr($segment, 0, $bracketPos);
+                $subscript = substr($segment, $bracketPos);
+            }
+
+            $result[] = $this->nameConverter->normalize($propertyName, $currentClass, $format, $context).$subscript;
+
+            $currentClass = $this->getPropertyClassFromReflection($currentClass, $propertyName);
+        }
+
+        return implode('.', $result);
+    }
+
+    private function getPropertyClassFromReflection(?string $class, string $property): ?string
+    {
+        if (null === $class) {
+            return null;
+        }
+
+        try {
+            $type = (new \ReflectionProperty($class, $property))->getType();
+            if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                return $type->getName();
+            }
+        } catch (\ReflectionException) {
+        }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Dummy/DummyClassTwo.php
+++ b/src/Symfony/Component/Serializer/Tests/Dummy/DummyClassTwo.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Dummy;
+
+use Symfony\Component\Serializer\Attribute\SerializedName;
+
+class DummyClassTwo
+{
+    #[SerializedName('nested')]
+    public DummyClassOne $child;
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
@@ -12,8 +12,14 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\ClassMetadata;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
+use Symfony\Component\Serializer\Tests\Dummy\DummyClassOne;
+use Symfony\Component\Serializer\Tests\Dummy\DummyClassTwo;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -105,6 +111,66 @@ error',
                     'propertyPath' => '',
                     'title' => 'error',
                     'template' => 'c',
+                    'parameters' => [],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $normalizer->normalize($list));
+    }
+
+    public function testNormalizeWithMetadataAwareNameConverter()
+    {
+        $attributeLoader = new AttributeLoader();
+        $attributeLoader->loadClassMetadata(new ClassMetadata(DummyClassOne::class));
+
+        $nameConverter = new MetadataAwareNameConverter(new ClassMetadataFactory($attributeLoader));
+        $normalizer = new ConstraintViolationListNormalizer([], $nameConverter);
+
+        $list = new ConstraintViolationList([
+            new ConstraintViolation('too long', 'a', [], new DummyClassOne(), 'code', ''),
+        ]);
+
+        $expected = [
+            'type' => 'https://symfony.com/errors/validation',
+            'title' => 'Validation Failed',
+            'detail' => 'identifier: too long',
+            'violations' => [
+                [
+                    'propertyPath' => 'identifier',
+                    'title' => 'too long',
+                    'template' => 'a',
+                    'parameters' => [],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $normalizer->normalize($list));
+    }
+
+    public function testNormalizeWithMetadataAwareNameConverterAndNestedPath()
+    {
+        $attributeLoader = new AttributeLoader();
+        $attributeLoader->loadClassMetadata(new ClassMetadata(DummyClassTwo::class));
+        $attributeLoader->loadClassMetadata(new ClassMetadata(DummyClassOne::class));
+
+        $nameConverter = new MetadataAwareNameConverter(new ClassMetadataFactory($attributeLoader));
+        $normalizer = new ConstraintViolationListNormalizer([], $nameConverter);
+
+        $root = new DummyClassTwo();
+        $list = new ConstraintViolationList([
+            new ConstraintViolation('too long', 'a', [], $root, 'child.code', ''),
+        ]);
+
+        $expected = [
+            'type' => 'https://symfony.com/errors/validation',
+            'title' => 'Validation Failed',
+            'detail' => 'nested.identifier: too long',
+            'violations' => [
+                [
+                    'propertyPath' => 'nested.identifier',
+                    'title' => 'too long',
+                    'template' => 'a',
                     'parameters' => [],
                 ],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #56962
| License       | MIT

When normalizing constraint violations, pass the root object's class to the name converter so that SerializedName attributes are respected in the property path. Also handle dotted paths for nested objects by converting each segment against its resolved class, walking the type graph via reflection.

I create a [reproducer](https://github.com/antten/symfony-issue-56962)
