### PR TITLE
[HtmlSanitizer] Add support for configuring the default action

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/CHANGELOG.md
+++ b/src/Symfony/Component/HtmlSanitizer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add support for configuring the default action to block or allow unconfigured elements instead of dropping them
+
 6.4
 ---
 

--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizer.php
@@ -103,7 +103,13 @@ final class HtmlSanitizer implements HtmlSanitizerInterface
 
             foreach ($this->config->getBlockedElements() as $blockedElement => $v) {
                 if (\array_key_exists($blockedElement, W3CReference::HEAD_ELEMENTS)) {
-                    $elementsConfig[$blockedElement] = false;
+                    $elementsConfig[$blockedElement] = HtmlSanitizerAction::Block;
+                }
+            }
+
+            foreach ($this->config->getDroppedElements() as $droppedElement => $v) {
+                if (\array_key_exists($droppedElement, W3CReference::HEAD_ELEMENTS)) {
+                    $elementsConfig[$droppedElement] = HtmlSanitizerAction::Drop;
                 }
             }
 
@@ -119,7 +125,13 @@ final class HtmlSanitizer implements HtmlSanitizerInterface
 
         foreach ($this->config->getBlockedElements() as $blockedElement => $v) {
             if (!\array_key_exists($blockedElement, W3CReference::HEAD_ELEMENTS)) {
-                $elementsConfig[$blockedElement] = false;
+                $elementsConfig[$blockedElement] = HtmlSanitizerAction::Block;
+            }
+        }
+
+        foreach ($this->config->getDroppedElements() as $droppedElement => $v) {
+            if (!\array_key_exists($droppedElement, W3CReference::HEAD_ELEMENTS)) {
+                $elementsConfig[$droppedElement] = HtmlSanitizerAction::Drop;
             }
         }
 

--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerAction.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerAction.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HtmlSanitizer;
+
+enum HtmlSanitizerAction: string
+{
+    /**
+     * Dropped elements are elements the sanitizer should remove from the input, including their children.
+     */
+    case Drop = 'drop';
+
+    /**
+     * Blocked elements are elements the sanitizer should remove from the input, but retain their children.
+     */
+    case Block = 'block';
+
+    /**
+     * Allowed elements are elements the sanitizer should retain from the input.
+     */
+    case Allow = 'allow';
+}

--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
@@ -19,6 +19,15 @@ use Symfony\Component\HtmlSanitizer\Visitor\AttributeSanitizer\AttributeSanitize
  */
 class HtmlSanitizerConfig
 {
+    private HtmlSanitizerAction $defaultAction = HtmlSanitizerAction::Drop;
+
+    /**
+     * Elements that should be removed.
+     *
+     * @var array<string, true>
+     */
+    private array $droppedElements = [];
+
     /**
      * Elements that should be removed but their children should be retained.
      *
@@ -97,6 +106,19 @@ class HtmlSanitizerConfig
         $this->attributeSanitizers = [
             new Visitor\AttributeSanitizer\UrlAttributeSanitizer(),
         ];
+    }
+
+    /**
+     * Sets the default action for elements which are not otherwise specifically allowed or blocked.
+     *
+     * Note that a default action of Allow will allow all tags but they will not have any attributes.
+     */
+    public function defaultAction(HtmlSanitizerAction $action): static
+    {
+        $clone = clone $this;
+        $clone->defaultAction = $action;
+
+        return $clone;
     }
 
     /**
@@ -261,8 +283,8 @@ class HtmlSanitizerConfig
     {
         $clone = clone $this;
 
-        // Unblock the element is necessary
-        unset($clone->blockedElements[$element]);
+        // Unblock/undrop the element if necessary
+        unset($clone->blockedElements[$element], $clone->droppedElements[$element]);
 
         $clone->allowedElements[$element] = [];
 
@@ -284,8 +306,8 @@ class HtmlSanitizerConfig
     {
         $clone = clone $this;
 
-        // Disallow the element is necessary
-        unset($clone->allowedElements[$element]);
+        // Disallow/undrop the element if necessary
+        unset($clone->allowedElements[$element], $clone->droppedElements[$element]);
 
         $clone->blockedElements[$element] = true;
 
@@ -300,12 +322,14 @@ class HtmlSanitizerConfig
      *
      * Note: when using an empty configuration, all unknown elements are dropped
      * automatically. This method let you drop elements that were allowed earlier
-     * in the configuration.
+     * in the configuration, or explicitly drop some if you changed the default action.
      */
     public function dropElement(string $element): static
     {
         $clone = clone $this;
         unset($clone->allowedElements[$element], $clone->blockedElements[$element]);
+
+        $clone->droppedElements[$element] = true;
 
         return $clone;
     }
@@ -426,6 +450,11 @@ class HtmlSanitizerConfig
         return $this->maxInputLength;
     }
 
+    public function getDefaultAction(): HtmlSanitizerAction
+    {
+        return $this->defaultAction;
+    }
+
     /**
      * @return array<string, array<string, true>>
      */
@@ -440,6 +469,14 @@ class HtmlSanitizerConfig
     public function getBlockedElements(): array
     {
         return $this->blockedElements;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    public function getDroppedElements(): array
+    {
+        return $this->droppedElements;
     }
 
     /**

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HtmlSanitizer\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerAction;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 
 class HtmlSanitizerAllTest extends TestCase
@@ -577,5 +578,26 @@ class HtmlSanitizerAllTest extends TestCase
         $sanitized = $sanitizer->sanitize($input);
 
         $this->assertSame(\strlen($input), \strlen($sanitized));
+    }
+
+    public function testBlockByDefault()
+    {
+        $config = (new HtmlSanitizerConfig())
+            ->defaultAction(HtmlSanitizerAction::Block)
+            ->allowElement('p');
+
+        $sanitizer = new HtmlSanitizer($config);
+        self::assertSame('<p>Hello</p>', $sanitizer->sanitize('<foo><div><p><a target="_blank">Hello</a></p></div></foo>'));
+    }
+
+    public function testAllowByDefault()
+    {
+        $config = (new HtmlSanitizerConfig())
+            ->defaultAction(HtmlSanitizerAction::Allow)
+            ->allowElement('p')
+            ->dropElement('span');
+
+        $sanitizer = new HtmlSanitizer($config);
+        self::assertSame('<foo><div><p><a>Hello</a></p></div></foo>', $sanitizer->sanitize('<foo data-attr="value"><div class="foo"><p><a target="_blank">Hello<span> World</span></a></p></div></foo>'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #48358
| License       | MIT

The default action can be set to block or allow unconfigured elements instead of dropping them

Kinda replaces #49920 but it would need some work on the configuration handling side to allow configuring default actions. I am just using this as a library so I am not so keen on doing that part sorry but maybe @Neirda24 might want to take care of it if this PR gets accepted.
