### PR TITLE
[DependencyInjection] Fix ignore invalid_reference behavior param for the some services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1033,7 +1033,7 @@ EOF;
         $name = $this->getNextVariableName();
         $this->referenceVariables[$targetId] = new Variable($name);
 
-        $reference = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $behavior ? new Reference($targetId, $behavior) : null;
+        $reference = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $behavior ? new Reference($targetId, $behavior) : null;
         $code .= \sprintf("        \$%s = %s;\n", $name, $this->getServiceCall($targetId, $reference));
 
         if (!$hasSelfRef || !$forConstructor) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1466,6 +1466,39 @@ PHP
         $this->assertEquals((object) ['foo' => (object) [123]], $container->get('bar'));
     }
 
+    public function testSyntheticServiceWithNullOnInvalidReference()
+    {
+        $container = new ContainerBuilder();
+        $container->register('synthetic_service', 'stdClass')->setPublic(true)->setSynthetic(true);
+        // Reference the synthetic service twice so the dumper creates a variable for it
+        $container->register('bar', 'stdClass')->setPublic(true)->setShared(false)
+            ->setProperty('synth', new Reference('synthetic_service', ContainerBuilder::NULL_ON_INVALID_REFERENCE))
+            ->setProperty('synth2', new Reference('synthetic_service', ContainerBuilder::NULL_ON_INVALID_REFERENCE));
+
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dump = $dumper->dump([
+            'class' => 'Symfony_DI_PhpDumper_Test_SyntheticNullOnInvalid',
+        ]);
+
+        // The dumped code should pass the behavior (2 = NULL_ON_INVALID_REFERENCE) when getting the synthetic service
+        $this->assertStringContainsString("->get('synthetic_service', 2)", $dump);
+
+        eval('?>'.$dump);
+
+        $container = new \Symfony_DI_PhpDumper_Test_SyntheticNullOnInvalid();
+
+        // Without the synthetic service being set, bar should still be instantiable with synth=null
+        $bar = $container->get('bar');
+        $this->assertNull($bar->synth);
+
+        // After setting the synthetic service, it should be injected
+        $container->set('synthetic_service', (object) ['test' => 123]);
+        $bar2 = $container->get('bar');
+        $this->assertEquals((object) ['test' => 123], $bar2->synth);
+    }
+
     public function testAdawsonContainer()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes 
| New feature?  | -
| Deprecations? | -
| Issues        | Fix #57560 
| License       | MIT

This bug has more than 5 years old, but it make possible to reproduce after introducing a new console command profiler. 

PHP DI dumper may ignore invalid reference behavior in the some cases. See example.

```php
    $container->services()
        ->set('data_collector.config', ConfigDataCollector::class)
            ->call('setKernel', [service('kernel')->ignoreOnInvalid()])
            ->tag('data_collector', ['template' => '@WebProfiler/Collector/config.html.twig', 'id' => 'config', 'priority' => -255])
```

As you can see `ignoreOnInvalid` option is dropped on this line 

```php 
$container->get('kernel')
```

```php
    protected static function get_Container_Private_ProfilerService($container)
    {
        $a = new \Symfony\Bridge\Monolog\Logger('profiler');
        $a->pushProcessor(($container->privates['oro_logger.processor.log_message'] ??= new \Monolog\Processor\PsrLogMessageProcessor()));
        $a->pushProcessor(($container->privates['oro_message_queue.log.processor.add_consumer_state'] ?? self::getOroMessageQueue_Log_Processor_AddConsumerStateService($container)));
        $a->pushHandler(($container->privates['monolog.handler.main'] ?? self::getMonolog_Handler_MainService($container)));
        $a->pushHandler(($container->privates['oro_message_queue.log.handler.console'] ?? self::getOroMessageQueue_Log_Handler_ConsoleService($container)));
        ($container->privates['debug.debug_logger_configurator'] ?? self::getDebug_DebugLoggerConfiguratorService($container))->pushDebugLogger($a);

        $container->services['.container.private.profiler'] = $instance = new \Oro\Bundle\PlatformBundle\Profiler\ConfigurableProfiler(new \Oro\Bundle\PlatformBundle\Profiler\RepeatableFileProfilerStorage(('file:'.$container->targetDir.''.'/profiler')), $a, true);

        $b = ($container->services['kernel'] ?? $container->get('kernel'));
        $c = ($container->services['.virtual_request_stack'] ?? self::get_VirtualRequestStackService($container));
        $d = new \Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector();
        $d->registerClient('http_client', ($container->privates['.debug.http_client'] ?? self::get_Debug_HttpClientService($container)));
        $d->registerClient('hwi_oauth.http_client', ($container->privates['.debug.hwi_oauth.http_client'] ?? self::get_Debug_HwiOauth_HttpClientService($container)));
        $e = new \Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector(($container->services['doctrine'] ?? self::getDoctrineService($container)), true, NULL);

        $f = ($container->privates['doctrine.dbal.logger.profiling.default'] ??= new \Doctrine\DBAL\Logging\DebugStack());
        $g = ($container->privates['doctrine.dbal.logger.profiling.sql_validator'] ??= new \Doctrine\DBAL\Logging\DebugStack());
        $h = ($container->privates['doctrine.dbal.logger.profiling.system'] ??= new \Doctrine\DBAL\Logging\DebugStack());

        $e->addLogger('default', $f);
        $e->addLogger('sql_validator', $g);
        $e->addLogger('system', $h);
        $i = new \Oro\Bundle\EntityBundle\DataCollector\DuplicateQueriesDataCollector();
        $i->addLogger('default', $f);
        $i->addLogger('sql_validator', $g);
        $i->addLogger('system', $h);
        $j = new \Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector();
        if ($container->has('kernel')) {
            $j->setKernel($b);
        }
```
