### PR TITLE
[HttpFoundation] Fix MockArraySessionStorage to generate more conform ids

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -226,14 +226,11 @@ class MockArraySessionStorage implements SessionStorageInterface
     /**
      * Generates a session ID.
      *
-     * This doesn't need to be particularly cryptographically secure since this is just
-     * a mock.
-     *
      * @return string
      */
     protected function generateId()
     {
-        return hash('sha256', uniqid('ss_mock_', true));
+        return bin2hex(random_bytes(16));
     }
 
     protected function loadSession()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Per https://wiki.php.net/rfc/deprecations_php_8_4#sessionsid_length_and_sessionsid_bits_per_character the session id really shouldn't need more than 128bits of entropy, which this PR uses. While this code indeed does not need cryptographically secure level of entropy, it also doesn't really cost that much so I did it this way, as it's IMO good to avoid having cryptographically-insecure code out there where people might take inspiration from it.

As an aside, uniqid might also end up being deprecated, so it's good to get rid of it anyway here https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_uniqid 

And as another aside, I've had to override this code in the past because we had DB tables storing session ids not accepting the 64chars long session ids the old code produces, so producing shorter (32chars) ids is more compatible 👍🏻 