### PR TITLE
[AssetMapper][FrameworkBundle] Revert "feature #57073  Do not require `http_client` service (ruudk)"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -197,7 +197,7 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('asset_mapper.importmap.resolver', JsDelivrEsmResolver::class)
-            ->args([service('http_client')->nullOnInvalid()])
+            ->args([service('http_client')])
 
         ->set('asset_mapper.importmap.renderer', ImportMapRenderer::class)
             ->args([
@@ -212,12 +212,12 @@ return static function (ContainerConfigurator $container) {
         ->set('asset_mapper.importmap.auditor', ImportMapAuditor::class)
         ->args([
             service('asset_mapper.importmap.config_reader'),
-            service('http_client')->nullOnInvalid(),
+            service('http_client'),
         ])
         ->set('asset_mapper.importmap.update_checker', ImportMapUpdateChecker::class)
         ->args([
             service('asset_mapper.importmap.config_reader'),
-            service('http_client')->nullOnInvalid(),
+            service('http_client'),
         ])
 
         ->set('asset_mapper.importmap.command.require', ImportMapRequireCommand::class)

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapUpdateChecker.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapUpdateChecker.php
@@ -11,20 +11,16 @@
 
 namespace Symfony\Component\AssetMapper\ImportMap;
 
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ImportMapUpdateChecker
 {
     private const URL_PACKAGE_METADATA = 'https://registry.npmjs.org/%s';
 
-    private readonly HttpClientInterface $httpClient;
-
     public function __construct(
         private readonly ImportMapConfigReader $importMapConfigReader,
-        ?HttpClientInterface $httpClient = null,
+        private readonly HttpClientInterface $httpClient,
     ) {
-        $this->httpClient = $httpClient ?? HttpClient::create();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Reverts #57073, which is replaced by #57533 /cc @ruudk @xabbuh 