### PR TITLE
[Serializer] forward exceptions caught in the `AbstractObjectNormalizer`

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NotNormalizableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NotNormalizableDummy.php
@@ -26,6 +26,6 @@ class NotNormalizableDummy implements DenormalizableInterface
 
     public function denormalize(DenormalizerInterface $denormalizer, $data, ?string $format = null, array $context = []): void
     {
-        throw new NotNormalizableValueException();
+        throw new NotNormalizableValueException('Custom exception message');
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -946,6 +946,7 @@ class AbstractObjectNormalizerTest extends TestCase
     public function testDenormalizeUntypedFormatNotNormalizable()
     {
         $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Custom exception message');
         $serializer = new Serializer([new CustomNormalizer(), new ObjectNormalizer(null, null, null, new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]))]);
         $serializer->denormalize(['value' => 'test'], DummyWithNotNormalizable::class, 'xml');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57427
| License       | MIT