### PR TITLE
[Console] Expose the original input arguments and options and to unparse options

### DIFF
--- a/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Attribute\ValueResolver;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\RawInputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Contracts\Service\ServiceProviderInterface;
@@ -116,6 +117,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
 
             if ($typeName && \in_array($typeName, [
                 InputInterface::class,
+                RawInputInterface::class,
                 OutputInterface::class,
                 SymfonyStyle::class,
                 Cursor::class,

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Allow setting a boolean default value on `InputOption::VALUE_NEGATABLE` options
  * Deprecate passing both `InputArgument::REQUIRED` and `InputArgument::OPTIONAL` modes to `InputArgument` constructor
  * Deprecate passing more than one out of `InputOption::VALUE_NONE`, `InputOption::VALUE_REQUIRED` and `InputOption::VALUE_OPTIONAL` modes to `InputOption` constructor
+ * Add `RawInputInterface` to expose the original arguments and options and to unparse options, implemented by `Input`
 
 8.0
 ---

--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\RawInputInterface;
 use Symfony\Component\Console\Interaction\Interaction;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -141,6 +142,7 @@ class InvokableCommand implements SignalableCommandInterface
             if ($type instanceof \ReflectionNamedType) {
                 $argument = match ($type->getName()) {
                     InputInterface::class => $input,
+                    RawInputInterface::class => $input,
                     OutputInterface::class => $output,
                     SymfonyStyle::class => new SymfonyStyle($input, $output, $this->command->getApplication()?->getDispatcher()),
                     Cursor::class => new Cursor($output),

--- a/src/Symfony/Component/Console/DependencyInjection/RegisterCommandArgumentLocatorsPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/RegisterCommandArgumentLocatorsPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\DependencyInjection;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\RawInputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
@@ -136,7 +137,7 @@ final class RegisterCommandArgumentLocatorsPass implements CompilerPassInterface
                     }
 
                     // Skip console-specific types that are resolved by other resolvers
-                    if (InputInterface::class === $type || OutputInterface::class === $type) {
+                    if (\in_array($type, [InputInterface::class, RawInputInterface::class, OutputInterface::class], true)) {
                         continue;
                     }
 

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class Input implements InputInterface, StreamableInputInterface
+abstract class Input implements RawInputInterface, StreamableInputInterface
 {
     protected InputDefinition $definition;
     /** @var resource */
@@ -170,5 +170,39 @@ abstract class Input implements InputInterface, StreamableInputInterface
     public function getStream()
     {
         return $this->stream;
+    }
+
+    public function getRawArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    public function getRawOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function unparse(?array $optionNames = null): array
+    {
+        $rawOptions = $this->getRawOptions();
+
+        $filteredRawOptions = null === $optionNames
+            ? $rawOptions
+            : array_intersect_key($rawOptions, array_fill_keys($optionNames, ''));
+
+        $unparsedOptions = [];
+
+        foreach ($filteredRawOptions as $optionName => $parsedOption) {
+            $option = $this->definition->getOption($optionName);
+
+            $unparsedOptions[] = match (true) {
+                $option->isNegatable() => [\sprintf('--%s%s', $parsedOption ? '' : 'no-', $optionName)],
+                !$option->acceptValue() => [\sprintf('--%s', $optionName)],
+                $option->isArray() => array_map(static fn ($item) => \sprintf('--%s=%s', $optionName, $item), $parsedOption),
+                default => [\sprintf('--%s=%s', $optionName, $parsedOption)],
+            };
+        }
+
+        return array_merge(...$unparsedOptions);
     }
 }

--- a/src/Symfony/Component/Console/Input/RawInputInterface.php
+++ b/src/Symfony/Component/Console/Input/RawInputInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Input;
+
+/**
+ * Provides access to the original input arguments and options
+ * before they are merged with default values, and allows
+ * unparsing options back to their CLI representation.
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+interface RawInputInterface extends InputInterface
+{
+    /**
+     * Returns all the given arguments NOT merged with the default values.
+     *
+     * @return array<string|bool|int|float|array<string|bool|int|float|null>|null>
+     */
+    public function getRawArguments(): array;
+
+    /**
+     * Returns all the given options NOT merged with the default values.
+     *
+     * @return array<string|bool|int|float|array<string|bool|int|float|null>|null>
+     */
+    public function getRawOptions(): array;
+
+    /**
+     * Returns a stringified representation of the options passed to the command.
+     *
+     * The options are NOT escaped, as otherwise passing them to a Process
+     * would result in them being escaped twice.
+     *
+     * @param string[]|null $optionNames Names of the options returned. If null, all options are returned.
+     *                                   Requested options that either do not exist or were not passed
+     *                                   (even if the option has a default value) will be ignored.
+     *
+     * @return list<string>
+     */
+    public function unparse(?array $optionNames = null): array;
+}

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -589,4 +589,274 @@ class ArgvInputTest extends TestCase
         yield [['app/console', '--no-ansi', 'foo:bar', 'foo:bar'], ['foo:bar']];
         yield [['app/console', '--no-ansi', 'foo:bar', '--', 'argument'], ['--', 'argument']];
     }
+
+    #[DataProvider('unparseProvider')]
+    public function testUnparse(?InputDefinition $inputDefinition, ArgvInput $input, ?array $parsedOptions, array $expected)
+    {
+        if (null !== $inputDefinition) {
+            $input->bind($inputDefinition);
+        }
+
+        $actual = null === $parsedOptions ? $input->unparse() : $input->unparse($parsedOptions);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function unparseProvider(): iterable
+    {
+        yield 'empty input and empty definition' => [
+            new InputDefinition(),
+            new ArgvInput([]),
+            null,
+            [],
+        ];
+
+        yield 'empty input and definition with default values: ignore default values' => [
+            new InputDefinition([
+                new InputArgument(
+                    'argWithDefaultValue',
+                    InputArgument::OPTIONAL,
+                    'Argument with a default value',
+                    'arg1DefaultValue',
+                ),
+                new InputOption(
+                    'optWithDefaultValue',
+                    null,
+                    InputOption::VALUE_REQUIRED,
+                    'Option with a default value',
+                    'opt1DefaultValue',
+                ),
+            ]),
+            new ArgvInput([]),
+            null,
+            [],
+        ];
+
+        $completeInputDefinition = new InputDefinition([
+            new InputArgument(
+                'requiredArgWithoutDefaultValue',
+                InputArgument::REQUIRED,
+                'Argument without a default value',
+            ),
+            new InputArgument(
+                'optionalArgWithDefaultValue',
+                InputArgument::OPTIONAL,
+                'Argument with a default value',
+                'argDefaultValue',
+            ),
+            new InputOption(
+                'optWithoutDefaultValue',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Option without a default value',
+            ),
+            new InputOption(
+                'optWithDefaultValue',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Option with a default value',
+                'optDefaultValue',
+            ),
+        ]);
+
+        yield 'arguments & options: returns all passed options but ignore default values' => [
+            $completeInputDefinition,
+            new ArgvInput(['argValue', '--optWithoutDefaultValue=optValue']),
+            null,
+            ['--optWithoutDefaultValue=optValue'],
+        ];
+
+        yield 'arguments & options; explicitly pass the default values: the default values are returned' => [
+            $completeInputDefinition,
+            new ArgvInput(['argValue', 'argDefaultValue', '--optWithoutDefaultValue=optValue', '--optWithDefaultValue=optDefaultValue']),
+            null,
+            [
+                '--optWithoutDefaultValue=optValue',
+                '--optWithDefaultValue=optDefaultValue',
+            ],
+        ];
+
+        yield 'arguments & options; no input definition: nothing returned' => [
+            null,
+            new ArgvInput(['argValue', 'argDefaultValue', '--optWithoutDefaultValue=optValue', '--optWithDefaultValue=optDefaultValue']),
+            null,
+            [],
+        ];
+
+        yield 'arguments & options; parsing an argument name instead of an option name: that option is ignored' => [
+            $completeInputDefinition,
+            new ArgvInput(['argValue']),
+            ['requiredArgWithoutDefaultValue'],
+            [],
+        ];
+
+        yield 'arguments & options; non passed option: it is ignored' => [
+            $completeInputDefinition,
+            new ArgvInput(['argValue']),
+            ['optWithDefaultValue'],
+            [],
+        ];
+
+        yield 'arguments & options; requesting a specific option' => [
+            $completeInputDefinition,
+            new ArgvInput([
+                '--optWithoutDefaultValue=optValue1',
+                '--optWithDefaultValue=optValue2',
+            ]),
+            ['optWithDefaultValue'],
+            ['--optWithDefaultValue=optValue2'],
+        ];
+
+        yield 'arguments & options; requesting no options' => [
+            $completeInputDefinition,
+            new ArgvInput([
+                '--optWithoutDefaultValue=optValue1',
+                '--optWithDefaultValue=optValue2',
+            ]),
+            [],
+            [],
+        ];
+
+        $createSingleOptionScenario = static fn (
+            InputOption $option,
+            array $input,
+            array $expected,
+        ) => [
+            new InputDefinition([$option]),
+            new ArgvInput(['appName', ...$input]),
+            null,
+            $expected,
+        ];
+
+        yield 'option without value' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NONE,
+            ),
+            ['--opt'],
+            ['--opt'],
+        );
+
+        yield 'option without value by shortcut' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                'o',
+                InputOption::VALUE_NONE,
+            ),
+            ['-o'],
+            ['--opt'],
+        );
+
+        yield 'option with value required' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt=foo'],
+            ['--opt=foo'],
+        );
+
+        yield 'option with non string value (bool)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt=1'],
+            ['--opt=1'],
+        );
+
+        yield 'option with non string value (int)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt=20'],
+            ['--opt=20'],
+        );
+
+        yield 'option with non string value (float)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt=5.3'],
+            ['--opt=5.3'],
+        );
+
+        yield 'option with non string value (array of strings)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            ),
+            ['--opt=v1', '--opt=v2', '--opt=v3 --opt=v4'],
+            ['--opt=v1', '--opt=v2', '--opt=v3 --opt=v4'],
+        );
+
+        yield 'negatable option (positive)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NEGATABLE,
+            ),
+            ['--opt'],
+            ['--opt'],
+        );
+
+        yield 'negatable option (negative)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NEGATABLE,
+            ),
+            ['--no-opt'],
+            ['--no-opt'],
+        );
+
+        $createEscapeOptionTokenScenario = static fn (
+            string $optionValue,
+            ?string $expected,
+        ) => [
+            new InputDefinition([
+                new InputOption(
+                    'opt',
+                    null,
+                    InputOption::VALUE_REQUIRED,
+                ),
+            ]),
+            new ArgvInput(['appName', '--opt='.$optionValue]),
+            null,
+            ['--opt='.$expected],
+        ];
+
+        yield 'escape token; string token' => $createEscapeOptionTokenScenario(
+            'foo',
+            'foo',
+        );
+
+        yield 'escape token; escaped string token' => $createEscapeOptionTokenScenario(
+            '"foo"',
+            '"foo"',
+        );
+
+        yield 'escape token; escaped string token with both types of quotes' => $createEscapeOptionTokenScenario(
+            '"o_id in(\'20\')"',
+            '"o_id in(\'20\')"',
+        );
+
+        yield 'escape token; string token with spaces' => $createEscapeOptionTokenScenario(
+            'a b c d',
+            'a b c d',
+        );
+
+        yield 'escape token; string token with line return' => $createEscapeOptionTokenScenario(
+            "A\nB'C",
+            "A\nB'C",
+        );
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -167,4 +167,291 @@ class ArrayInputTest extends TestCase
         $input = new ArrayInput(['array_arg' => ['val_1', 'val_2']]);
         $this->assertSame('val_1 val_2', (string) $input);
     }
+
+    #[DataProvider('unparseProvider')]
+    public function testUnparse(?InputDefinition $inputDefinition, ArrayInput $input, ?array $parsedOptions, array $expected)
+    {
+        if (null !== $inputDefinition) {
+            $input->bind($inputDefinition);
+        }
+
+        $actual = $input->unparse($parsedOptions);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function unparseProvider(): iterable
+    {
+        yield 'empty input and empty definition' => [
+            new InputDefinition(),
+            new ArrayInput([]),
+            null,
+            [],
+        ];
+
+        yield 'empty input and definition with default values: ignore default values' => [
+            new InputDefinition([
+                new InputArgument(
+                    'argWithDefaultValue',
+                    InputArgument::OPTIONAL,
+                    'Argument with a default value',
+                    'arg1DefaultValue',
+                ),
+                new InputOption(
+                    'optWithDefaultValue',
+                    null,
+                    InputOption::VALUE_REQUIRED,
+                    'Option with a default value',
+                    'opt1DefaultValue',
+                ),
+            ]),
+            new ArrayInput([]),
+            null,
+            [],
+        ];
+
+        $completeInputDefinition = new InputDefinition([
+            new InputArgument(
+                'requiredArgWithoutDefaultValue',
+                InputArgument::REQUIRED,
+                'Argument without a default value',
+            ),
+            new InputArgument(
+                'optionalArgWithDefaultValue',
+                InputArgument::OPTIONAL,
+                'Argument with a default value',
+                'argDefaultValue',
+            ),
+            new InputOption(
+                'optWithoutDefaultValue',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Option without a default value',
+            ),
+            new InputOption(
+                'optWithDefaultValue',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Option with a default value',
+                'optDefaultValue',
+            ),
+        ]);
+
+        yield 'arguments & options: returns all passed options but ignore default values' => [
+            $completeInputDefinition,
+            new ArrayInput([
+                'requiredArgWithoutDefaultValue' => 'argValue',
+                '--optWithoutDefaultValue' => 'optValue',
+            ]),
+            null,
+            ['--optWithoutDefaultValue=optValue'],
+        ];
+
+        yield 'arguments & options; explicitly pass the default values: the default values are returned' => [
+            $completeInputDefinition,
+            new ArrayInput([
+                'requiredArgWithoutDefaultValue' => 'argValue',
+                'optionalArgWithDefaultValue' => 'argDefaultValue',
+                '--optWithoutDefaultValue' => 'optValue',
+                '--optWithDefaultValue' => 'optDefaultValue',
+            ]),
+            null,
+            [
+                '--optWithoutDefaultValue=optValue',
+                '--optWithDefaultValue=optDefaultValue',
+            ],
+        ];
+
+        yield 'arguments & options; no input definition: nothing returned' => [
+            null,
+            new ArrayInput([
+                'requiredArgWithoutDefaultValue' => 'argValue',
+                'optionalArgWithDefaultValue' => 'argDefaultValue',
+                '--optWithoutDefaultValue' => 'optValue',
+                '--optWithDefaultValue' => 'optDefaultValue',
+            ]),
+            null,
+            [],
+        ];
+
+        yield 'arguments & options; parsing an argument name instead of an option name: that option is ignored' => [
+            $completeInputDefinition,
+            new ArrayInput(['requiredArgWithoutDefaultValue' => 'argValue']),
+            ['requiredArgWithoutDefaultValue'],
+            [],
+        ];
+
+        yield 'arguments & options; non passed option: it is ignored' => [
+            $completeInputDefinition,
+            new ArrayInput(['requiredArgWithoutDefaultValue' => 'argValue']),
+            ['optWithDefaultValue'],
+            [],
+        ];
+
+        yield 'arguments & options; requesting a specific option' => [
+            $completeInputDefinition,
+            new ArrayInput([
+                '--optWithoutDefaultValue' => 'optValue1',
+                '--optWithDefaultValue' => 'optValue2',
+            ]),
+            ['optWithDefaultValue'],
+            ['--optWithDefaultValue=optValue2'],
+        ];
+
+        yield 'arguments & options; requesting no options' => [
+            $completeInputDefinition,
+            new ArrayInput([
+                '--optWithoutDefaultValue' => 'optValue1',
+                '--optWithDefaultValue' => 'optValue2',
+            ]),
+            [],
+            [],
+        ];
+
+        $createSingleOptionScenario = static fn (
+            InputOption $option,
+            array $input,
+            array $expected,
+        ) => [
+            new InputDefinition([$option]),
+            new ArrayInput($input),
+            null,
+            $expected,
+        ];
+
+        yield 'option without value' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NONE,
+            ),
+            ['--opt' => null],
+            ['--opt'],
+        );
+
+        yield 'option without value by shortcut' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                'o',
+                InputOption::VALUE_NONE,
+            ),
+            ['-o' => null],
+            ['--opt'],
+        );
+
+        yield 'option with value required' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => 'foo'],
+            ['--opt=foo'],
+        );
+
+        yield 'option with non string value (bool)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => true],
+            ['--opt=1'],
+        );
+
+        yield 'option with non string value (int)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => 20],
+            ['--opt=20'],
+        );
+
+        yield 'option with non string value (float)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => 5.3],
+            ['--opt=5.3'],
+        );
+
+        yield 'option with non string value (array of strings)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            ),
+            ['--opt' => ['v1', 'v2', 'v3']],
+            ['--opt=v1', '--opt=v2', '--opt=v3'],
+        );
+
+        yield 'negatable option (positive)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NEGATABLE,
+            ),
+            ['--opt' => null],
+            ['--opt'],
+        );
+
+        yield 'negatable option (negative)' => $createSingleOptionScenario(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NEGATABLE,
+            ),
+            ['--no-opt' => null],
+            ['--no-opt'],
+        );
+
+        $createEscapeOptionTokenScenario = static fn (
+            string $optionValue,
+            ?string $expected,
+        ) => [
+            new InputDefinition([
+                new InputOption(
+                    'opt',
+                    null,
+                    InputOption::VALUE_REQUIRED,
+                ),
+            ]),
+            new ArrayInput([
+                '--opt' => $optionValue,
+            ]),
+            null,
+            [
+                '--opt='.$expected,
+            ],
+        ];
+
+        yield 'escape token; string token' => $createEscapeOptionTokenScenario(
+            'foo',
+            'foo',
+        );
+
+        yield 'escape token; escaped string token' => $createEscapeOptionTokenScenario(
+            '"foo"',
+            '"foo"',
+        );
+
+        yield 'escape token; escaped string token with both types of quotes' => $createEscapeOptionTokenScenario(
+            '"o_id in(\'20\')"',
+            '"o_id in(\'20\')"',
+        );
+
+        yield 'escape token; string token with spaces' => $createEscapeOptionTokenScenario(
+            'a b c d',
+            'a b c d',
+        );
+
+        yield 'escape token; string token with line return' => $createEscapeOptionTokenScenario(
+            "A\nB'C",
+            "A\nB'C",
+        );
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -45,6 +45,7 @@ class InputTest extends TestCase
         $input = new ArrayInput(['--name' => 'foo', '--bar' => null], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $this->assertNull($input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
         $this->assertSame(['name' => 'foo', 'bar' => null], $input->getOptions(), '->getOptions() returns all option values');
+        $this->assertSame(['name' => 'foo', 'bar' => null], $input->getRawOptions(), '->getRawOptions() returns all option values');
 
         $input = new ArrayInput(['--name' => null], new InputDefinition([new InputOption('name', null, InputOption::VALUE_NEGATABLE)]));
         $this->assertTrue($input->hasOption('name'));
@@ -89,10 +90,12 @@ class InputTest extends TestCase
         $input->setArgument('name', 'bar');
         $this->assertSame('bar', $input->getArgument('name'), '->setArgument() sets the value for a given argument');
         $this->assertSame(['name' => 'bar'], $input->getArguments(), '->getArguments() returns all argument values');
+        $this->assertSame(['name' => 'bar'], $input->getRawArguments(), '->getRawArguments() returns all argument values');
 
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
         $this->assertSame('default', $input->getArgument('bar'), '->getArgument() returns the default value for optional arguments');
         $this->assertSame(['name' => 'foo', 'bar' => 'default'], $input->getArguments(), '->getArguments() returns all argument values, even optional ones');
+        $this->assertSame(['name' => 'foo'], $input->getRawArguments(), '->getRawArguments() returns all argument values, excluding optional ones');
     }
 
     public function testSetInvalidArgument()

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\RawInputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Dotenv\Dotenv;
@@ -229,6 +230,7 @@ class SymfonyRuntime extends GenericRuntime
         return match ($type) {
             Request::class => $this->request ??= Request::createFromGlobals(),
             InputInterface::class => $this->getInput(),
+            RawInputInterface::class => $this->getInput(),
             OutputInterface::class => $this->output ??= new ConsoleOutput(),
             Application::class => $this->console ??= new Application(),
             Command::class => $this->command ??= new Command(),
@@ -246,6 +248,7 @@ class SymfonyRuntime extends GenericRuntime
             Application::class => $self,
             Command::class => $self,
             InputInterface::class => $self,
+            RawInputInterface::class => $self,
             OutputInterface::class => $self,
         ];
         $runtime->options = $self->options;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | None
| License       | MIT

Adds `RawInputInterface` (extending `InputInterface`) with three methods to support forwarding parsed input to child processes:

- `getRawArguments()`: returns arguments without default values merged in
- `getRawOptions()`: returns options without default values merged in
- `unparse(?array $optionNames = null): array`: converts parsed options back to their CLI representation (`['--opt=value', '--flag']`), suitable for passing to `Process`

`Input` (the base class for `ArgvInput`, `ArrayInput`, `StringInput`) implements the new interface. The interface is also wired into the argument resolver, invokable commands, DI, and `SymfonyRuntime` so that commands can type-hint `RawInputInterface` directly.

### Use case

Forwarding the current command's input to a child process, e.g. in [console-parallelization](https://github.com/webmozarts/console-parallelization):

```php
$options = $input->getRawOptions();
unset($options['main-process-only-option']);
$options['child'] = true;

$process = new Process([
    PHP_BINARY, 'bin/console', 'my:command',
    ...$input->getRawArguments(),
    ...$input->unparse(array_keys($options)),
]);
```

### Design notes

- **No BC break**: `InputInterface` is untouched. `RawInputInterface extends InputInterface` so type-hinting it gives access to the full input API.
- **`unparse()` returns `list<string>`** (not a concatenated string) so each element maps to a single process argument — no double-escaping.
- **Default values are excluded** from `getRawArguments()`/`getRawOptions()` so only explicitly passed input is forwarded.