### PR TITLE
[Security] check token in payload instead just request

### DIFF
--- a/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
@@ -46,7 +46,7 @@ final class IsCsrfTokenValidAttributeListener implements EventSubscriberInterfac
         foreach ($attributes as $attribute) {
             $id = $this->getTokenId($attribute->id, $request, $arguments);
 
-            if (!$this->csrfTokenManager->isTokenValid(new CsrfToken($id, $request->request->getString($attribute->tokenKey)))) {
+            if (!$this->csrfTokenManager->isTokenValid(new CsrfToken($id, $request->getPayload()->getString($attribute->tokenKey)))) {
                 throw new InvalidCsrfTokenException('Invalid CSRF token.');
             }
         }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
@@ -88,6 +88,28 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
         $listener->onKernelControllerArguments($event);
     }
 
+    public function testIsCsrfTokenValidCalledCorrectlyInPayload()
+    {
+        $request = new Request(server: ['headers' => ['content-type' => 'application/json']], content: json_encode(['_token' => 'bar']));
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')
+            ->with(new CsrfToken('foo', 'bar'))
+            ->willReturn(true);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsCsrfTokenValidAttributeMethodsController(), 'withDefaultTokenKey'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerArguments($event);
+    }
+
     public function testIsCsrfTokenValidCalledCorrectlyWithCustomExpressionId()
     {
         $request = new Request(query: ['id' => '123'], request: ['_token' => 'bar']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| License       | MIT

Replace request by getPayload for allow token to ba passed in Json for an API call
