### PR TITLE
[Serializer] [ObjectNormalizer] Use bool filter when FILTER_BOOL is set

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -566,6 +566,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     return (float) $data;
                 }
 
+                if (LegacyType::BUILTIN_TYPE_BOOL === $builtinType && \is_string($data) && ($context[self::FILTER_BOOL] ?? false)) {
+                    return filter_var($data, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE);
+                }
+
                 if ((LegacyType::BUILTIN_TYPE_FALSE === $builtinType && false === $data) || (LegacyType::BUILTIN_TYPE_TRUE === $builtinType && true === $data)) {
                     return $data;
                 }
@@ -785,6 +789,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 // a float is expected.
                 if (TypeIdentifier::FLOAT === $typeIdentifier && \is_int($data) && null !== $format && str_contains($format, JsonEncoder::FORMAT)) {
                     return (float) $data;
+                }
+
+                if (TypeIdentifier::BOOL === $typeIdentifier && \is_string($data) && ($context[self::FILTER_BOOL] ?? false)) {
+                    return filter_var($data, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE);
                 }
 
                 $dataMatchesExpectedType = match ($typeIdentifier) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1195,6 +1195,34 @@ class AbstractObjectNormalizerTest extends TestCase
             [['foo' => false], TruePropertyDummy::class],
         ];
     }
+
+    /**
+     * @dataProvider provideDenormalizeWithFilterBoolData
+     */
+    public function testDenormalizeBooleanTypeWithFilterBool(array $data, ?bool $expectedFoo)
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        $dummy = $normalizer->denormalize($data, BoolPropertyDummy::class, null, [AbstractNormalizer::FILTER_BOOL => true]);
+
+        $this->assertSame($expectedFoo, $dummy->foo);
+    }
+
+    public function provideDenormalizeWithFilterBoolData(): array
+    {
+        return [
+            [['foo' => 'true'], true],
+            [['foo' => '1'], true],
+            [['foo' => 'yes'], true],
+            [['foo' => 'false'], false],
+            [['foo' => '0'], false],
+            [['foo' => 'no'], false],
+            [['foo' => ''], false],
+            [['foo' => null], null],
+            [['foo' => 'null'], null],
+            [['foo' => 'something'], null],
+        ];
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
@@ -1477,6 +1505,12 @@ class FalsePropertyDummy
 class TruePropertyDummy
 {
     /** @var true */
+    public $foo;
+}
+
+class BoolPropertyDummy
+{
+    /** @var null|bool */
     public $foo;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #57540 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

With 7.1 it is possible to map query booleans to php bool parameters (https://symfony.com/blog/new-in-symfony-7-1-misc-improvements-part-3#mapping-boolean-query-string-parameters). But as we found out, this only works when the DTO is initialized via `construct`. Otherwise the `FILTER_BOOL` flag will be ignored and e.g. "false" will be deserialized as `true`.

To fix this, I suggest to look for the `FILTER_BOOL` in the context and apply the filter, when the type is `bool` and the data is `string`.