### PR TITLE
[SecurityBundle] Remove unused memory users’ `name` attribute from the XSD

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -113,7 +113,6 @@
 
     <xsd:complexType name="user">
         <xsd:attribute name="identifier" type="xsd:string" />
-        <xsd:attribute name="name" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />
         <xsd:attribute name="roles" type="xsd:string" />
     </xsd:complexType>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix cdb8354a152b5c8299ab2bb66933922b644920a9
| License       | MIT

#57520 has been reverted because

> [The] change […] risks that someone receives errors on the next patch release if their XML config still makes use of the now removed attribute.

But nobody could use it since v6.0: as #41613 removed the BC layer, the config would crash.

Keeping `name` in the XSD for 6.4, 7.0 and 7.1 branches means people using these versions would have their IDE suggesting an attribute which would make their app crash.