### PR TITLE
[FrameworkBundle] Simpler Kernel setup with `MicroKernelTrait`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add support for setting `headers` with `Symfony\Bundle\FrameworkBundle\Controller\TemplateController`
  * Derivate `kernel.secret` from the decryption secret when its env var is not defined
+ * Make the `config/` directory optional in `MicroKernelTrait`, add support for service arguments in the
+   invokable Kernel class, and register `FrameworkBundle` by default when the `bundles.php` file is missing
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Kernel;
 
 use Psr\Log\NullLogger;
-use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -44,13 +43,6 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
     public function dangerousAction()
     {
         throw new Danger();
-    }
-
-    public function registerBundles(): iterable
-    {
-        return [
-            new FrameworkBundle(),
-        ];
     }
 
     public function getCacheDir(): string

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Kernel;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -140,6 +139,17 @@ class MicroKernelTraitTest extends TestCase
 
         $this->assertSame('Hello World!', $response->getContent());
     }
+
+    public function testSimpleKernel()
+    {
+        $kernel = $this->kernel = new SimpleKernel('simple_kernel');
+        $kernel->boot();
+
+        $request = Request::create('/');
+        $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, false);
+
+        $this->assertSame('Hello World!', $response->getContent());
+    }
 }
 
 abstract class MinimalKernel extends Kernel
@@ -153,11 +163,6 @@ abstract class MinimalKernel extends Kernel
         parent::__construct('test', false);
 
         $this->cacheDir = sys_get_temp_dir().'/'.$cacheDir;
-    }
-
-    public function registerBundles(): iterable
-    {
-        yield new FrameworkBundle();
     }
 
     public function getCacheDir(): string

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/SimpleKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/SimpleKernel.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Kernel;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class SimpleKernel extends MinimalKernel
+{
+    #[Route('/')]
+    public function __invoke(UrlGeneratorInterface $urlGenerator): Response
+    {
+        return new Response('Hello World!');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Minor improvements to create minimalistic Symfony apps with zero config (initially) + invokable controller using the Kernel class only:
```php
// index.php
<?php

require_once __DIR__.'/vendor/autoload_runtime.php';

// ...

class StripeWebhookEventSubscriber extends Kernel
{
    use MicroKernelTrait;

    #[Route('/', methods: 'GET')]
    public function __invoke(Request $request, NotifierInterface $notifier): Response
    {
        // ...

        return new Response('OK');
    }
}

return static function (array $context) {
    $kernel = new StripeWebhookEventSubscriber($context['APP_ENV'], (bool) $context['APP_DEBUG']);

    return \PHP_SAPI === 'cli' ? new Application($kernel) : $kernel;
};
```
> [!NOTE]
> Ideal for one-file apps or workers.

**What exactly does this PR improve?**
* It makes the `config/` directory optional. Then you can add extension configs by redefining the `configureContainer()` method or by importing external files in `config/packages/*` as usual.
* It adds support for service arguments when an invokable controller is defined within the same kernel class (as shown in the example)
* Fall back to `yield new FrameworkBundle()` in `registerBundles()` method in case the `$this->getBundlesPath()` file does not exist.

What do you think?