### PR TITLE
[Serializer] Use `SUPPORTED_TYPES` in Normalizers when available

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -44,11 +44,7 @@ final class DataUriNormalizer implements NormalizerInterface, DenormalizerInterf
 
     public function getSupportedTypes(?string $format): array
     {
-        return [
-            \SplFileInfo::class => true,
-            \SplFileObject::class => true,
-            File::class => true,
-        ];
+        return self::SUPPORTED_TYPES;
     }
 
     public function normalize(mixed $object, ?string $format = null, array $context = []): string

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -50,11 +50,7 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
 
     public function getSupportedTypes(?string $format): array
     {
-        return [
-            \DateTimeInterface::class => true,
-            \DateTimeImmutable::class => true,
-            \DateTime::class => true,
-        ];
+        return self::SUPPORTED_TYPES;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In both normalizers, a constant exists to define supported types. Let's reuse it in `getSupportedTypes()` to ease addition/removal of type in the future?