### PR TITLE
[FrameworkBundle] Lazy `kernel.secret` parameter resolving

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -23,6 +23,7 @@ use Symfony\Component\Config\ResourceCheckerConfigCacheFactory;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResourceChecker;
 use Symfony\Component\DependencyInjection\EnvVarProcessor;
+use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -154,7 +155,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('uri_signer', UriSigner::class)
             ->args([
-                param('kernel.secret'),
+                new Parameter('kernel.secret')
             ])
         ->alias(UriSigner::class, 'uri_signer')
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_login_link.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_login_link.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\SecurityBundle\LoginLink\FirewallAwareLoginLinkHandler;
+use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\Security\Core\Signature\ExpiredSignatureStorage;
 use Symfony\Component\Security\Core\Signature\SignatureHasher;
 use Symfony\Component\Security\Http\Authenticator\LoginLinkAuthenticator;
@@ -43,7 +44,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('property_accessor'),
                 abstract_arg('signature properties'),
-                '%kernel.secret%',
+                new Parameter('kernel.secret'),
                 abstract_arg('expired signature storage'),
                 abstract_arg('max signature uses'),
             ])

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\SecurityBundle\RememberMe\FirewallAwareRememberMeHandler;
+use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\Security\Core\Signature\SignatureHasher;
 use Symfony\Component\Security\Http\Authenticator\RememberMeAuthenticator;
 use Symfony\Component\Security\Http\EventListener\CheckRememberMeConditionsListener;
@@ -30,7 +31,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('property_accessor'),
                 abstract_arg('signature properties'),
-                '%kernel.secret%',
+                new Parameter('kernel.secret'),
                 null,
                 null,
             ])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

https://github.com/symfony/symfony/pull/56985 and https://github.com/symfony/recipes/pull/1317 following up

The goal of this PR is to fix the current compiler-errors about a missing `kernel.secret` parameter when it's not set at all. Thus, improving the first-time experience with minimalistic apps.
