### PR TITLE
[Mailer] Add additional headers in Scaleway bridge

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Transport/ScalewayApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Transport/ScalewayApiTransportTest.php
@@ -69,6 +69,8 @@ class ScalewayApiTransportTest extends TestCase
             $this->assertSame('attachment.txt', $body['attachments'][0]['name']);
             $this->assertSame('text/plain', $body['attachments'][0]['type']);
             $this->assertSame(base64_encode('some attachment'), $body['attachments'][0]['content']);
+            $this->assertSame('Reply-To', $body['additional_headers'][0]['key']);
+            $this->assertStringContainsString('foo@bar.fr', $body['additional_headers'][0]['value']);
 
             return new JsonMockResponse(['emails' => [['message_id' => 'foobar']]], [
                 'http_code' => 200,
@@ -81,6 +83,7 @@ class ScalewayApiTransportTest extends TestCase
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->replyTo(new Address('foo@bar.fr', 'Foo'))
             ->text('Hello There!')
             ->addPart(new DataPart('some attachment', 'attachment.txt', 'text/plain'));
 

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Transport/ScalewayApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Transport/ScalewayApiTransport.php
@@ -101,6 +101,9 @@ final class ScalewayApiTransport extends AbstractApiTransport
         if ($attachements = $this->prepareAttachments($email)) {
             $payload['attachments'] = $attachements;
         }
+        if ($headers = $this->getCustomHeaders($email)) {
+            $payload['additional_headers'] = $headers;
+        }
 
         return $payload;
     }
@@ -120,6 +123,24 @@ final class ScalewayApiTransport extends AbstractApiTransport
         }
 
         return $attachments;
+    }
+
+    private function getCustomHeaders(Email $email): array
+    {
+        $headers = [];
+        $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender'];
+        foreach ($email->getHeaders()->all() as $name => $header) {
+            if (\in_array($name, $headersToBypass, true)) {
+                continue;
+            }
+
+            $headers[] = [
+                'key' => $header->getName(),
+                'value' => $header->getBodyAsString(),
+            ];
+        }
+
+        return $headers;
     }
 
     private function formatAddress(Address $address): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?         | 6.4 
| Bug fix?       | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This adds the missing additional headers in the Scaleway bridge (I forgot to add them in the original implementation). This can be used, for example, to add a `Reply-To` header that doesn't have its own field, but is supported in the `additional_headers` field (see the [Scaleway documentation](https://www.scaleway.com/en/docs/managed-services/transactional-email/api-cli/send-emails-with-api/)). Tested with the Scaleway API and is working fine 🚀 