### PR TITLE
[Yaml] Dump stringable objects

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -130,6 +130,10 @@ class Inline
                     return self::dumpHashArray($value, $flags);
                 }
 
+                if ($value instanceof \Stringable) {
+                    return self::dump((string) $value);
+                }
+
                 if (Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE & $flags) {
                     throw new DumpException('Object support when dumping a YAML file has been disabled.');
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

The YAML dumper should be able to respond to an object being `Stringable` and dump accordingly.