### PR TITLE
[ErrorHandler] Handle binary string args in `FlattenException`

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -381,6 +381,9 @@ class FlattenException
             } elseif (\is_resource($value)) {
                 $result[$key] = ['resource', get_resource_type($value)];
             } else {
+                if (!preg_match('//u', (string) $value)) {
+                    $value = base64_encode($value);
+                }
                 $result[$key] = ['string', (string) $value];
             }
         }

--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -293,4 +293,22 @@ class FlattenExceptionTest extends TestCase
         $this->assertSame($exception->getTraceAsString(), $flattened->getTraceAsString());
         $this->assertSame($exception->__toString(), $flattened->getAsString());
     }
+
+    public function testBinaryTraceArgs()
+    {
+        $binaryContent = base64_decode('gP8=');
+        $flattened = FlattenException::create(new \RuntimeException());
+        $flattened->setTrace([[
+            'namespace' => __NAMESPACE__,
+            'short_class' => '',
+            'class' => __CLASS__,
+            'type' => '->',
+            'function' => 'methodThrowingAnException',
+            'file' => __FILE__,
+            'line' => __LINE__,
+            'args' => [$binaryContent],
+        ]], __FILE__, __LINE__);
+
+        $this->assertSame([['string', base64_encode($binaryContent)]], $flattened->getTrace()[1]['args']);
+    }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57535
| License       | MIT

Handle binary string contained in Exception when flattened before serialization.
See #57535 for more details on this bug. 
