### PR TITLE
[HttpClient] Fix initializing InformationalChunk

### DIFF
--- a/src/Symfony/Component/HttpClient/Chunk/InformationalChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/InformationalChunk.php
@@ -23,6 +23,8 @@ class InformationalChunk extends DataChunk
     public function __construct(int $statusCode, array $headers)
     {
         $this->status = [$statusCode, $headers];
+
+        parent::__construct();
     }
 
     public function getInformationalStatus(): ?array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57563
| License       | MIT

We introduced this regression when we moved DataChunk to CPP: we removed their defaults from properties when doing so.
(Moving to) CPP is dangerous!