### PR TITLE
[Validator] Add `Timestamp` constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add the `Yaml` constraint for validating YAML content
  * Add `errorPath` to Unique constraint
  * Add the `format` option to the `Ulid` constraint to allow accepting different ULID formats
+ * Add `Timestamp` constraint
 
 7.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/Timestamp.php
+++ b/src/Symfony/Component/Validator/Constraints/Timestamp.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Timestamp extends Constraint
+{
+
+    // I don't know if there is a specific way to generate error code, I just generate uuid v4
+    public const TOO_HIGH_ERROR = '23a9537e-d030-48c7-abfb-4220578171c3';
+    public const TOO_LOW_ERROR = '96bb47a0-c0e1-43b6-9e5b-34719eafd06c';
+    public const INVALID_TIMESTAMP_ERROR = 'df660c56-e0e1-4d42-82ba-d1e9abbea423';
+
+    protected const ERROR_NAMES = [
+        self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
+        self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
+        self::INVALID_TIMESTAMP_ERROR => 'INVALID_TIMESTAMP_ERROR',
+    ];
+
+    public string $message = 'The value "{{ value }}" is not a valid timestamp.';
+    public string $greaterThanMessage = 'This value should be greater than {{ compared_value }}.';
+    public string $greaterThanOrEqualMessage = 'This value should be greater than or equal to {{ compared_value }}.';
+    public string $lessThanMessage = 'This value should be less than {{ compared_value }}.';
+    public string $lessThanOrEqualMessage = 'This value should be less than or equal to {{ compared_value }}.';
+    public ?string $greaterThan;
+    public ?string $greaterThanOrEqual;
+    public ?string $lessThan;
+    public ?string $lessThanOrEqual;
+
+    public function __construct(
+        mixed $options = null,
+        ?array $groups = null,
+        mixed $payload = null,
+        ?string $greaterThan = null,
+        ?string $greaterThanOrEqual = null,
+        ?string $lessThan = null,
+        ?string $lessThanOrEqual = null,
+        ?string $greaterThanMessage = null,
+        ?string $greaterThanOrEqualMessage = null,
+        ?string $lessThanMessage = null,
+        ?string $lessThanOrEqualMessage = null,
+    )
+    {
+        $greaterThan ??= $options['greaterThan'] ?? null;
+        $greaterThanOrEqual ??= $options['greaterThanOrEqual'] ?? null;
+        $lessThan ??= $options['lessThan'] ?? null;
+        $lessThanOrEqual ??= $options['lessThanOrEqual'] ?? null;
+
+        parent::__construct($options, $groups, $payload);
+        $this->greaterThan = $greaterThan;
+        $this->greaterThanOrEqual = $greaterThanOrEqual;
+        $this->lessThan = $lessThan;
+        $this->lessThanOrEqual = $lessThanOrEqual;
+        $this->greaterThanMessage = $greaterThanMessage ?? $this->greaterThanMessage;
+        $this->greaterThanOrEqualMessage = $greaterThanOrEqualMessage ?? $this->greaterThanOrEqualMessage;
+        $this->lessThanMessage = $lessThanMessage ?? $this->lessThanMessage;
+        $this->lessThanOrEqualMessage = $lessThanOrEqualMessage ?? $this->lessThanOrEqualMessage;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/TimestampValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimestampValidator.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class TimestampValidator extends ConstraintValidator
+{
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof Timestamp){
+            throw new UnexpectedTypeException($constraint::class, self::class);
+        }
+
+        if (null === $value){
+            return;
+        }
+
+        if (!is_int($value)){
+            throw new UnexpectedValueException($value, 'int');
+        }
+
+        if (0 > $value){
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $value)
+                ->setInvalidValue($value)
+                ->setCode(Timestamp::INVALID_TIMESTAMP_ERROR)
+                ->addViolation();
+        }
+
+        // Not sure if there is value that can fall in this case
+        $date = \DateTimeImmutable::createFromFormat('U', $value);
+        if ($date === false){
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $value)
+                ->setInvalidValue($value)
+                ->setCode(Timestamp::INVALID_TIMESTAMP_ERROR)
+                ->addViolation();
+        }
+        $timestamp = $value;
+
+        if ($constraint->greaterThan && date_create($constraint->greaterThan)->getTimestamp() >= $timestamp){
+            $this->context->buildViolation($constraint->greaterThanMessage)
+                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ compared_value }}', $this->formatValue(date_create($constraint->greaterThan), self::PRETTY_DATE))
+                ->setInvalidValue($value)
+                ->setCode(Timestamp::TOO_LOW_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        if ($constraint->lessThan && date_create($constraint->lessThan)->getTimestamp() <= $timestamp){
+            $this->context->buildViolation($constraint->lessThanMessage)
+                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ compared_value }}', $this->formatValue(date_create($constraint->lessThan), self::PRETTY_DATE))
+                ->setInvalidValue($value)
+                ->setCode(Timestamp::TOO_HIGH_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        if ($constraint->greaterThanOrEqual &&
+            date_create($constraint->greaterThanOrEqual)->getTimestamp() > $timestamp)
+        {
+            $this->context->buildViolation($constraint->greaterThanOrEqualMessage)
+                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ compared_value }}', $this->formatValue(date_create($constraint->greaterThanOrEqual), self::PRETTY_DATE))
+                ->setInvalidValue($value)
+                ->setCode(Timestamp::TOO_LOW_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        if ($constraint->lessThanOrEqual &&
+            date_create($constraint->lessThanOrEqual)->getTimestamp() < $timestamp)
+        {
+            $this->context->buildViolation($constraint->lessThanOrEqualMessage)
+                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ compared_value }}', $this->formatValue(date_create($constraint->lessThanOrEqual), self::PRETTY_DATE))
+                ->setInvalidValue($value)
+                ->setCode(Timestamp::TOO_HIGH_ERROR)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimestampTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimestampTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Timestamp;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
+
+class TimestampTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(TimestampDummy::class);
+        $loader = new AttributeLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        self::assertSame('+1 month', $aConstraint->greaterThan);
+    }
+}
+
+class TimestampDummy
+{
+    #[Timestamp(greaterThan: '+1 month')]
+    private $a;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimestampValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimestampValidatorTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Timestamp;
+use Symfony\Component\Validator\Constraints\TimestampValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class TimestampValidatorTest extends ConstraintValidatorTestCase
+{
+
+    protected function createValidator(): ConstraintValidatorInterface
+    {
+        return new TimestampValidator();
+    }
+
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new Timestamp());
+
+        $this->assertNoViolation();
+    }
+
+    public function testNegativeNumberIsInvalid()
+    {
+        $this->validator->validate(-1, new Timestamp([
+            'message' => 'myMessage',
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', -1)
+            ->setInvalidValue(-1)
+            ->setCode(Timestamp::INVALID_TIMESTAMP_ERROR)
+            ->assertRaised();
+    }
+
+    public function getGreaterThan()
+    {
+        return [
+            [1719610882, '@1718210882', "Jun 12, 2024, 4:48\u{202F}PM"],
+        ];
+    }
+
+    public function getLessThan()
+    {
+        return [
+            [1718210882, '@1719610882', "Jun 28, 2024, 9:41\u{202F}PM"],
+        ];
+    }
+
+    public static function getGreaterThanOrEqual()
+    {
+        return [
+            [1719610882, '@1719610882', "Jun 28, 2024, 9:41\u{202F}PM"],
+            [1719610882, '@1718210882', "Jun 12, 2024, 4:48\u{202F}PM"],
+        ];
+    }
+
+    public static function getLessThanOrEqual()
+    {
+        return [
+            [1719610882, '@1719610882', "Jun 28, 2024, 9:41\u{202F}PM"],
+            [1718210882, '@1719610882', "Jun 28, 2024, 9:41\u{202F}PM"],
+        ];
+    }
+
+    /**
+     * @dataProvider getGreaterThan
+     */
+    public function testValidValueGreaterThan(int $value, string $greaterThan)
+    {
+        $constraint = new Timestamp(['greaterThan' => $greaterThan]);
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getGreaterThanOrEqual
+     */
+    public function testValidValueGreaterThanOrEqualTo(int $value, string $greaterThanOrEqual)
+    {
+        $constraint = new Timestamp(['greaterThanOrEqual' => $greaterThanOrEqual]);
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getLessThan
+     */
+    public function testValidValueLessThan(int $value, string $lessThan)
+    {
+        $constraint = new Timestamp(['lessThan' => $lessThan]);
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getLessThanOrEqual
+     */
+    public function testValidValueLessThanOrEqualTo(int $value, string $lessThanOrEqual)
+    {
+        $constraint = new Timestamp(['lessThanOrEqual' => $lessThanOrEqual]);
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getLessThanOrEqual
+     */
+    public function testInvalidValueGreaterThan(int $value, string $greaterThan, string $comparedValue)
+    {
+        $constraint = new Timestamp([
+            'greaterThan' => $greaterThan,
+            'greaterThanMessage' => 'myMessage',
+        ]);
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ compared_value }}', $comparedValue)
+            ->setInvalidValue($value)
+            ->setCode(Timestamp::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getLessThan
+     */
+    public function testInvalidValueGreaterThanOrEqual(int $value, string $greaterThan, string $comparedValue)
+    {
+        $constraint = new Timestamp([
+            'greaterThanOrEqual' => $greaterThan,
+            'greaterThanOrEqualMessage' => 'myMessage',
+        ]);
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ compared_value }}', $comparedValue)
+            ->setInvalidValue($value)
+            ->setCode(Timestamp::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+
+    /**
+     * @dataProvider getGreaterThanOrEqual
+     */
+    public function testInvalidValueLessThan(int $value, string $lessThan, string $comparedValue)
+    {
+        $constraint = new Timestamp([
+            'lessThan' => $lessThan,
+            'lessThanMessage' => 'myMessage',
+        ]);
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ compared_value }}', $comparedValue)
+            ->setInvalidValue($value)
+            ->setCode(Timestamp::TOO_HIGH_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getGreaterThan
+     */
+    public function testInvalidValueLessThanOrEqual(int $value, string $lessThanOrEqual, string $comparedValue)
+    {
+        $constraint = new Timestamp([
+            'lessThanOrEqual' => $lessThanOrEqual,
+            'lessThanOrEqualMessage' => 'myMessage',
+        ]);
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ compared_value }}', $comparedValue)
+            ->setInvalidValue($value)
+            ->setCode(Timestamp::TOO_HIGH_ERROR)
+            ->assertRaised();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | #57526 
| License       | MIT

As describe in the issue this PR aim to add a constraint to validate a timestamp against DateTime like what the GreaterThan/LessThan allow on DateTime value 
