### PR TITLE
[Console] Add finished indicator to `ProgressIndicator`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `verbosity` argument to `mustRun` process helper method
  * [BC BREAK] Add silent verbosity (`--silent`/`SHELL_VERBOSITY=-2`) to suppress all output, including errors
  * Add `OutputInterface::isSilent()`, `Output::isSilent()`, `OutputStyle::isSilent()` methods
+ * Add a configurable finished indicator to the progress indicator to show that the progress is finished
 
 7.1
 ---

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -54,11 +54,11 @@ class ProgressIndicatorTest extends TestCase
             $this->generateOutput(' \\ Starting...').
             $this->generateOutput(' \\ Advancing...').
             $this->generateOutput(' | Advancing...').
-            $this->generateOutput(' | Done...').
+            $this->generateOutput(' ✔ Done...').
             \PHP_EOL.
             $this->generateOutput(' - Starting Again...').
             $this->generateOutput(' \\ Starting Again...').
-            $this->generateOutput(' \\ Done Again...').
+            $this->generateOutput(' ✔ Done Again...').
             \PHP_EOL,
             stream_get_contents($output->getStream())
         );
@@ -105,6 +105,39 @@ class ProgressIndicatorTest extends TestCase
             $this->generateOutput(' b Starting...').
             $this->generateOutput(' c Starting...').
             $this->generateOutput(' a Starting...'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testCustomFinishedIndicatorValue()
+    {
+        $bar = new ProgressIndicator($output = $this->getOutputStream(), null, 100, ['a', 'b'], '✅');
+
+        $bar->start('Starting...');
+        usleep(101000);
+        $bar->finish('Done');
+
+        rewind($output->getStream());
+
+        $this->assertSame(
+            $this->generateOutput(' a Starting...').
+            $this->generateOutput(' ✅ Done').\PHP_EOL,
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testCustomFinishedIndicatorWhenFinishingProcess()
+    {
+        $bar = new ProgressIndicator($output = $this->getOutputStream(), null, 100, ['a', 'b']);
+
+        $bar->start('Starting...');
+        $bar->finish('Process failed', '❌');
+
+        rewind($output->getStream());
+
+        $this->assertEquals(
+            $this->generateOutput(' a Starting...').
+            $this->generateOutput(' ❌ Process failed').\PHP_EOL,
             stream_get_contents($output->getStream())
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Add a (configurable) finished indicator to the progress indicator to show that the progress is finished instead of last used indicator value.
This will make the output a bit nicer


instead of
```
 - Process A (4 secs, 8.0 MiB)
 \ Process B (1 min, 39 secs, 18.0 MiB)
 - Process C (7 secs, 18.0 MiB)
 - Process D (48 secs, 20.0 MiB)
 / Process E (45 secs, 20.0 MiB)

```
 
The output will look now like this:
```
 ✔ Process A (4 secs, 8.0 MiB)
 ✔ Process B (1 min, 39 secs, 18.0 MiB)
 ✔ Process C (7 secs, 18.0 MiB)
 ✔ Process D (48 secs, 20.0 MiB)
 ✔ Process E (45 secs, 20.0 MiB)
```
