### PR TITLE
Add return type to `__toString()` methods

### DIFF
--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -226,7 +226,7 @@ final class CompletionInput extends ArgvInput
         return $this->currentIndex >= $nrOfTokens;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $str = '';
         foreach ($this->tokens as $i => $token) {

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -871,7 +871,7 @@ CSV;
                         'FOO_ENV_LOADER' => '123',
                         'BAZ_ENV_LOADER' => '',
                         'LAZY_ENV_LOADER' => new class() {
-                            public function __toString()
+                            public function __toString(): string
                             {
                                 return '';
                             }
@@ -888,7 +888,7 @@ CSV;
                         'BAR_ENV_LOADER' => '456',
                         'BAZ_ENV_LOADER' => '567',
                         'LAZY_ENV_LOADER' => new class() {
-                            public function __toString()
+                            public function __toString(): string
                             {
                                 return '678';
                             }

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -519,7 +519,7 @@ class MockHttpClientTest extends HttpClientTestCase
         $client = new MockHttpClient();
 
         $param = new class() {
-            public function __toString()
+            public function __toString(): string
             {
                 return 'bar';
             }

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -1076,7 +1076,7 @@ class UrlGeneratorTest extends TestCase
 
 class StringableObject
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'bar';
     }
@@ -1086,7 +1086,7 @@ class StringableObjectWithPublicProperty
 {
     public $foo = 'property';
 
-    public function __toString()
+    public function __toString(): string
     {
         return 'bar';
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -176,7 +176,7 @@ class FormLoginAuthenticatorTest extends TestCase
     public function testHandleNonStringPasswordWithToString(bool $postOnly)
     {
         $passwordObject = new class() {
-            public function __toString()
+            public function __toString(): string
             {
                 return 's$cr$t';
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

CompletionInput::__toString() method should have string as the return type, synchronized with it's parent class.
