### PR TITLE
[Mailer] [Infobip] Add trackClicks, trackOpens and trackingUrl as supp…

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Infobip/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+* Add support of trackClicks, trackOpens and trackingUrl payload properties
+
 6.3
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
@@ -248,7 +248,11 @@ class InfobipApiTransportTest extends TestCase
             ->addTextHeader('X-Infobip-IntermediateReport', 'true')
             ->addTextHeader('X-Infobip-NotifyUrl', 'https://foo.bar')
             ->addTextHeader('X-Infobip-NotifyContentType', 'application/json')
-            ->addTextHeader('X-Infobip-MessageId', 'RANDOM-CUSTOM-ID');
+            ->addTextHeader('X-Infobip-MessageId', 'RANDOM-CUSTOM-ID')
+            ->addTextHeader('X-Infobip-Track', 'false')
+            ->addTextHeader('X-Infobip-TrackingUrl', 'https://bar.foo')
+            ->addTextHeader('X-Infobip-TrackClicks', 'true')
+            ->addTextHeader('X-Infobip-TrackOpens', 'true');
 
         $this->transport->send($email);
 
@@ -280,6 +284,30 @@ class InfobipApiTransportTest extends TestCase
             Content-Disposition: form-data; name="messageId"
 
             RANDOM-CUSTOM-ID
+            --%s
+            Content-Type: text/plain; charset=utf-8
+            Content-Transfer-Encoding: 8bit
+            Content-Disposition: form-data; name="track"
+
+            false
+            --%s
+            Content-Type: text/plain; charset=utf-8
+            Content-Transfer-Encoding: 8bit
+            Content-Disposition: form-data; name="trackingUrl"
+
+            https://bar.foo
+            --%s
+            Content-Type: text/plain; charset=utf-8
+            Content-Transfer-Encoding: 8bit
+            Content-Disposition: form-data; name="trackClicks"
+
+            true
+            --%s
+            Content-Type: text/plain; charset=utf-8
+            Content-Transfer-Encoding: 8bit
+            Content-Disposition: form-data; name="trackOpens"
+
+            true
             --%s--
             TXT,
             $options['body']
@@ -410,7 +438,10 @@ class InfobipApiTransportTest extends TestCase
             ->addTextHeader('X-Infobip-NotifyUrl', 'https://foo.bar')
             ->addTextHeader('X-Infobip-NotifyContentType', 'application/json')
             ->addTextHeader('X-Infobip-MessageId', 'RANDOM-CUSTOM-ID')
-            ->addTextHeader('X-Infobip-Track', 'false');
+            ->addTextHeader('X-Infobip-Track', 'false')
+            ->addTextHeader('X-Infobip-TrackingUrl', 'https://bar.foo')
+            ->addTextHeader('X-Infobip-TrackClicks', 'true')
+            ->addTextHeader('X-Infobip-TrackOpens', 'true');
 
         $sentMessage = $this->transport->send($email);
 
@@ -423,6 +454,9 @@ class InfobipApiTransportTest extends TestCase
             X-Infobip-NotifyContentType: application/json
             X-Infobip-MessageId: RANDOM-CUSTOM-ID
             X-Infobip-Track: false
+            X-Infobip-TrackingUrl: https://bar.foo
+            X-Infobip-TrackClicks: true
+            X-Infobip-TrackOpens: true
             %a
             TXT,
             $sentMessage->toString()

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
@@ -39,6 +39,9 @@ final class InfobipApiTransport extends AbstractApiTransport
         'X-Infobip-NotifyContentType' => 'notifyContentType',
         'X-Infobip-MessageId' => 'messageId',
         'X-Infobip-Track' => 'track',
+        'X-Infobip-TrackingUrl' => 'trackingUrl',
+        'X-Infobip-TrackClicks' => 'trackClicks',
+        'X-Infobip-TrackOpens' => 'trackOpens',
     ];
 
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#xxxxxxxx # TODO

# 📍 Context

This PR add three headers to configure Infobip email tracking with API V3.

# ➕ New feature

New payload attribute was added allowing end users to configure tracking.

| Attribute | Type | Description |
| --- | --- | --- |
| X-Infobip-TrackingUrl | string | The URL on your callback server on which the open and click notifications will be sent. | 
| X-Infobip-TrackClicks | boolean | Enable or disable track click feature. | 
| X-Infobip-TrackOpens | boolean | Enable or disable open click feature. | 