### PR TITLE
[FrameworkBundle] Split "var/build" from "var/cache" when compiling for the "prod" env

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Derivate `kernel.secret` from the decryption secret when its env var is not defined
  * Make the `config/` directory optional in `MicroKernelTrait`, add support for service arguments in the
    invokable Kernel class, and register `FrameworkBundle` by default when the `bundles.php` file is missing
+ * Split "var/build" from "var/cache" when compiling for the "prod" env
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\AbstractConfigurat
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader as ContainerPhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\Loader\PhpFileLoader as RoutingPhpFileLoader;
 use Symfony\Component\Routing\RouteCollection;
@@ -119,6 +120,9 @@ trait MicroKernelTrait
     {
         if (isset($_SERVER['APP_BUILD_DIR'])) {
             return $_SERVER['APP_BUILD_DIR'].'/'.$this->environment;
+        }
+        if ('prod' === $this->getEnvironment() && Kernel::class === (new \ReflectionMethod(parent::class, 'getCacheDir'))->class) {
+            return $this->getProjectDir().'/var/build/'.$this->environment;
         }
 
         return parent::getBuildDir();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

I think it's time to consider defaulting to having separate build vs cache folders.
#50391 opened the way, then @Okhoshi continued it in #52962, #52981, #54384, with a tweak in #57553.

I know that doing this change will improve the DX of deploying on Platform.sh: the container compilation happening during the offline generation of the container image will be reusable right away, without any step to copy the related artifacts in a writeable folder. I'm confident this can benefit other hosting systems too.

Let's have this discussion and figure out any blockers.