### PR TITLE
[DependencyInjection][Yaml] Add support for flags parsing with `binary_flags` type and tag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `binary_flags` parameter and argument types in `XmlFileLoader`
+
 7.1
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -623,6 +623,10 @@ class XmlFileLoader extends FileLoader
                 case 'constant':
                     $arguments[$key] = \constant(trim($arg->nodeValue));
                     break;
+                case 'binary_flags':
+                    $constants = \array_map(\constant(...), \array_map(trim(...), \explode('|', $arg->nodeValue)));
+                    $arguments[$key] = \array_reduce($constants, static fn ($carry, $item) => $carry | $item, 0);
+                    break;
                 default:
                     $arguments[$key] = XmlUtils::phpize($trim ? trim($arg->nodeValue) : $arg->nodeValue);
             }

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -342,6 +342,7 @@
       <xsd:enumeration value="string" />
       <xsd:enumeration value="constant" />
       <xsd:enumeration value="binary" />
+      <xsd:enumeration value="binary_flags" />
     </xsd:restriction>
   </xsd:simpleType>
 
@@ -354,6 +355,7 @@
       <xsd:enumeration value="string" />
       <xsd:enumeration value="constant" />
       <xsd:enumeration value="binary" />
+      <xsd:enumeration value="binary_flags" />
       <xsd:enumeration value="iterator" />
       <xsd:enumeration value="closure" />
       <xsd:enumeration value="service_closure" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooClassWithFlags.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooClassWithFlags.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooClassWithFlags
+{
+    public const FLAG_A = 2;
+    public const FLAG_B = 4;
+    public const FLAG_C = 8;
+
+    public function __construct(public int $flags)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_binary_flags.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_binary_flags.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <parameters>
+    <parameter key="my_flags" type="binary_flags">Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags::FLAG_A</parameter>
+  </parameters>
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags" class="Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags" public="true">
+      <argument type="binary_flags">Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags::FLAG_A | Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags::FLAG_C</argument>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_invalid_binary_flags.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_invalid_binary_flags.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags" class="Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags" public="true">
+      <argument type="binary_flags">Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags::WRONG_FLAG</argument>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -40,6 +40,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithFlags;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooWithAbstractArgument;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
@@ -962,6 +963,26 @@ class XmlFileLoaderTest extends TestCase
 
         $this->expectException(\Error::class);
         $loader->load('services_with_invalid_enumeration.xml');
+    }
+
+    public function testBinaryFlags()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_with_binary_flags.xml');
+        $container->compile();
+
+        $definition = $container->getDefinition(FooClassWithFlags::class);
+        $this->assertSame([FooClassWithFlags::FLAG_A | FooClassWithFlags::FLAG_C], $definition->getArguments());
+    }
+
+    public function testInvalidBinaryFlags()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+
+        $this->expectException(\Error::class);
+        $loader->load('services_with_invalid_binary_flags.xml');
     }
 
     public function testInstanceOfAndChildDefinition()

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate parsing duplicate mapping keys whose value is `null`
+ * Add support for binary flags with the `!!binary_flags` tag
 
 7.1
 ---

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -119,6 +119,42 @@ class InlineTest extends TestCase
         Inline::parse('!php/enum SomeEnum::Foo', Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
     }
 
+    public function testParseSingleBinaryFlag()
+    {
+        $this->assertSame(Yaml::PARSE_CONSTANT, Inline::parse('!!binary_flags Symfony\Component\Yaml\Yaml::PARSE_CONSTANT', Yaml::PARSE_CONSTANT));
+    }
+
+    public function testParseMultipleBinaryFlags()
+    {
+        $this->assertSame(Yaml::PARSE_CONSTANT | Yaml::PARSE_CUSTOM_TAGS, Inline::parse('!!binary_flags Symfony\Component\Yaml\Yaml::PARSE_CONSTANT | Symfony\Component\Yaml\Yaml::PARSE_CUSTOM_TAGS', Yaml::PARSE_CONSTANT));
+    }
+
+    public function testParseBinaryFlagsThrowsExceptionWhenUndefined()
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('The constant "WRONG_CONSTANT" is not defined');
+        Inline::parse('!!binary_flags WRONG_CONSTANT', Yaml::PARSE_CONSTANT);
+    }
+
+    public function testParseBinaryFlagsThrowsExceptionWhenNotAnInt()
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('The constant "DIRECTORY_SEPARATOR" is not an integer');
+        Inline::parse('!!binary_flags DIRECTORY_SEPARATOR', Yaml::PARSE_CONSTANT);
+    }
+
+    public function testParseBinaryFlagsWithoutFlags()
+    {
+        $this->assertNull(Inline::parse('!!binary_flags PHP_INT_MAX'));
+    }
+
+    public function testParseBinaryFlagsWithoutOptionToParseConstants()
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessageMatches('/The string "!!binary_flags PHP_INT_MAX" could not be parsed as binary flags.*/');
+        Inline::parse('!!binary_flags PHP_INT_MAX', Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+    }
+
     /**
      * @dataProvider getTestsForDump
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

After https://github.com/symfony/symfony-docs/pull/19965. This PR would allow to write such code (removed NS for readability of the example):

```yaml
App\Entity\Report:
    properties:
        customConfiguration:
            - Yaml:
                  message: Your configuration doesn't have valid YAML syntax.
                  flags: !!binary_flags YamlParser::PARSE_CONSTANT | YamlParser::PARSE_CUSTOM_TAGS | Yaml::PARSE_DATETIME
```

Same goes for XML, where a new `binary_flags` type is added.

When parsing, `binary_flags` assumes you give only constants as parameters, the goal is not to rewrite a complete bitwise ops parser.