### PR TITLE
[Mailer] Add Sweego bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2645,6 +2645,7 @@ class FrameworkExtension extends Extension
             MailerBridge\Scaleway\Transport\ScalewayTransportFactory::class => 'mailer.transport_factory.scaleway',
             MailerBridge\Sendgrid\Transport\SendgridTransportFactory::class => 'mailer.transport_factory.sendgrid',
             MailerBridge\Amazon\Transport\SesTransportFactory::class => 'mailer.transport_factory.amazon',
+            MailerBridge\Sweego\Transport\SweegoTransportFactory::class => 'mailer.transport_factory.sweego',
         ];
 
         foreach ($classToServices as $class => $service) {
@@ -2665,6 +2666,7 @@ class FrameworkExtension extends Extension
                 MailerBridge\Postmark\Webhook\PostmarkRequestParser::class => 'mailer.webhook.request_parser.postmark',
                 MailerBridge\Resend\Webhook\ResendRequestParser::class => 'mailer.webhook.request_parser.resend',
                 MailerBridge\Sendgrid\Webhook\SendgridRequestParser::class => 'mailer.webhook.request_parser.sendgrid',
+                MailerBridge\Sweego\Webhook\SweegoRequestParser::class => 'mailer.webhook.request_parser.sweego',
             ];
 
             foreach ($webhookRequestParsers as $class => $service) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
@@ -27,6 +27,7 @@ use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
+use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoTransportFactory;
 use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\NativeTransportFactory;
 use Symfony\Component\Mailer\Transport\NullTransportFactory;
@@ -65,6 +66,7 @@ return static function (ContainerConfigurator $container) {
         'sendgrid' => SendgridTransportFactory::class,
         'sendmail' => SendmailTransportFactory::class,
         'smtp' => EsmtpTransportFactory::class,
+        'sweego' => SweegoTransportFactory::class,
     ];
 
     foreach ($factories as $name => $class) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_webhook.php
@@ -27,6 +27,8 @@ use Symfony\Component\Mailer\Bridge\Resend\RemoteEvent\ResendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Resend\Webhook\ResendRequestParser;
 use Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent\SendgridPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Webhook\SendgridRequestParser;
+use Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent\SweegoPayloadConverter;
+use Symfony\Component\Mailer\Bridge\Sweego\Webhook\SweegoRequestParser;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -69,5 +71,10 @@ return static function (ContainerConfigurator $container) {
         ->set('mailer.webhook.request_parser.sendgrid', SendgridRequestParser::class)
             ->args([service('mailer.payload_converter.sendgrid')])
         ->alias(SendgridRequestParser::class, 'mailer.webhook.request_parser.sendgrid')
+
+        ->set('mailer.payload_converter.sweego', SweegoPayloadConverter::class)
+        ->set('mailer.webhook.request_parser.sweego', SweegoRequestParser::class)
+            ->args([service('mailer.payload_converter.sweego')])
+        ->alias(SweegoRequestParser::class, 'mailer.webhook.request_parser.sweego')
     ;
 };

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/.gitignore
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/README.md
@@ -1,0 +1,33 @@
+Sweego Bridge
+=============
+
+Provides Sweego integration for Symfony Mailer.
+
+Configuration example:
+
+```env
+# SMTP
+MAILER_DSN=sweego+smtp://LOGIN:PASSWORD@HOST:PORT
+```
+
+where:
+ - `LOGIN` is your Sweego SMTP login
+ - `PASSWORD` is your Sweego SMTP password
+ - `HOST` is your Sweego SMTP host
+ - `PORT` is your Sweego SMTP port
+
+```env
+# API
+MAILER_DSN=sweego+api://API_KEY@default
+```
+
+where:
+ - `API_KEY` is your Sweego API Key
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/RemoteEvent/SweegoPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/RemoteEvent/SweegoPayloadConverter.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent;
+
+use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\RemoteEvent\PayloadConverterInterface;
+
+final class SweegoPayloadConverter implements PayloadConverterInterface
+{
+    public function convert(array $payload): AbstractMailerEvent
+    {
+        if (\in_array($payload['event_type'], ['email_sent', 'delivered'], true)) {
+            $name = match ($payload['event_type']) {
+                'email_sent' => MailerDeliveryEvent::RECEIVED,
+                'delivered' => MailerDeliveryEvent::DELIVERED,
+            };
+
+            $event = new MailerDeliveryEvent($name, $payload['headers']['x-transaction-id'], $payload);
+        }
+
+        if (!$date = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $payload['timestamp'])) {
+            throw new ParseException(\sprintf('Invalid date "%s".', $payload['timestamp']));
+        }
+
+        $event->setDate($date);
+        $event->setRecipientEmail($payload['recipient']);
+        $event->setMetadata($payload['headers']);
+
+        return $event;
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Transport/SweegoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Transport/SweegoApiTransportTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sweego\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoApiTransport;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class SweegoApiTransportTest extends TestCase
+{
+    /**
+     * @dataProvider getTransportData
+     */
+    public function testToString(SweegoApiTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData(): \Generator
+    {
+        yield [
+            new SweegoApiTransport('ACCESS_KEY'),
+            'sweego+api://api.sweego.io',
+        ];
+
+        yield [
+            (new SweegoApiTransport('ACCESS_KEY'))->setHost('example.com'),
+            'sweego+api://example.com',
+        ];
+
+        yield [
+            (new SweegoApiTransport('ACCESS_KEY'))->setHost('example.com')->setPort(99),
+            'sweego+api://example.com:99',
+        ];
+    }
+
+    public function testCustomHeader()
+    {
+        $params = ['param1' => 'foo', 'param2' => 'bar'];
+        $json = json_encode(['custom_header_1' => 'custom_value_1']);
+
+        $email = new Email();
+        $email->getHeaders()
+            ->add(new MetadataHeader('custom', $json))
+            ->addTextHeader('templateId', 1)
+            ->addParameterizedHeader('params', 'params', $params)
+            ->addTextHeader('foo', 'bar');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new SweegoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SweegoApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('X-Metadata-custom', $payload['headers']);
+        $this->assertEquals($json, $payload['headers']['X-Metadata-custom']);
+        $this->assertArrayHasKey('templateId', $payload['headers']);
+        $this->assertEquals('1', $payload['headers']['templateId']);
+        $this->assertArrayHasKey('params', $payload['headers']);
+        $this->assertEquals('params; param1=foo; param2=bar', $payload['headers']['params']);
+        $this->assertArrayHasKey('foo', $payload['headers']);
+        $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testSendThrowsForErrorResponse()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.sweego.io:8984/send', $url);
+            $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
+
+            return new JsonMockResponse(['message' => 'i\'m a teapot'], [
+                'http_code' => 418,
+            ]);
+        });
+
+        $transport = new SweegoApiTransport('ACCESS_KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('tony.stark@marvel.com', 'Tony Stark'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email: {"message":"i\'m a teapot"} (code 418).');
+        $transport->send($mail);
+    }
+
+    public function testSend()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.sweego.io:8984/send', $url);
+            $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
+
+            return new JsonMockResponse(['transaction_id' => 'foobar'], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $transport = new SweegoApiTransport('ACCESS_KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('tony.stark@marvel.com', 'Tony Stark'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello here!')
+            ->html('Hello there!')
+            ->addCc('foo@bar.fr')
+            ->addBcc('foo@bar.fr')
+        ;
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    /**
+     * IDN (internationalized domain names) like kältetechnik-xyz.de need to be transformed to ACE
+     * (ASCII Compatible Encoding) e.g.xn--kltetechnik-xyz-0kb.de, otherwise Sweego api answers with 400 http code.
+     */
+    public function testSendForIdnDomains()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.sweego.io:8984/send', $url);
+            $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
+
+            $body = json_decode($options['body'], true);
+            // to
+            $this->assertSame([
+                'email' => 'kältetechnik@xn--kltetechnik-xyz-0kb.de',
+                'name' => 'Kältetechnik Xyz',
+            ], $body['recipients'][0]);
+            // sender
+            $this->assertStringContainsString('info@xn--kltetechnik-xyz-0kb.de', $body['from']['email']);
+            $this->assertStringContainsString('Kältetechnik Xyz', $body['from']['name']);
+
+            return new JsonMockResponse(['transaction_id' => 'foobar'], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $transport = new SweegoApiTransport('ACCESS_KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('kältetechnik@kältetechnik-xyz.de', 'Kältetechnik Xyz'))
+            ->from(new Address('info@kältetechnik-xyz.de', 'Kältetechnik Xyz'))
+            ->text('Hello here!')
+            ->html('Hello there!');
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Transport/SweegoTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Transport/SweegoTransportFactoryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sweego\Tests\Transport;
+
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoApiTransport;
+use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoSmtpTransport;
+use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoTransportFactory;
+use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+class SweegoTransportFactoryTest extends TransportFactoryTestCase
+{
+    public function getFactory(): TransportFactoryInterface
+    {
+        return new SweegoTransportFactory(null, new MockHttpClient(), new NullLogger());
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [
+            new Dsn('sweego', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('sweego+smtp', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('sweego+smtp', 'example.com'),
+            true,
+        ];
+
+        yield [
+            new Dsn('sweego+api', 'default'),
+            true,
+        ];
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            new Dsn('sweego', 'default', self::USER, self::PASSWORD, 465),
+            new SweegoSmtpTransport('default', 465, self::USER, self::PASSWORD, null, new NullLogger()),
+        ];
+
+        yield [
+            new Dsn('sweego+smtp', 'default', self::USER, self::PASSWORD, 465),
+            new SweegoSmtpTransport('default', 465, self::USER, self::PASSWORD, null, new NullLogger()),
+        ];
+
+        yield [
+            new Dsn('sweego+smtp', 'default', self::USER, self::PASSWORD, 465),
+            new SweegoSmtpTransport('default', 465, self::USER, self::PASSWORD, null, new NullLogger()),
+        ];
+
+        yield [
+            new Dsn('sweego+api', 'default', self::USER),
+            new SweegoApiTransport(self::USER, new MockHttpClient(), null, new NullLogger()),
+        ];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield [
+            new Dsn('sweego+foo', 'default', self::USER, self::PASSWORD, 465),
+            'The "sweego+foo" scheme is not supported; supported schemes for mailer "sweego" are: "sweego", "sweego+smtp", "sweego+api".',
+        ];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield [new Dsn('sweego+smtp', 'default', self::USER)];
+
+        yield [new Dsn('sweego+api', 'default')];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/delivered.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/delivered.json
@@ -1,0 +1,15 @@
+{
+    "event_type": "delivered",
+    "timestamp": "2024-08-15T16:05:59+00:00",
+    "swg_uid": "02-0d4affd0-1183-43b1-a980-ab30b3374dd3",
+    "event_id": "9f26b9d0-13d7-410c-ba04-5019cd30e6d0",
+    "channel": "email",
+    "headers": {
+        "x-transaction-id": "d4fbec9d-eed9-44d5-af47-c1126467a5ca"
+    },
+    "campaign_tags": null,
+    "campaign_type": "transac",
+    "campaign_id": "transac",
+    "recipient": "recipient@example.com",
+    "domain_from": "example.org"
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/delivered.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/delivered.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, 'd4fbec9d-eed9-44d5-af47-c1126467a5ca', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-transaction-id' => 'd4fbec9d-eed9-44d5-af47-c1126467a5ca',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-08-15T16:05:59+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/sent.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/sent.json
@@ -1,0 +1,15 @@
+{
+    "event_type": "email_sent",
+    "timestamp": "2024-08-15T16:05:59+00:00",
+    "swg_uid": "02-0d4affd0-1183-43b1-a980-ab30b3374dd3",
+    "event_id": "97cf3afe-f63a-4d92-abac-bde9c7e6523e",
+    "channel": "email",
+    "headers": {
+        "x-transaction-id": "d4fbec9d-eed9-44d5-af47-c1126467a5ca"
+    },
+    "campaign_tags": null,
+    "campaign_type": "transac",
+    "campaign_id": "transac",
+    "recipient": "recipient@example.com",
+    "domain_from": "example.org"
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/sent.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/sent.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::RECEIVED, 'd4fbec9d-eed9-44d5-af47-c1126467a5ca', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-transaction-id' => 'd4fbec9d-eed9-44d5-af47-c1126467a5ca',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-08-15T16:05:59+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sweego\Tests\Webhook;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent\SweegoPayloadConverter;
+use Symfony\Component\Mailer\Bridge\Sweego\Webhook\SweegoRequestParser;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
+
+class SweegoRequestParserTest extends AbstractRequestParserTestCase
+{
+    protected function createRequestParser(): RequestParserInterface
+    {
+        return new SweegoRequestParser(new SweegoPayloadConverter());
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        return Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+        ], $payload);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoApiTransport.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sweego\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\Headers;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class SweegoApiTransport extends AbstractApiTransport
+{
+    public function __construct(
+        #[\SensitiveParameter] private readonly string $apiKey,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct($client, $dispatcher, $logger);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('sweego+api://%s', $this->getEndpoint());
+    }
+
+    protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
+    {
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/send', [
+            'json' => $this->getPayload($email, $envelope),
+            'headers' => [
+                'Api-Key' => $this->apiKey,
+            ],
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+            $result = $response->toArray(false);
+        } catch (DecodingExceptionInterface) {
+            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).\sprintf(' (code %d).', $statusCode), $response);
+        } catch (TransportExceptionInterface $e) {
+            throw new HttpTransportException('Could not reach the remote Sweego server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
+            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).\sprintf(' (code %d).', $statusCode), $response);
+        }
+
+        $sentMessage->setMessageId($result['transaction_id']);
+
+        return $response;
+    }
+
+    /**
+     * @param Address[] $addresses
+     *
+     * @return list<string>
+     */
+    private function formatAddresses(array $addresses): array
+    {
+        return array_map(fn (Address $address) => $this->formatAddress($address), $addresses);
+    }
+
+    private function getPayload(Email $email, Envelope $envelope): array
+    {
+        // "From" and "Subject" headers are handled by the message itself
+        $payload = [
+            'recipients' => $this->formatAddresses($this->getRecipients($email, $envelope)),
+            'from' => $this->formatAddress($envelope->getSender()),
+            'subject' => $email->getSubject(),
+            'campaign-type' => 'transac',
+        ];
+
+        if ($email->getTextBody()) {
+            $payload['message-txt'] = $email->getTextBody();
+        }
+
+        if ($email->getHtmlBody()) {
+            $payload['message-html'] = $email->getHtmlBody();
+        }
+
+        if ($payload['headers'] = $this->prepareHeaders($email->getHeaders())) {
+            if (\count($payload['headers']) > 5) {
+                throw new InvalidArgumentException('Sweego API supports up to 5 headers.');
+            }
+        }
+
+        $payload['provider'] = 'sweego';
+
+        return $payload;
+    }
+
+    private function prepareHeaders(Headers $headers): array
+    {
+        $headersPrepared = [];
+        // Sweego API does not accept those headers.
+        $headersToBypass = ['To', 'From', 'Subject'];
+        foreach ($headers->all() as $header) {
+            if (\in_array($header->getName(), $headersToBypass, true)) {
+                continue;
+            }
+
+            $headersPrepared[$header->getName()] = $header->getBodyAsString();
+        }
+
+        return $headersPrepared;
+    }
+
+    private function formatAddress(Address $address): array
+    {
+        $formattedAddress = ['email' => $address->getEncodedAddress()];
+
+        if ($address->getName()) {
+            $formattedAddress['name'] = $address->getName();
+        }
+
+        return $formattedAddress;
+    }
+
+    private function getEndpoint(): ?string
+    {
+        return ($this->host ?: 'api.sweego.io').($this->port ? ':'.$this->port : '');
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoSmtpTransport.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sweego\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class SweegoSmtpTransport extends EsmtpTransport
+{
+    public function __construct(string $host, int $port, string $login, #[\SensitiveParameter] string $password, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null)
+    {
+        parent::__construct($host, $port, true, $dispatcher, $logger);
+
+        $this->setUsername($login);
+        $this->setPassword($password);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoTransportFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sweego\Transport;
+
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class SweegoTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        return match ($dsn->getScheme()) {
+            'sweego', 'sweego+smtp' => new SweegoSmtpTransport($dsn->getHost(), $dsn->getPort(), $this->getUser($dsn), $this->getPassword($dsn), $this->dispatcher, $this->logger),
+            'sweego+api' => (new SweegoApiTransport($this->getUser($dsn), $this->client, $this->dispatcher, $this->logger))
+                ->setHost('default' === $dsn->getHost() ? null : $dsn->getHost())
+                ->setPort($dsn->getPort()),
+            default => throw new UnsupportedSchemeException($dsn, 'sweego', $this->getSupportedSchemes()),
+        };
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['sweego', 'sweego+smtp', 'sweego+api'];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sweego\Webhook;
+
+use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent\SweegoPayloadConverter;
+use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\Webhook\Client\AbstractRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+final class SweegoRequestParser extends AbstractRequestParser
+{
+    public function __construct(
+        private readonly SweegoPayloadConverter $converter,
+    ) {
+    }
+
+    protected function getRequestMatcher(): RequestMatcherInterface
+    {
+        return new ChainRequestMatcher([
+            new MethodRequestMatcher('POST'),
+            new IsJsonRequestMatcher(),
+        ]);
+    }
+
+    protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
+    {
+        $content = $request->toArray();
+
+        if (
+            !isset($content['event_type'])
+            || !isset($content['timestamp'])
+            || !isset($content['headers'])
+            || !isset($content['headers']['x-transaction-id'])
+            || !isset($content['recipient'])
+        ) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        try {
+            return $this->converter->convert($content);
+        } catch (ParseException $e) {
+            throw new RejectWebhookException(406, $e->getMessage(), $e);
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "symfony/sweego-mailer",
+    "type": "symfony-mailer-bridge",
+    "description": "Symfony Sweego Mailer Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathieu Santostefano",
+            "homepage": "https://github.com/welcoMattic"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "symfony/mailer": "^7.2"
+    },
+    "require-dev": {
+        "symfony/http-client": "^6.4|^7.0",
+        "symfony/http-foundation": "^7.1",
+        "symfony/webhook": "^6.4|^7.0"
+    },
+    "conflict": {
+        "symfony/http-foundation": "<7.1"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Sweego\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Sweego Mailer Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>

--- a/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
@@ -84,6 +84,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Amazon\Transport\SesTransportFactory::class,
             'package' => 'symfony/amazon-mailer',
         ],
+        'sweego' => [
+            'class' => Bridge\Sweego\Transport\SweegoTransportFactory::class,
+            'package' => 'symfony/sweego-mailer',
+        ],
     ];
 
     public function __construct(Dsn $dsn, ?string $name = null, array $supported = [])

--- a/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
+use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoTransportFactory;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\Dsn;
 
@@ -57,6 +58,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             ScalewayTransportFactory::class => false,
             SendgridTransportFactory::class => false,
             SesTransportFactory::class => false,
+            SweegoTransportFactory::class => false,
         ]);
     }
 
@@ -91,6 +93,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['scaleway', 'symfony/scaleway-mailer'];
         yield ['sendgrid', 'symfony/sendgrid-mailer'];
         yield ['ses', 'symfony/amazon-mailer'];
+        yield ['sweego', 'symfony/sweego-mailer'];
     }
 
     /**

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -29,6 +29,7 @@ use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
+use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoTransportFactory;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -66,6 +67,7 @@ final class Transport
         ScalewayTransportFactory::class,
         SendgridTransportFactory::class,
         SesTransportFactory::class,
+        SweegoTransportFactory::class,
     ];
 
     public static function fromDsn(#[\SensitiveParameter] string $dsn, ?EventDispatcherInterface $dispatcher = null, ?HttpClientInterface $client = null, ?LoggerInterface $logger = null): TransportInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/20136
| Recipe PR     | https://github.com/symfony/recipes/pull/1334

This PR adds a new Mailer bridge for 🇫🇷 French based service [Sweego](https://www.sweego.io).
For now, it does not support attachments, neither webhooks. I'm in touch with @pydubreucq CTO at Sweego to improve this bridge once attachments, webhooks are available.

NB: Docs PR will land later this week
