### PR TITLE
[Security][SecurityBundle] Allow passing attributes to passport via `Security::login()`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * Allow passing passport attributes to `Security::login()`
  * Allow configuring the secret used to sign login links
 
 7.1

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -74,14 +74,15 @@ class Security implements AuthorizationCheckerInterface
     }
 
     /**
-     * @param UserInterface    $user              The user to authenticate
-     * @param string|null      $authenticatorName The authenticator name (e.g. "form_login") or service id (e.g. SomeApiKeyAuthenticator::class) - required only if multiple authenticators are configured
-     * @param string|null      $firewallName      The firewall name - required only if multiple firewalls are configured
-     * @param BadgeInterface[] $badges            Badges to add to the user's passport
+     * @param UserInterface         $user              The user to authenticate
+     * @param string|null           $authenticatorName The authenticator name (e.g. "form_login") or service id (e.g. SomeApiKeyAuthenticator::class) - required only if multiple authenticators are configured
+     * @param string|null           $firewallName      The firewall name - required only if multiple firewalls are configured
+     * @param BadgeInterface[]      $badges            Badges to add to the user's passport
+     * @param array<string, mixed>  $attributes        Attributes to add to the user's passport
      *
      * @return Response|null The authenticator success response if any
      */
-    public function login(UserInterface $user, ?string $authenticatorName = null, ?string $firewallName = null, array $badges = []): ?Response
+    public function login(UserInterface $user, ?string $authenticatorName = null, ?string $firewallName = null, array $badges = [], array $attributes = []): ?Response
     {
         $request = $this->container->get('request_stack')->getCurrentRequest();
         if (null === $request) {
@@ -98,7 +99,7 @@ class Security implements AuthorizationCheckerInterface
 
         $this->container->get('security.user_checker')->checkPreAuth($user);
 
-        return $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request, $badges);
+        return $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request, $badges, $attributes);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -62,12 +62,17 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
     }
 
     /**
-     * @param BadgeInterface[] $badges Optionally, pass some Passport badges to use for the manual login
+     * @param BadgeInterface[]     $badges Optionally, pass some Passport badges to use for the manual login
+     * @param array<string, mixed> $attributes Optionally, pass some Passport attributes to use for the manual login
      */
-    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = []): ?Response
+    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = [], array $attributes = []): ?Response
     {
         // create an authentication token for the User
         $passport = new SelfValidatingPassport(new UserBadge($user->getUserIdentifier(), fn () => $user), $badges);
+        foreach ($attributes as $attribute => $value) {
+            $passport->setAttribute($attribute, $value);
+        }
+
         $token = $authenticator->createToken($passport, $this->firewallName);
 
         // announce the authentication token

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * Allow passing passport attributes to `AuthenticatorManager::authenticateUser()`
  * Deprecate argument `$secret` of `RememberMeAuthenticator`
 
 7.1


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

When using the `Security::login()` function it was not possible to set attributes on a passport. My authenticator is trying to get an attribute from a passport hence this PR.