### PR TITLE
[String] Fixed u()->snake(), b()->snake() and s()->snake() methods

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -366,8 +366,8 @@ abstract class AbstractUnicodeString extends AbstractString
 
     public function snake(): parent
     {
-        $str = $this->camel();
-        $str->string = mb_strtolower(preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1_\2', $str->string), 'UTF-8');
+        $str = clone $this;
+        $str->string = str_replace(' ', '_', mb_strtolower(preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1 \2', $str->string), 'UTF-8'));
 
         return $str;
     }

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -366,8 +366,8 @@ class ByteString extends AbstractString
 
     public function snake(): parent
     {
-        $str = $this->camel();
-        $str->string = strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1_\2', $str->string));
+        $str = clone $this;
+        $str->string = str_replace(' ', '_', strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1 \2', $str->string)));
 
         return $str;
     }

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1077,6 +1077,8 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfony_is_great', 'symfonyIsGREAT'],
             ['symfony_is_really_great', 'symfonyIsREALLYGreat'],
             ['symfony', 'SYMFONY'],
+            ['symfony_is_great', 'SYMFONY IS GREAT'],
+            ['symfony_is_great', 'SYMFONY_IS_GREAT'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57464
| License       | MIT

[String] ByteString::snake and AbstractUnitcodeString::snake methods doesn't convert all uppercase words in the right way.

For example, string "GREAT SYMFONY" is converted to "greatsymfony" instead of "great_symfony".
