### PR TITLE
[DoctrineBridge] Test reset with a true manager

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DummyManager.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DummyManager.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+
+class DummyManager implements ObjectManager
+{
+    public $bar;
+
+    public function find($className, $id): ?object
+    {
+    }
+
+    public function persist($object): void
+    {
+    }
+
+    public function remove($object): void
+    {
+    }
+
+    public function merge($object)
+    {
+    }
+
+    public function clear($objectName = null): void
+    {
+    }
+
+    public function detach($object): void
+    {
+    }
+
+    public function refresh($object): void
+    {
+    }
+
+    public function flush(): void
+    {
+    }
+
+    public function getRepository($className): ObjectRepository
+    {
+    }
+
+    public function getClassMetadata($className): ClassMetadata
+    {
+    }
+
+    public function getMetadataFactory(): ClassMetadataFactory
+    {
+    }
+
+    public function initializeObject($obj): void
+    {
+    }
+
+    public function contains($object): bool
+    {
+    }
+
+    public function isUninitializedObject($value): bool
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Now that [assertions were added to the `AbstractManagerRegistry`](https://github.com/doctrine/persistence/pull/375), the `ManagerRegistryTest` must register instances of `ObjectManager` to avoid tests failing with
```
assert(): assert($service instanceof ObjectManager) failed
```

Changes mostly come from #48484 but the ProxyManager is still used on 5.4, so beware when merging this in 6.4.