### PR TITLE
[HttpFoundation] Use HTTP Response constant as default value for Response

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -45,7 +45,7 @@ class BinaryFileResponse extends Response
      * @param bool                $autoEtag           Whether the ETag header should be automatically set
      * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
      */
-    public function __construct($file, int $status = 200, array $headers = [], bool $public = true, ?string $contentDisposition = null, bool $autoEtag = false, bool $autoLastModified = true)
+    public function __construct($file, int $status = self::HTTP_OK, array $headers = [], bool $public = true, ?string $contentDisposition = null, bool $autoEtag = false, bool $autoLastModified = true)
     {
         parent::__construct(null, $status, $headers);
 

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -39,7 +39,7 @@ class JsonResponse extends Response
      * @param array $headers An array of response headers
      * @param bool  $json    If the data is already a JSON string
      */
-    public function __construct($data = null, int $status = 200, array $headers = [], bool $json = false)
+    public function __construct($data = null, int $status = self::HTTP_OK, array $headers = [], bool $json = false)
     {
         parent::__construct('', $status, $headers);
 
@@ -91,7 +91,7 @@ class JsonResponse extends Response
      *
      * @return static
      */
-    public static function fromJsonString(string $data, int $status = 200, array $headers = [])
+    public static function fromJsonString(string $data, int $status = self::HTTP_OK, array $headers = [])
     {
         return new static($data, $status, $headers, true);
     }

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -212,7 +212,7 @@ class Response
     /**
      * @throws \InvalidArgumentException When the HTTP status code is not valid
      */
-    public function __construct(?string $content = '', int $status = 200, array $headers = [])
+    public function __construct(?string $content = '', int $status = self::HTTP_OK, array $headers = [])
     {
         $this->headers = new ResponseHeaderBag($headers);
         $this->setContent($content);

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -30,7 +30,7 @@ class StreamedResponse extends Response
     protected $streamed;
     private $headersSent;
 
-    public function __construct(?callable $callback = null, int $status = 200, array $headers = [])
+    public function __construct(?callable $callback = null, int $status = self::HTTP_OK, array $headers = [])
     {
         parent::__construct(null, $status, $headers);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR aims to improve the DX by using the Response::HTTP_OK constant in the methods signature rather than by redefining the value