### PR TITLE
[DependencyInjection] feat(env processor): add doc/help on `APP_SECRET` env var not found exception

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -218,7 +218,19 @@ class EnvVarProcessor implements EnvVarProcessorInterface, ResetInterface
 
             if (false === $env) {
                 if (!$this->container->hasParameter("env($name)")) {
-                    throw new EnvNotFoundException(sprintf('Environment variable not found: "%s".', $name));
+                    $message = sprintf('Environment variable not found: "%s".', $name);
+
+                    // Symfony internal
+                    if ('APP_SECRET' === $name) {
+                        $message = <<<MESSAGE
+Environment variable not found: "APP_SECRET" that is needed for security reason.
+Define it in your .env file via `php -r 'file_put_contents(".env", "\nAPP_SECRET=" . bin2hex(random_bytes(16)), FILE_APPEND);'` or manually as a strong and secure token
+or in your vault via `php bin/console secrets:set APP_SECRET --random`
+Read more at https://symfony.com/doc/current/configuration.html#configuration-based-on-environment-variables
+MESSAGE;
+                    }
+
+                    throw new EnvNotFoundException($message);
                 }
 
                 $env = $this->container->getParameter("env($name)");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix inconsisteny that may occur when installing a deployment that needs `APP_SECRET` env var that now may be undefined
| License       | MIT

---

Hey, I've followed recently the work on this topic, ref one of my try on [related issue](https://github.com/symfony/symfony/issues/38021)

I tend to agree that, just throwing an ex here can be problematic/inappropriate, mostly for newcomers that never have read a thing related to this `Symfony .env APP_SECRET`

Here is one attempt to fill the comment https://github.com/symfony/symfony/pull/56985#issuecomment-2135540693

Friendly ping @javiereguiluz @nicolas-grekas do you have a better wording/phrasing and is it the best place?

---

For documentation inside the doc repo, I have no idea where to define such message, any idea ?
in the env config part? or in the vault part? elsewhere?
ref https://github.com/symfony/symfony-docs/issues/19916