### PR TITLE
[Workflow] Add phpdoc about exception

### DIFF
--- a/src/Symfony/Component/Workflow/WorkflowInterface.php
+++ b/src/Symfony/Component/Workflow/WorkflowInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Workflow;
 
 use Symfony\Component\Workflow\Exception\LogicException;
+use Symfony\Component\Workflow\Exception\UndefinedTransitionException;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
 
@@ -38,6 +39,8 @@ interface WorkflowInterface
 
     /**
      * Builds a TransitionBlockerList to know why a transition is blocked.
+     *
+     * @throws UndefinedTransitionException If the transition is not defined
      */
     public function buildTransitionBlockerList(object $subject, string $transitionName): TransitionBlockerList;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

I recently changed a `can` call to a `buildTransitionBlockerList` and got many exceptions.

When looking at the interface we could believe the behavior of these method are similar with
- can returning true/false
- buildTransitionBlockerList returning a list empty or not

But it's not true.
When we try to call `buildTransitionBlockerList` with a not defined transition, 
- can return false
- buildTransitionBlockerList throw an exception

I think this should at least be mentioned in the PHPdoc.
Dunno if this need to wait 7.2 or can be done on previous versions.

cc @lyrixx 