### PR TITLE
[HttpClient][Mailer] Revert "Let curl handle transfer encoding", use HTTP/1.1 for Mailgun

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -246,8 +246,9 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
             if (isset($options['normalized_headers']['content-length'][0])) {
                 $curlopts[\CURLOPT_INFILESIZE] = (int) substr($options['normalized_headers']['content-length'][0], \strlen('Content-Length: '));
-            } elseif (!isset($options['normalized_headers']['transfer-encoding'])) {
-                $curlopts[\CURLOPT_INFILESIZE] = -1;
+            }
+            if (!isset($options['normalized_headers']['transfer-encoding'])) {
+                $curlopts[\CURLOPT_HTTPHEADER][] = 'Transfer-Encoding:'.(isset($curlopts[\CURLOPT_INFILESIZE]) ? '' : ' chunked');
             }
 
             if ('POST' !== $method) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
@@ -63,6 +63,7 @@ class MailgunHttpTransport extends AbstractHttpTransport
 
         $endpoint = sprintf('%s/v3/%s/messages.mime', $this->getEndpoint(), urlencode($this->domain));
         $response = $this->client->request('POST', 'https://'.$endpoint, [
+            'http_version' => '1.1',
             'auth_basic' => 'api:'.$this->key,
             'headers' => $headers,
             'body' => $body->bodyToIterable(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57544
| License       | MIT

This PR reverts #54517 and fixes #54491 by forcing HTTP/1.1 when talking to Mailgun

The issue that #54517 tries to fix shouldn't happen since curl 7.51, which dates back from 2016 (https://github.com/curl/curl/commit/d4c5a917226ad6d5bee1b1d6deb099e1d9a895e6). If you experience it, try upgrading.

The previous code worked fine for years but the new one generated reports a few weeks after its release so I'd feel more confident reverting.