### PR TITLE
[PasswordHasher] Add a message on invalid `password_hasher` configuration

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -43,6 +43,9 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
             $hasherKey = $hasherName;
         } else {
             foreach ($this->passwordHashers as $class => $hasher) {
+                if(!class_exists($class)) {
+                    throw new \RuntimeException(sprintf('Invalid class on parameters given to security.password_hashers "%s".', $class));
+                }
                 if ((\is_object($user) && $user instanceof $class) || (!\is_object($user) && (is_subclass_of($user, $class) || $user == $class))) {
                     $hasherKey = $class;
                     break;

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -44,7 +44,7 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
         } else {
             foreach ($this->passwordHashers as $class => $hasher) {
                 if(!class_exists($class)) {
-                    throw new \RuntimeException(sprintf('Invalid class on parameters given to security.password_hashers "%s".', $class));
+                    throw new LogicException(sprintf('Invalid password hashers\' configuration: class or interface "%s" not found.', $class));
                 }
                 if ((\is_object($user) && $user instanceof $class) || (!\is_object($user) && (is_subclass_of($user, $class) || $user == $class))) {
                     $hasherKey = $class;

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -43,7 +43,7 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
             $hasherKey = $hasherName;
         } else {
             foreach ($this->passwordHashers as $class => $hasher) {
-                if(!class_exists($class)) {
+                if (!class_exists($class) && !interface_exists($class, false)) {
                     throw new LogicException(sprintf('Invalid password hashers\' configuration: class or interface "%s" not found.', $class));
                 }
                 if ((\is_object($user) && $user instanceof $class) || (!\is_object($user) && (is_subclass_of($user, $class) || $user == $class))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix
| License       | MIT

I spent a little while looking for an error, and a message like this would have saved me a lot of time.
Could be useful for others!
