### PR TITLE
[Notifier] [Lox24] Fix request body format to JSON string

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Lox24Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Lox24Transport.php
@@ -101,7 +101,7 @@ final class Lox24Transport extends AbstractTransport
                 'Content-Type' => 'application/json',
                 'User-Agent' => 'LOX24 Symfony Notifier',
             ],
-            'body' => $body,
+            'json' => $body,
         ]);
 
         try {

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/README.md
@@ -8,7 +8,7 @@ DSN example
 -----------
 
 ```
-LOX24_DSN=lox24://USER:TOKEN@default?from=FROM&type=SERVICE_CODE&voice_lang=VOICE_LANGUAGE&delete_text=DELETE_TEXT&callback_data=CALLBACK_DATA
+LOX24_DSN=lox24://USER:TOKEN@default?from=FROM&type=TYPE&voice_lang=VOICE_LANGUAGE&delete_text=DELETE_TEXT&callback_data=CALLBACK_DATA
 ```
 
 where:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | 
| License       | MIT

After lox24-notifier was release (version 7.1) i've found a bug. Request's header `Content-Type` changed to `application/x-www-form-urlencoded` from `application\json`. 

Issue was relate to array type of the body. I've changed it to JSON string and tested. Looks good. Please merge.
