### PR TITLE
[Serializer] Fix access to wrong Type class

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -571,16 +571,16 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 }
 
                 switch ($builtinType) {
-                    case Type::BUILTIN_TYPE_ARRAY:
-                    case Type::BUILTIN_TYPE_BOOL:
-                    case Type::BUILTIN_TYPE_CALLABLE:
-                    case Type::BUILTIN_TYPE_FLOAT:
-                    case Type::BUILTIN_TYPE_INT:
-                    case Type::BUILTIN_TYPE_ITERABLE:
-                    case Type::BUILTIN_TYPE_NULL:
-                    case Type::BUILTIN_TYPE_OBJECT:
-                    case Type::BUILTIN_TYPE_RESOURCE:
-                    case Type::BUILTIN_TYPE_STRING:
+                    case LegacyType::BUILTIN_TYPE_ARRAY:
+                    case LegacyType::BUILTIN_TYPE_BOOL:
+                    case LegacyType::BUILTIN_TYPE_CALLABLE:
+                    case LegacyType::BUILTIN_TYPE_FLOAT:
+                    case LegacyType::BUILTIN_TYPE_INT:
+                    case LegacyType::BUILTIN_TYPE_ITERABLE:
+                    case LegacyType::BUILTIN_TYPE_NULL:
+                    case LegacyType::BUILTIN_TYPE_OBJECT:
+                    case LegacyType::BUILTIN_TYPE_RESOURCE:
+                    case LegacyType::BUILTIN_TYPE_STRING:
                         if (('is_'.$builtinType)($data)) {
                             return $data;
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | 
| License       | MIT

Starting from 7.1, the `Type` class refers to `TypeInfo`. Therefore, the `LegacyType` class must be used instead.