### PR TITLE
[Messenger] Introduce `#[AsMessage]` attribute for message routing

### DIFF
--- a/src/Symfony/Component/Messenger/Attribute/AsMessage.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessage.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Attribute;
+
+/**
+ * Attribute for configuring message routing.
+ *
+ * @author Pierre Rineau pierre.rineau@processus.org>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class AsMessage
+{
+    public function __construct(
+        /**
+         * Name of the transports to which the message should be routed.
+         */
+        public null|string|array $transport = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * Add `#[AsMessage]` attribute with `$transport` parameter for message routing
  * Add `--format` option to the `messenger:stats` command
 
 7.1

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage(transport: ['first_sender', 'second_sender'])]
+class DummyMessageWithAttribute implements DummyMessageInterface
+{
+    public function __construct(
+        private string $message,
+    ) {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\Sender;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
@@ -45,6 +46,7 @@ class SendersLocator implements SendersLocatorInterface
         }
 
         $seen = [];
+        $found = false;
 
         foreach (HandlersLocator::listTypes($envelope) as $type) {
             if (str_ends_with($type, '*') && $seen) {
@@ -58,9 +60,37 @@ class SendersLocator implements SendersLocatorInterface
                     $seen[] = $senderAlias;
 
                     yield from $this->getSenderFromAlias($senderAlias);
+                    $found = true;
                 }
             }
         }
+
+        // Let the configuration-driven map upper override message attributes,
+        // this allows environment-specific configuration overriding hardcoded
+        // transport name.
+        if ($found) {
+            return;
+        }
+
+        foreach ($this->getTransportNamesFromAttribute($envelope) as $senderAlias) {
+            yield from $this->getSenderFromAlias($senderAlias);
+        }
+    }
+
+    private function getTransportNamesFromAttribute(Envelope $envelope): array
+    {
+        $transports = [];
+        $message = $envelope->getMessage();
+
+        foreach ((new \ReflectionClass($message))->getAttributes(AsMessage::class, \ReflectionAttribute::IS_INSTANCEOF) as $refAttr) {
+            $asMessage = $refAttr->newInstance();
+
+            if ($asMessage->transport) {
+                $transports = \array_merge($transports, (array) $asMessage->transport);
+            }
+        }
+
+        return $transports;
     }
 
     private function getSenderFromAlias(string $senderAlias): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57506
| License       | MIT

Basic implementation of #57506.

* Adds the `Symfony\Component\Messenger\Attribute\AsMessage` attribute, with the `$transport` parameter which can be `string` or `array`.
* Implement runtime routing in `Symfony\Component\Messenger\Transport\Sender\SendersLocator`.

Rationale:

* Messages are not services, it cannot be computed during container compilation.
* Reflection is very fast, it shouldn't be significant for performances, yet I don't have measured it yet.
* YAML configuration and `Symfony\Component\Messenger\Stamp\TransportNamesStamp` will always override the attribute values, allowing users to change hardcoded routing on a per-environment basis.
* This is the simplest implementation I could think of for discussion.

Links and references:

* https://github.com/symfony/symfony/issues/33912 where the discussion started, 5 years ago.
* https://github.com/symfony/symfony/pull/49143 closed PR that was doing the same, but at compile time, rejected because the actual doctrine is that messages should never be services.
* https://github.com/symfony/symfony/pull/41179 is stilled opened, and awaiting for modifications, but it was written for an earlier version of Symfony and is inactive for a year or so, yet messenger code has evolved since, and this PR will never merge as-is, it requires to be fully rewrote, reason why I opened this new one.

