### PR TITLE
[HttpFoundation] Use HTTP Response constant as default value for Response

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedJsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedJsonResponse.php
@@ -54,7 +54,7 @@ class StreamedJsonResponse extends StreamedResponse
      */
     public function __construct(
         private readonly iterable $data,
-        int $status = 200,
+        int $status = self::HTTP_OK,
         array $headers = [],
         private int $encodingOptions = JsonResponse::DEFAULT_ENCODING_OPTIONS,
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | N/A
| License       | MIT

This is the friend of https://github.com/symfony/symfony/pull/57457