### PR TITLE
[Console] Use match instead of switch statement

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -951,23 +951,13 @@ class Application implements ResetInterface
             $input->setInteractive(false);
         }
 
-        switch ($shellVerbosity = (int) getenv('SHELL_VERBOSITY')) {
-            case -1:
-                $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
-                break;
-            case 1:
-                $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
-                break;
-            case 2:
-                $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
-                break;
-            case 3:
-                $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-                break;
-            default:
-                $shellVerbosity = 0;
-                break;
-        }
+        match ($shellVerbosity = (int) getenv('SHELL_VERBOSITY')) {
+            -1 => $output->setVerbosity(OutputInterface::VERBOSITY_QUIET),
+            1 => $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE),
+            2 => $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE),
+            3 => $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG),
+            default => $shellVerbosity = 0,
+        };
 
         if (true === $input->hasParameterOption(['--quiet', '-q'], true)) {
             $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Because v6.4 requires php to be ">=8.1", it's safe to use match anywhere. Use match instead of switch statement inside Console\Application to determine output verbosity makes code a bit easier to read.


```php
match ($shellVerbosity = (int) getenv('SHELL_VERBOSITY')) {
    -1 => $output->setVerbosity(OutputInterface::VERBOSITY_QUIET),
    1 => $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE),
    2 => $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE),
    3 => $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG),
    default => $shellVerbosity = 0,
};
```