### PR TITLE
[Messenger] Double check if pcntl function exists

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/DispatchPcntlSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/DispatchPcntlSignalListener.php
@@ -21,6 +21,10 @@ class DispatchPcntlSignalListener implements EventSubscriberInterface
 {
     public function onWorkerRunning(): void
     {
+        if (!\function_exists('pcntl_signal_dispatch')) {
+            return;
+        }
+
         pcntl_signal_dispatch();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I have a system where we use the `kernel.terminate` event to trigger `messenger:consume` in case there's no real worker available. Which means there might be the case that when building the container on cli, `pcntl_signal_dispatch` exists but in the web process it of course doesn't.

Super edge-case but these 3 lines would save me from implementing some logic to unregister this listener myself and I don't see why it would hurt anybody else.