### PR TITLE
Add more precise types in reusable test cases

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -1,5 +1,5 @@
 # Run these steps to update this file:
-sed -i 's/ *"\*\*\/Tests\/"//' composer.json
+sed -i 's/ *"\*\*\/Tests\/",\?//' composer.json
 composer u -o
 SYMFONY_PATCH_TYPE_DECLARATIONS='force=2&php=8.1' php .github/patch-types.php
 head=$(sed '/^diff /Q' .github/expected-missing-return-types.diff)
@@ -7,6 +7,16 @@ git checkout src/Symfony/Contracts/Service/ResetInterface.php
 (echo "$head" && echo && git diff -U2 src/ | grep '^index ' -v) > .github/expected-missing-return-types.diff
 git checkout composer.json src/
 
+diff --git a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
++++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+@@ -52,5 +52,5 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
+      * @return FormExtensionInterface[]
+      */
+-    protected function getExtensions()
++    protected function getExtensions(): array
+     {
+         return [
 diff --git a/src/Symfony/Component/BrowserKit/AbstractBrowser.php b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
 --- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
 +++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -22,7 +32,7 @@ diff --git a/src/Symfony/Component/BrowserKit/AbstractBrowser.php b/src/Symfony/
       */
 -    abstract protected function doRequest(object $request);
 +    abstract protected function doRequest(object $request): object;
-
+ 
      /**
 @@ -451,5 +451,5 @@ abstract class AbstractBrowser
       * @throws LogicException When this abstract class is not implemented
@@ -146,21 +156,21 @@ diff --git a/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterf
       */
 -    public function load(array $configs, ContainerBuilder $container);
 +    public function load(array $configs, ContainerBuilder $container): void;
-
+ 
      /**
 @@ -37,5 +37,5 @@ interface ExtensionInterface
       * @return string
       */
 -    public function getNamespace();
 +    public function getNamespace(): string;
-
+ 
      /**
 @@ -44,5 +44,5 @@ interface ExtensionInterface
       * @return string|false
       */
 -    public function getXsdValidationBasePath();
 +    public function getXsdValidationBasePath(): string|false;
-
+ 
      /**
 @@ -53,4 +53,4 @@ interface ExtensionInterface
       * @return string
@@ -189,13 +199,13 @@ diff --git a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php 
 diff --git a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
 --- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
 +++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
-@@ -139,5 +139,5 @@ class ExpressionLanguage
+@@ -149,5 +149,5 @@ class ExpressionLanguage
       * @return void
       */
 -    protected function registerFunctions()
 +    protected function registerFunctions(): void
      {
-         $this->addFunction(ExpressionFunction::fromPhp('constant'));
+         $basicPhpFunctions = ['constant', 'min', 'max'];
 diff --git a/src/Symfony/Component/Form/AbstractType.php b/src/Symfony/Component/Form/AbstractType.php
 --- a/src/Symfony/Component/Form/AbstractType.php
 +++ b/src/Symfony/Component/Form/AbstractType.php
@@ -249,35 +259,35 @@ diff --git a/src/Symfony/Component/Form/FormTypeInterface.php b/src/Symfony/Comp
       */
 -    public function getParent();
 +    public function getParent(): ?string;
-
+ 
      /**
 @@ -34,5 +34,5 @@ interface FormTypeInterface
       * @return void
       */
 -    public function configureOptions(OptionsResolver $resolver);
 +    public function configureOptions(OptionsResolver $resolver): void;
-
+ 
      /**
 @@ -48,5 +48,5 @@ interface FormTypeInterface
       * @see FormTypeExtensionInterface::buildForm()
       */
 -    public function buildForm(FormBuilderInterface $builder, array $options);
 +    public function buildForm(FormBuilderInterface $builder, array $options): void;
-
+ 
      /**
 @@ -66,5 +66,5 @@ interface FormTypeInterface
       * @see FormTypeExtensionInterface::buildView()
       */
 -    public function buildView(FormView $view, FormInterface $form, array $options);
 +    public function buildView(FormView $view, FormInterface $form, array $options): void;
-
+ 
      /**
 @@ -85,5 +85,5 @@ interface FormTypeInterface
       * @see FormTypeExtensionInterface::finishView()
       */
 -    public function finishView(FormView $view, FormInterface $form, array $options);
 +    public function finishView(FormView $view, FormInterface $form, array $options): void;
-
+ 
      /**
 @@ -95,4 +95,4 @@ interface FormTypeInterface
       * @return string
@@ -285,6 +295,61 @@ diff --git a/src/Symfony/Component/Form/FormTypeInterface.php b/src/Symfony/Comp
 -    public function getBlockPrefix();
 +    public function getBlockPrefix(): string;
  }
+diff --git a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
++++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+@@ -40,5 +40,5 @@ abstract class FormIntegrationTestCase extends TestCase
+      * @return FormExtensionInterface[]
+      */
+-    protected function getExtensions()
++    protected function getExtensions(): array
+     {
+         return [];
+@@ -48,5 +48,5 @@ abstract class FormIntegrationTestCase extends TestCase
+      * @return FormTypeExtensionInterface[]
+      */
+-    protected function getTypeExtensions()
++    protected function getTypeExtensions(): array
+     {
+         return [];
+@@ -56,5 +56,5 @@ abstract class FormIntegrationTestCase extends TestCase
+      * @return FormTypeInterface[]
+      */
+-    protected function getTypes()
++    protected function getTypes(): array
+     {
+         return [];
+@@ -64,5 +64,5 @@ abstract class FormIntegrationTestCase extends TestCase
+      * @return FormTypeGuesserInterface[]
+      */
+-    protected function getTypeGuessers()
++    protected function getTypeGuessers(): array
+     {
+         return [];
+diff --git a/src/Symfony/Component/Form/Test/TypeTestCase.php b/src/Symfony/Component/Form/Test/TypeTestCase.php
+--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
++++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
+@@ -33,5 +33,5 @@ abstract class TypeTestCase extends FormIntegrationTestCase
+      * @return FormExtensionInterface[]
+      */
+-    protected function getExtensions()
++    protected function getExtensions(): array
+     {
+         $extensions = [];
+@@ -47,5 +47,5 @@ abstract class TypeTestCase extends FormIntegrationTestCase
+      * @return void
+      */
+-    public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual)
++    public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual): void
+     {
+         self::assertEquals($expected->format('c'), $actual->format('c'));
+@@ -55,5 +55,5 @@ abstract class TypeTestCase extends FormIntegrationTestCase
+      * @return void
+      */
+-    public static function assertDateIntervalEquals(\DateInterval $expected, \DateInterval $actual)
++    public static function assertDateIntervalEquals(\DateInterval $expected, \DateInterval $actual): void
+     {
+         self::assertEquals($expected->format('%RP%yY%mM%dDT%hH%iM%sS'), $actual->format('%RP%yY%mM%dDT%hH%iM%sS'));
 diff --git a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
 --- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
 +++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -324,26 +389,26 @@ diff --git a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php b/src/S
       */
 -    public function boot();
 +    public function boot(): void;
-
+ 
      /**
 @@ -35,5 +35,5 @@ interface BundleInterface
       * @return void
       */
 -    public function shutdown();
 +    public function shutdown(): void;
-
+ 
      /**
 @@ -44,5 +44,5 @@ interface BundleInterface
       * @return void
       */
 -    public function build(ContainerBuilder $container);
 +    public function build(ContainerBuilder $container): void;
-
+ 
      /**
 diff --git a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
 --- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
 +++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
-@@ -101,5 +101,5 @@ abstract class DataCollector implements DataCollectorInterface
+@@ -113,5 +113,5 @@ abstract class DataCollector implements DataCollectorInterface
       * @return void
       */
 -    public function reset()
@@ -358,7 +423,7 @@ diff --git a/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterfa
       */
 -    public function collect(Request $request, Response $response, ?\Throwable $exception = null);
 +    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void;
-
+ 
      /**
 @@ -35,4 +35,4 @@ interface DataCollectorInterface extends ResetInterface
       * @return string
@@ -383,38 +448,38 @@ diff --git a/src/Symfony/Component/HttpKernel/KernelInterface.php b/src/Symfony/
       */
 -    public function registerContainerConfiguration(LoaderInterface $loader);
 +    public function registerContainerConfiguration(LoaderInterface $loader): void;
-
+ 
      /**
 @@ -44,5 +44,5 @@ interface KernelInterface extends HttpKernelInterface
       * @return void
       */
 -    public function boot();
 +    public function boot(): void;
-
+ 
      /**
 @@ -53,5 +53,5 @@ interface KernelInterface extends HttpKernelInterface
       * @return void
       */
 -    public function shutdown();
 +    public function shutdown(): void;
-
+ 
      /**
 diff --git a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
 --- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
 +++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
-@@ -234,5 +234,5 @@ abstract class AttributeClassLoader implements LoaderInterface
+@@ -236,5 +236,5 @@ abstract class AttributeClassLoader implements LoaderInterface
       * @return string
       */
 -    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
 +    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method): string
      {
          $name = str_replace('\\', '_', $class->name).'_'.$method->name;
-@@ -333,5 +333,5 @@ abstract class AttributeClassLoader implements LoaderInterface
+@@ -335,5 +335,5 @@ abstract class AttributeClassLoader implements LoaderInterface
       * @return void
       */
 -    abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot);
 +    abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void;
-
+ 
      /**
 diff --git a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
 --- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
@@ -424,21 +489,21 @@ diff --git a/src/Symfony/Component/Security/Core/Authentication/RememberMe/Token
       */
 -    public function loadTokenBySeries(string $series);
 +    public function loadTokenBySeries(string $series): PersistentTokenInterface;
-
+ 
      /**
 @@ -35,5 +35,5 @@ interface TokenProviderInterface
       * @return void
       */
 -    public function deleteTokenBySeries(string $series);
 +    public function deleteTokenBySeries(string $series): void;
-
+ 
      /**
 @@ -44,5 +44,5 @@ interface TokenProviderInterface
       * @throws TokenNotFoundException if the token is not found
       */
 -    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed);
 +    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed): void;
-
+ 
      /**
 @@ -51,4 +51,4 @@ interface TokenProviderInterface
       * @return void
@@ -449,28 +514,28 @@ diff --git a/src/Symfony/Component/Security/Core/Authentication/RememberMe/Token
 diff --git a/src/Symfony/Component/Security/Http/Firewall.php b/src/Symfony/Component/Security/Http/Firewall.php
 --- a/src/Symfony/Component/Security/Http/Firewall.php
 +++ b/src/Symfony/Component/Security/Http/Firewall.php
-@@ -51,5 +51,5 @@ class Firewall implements EventSubscriberInterface
+@@ -48,5 +48,5 @@ class Firewall implements EventSubscriberInterface
       * @return void
       */
 -    public function onKernelRequest(RequestEvent $event)
 +    public function onKernelRequest(RequestEvent $event): void
      {
          if (!$event->isMainRequest()) {
-@@ -99,5 +99,5 @@ class Firewall implements EventSubscriberInterface
+@@ -96,5 +96,5 @@ class Firewall implements EventSubscriberInterface
       * @return void
       */
 -    public function onKernelFinishRequest(FinishRequestEvent $event)
 +    public function onKernelFinishRequest(FinishRequestEvent $event): void
      {
          $request = $event->getRequest();
-@@ -112,5 +112,5 @@ class Firewall implements EventSubscriberInterface
+@@ -109,5 +109,5 @@ class Firewall implements EventSubscriberInterface
       * @return array
       */
 -    public static function getSubscribedEvents()
 +    public static function getSubscribedEvents(): array
      {
          return [
-@@ -123,5 +123,5 @@ class Firewall implements EventSubscriberInterface
+@@ -120,5 +120,5 @@ class Firewall implements EventSubscriberInterface
       * @return void
       */
 -    protected function callListeners(RequestEvent $event, iterable $listeners)
@@ -485,7 +550,7 @@ diff --git a/src/Symfony/Component/Translation/Extractor/ExtractorInterface.php 
       */
 -    public function extract(string|iterable $resource, MessageCatalogue $catalogue);
 +    public function extract(string|iterable $resource, MessageCatalogue $catalogue): void;
-
+ 
      /**
 @@ -36,4 +36,4 @@ interface ExtractorInterface
       * @return void
@@ -501,7 +566,7 @@ diff --git a/src/Symfony/Component/Validator/ConstraintValidatorInterface.php b/
       */
 -    public function initialize(ExecutionContextInterface $context);
 +    public function initialize(ExecutionContextInterface $context): void;
-
+ 
      /**
 @@ -31,4 +31,4 @@ interface ConstraintValidatorInterface
       * @return void
@@ -526,7 +591,7 @@ diff --git a/src/Symfony/Contracts/Translation/LocaleAwareInterface.php b/src/Sy
       */
 -    public function setLocale(string $locale);
 +    public function setLocale(string $locale): void;
-
+ 
      /**
 diff --git a/src/Symfony/Contracts/Translation/TranslatorTrait.php b/src/Symfony/Contracts/Translation/TranslatorTrait.php
 --- a/src/Symfony/Contracts/Translation/TranslatorTrait.php

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -29,7 +29,7 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
 
     private EntityManager $em;
 
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         $manager = $this->createMock(ManagerRegistry::class);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -86,7 +86,7 @@ class EntityTypeTest extends BaseTypeTestCase
         }
     }
 
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         return array_merge(parent::getExtensions(), [
             new DoctrineOrmExtension($this->emRegistry),

--- a/src/Symfony/Bridge/Twig/Test/FormLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Test/FormLayoutTestCase.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Test\FormIntegrationTestCase;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
+use Twig\Extension\ExtensionInterface;
 use Twig\Loader\FilesystemLoader;
 
 /**
@@ -81,15 +82,27 @@ abstract class FormLayoutTestCase extends FormIntegrationTestCase
         }
     }
 
+    /**
+     * @return string[]
+     */
     abstract protected function getTemplatePaths(): array;
 
+    /**
+     * @return ExtensionInterface[]
+     */
     abstract protected function getTwigExtensions(): array;
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getTwigGlobals(): array
     {
         return [];
     }
 
+    /**
+     * @return string[]
+     */
     abstract protected function getThemes(): array;
 
     protected function renderForm(FormView $view, array $vars = []): string

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Tests\VersionAwareTest;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -47,6 +48,9 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         parent::setUp();
     }
 
+    /**
+     * @return FormExtensionInterface[]
+     */
     protected function getExtensions()
     {
         return [

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
@@ -26,7 +26,7 @@ class FormExtensionFieldHelpersTest extends FormIntegrationTestCase
     private FormExtension $translatorExtension;
     private FormView $view;
 
-    protected function getTypes()
+    protected function getTypes(): array
     {
         return [new TextType(), new ChoiceType()];
     }

--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -12,8 +12,12 @@
 namespace Symfony\Component\Form\Test;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Forms;
+use Symfony\Component\Form\FormTypeExtensionInterface;
+use Symfony\Component\Form\FormTypeGuesserInterface;
+use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -32,21 +36,33 @@ abstract class FormIntegrationTestCase extends TestCase
             ->getFormFactory();
     }
 
+    /**
+     * @return FormExtensionInterface[]
+     */
     protected function getExtensions()
     {
         return [];
     }
 
+    /**
+     * @return FormTypeExtensionInterface[]
+     */
     protected function getTypeExtensions()
     {
         return [];
     }
 
+    /**
+     * @return FormTypeInterface[]
+     */
     protected function getTypes()
     {
         return [];
     }
 
+    /**
+     * @return FormTypeGuesserInterface[]
+     */
     protected function getTypeGuessers()
     {
         return [];

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Test;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 abstract class TypeTestCase extends FormIntegrationTestCase
@@ -28,6 +29,9 @@ abstract class TypeTestCase extends FormIntegrationTestCase
         $this->builder = new FormBuilder('', null, $this->dispatcher, $this->factory);
     }
 
+    /**
+     * @return FormExtensionInterface[]
+     */
     protected function getExtensions()
     {
         $extensions = [];
@@ -39,11 +43,17 @@ abstract class TypeTestCase extends FormIntegrationTestCase
         return $extensions;
     }
 
+    /**
+     * @return void
+     */
     public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual)
     {
         self::assertEquals($expected->format('c'), $actual->format('c'));
     }
 
+    /**
+     * @return void
+     */
     public static function assertDateIntervalEquals(\DateInterval $expected, \DateInterval $actual)
     {
         self::assertEquals($expected->format('%RP%yY%mM%dDT%hH%iM%sS'), $actual->format('%RP%yY%mM%dDT%hH%iM%sS'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTranslationTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTranslationTest.php
@@ -27,7 +27,7 @@ class ChoiceTypeTranslationTest extends TypeTestCase
         'Roman' => 'e',
     ];
 
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects($this->any())->method('trans')

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -23,7 +23,7 @@ class FileTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\FileType';
 
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         return array_merge(parent::getExtensions(), [new CoreExtension(null, null, new IdentityTranslator())]);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -42,7 +42,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         return array_merge(parent::getExtensions(), [
             new CsrfExtension($this->tokenManager, new IdentityTranslator()),

--- a/src/Symfony/Component/Form/Tests/Extension/HtmlSanitizer/Type/TextTypeHtmlSanitizerExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HtmlSanitizer/Type/TextTypeHtmlSanitizerExtensionTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 class TextTypeHtmlSanitizerExtensionTest extends TypeTestCase
 {
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         $fooSanitizer = $this->createMock(HtmlSanitizerInterface::class);
         $fooSanitizer->expects($this->once())

--- a/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
@@ -40,7 +40,7 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         return array_merge(parent::getExtensions(), [
             new PasswordHasherExtension(new PasswordHasherListener($this->passwordHasher)),

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Validation;
  */
 class FormValidatorPerformanceTest extends FormPerformanceTestCase
 {
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         return [
             new ValidatorExtension(Validation::createValidator(), false),

--- a/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
@@ -37,15 +37,27 @@ abstract class TransportFactoryTestCase extends TestCase
 
     abstract public function getFactory(): TransportFactoryInterface;
 
+    /**
+     * @psalm-return iterable<array{0: Dsn, 1: bool}>
+     */
     abstract public static function supportsProvider(): iterable;
 
+    /**
+     * @psalm-return iterable<array{0: Dsn, 1: TransportInterface}>
+     */
     abstract public static function createProvider(): iterable;
 
+    /**
+     * @psalm-return iterable<array{0: Dsn, 1?: string|null}>
+     */
     public static function unsupportedSchemeProvider(): iterable
     {
         return [];
     }
 
+    /**
+     * @psalm-return iterable<array{0: Dsn}>
+     */
     public static function incompleteDsnProvider(): iterable
     {
         return [];

--- a/src/Symfony/Component/Notifier/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Notifier/Test/TransportFactoryTestCase.php
@@ -39,7 +39,7 @@ abstract class TransportFactoryTestCase extends TestCase
     abstract public static function createProvider(): iterable;
 
     /**
-     * @return iterable<array{0: string, 1: string|null}>
+     * @return iterable<array{0: string, 1?: string|null}>
      */
     public static function unsupportedSchemeProvider(): iterable
     {
@@ -47,7 +47,7 @@ abstract class TransportFactoryTestCase extends TestCase
     }
 
     /**
-     * @return iterable<array{0: string, 1: string|null}>
+     * @return iterable<array{0: string, 1?: string|null}>
      */
     public static function incompleteDsnProvider(): iterable
     {
@@ -55,7 +55,7 @@ abstract class TransportFactoryTestCase extends TestCase
     }
 
     /**
-     * @return iterable<array{0: string, 1: string|null}>
+     * @return iterable<array{0: string, 1?: string|null}>
      */
     public static function missingRequiredOptionProvider(): iterable
     {

--- a/src/Symfony/Component/Notifier/Test/TransportTestCase.php
+++ b/src/Symfony/Component/Notifier/Test/TransportTestCase.php
@@ -35,12 +35,12 @@ abstract class TransportTestCase extends TestCase
     abstract public static function toStringProvider(): iterable;
 
     /**
-     * @return iterable<array{0: MessageInterface, 1: TransportInterface}>
+     * @return iterable<array{0: MessageInterface, 1?: TransportInterface}>
      */
     abstract public static function supportedMessagesProvider(): iterable;
 
     /**
-     * @return iterable<array{0: MessageInterface, 1: TransportInterface}>
+     * @return iterable<array{0: MessageInterface, 1?: TransportInterface}>
      */
     abstract public static function unsupportedMessagesProvider(): iterable;
 

--- a/src/Symfony/Component/Translation/Test/ProviderFactoryTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderFactoryTestCase.php
@@ -51,7 +51,7 @@ abstract class ProviderFactoryTestCase extends TestCase
     abstract public static function createProvider(): iterable;
 
     /**
-     * @return iterable<array{0: string, 1: string|null}>
+     * @return iterable<array{0: string, 1?: string|null}>
      */
     public static function unsupportedSchemeProvider(): iterable
     {
@@ -59,7 +59,7 @@ abstract class ProviderFactoryTestCase extends TestCase
     }
 
     /**
-     * @return iterable<array{0: string, 1: string|null}>
+     * @return iterable<array{0: string, 1?: string|null}>
      */
     public static function incompleteDsnProvider(): iterable
     {

--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
@@ -27,6 +27,9 @@ trait VarDumperTestTrait
         'flags' => null,
     ];
 
+    /**
+     * @param array<string, callable> $casters
+     */
     protected function setUpVarDumper(array $casters, ?int $flags = null): void
     {
         $this->varDumperConfig['casters'] = $casters;

--- a/src/Symfony/Component/Webhook/Test/AbstractRequestParserTestCase.php
+++ b/src/Symfony/Component/Webhook/Test/AbstractRequestParserTestCase.php
@@ -32,6 +32,9 @@ abstract class AbstractRequestParserTestCase extends TestCase
         $this->assertEquals($expected, $wh);
     }
 
+    /**
+     * @return iterable<array{string, RemoteEvent}>
+     */
     public static function getPayloads(): iterable
     {
         $currentDir = \dirname((new \ReflectionClass(static::class))->getFileName());

--- a/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
+++ b/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
@@ -19,6 +19,9 @@ use Symfony\Contracts\Service\ServiceLocatorTrait;
 
 abstract class ServiceLocatorTestCase extends TestCase
 {
+    /**
+     * @param array<string, callable> $factories
+     */
     protected function getServiceLocator(array $factories): ContainerInterface
     {
         return new class($factories) implements ContainerInterface {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | n/a
| License       | MIT

This deprecates extending `FormIntegrationTestCase` without adding the `array` return type when overriding its protected method. This is similar to our return type additions done between Symfony 6 and 7.0 (those were forgotten because the phpdoc was missing)