### PR TITLE
[HttpKernel] MapQueryString/MapRequestPayload skips validation when empty request is sent

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -186,7 +186,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
     private function mapQueryString(Request $request, ArgumentMetadata $argument, MapQueryString $attribute): ?object
     {
         if (!$data = $request->query->all()) {
-            return null;
+            return $attribute->metadata->hasDefaultValue() ? $attribute->metadata->getDefaultValue() : null;
         }
 
         return $this->serializer->denormalize($data, $argument->getType(), null, $attribute->serializationContext + self::CONTEXT_DENORMALIZE + ['filter_bool' => true]);
@@ -213,7 +213,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
         }
 
         if ('' === $data = $request->getContent()) {
-            return null;
+            return $attribute->metadata->hasDefaultValue() ? $attribute->metadata->getDefaultValue() : null;
         }
 
         if ('form' === $format) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -67,7 +67,7 @@ class RequestPayloadValueResolverTest extends TestCase
         $payload = new RequestPayload(50);
 
         $validator = $this->createMock(ValidatorInterface::class);
-        $validator->expects($this->never())
+        $validator->expects($this->once())
            ->method('validate');
 
         $resolver = new RequestPayloadValueResolver(new Serializer(), $validator);
@@ -91,7 +91,7 @@ class RequestPayloadValueResolverTest extends TestCase
         $payload = new RequestPayload(50);
 
         $validator = $this->createMock(ValidatorInterface::class);
-        $validator->expects($this->never())
+        $validator->expects($this->once())
             ->method('validate');
 
         $resolver = new RequestPayloadValueResolver(new Serializer(), $validator);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54617  
| License       | MIT

