### PR TITLE
[HttpClient] Fix parsing SSE

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
@@ -15,9 +15,11 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\Chunk\DataChunk;
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
+use Symfony\Component\HttpClient\Chunk\LastChunk;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Component\HttpClient\Exception\EventSourceException;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -34,7 +36,11 @@ class EventSourceHttpClientTest extends TestCase
      */
     public function testGetServerSentEvents(string $sep)
     {
-        $rawData = <<<TXT
+        $es = new EventSourceHttpClient(new MockHttpClient(function (string $method, string $url, array $options) use ($sep): MockResponse {
+            $this->assertSame(['Accept: text/event-stream', 'Cache-Control: no-cache'], $options['headers']);
+
+            return new MockResponse([
+                str_replace("\n", $sep, <<<TXT
 event: builderror
 id: 46
 data: {"foo": "bar"}
@@ -43,7 +49,18 @@ event: reload
 id: 47
 data: {}
 
+: this is a oneline comment
+
+: this is a
+: multiline comment
+
+: comments are ignored
 event: reload
+
+TXT
+                ),
+                str_replace("\n", $sep, <<<TXT
+: anywhere
 id: 48
 data: {}
 
@@ -62,58 +79,33 @@ data: </tag>
 
 id: 60
 data
-TXT;
-        $data = str_replace("\n", $sep, $rawData);
-
-        $chunk = new DataChunk(0, $data);
-        $response = new MockResponse('', ['canceled' => false, 'http_method' => 'GET', 'url' => 'http://localhost:8080/events', 'response_headers' => ['content-type: text/event-stream']]);
-        $responseStream = new ResponseStream((function () use ($response, $chunk) {
-            yield $response => new FirstChunk();
-            yield $response => $chunk;
-            yield $response => new ErrorChunk(0, 'timeout');
-        })());
-
-        $hasCorrectHeaders = function ($options) {
-            $this->assertSame(['Accept: text/event-stream', 'Cache-Control: no-cache'], $options['headers']);
-
-            return true;
-        };
-
-        $httpClient = $this->createMock(HttpClientInterface::class);
-        $httpClient->method('request')->with('GET', 'http://localhost:8080/events', $this->callback($hasCorrectHeaders))->willReturn($response);
-
-        $httpClient->method('stream')->willReturn($responseStream);
-
-        $es = new EventSourceHttpClient($httpClient);
+TXT
+                ),
+            ], [
+                'canceled' => false,
+                'http_method' => 'GET',
+                'url' => 'http://localhost:8080/events',
+                'response_headers' => ['content-type: text/event-stream'],
+            ]);
+        }));
         $res = $es->connect('http://localhost:8080/events');
 
         $expected = [
             new FirstChunk(),
             new ServerSentEvent(str_replace("\n", $sep, "event: builderror\nid: 46\ndata: {\"foo\": \"bar\"}\n\n")),
             new ServerSentEvent(str_replace("\n", $sep, "event: reload\nid: 47\ndata: {}\n\n")),
-            new ServerSentEvent(str_replace("\n", $sep, "event: reload\nid: 48\ndata: {}\n\n")),
+            new DataChunk(-1, str_replace("\n", $sep, ": this is a oneline comment\n\n")),
+            new DataChunk(-1, str_replace("\n", $sep, ": this is a\n: multiline comment\n\n")),
+            new ServerSentEvent(str_replace("\n", $sep, ": comments are ignored\nevent: reload\n: anywhere\nid: 48\ndata: {}\n\n")),
             new ServerSentEvent(str_replace("\n", $sep, "data: test\ndata:test\nid: 49\nevent: testEvent\n\n\n")),
             new ServerSentEvent(str_replace("\n", $sep, "id: 50\ndata: <tag>\ndata\ndata:   <foo />\ndata\ndata: </tag>\n\n")),
+            new DataChunk(-1, str_replace("\n", $sep, "id: 60\ndata")),
+            new LastChunk("\r\n" === $sep ? 355 : 322),
         ];
-        $i = 0;
-
-        $this->expectExceptionMessage('Response has been canceled');
-        while ($res) {
-            if ($i > 0) {
-                $res->cancel();
-            }
-            foreach ($es->stream($res) as $chunk) {
-                if ($chunk->isTimeout()) {
-                    continue;
-                }
-
-                if ($chunk->isLast()) {
-                    continue;
-                }
-
-                $this->assertEquals($expected[$i++], $chunk);
-            }
+        foreach ($es->stream($res) as $chunk) {
+            $this->assertEquals(array_shift($expected), $chunk);
         }
+        $this->assertSame([], $expected);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR fixes at least 2 behaviors:
* Correctly parse comments to ignore them (yield them as DataChunk)
* Avoid yielding a final empty SSE

I also reworked the test to leverage MockHttpClient.