### PR TITLE
[SecurityBundle] Add `provider` XML attribute to the authenticators it’s missing from

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -230,6 +230,7 @@
         <xsd:attribute name="check-path" type="xsd:string" />
         <xsd:attribute name="use-forward" type="xsd:boolean" />
         <xsd:attribute name="require-previous-session" type="xsd:boolean" />
+        <xsd:attribute name="provider" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:attributeGroup name="success-handler-options">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -64,9 +64,8 @@
             <http-basic />
         </firewall>
 
-        <firewall name="with_user_checker" provider="default">
+        <firewall name="with_user_checker" provider="default" user-checker="app.user_checker">
             <http-basic />
-            <user-checker>app.user_checker</user-checker>
         </firewall>
 
         <role id="ROLE_ADMIN">ROLE_USER</role>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_provider.xml
@@ -15,7 +15,7 @@
 
         <sec:firewalls>
             <sec:firewall name="main" provider="with-dash">
-                <sec:form_login />
+                <sec:form-login />
             </sec:firewall>
         </sec:firewalls>
     </sec:config>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_undefined_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_undefined_provider.xml
@@ -15,7 +15,7 @@
 
         <sec:firewalls>
             <sec:firewall name="main" provider="undefined">
-                <sec:form_login />
+                <sec:form-login />
             </sec:firewall>
         </sec:firewalls>
     </sec:config>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/legacy_container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/legacy_container1.xml
@@ -66,10 +66,9 @@
             <http-basic />
         </firewall>
 
-        <firewall name="with_user_checker" provider="default">
+        <firewall name="with_user_checker" provider="default" user-checker="app.user_checker">
             <anonymous />
             <http-basic />
-            <user-checker>app.user_checker</user-checker>
         </firewall>
 
         <role id="ROLE_ADMIN">ROLE_USER</role>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/legacy_encoders.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/legacy_encoders.xml
@@ -66,10 +66,9 @@
             <http-basic />
         </firewall>
 
-        <firewall name="with_user_checker" provider="default">
+        <firewall name="with_user_checker" provider="default" user-checker="app.user_checker">
             <anonymous />
             <http-basic />
-            <user-checker>app.user_checker</user-checker>
         </firewall>
 
         <role id="ROLE_ADMIN">ROLE_USER</role>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_provider.xml
@@ -15,7 +15,7 @@
 
         <sec:firewalls>
             <sec:firewall name="main">
-                <sec:form_login provider="default" />
+                <sec:form-login provider="default" />
             </sec:firewall>
         </sec:firewalls>
     </sec:config>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_undefined_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_undefined_provider.xml
@@ -15,7 +15,7 @@
 
         <sec:firewalls>
             <sec:firewall name="main">
-                <sec:form_login provider="undefined" />
+                <sec:form-login provider="undefined" />
             </sec:firewall>
         </sec:firewalls>
     </sec:config>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
@@ -22,7 +22,6 @@
             <switch-user />
             <x509 />
             <remote-user />
-            <user-checker />
             <logout />
             <remember-me secret="TheSecret"/>
         </firewall>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR fixes the issues found while investigating #57463 (but not #57463 itself as I’m not sure about its impact):

- `provider` attribute is missing for several authenticators in the XSD
- fixtures use a `form_login` instead of the `form-login` authenticator
- fixtures use `user-checker` as a `firewall` element rather than attribute