### PR TITLE
[Validator] Add the `format` option to the `Ulid` constraint to allow accepting different ULID formats

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Make `PasswordStrengthValidator::estimateStrength()` public
  * Add the `Yaml` constraint for validating YAML content
  * Add `errorPath` to Unique constraint
+ * Add the `format` option to the `Ulid` constraint to allow accepting different ULID formats
 
 7.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/Ulid.php
+++ b/src/Symfony/Component/Validator/Constraints/Ulid.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * Validates that a value is a valid Universally Unique Lexicographically Sortable Identifier (ULID).
@@ -35,20 +36,31 @@ class Ulid extends Constraint
         self::TOO_LARGE_ERROR => 'TOO_LARGE_ERROR',
     ];
 
+    public const FORMAT_BASE_32 = 'base32';
+    public const FORMAT_BASE_58 = 'base58';
+
     public string $message = 'This is not a valid ULID.';
+    public string $format = self::FORMAT_BASE_32;
 
     /**
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
+     * @param self::FORMAT_*|null      $format
      */
     public function __construct(
         ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
+        ?string $format = null,
     ) {
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;
+        $this->format = $format ?? $this->format;
+
+        if (!\in_array($this->format, [self::FORMAT_BASE_32, self::FORMAT_BASE_58], true)) {
+            throw new ConstraintDefinitionException(sprintf('The "%s" validation format is not supported.', $format));
+        }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UlidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UlidTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Ulid;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
@@ -31,6 +32,14 @@ class UlidTest extends TestCase
         [$cConstraint] = $metadata->properties['c']->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
+    }
+
+    public function testUnexpectedValidationFormat()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The "invalid" validation format is not supported.');
+
+        new Ulid(format: 'invalid');
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
@@ -53,6 +53,13 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testValidUlidAsBase58()
+    {
+        $this->validator->validate('1CCD2w4mK2m455S2BAXFht', new Ulid(format: Ulid::FORMAT_BASE_58));
+
+        $this->assertNoViolation();
+    }
+
     /**
      * @dataProvider getInvalidUlids
      */
@@ -65,18 +72,49 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($ulid, $constraint);
 
         $this->buildViolation('testMessage')
-            ->setParameter('{{ value }}', '"'.$ulid.'"')
+            ->setParameters([
+                '{{ value }}' => '"'.$ulid.'"',
+                '{{ format }}' => Ulid::FORMAT_BASE_32,
+            ])
             ->setCode($code)
             ->assertRaised();
     }
 
-    public static function getInvalidUlids()
+    public static function getInvalidUlids(): array
     {
         return [
             ['01ARZ3NDEKTSV4RRFFQ69G5FA', Ulid::TOO_SHORT_ERROR],
             ['01ARZ3NDEKTSV4RRFFQ69G5FAVA', Ulid::TOO_LONG_ERROR],
             ['01ARZ3NDEKTSV4RRFFQ69G5FAO', Ulid::INVALID_CHARACTERS_ERROR],
             ['Z1ARZ3NDEKTSV4RRFFQ69G5FAV', Ulid::TOO_LARGE_ERROR],
+            ['not-even-ulid-like', Ulid::TOO_SHORT_ERROR],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidBase58Ulids
+     */
+    public function testInvalidBase58Ulid(string $ulid, string $code)
+    {
+        $constraint = new Ulid(message: 'testMessage', format: Ulid::FORMAT_BASE_58);
+
+        $this->validator->validate($ulid, $constraint);
+
+        $this->buildViolation('testMessage')
+            ->setParameters([
+                '{{ value }}' => '"'.$ulid.'"',
+                '{{ format }}' => Ulid::FORMAT_BASE_58,
+            ])
+            ->setCode($code)
+            ->assertRaised();
+    }
+
+    public static function getInvalidBase58Ulids(): array
+    {
+        return [
+            ['1CCD2w4mK2m455S2BAXFh', Ulid::TOO_SHORT_ERROR],
+            ['1CCD2w4mK2m455S2BAXFhttt', Ulid::TOO_LONG_ERROR],
+            ['1CCD2w4mK2m455S2BAXFhO', Ulid::INVALID_CHARACTERS_ERROR],
             ['not-even-ulid-like', Ulid::TOO_SHORT_ERROR],
         ];
     }
@@ -88,7 +126,10 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate('01ARZ3NDEKTSV4RRFFQ69G5FA', $constraint);
 
         $this->buildViolation('testMessage')
-            ->setParameter('{{ value }}', '"01ARZ3NDEKTSV4RRFFQ69G5FA"')
+            ->setParameters([
+                '{{ value }}' => '"01ARZ3NDEKTSV4RRFFQ69G5FA"',
+                '{{ format }}' => Ulid::FORMAT_BASE_32,
+            ])
             ->setCode(Ulid::TOO_SHORT_ERROR)
             ->assertRaised();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Related to #51540 and #57398