### PR TITLE
Reviewed Catalan missing translations

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ca.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ca.xlf
@@ -64,7 +64,7 @@
             </trans-unit>
             <trans-unit id="17">
                 <source>Too many failed login attempts, please try again later.</source>
-                <target>Massa intents d'inici de sessió fallits, torneu-ho a provar més tard.</target>
+                <target>Massa intents d'inici de sessió fallits, si us plau torneu-ho a provar més tard.</target>
             </trans-unit>
             <trans-unit id="18">
                 <source>Invalid or expired login link.</source>
@@ -72,11 +72,11 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Massa intents d'inici de sessió fallits, torneu-ho a provar en %minutes% minut.</target>
+                <target>Massa intents d'inici de sessió fallits, si us plau torneu-ho a provar en %minutes% minut.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">Massa intents fallits d'inici de sessió, torneu-ho a provar d'aquí a %minutes% minuts.</target>
+                <target>Massa intents d'inici de sessió fallits, si us plau torneu-ho a provar en %minutes% minuts.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #54947 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Reviewed Catalan translation and added some changes.

```xlf
<trans-unit id="18">
        <source>Invalid or expired login link.</source>
        <target>Enllaç d'inici de sessió no vàlid o caducat.</target>
</trans-unit>
<trans-unit id="19">
        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
        <target>Massa intents d'inici de sessió fallits, si us plau torneu-ho a provar en %minutes% minut.</target>
</trans-unit>
<trans-unit id="20">
       <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
       <target>Massa intents d'inici de sessió fallits, si us plau torneu-ho a provar en %minutes% minuts.</target>
</trans-unit>
```