### PR TITLE
[Console] Test convert CompletionInput into string

### DIFF
--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -53,7 +53,7 @@ final class CompletionInput extends ArgvInput
      * Create an input based on an COMP_WORDS token list.
      *
      * @param string[] $tokens       the set of split tokens (e.g. COMP_WORDS or argv)
-     * @param          $currentIndex the index of the cursor (e.g. COMP_CWORD)
+     * @param int      $currentIndex the index of the cursor (e.g. COMP_CWORD)
      */
     public static function fromTokens(array $tokens, int $currentIndex): self
     {

--- a/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
@@ -133,4 +133,19 @@ class CompletionInputTest extends TestCase
         yield ['bin/console cache:clear "multi word string"', ['bin/console', 'cache:clear', '"multi word string"']];
         yield ['bin/console cache:clear \'multi word string\'', ['bin/console', 'cache:clear', '\'multi word string\'']];
     }
+
+    public function testToString()
+    {
+        $input = CompletionInput::fromTokens(['foo', 'bar', 'baz'], 0);
+        $this->assertSame('foo| bar baz', (string) $input);
+
+        $input = CompletionInput::fromTokens(['foo', 'bar', 'baz'], 1);
+        $this->assertSame('foo bar| baz', (string) $input);
+
+        $input = CompletionInput::fromTokens(['foo', 'bar', 'baz'], 2);
+        $this->assertSame('foo bar baz|', (string) $input);
+
+        $input = CompletionInput::fromTokens(['foo', 'bar', 'baz'], 11);
+        $this->assertSame('foo bar baz |', (string) $input);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

CompletionInput can be converted into string but there are no tests for it. So, I a simple test here based on it's current behavior.
