### PR TITLE
[String] Add method `toNullOrNonEmptyString()`

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -525,6 +525,14 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         return new CodePointString($this->string);
     }
 
+    /**
+     * @return non-empty-string|null
+     */
+    public function toNullOrNonEmptyString(): ?string
+    {
+        return '' === $this->string ? null : $this->string;
+    }
+
     public function toString(): string
     {
         return $this->string;

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `toNullOrNonEmptyString()` method
+
 7.1
 ---
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1525,6 +1525,26 @@ abstract class AbstractAsciiTestCase extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideToNullOrNonEmptyString
+     */
+    public function testToNullOrNonEmptyString(?string $expected, string $origin)
+    {
+        $instance = static::createFromString($origin);
+
+        self::assertSame($expected, $instance->toNullOrNonEmptyString());
+    }
+
+    public static function provideToNullOrNonEmptyString()
+    {
+        return [
+            [null, ''],
+            [' ', ' '],
+            ['0', '0'],
+            ['foo', 'foo'],
+        ];
+    }
+
     public function testToString()
     {
         $instance = static::createFromString('foobar');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #57331
| License       | MIT

Usually the method will be combined with `trim()`:

```php
$v = u($input)->trim()->toNullOrNonEmptyString();
```