### PR TITLE
[PropertyInfo] Add `PropertyAttributesExtractor`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -73,6 +73,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'property_info.initializable_extractor',
         'property_info.list_extractor',
         'property_info.type_extractor',
+        'property_info.attributes_extractor',
         'proxy',
         'remote_event.consumer',
         'routing.condition_service',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -130,6 +130,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyAttributesExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
@@ -642,6 +643,8 @@ class FrameworkExtension extends Extension
             ->addTag('property_info.access_extractor');
         $container->registerForAutoconfiguration(PropertyInitializableExtractorInterface::class)
             ->addTag('property_info.initializable_extractor');
+        $container->registerForAutoconfiguration(PropertyAttributesExtractorInterface::class)
+            ->addTag('property_info.attributes_extractor');
         $container->registerForAutoconfiguration(EncoderInterface::class)
             ->addTag('serializer.encoder');
         $container->registerForAutoconfiguration(DecoderInterface::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyAttributesExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
@@ -26,7 +27,7 @@ use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('property_info', PropertyInfoExtractor::class)
-            ->args([[], [], [], [], []])
+            ->args([[], [], [], [], [], []])
 
         ->alias(PropertyAccessExtractorInterface::class, 'property_info')
         ->alias(PropertyDescriptionExtractorInterface::class, 'property_info')
@@ -34,6 +35,7 @@ return static function (ContainerConfigurator $container) {
         ->alias(PropertyTypeExtractorInterface::class, 'property_info')
         ->alias(PropertyListExtractorInterface::class, 'property_info')
         ->alias(PropertyInitializableExtractorInterface::class, 'property_info')
+        ->alias(PropertyAttributesExtractorInterface::class, 'property_info')
 
         ->set('property_info.cache', PropertyInfoCacheExtractor::class)
             ->decorate('property_info')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
@@ -45,6 +45,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('property_info.type_extractor', ['priority' => -1002])
             ->tag('property_info.access_extractor', ['priority' => -1000])
             ->tag('property_info.initializable_extractor', ['priority' => -1000])
+            ->tag('property_info.attributes_extractor', ['priority' => -1000])
 
         ->alias(PropertyReadInfoExtractorInterface::class, 'property_info.reflection_extractor')
         ->alias(PropertyWriteInfoExtractorInterface::class, 'property_info.reflection_extractor')

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.2
 ---
 
- * Add `PropertyAttributesExtractorInterface` to extract property attributes
+ * Add `PropertyAttributesExtractorInterface` to extract property attributes (implemented by `ReflectionExtractor`)
 
 7.1
 ---

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `PropertyAttributesExtractorInterface` to extract property attributes
+
 7.1
 ---
 

--- a/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
+++ b/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
@@ -49,6 +49,6 @@ class PropertyInfoPass implements CompilerPassInterface
         $definition->setArgument(4, new IteratorArgument($initializableExtractors));
 
         $attributesExtractor = $this->findAndSortTaggedServices('property_info.attributes_extractor', $container);
-        $definition->replaceArgument(5, new IteratorArgument($attributesExtractor));
+        $definition->setArgument(5, new IteratorArgument($attributesExtractor));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
+++ b/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
@@ -47,5 +47,8 @@ class PropertyInfoPass implements CompilerPassInterface
 
         $initializableExtractors = $this->findAndSortTaggedServices('property_info.initializable_extractor', $container);
         $definition->setArgument(4, new IteratorArgument($initializableExtractors));
+
+        $attributesExtractor = $this->findAndSortTaggedServices('property_info.attributes_extractor', $container);
+        $definition->replaceArgument(5, new IteratorArgument($attributesExtractor));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -521,7 +521,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
 
         $attributes = [];
-        foreach ($reflClass->getProperty($property)->getAttributes() as $attribute) {
+        $reflProperty = $reflClass->getProperty($property);
+        foreach ($reflProperty->getAttributes() as $attribute) {
             $attributes[] = [
                 'name' => $attribute->getName(),
                 'arguments' => $attribute->getArguments(),

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Extractor;
 
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyAttributesExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
@@ -36,7 +37,7 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolverInterface;
  *
  * @final
  */
-class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, PropertyReadInfoExtractorInterface, PropertyWriteInfoExtractorInterface, ConstructorArgumentTypeExtractorInterface
+class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, PropertyReadInfoExtractorInterface, PropertyWriteInfoExtractorInterface, ConstructorArgumentTypeExtractorInterface, PropertyAttributesExtractorInterface
 {
     /**
      * @internal
@@ -505,6 +506,29 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $noneProperty->setErrors(array_merge([], ...$errors));
 
         return $noneProperty;
+    }
+
+    public function getAttributes(string $class, string $property, array $context = []): ?array
+    {
+        try {
+            $reflClass = new \ReflectionClass($class);
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        if (!$reflClass->hasProperty($property)) {
+            return null;
+        }
+
+        $attributes = [];
+        foreach ($reflClass->getProperty($property)->getAttributes() as $attribute) {
+            $attributes[] = [
+                'name' => $attribute->getName(),
+                'arguments' => $attribute->getArguments(),
+            ];
+        }
+
+        return $attributes;
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/PropertyAttributesExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyAttributesExtractorInterface.php
@@ -21,7 +21,9 @@ interface PropertyAttributesExtractorInterface
      *
      * Returns an array of attributes, each attribute is an associative array with the following keys:
      * - name: The fully-qualified class name of the attribute
-     * - arguments: An associative array of attribute arguments
+     * - arguments: An associative array of attribute arguments if present
+     *
+     * @return array<int, array{name: string, arguments: array<array-key, mixed>}>|null
      */
     public function getAttributes(string $class, string $property, array $context = []): ?array;
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyAttributesExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyAttributesExtractorInterface.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\PropertyInfo;
 
+/**
+ * @author Andrew Alyamovsky <andrew.alyamovsky@gmail.com>
+ */
 interface PropertyAttributesExtractorInterface
 {
     /**
@@ -19,9 +22,6 @@ interface PropertyAttributesExtractorInterface
      * Returns an array of attributes, each attribute is an associative array with the following keys:
      * - name: The fully-qualified class name of the attribute
      * - arguments: An associative array of attribute arguments
-     *
-     * Example:
-     * [['name' => 'FQCN', 'arguments' => ['key' => 'value']], ...]
      */
     public function getAttributes(string $class, string $property, array $context = []): ?array;
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyAttributesExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyAttributesExtractorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo;
+
+interface PropertyAttributesExtractorInterface
+{
+    /**
+     * Gets the attributes of the property.
+     *
+     * Returns an array of attributes, each attribute is an associative array with the following keys:
+     * - name: The fully-qualified class name of the attribute
+     * - arguments: An associative array of attribute arguments
+     *
+     * Example:
+     * [['name' => 'FQCN', 'arguments' => ['key' => 'value']], ...]
+     */
+    public function getAttributes(string $class, string $property, array $context = []): ?array;
+}

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -21,7 +21,7 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @final
  */
-class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, PropertyInitializableExtractorInterface
+class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, PropertyInitializableExtractorInterface, PropertyAttributesExtractorInterface
 {
     private array $arrayCache = [];
 
@@ -67,6 +67,11 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
         return $this->extract('getTypes', [$class, $property, $context]);
+    }
+
+    public function getAttributes(string $class, string $property, array $context = []): ?array
+    {
+        return $this->extract('getAttributes', [$class, $property, $context]);
     }
 
     public function isInitializable(string $class, string $property, array $context = []): ?bool

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -28,6 +28,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
      * @param iterable<mixed, PropertyDescriptionExtractorInterface>   $descriptionExtractors
      * @param iterable<mixed, PropertyAccessExtractorInterface>        $accessExtractors
      * @param iterable<mixed, PropertyInitializableExtractorInterface> $initializableExtractors
+     * @param iterable<mixed, PropertyAttributesExtractorInterface>    $attributesExtractors
      */
     public function __construct(
         private readonly iterable $listExtractors = [],
@@ -35,6 +36,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
         private readonly iterable $descriptionExtractors = [],
         private readonly iterable $accessExtractors = [],
         private readonly iterable $initializableExtractors = [],
+        private readonly iterable $attributesExtractors = [],
     ) {
     }
 
@@ -64,6 +66,11 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
         return $this->extract($this->typeExtractors, 'getTypes', [$class, $property, $context]);
+    }
+
+    public function getAttributes(string $class, string $property, array $context = []): ?array
+    {
+        return $this->extract($this->attributesExtractors, 'getAttributes', [$class, $property, $context]);
     }
 
     public function isReadable(string $class, string $property, array $context = []): ?bool

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -20,7 +20,7 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @final
  */
-class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyInitializableExtractorInterface
+class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyInitializableExtractorInterface, PropertyAttributesExtractorInterface
 {
     /**
      * @param iterable<mixed, PropertyListExtractorInterface>          $listExtractors

--- a/src/Symfony/Component/PropertyInfo/Tests/DependencyInjection/PropertyInfoPassTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/DependencyInjection/PropertyInfoPassTest.php
@@ -26,7 +26,7 @@ class PropertyInfoPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $definition = $container->register('property_info')->setArguments([null, null, null, null, null]);
+        $definition = $container->register('property_info')->setArguments([null, null, null, null, null, null]);
         $container->register('n2')->addTag($tag, ['priority' => 100]);
         $container->register('n1')->addTag($tag, ['priority' => 200]);
         $container->register('n3')->addTag($tag);
@@ -50,6 +50,7 @@ class PropertyInfoPassTest extends TestCase
             [2, 'property_info.description_extractor'],
             [3, 'property_info.access_extractor'],
             [4, 'property_info.initializable_extractor'],
+            [5, 'property_info.attributes_extractor'],
         ];
     }
 
@@ -57,7 +58,7 @@ class PropertyInfoPassTest extends TestCase
     {
         $container = new ContainerBuilder();
         $propertyInfoExtractorDefinition = $container->register('property_info')
-            ->setArguments([[], [], [], [], []]);
+            ->setArguments([[], [], [], [], [], []]);
 
         $propertyInfoPass = new PropertyInfoPass();
         $propertyInfoPass->process($container);
@@ -67,5 +68,6 @@ class PropertyInfoPassTest extends TestCase
         $this->assertEquals(new IteratorArgument([]), $propertyInfoExtractorDefinition->getArgument(2));
         $this->assertEquals(new IteratorArgument([]), $propertyInfoExtractorDefinition->getArgument(3));
         $this->assertEquals(new IteratorArgument([]), $propertyInfoExtractorDefinition->getArgument(4));
+        $this->assertEquals(new IteratorArgument([]), $propertyInfoExtractorDefinition->getArgument(5));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyAttribute;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithAttributes;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
@@ -495,6 +497,108 @@ class ReflectionExtractorTest extends TestCase
             [Php71DummyExtended2::class, 'intWithAccessor', true],
             [Php71DummyExtended2::class, 'intPrivate', false],
             [NotInstantiable::class, 'foo', false],
+        ];
+    }
+
+    /**
+     * @dataProvider getAttributes
+     */
+    public function testGetAttributes(string $class, string $property, ?array $expected)
+    {
+        $this->assertSame($expected, $this->extractor->getAttributes($class, $property));
+    }
+
+    public static function getAttributes(): array
+    {
+        return [
+            [
+                DummyWithAttributes::class,
+                'a',
+                [
+                    [
+                        'name' => DummyAttribute::class,
+                        'arguments' => [
+                            'type' => 'foo',
+                            'name' => 'nameA',
+                            'version' => 1,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                DummyWithAttributes::class,
+                'b',
+                [
+                    [
+                        'name' => DummyAttribute::class,
+                        'arguments' => [
+                            'type' => 'bar',
+                            'name' => 'nameB',
+                            'version' => 2,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                DummyWithAttributes::class,
+                'c',
+                [
+                    [
+                        'name' => DummyAttribute::class,
+                        'arguments' => [
+                            'type' => 'baz',
+                            'name' => 'nameC',
+                            'version' => 3,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                DummyWithAttributes::class,
+                'd',
+                [
+                    [
+                        'name' => DummyAttribute::class,
+                        'arguments' => [
+                            0 => 'foo',
+                            1 => 'nameD',
+                            2 => 4,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                DummyWithAttributes::class,
+                'e',
+                [
+                    [
+                        'name' => DummyAttribute::class,
+                        'arguments' => [
+                            'type' => 'foo',
+                            'name' => 'nameE1',
+                            'version' => 5,
+                        ],
+                    ],
+                    [
+                        'name' => DummyAttribute::class,
+                        'arguments' => [
+                            'type' => 'foo',
+                            'name' => 'nameE2',
+                            'version' => 10,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                DummyWithAttributes::class,
+                'f',
+                [],
+            ],
+            [
+                DummyWithAttributes::class,
+                'nonExistentProperty',
+                null,
+            ],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -501,14 +501,14 @@ class ReflectionExtractorTest extends TestCase
     }
 
     /**
-     * @dataProvider getAttributes
+     * @dataProvider attributesProvider
      */
     public function testGetAttributes(string $class, string $property, ?array $expected)
     {
         $this->assertSame($expected, $this->extractor->getAttributes($class, $property));
     }
 
-    public static function getAttributes(): array
+    public static function attributesProvider(): array
     {
         return [
             [

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyAttribute.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyAttribute.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_PROPERTY)]
+class DummyAttribute
+{
+    public function __construct(
+        public string $type,
+        public string $name,
+        public int $version,
+    )
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyAttribute.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyAttribute.php
@@ -9,7 +9,6 @@ class DummyAttribute
         public string $type,
         public string $name,
         public int $version,
-    )
-    {
+    ) {
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyExtractor.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
 use Symfony\Component\PropertyInfo\Extractor\ConstructorArgumentTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyAttributesExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
@@ -23,7 +24,7 @@ use Symfony\Component\TypeInfo\Type;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class DummyExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, ConstructorArgumentTypeExtractorInterface
+class DummyExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, ConstructorArgumentTypeExtractorInterface, PropertyAttributesExtractorInterface
 {
     public function getShortDescription($class, $property, array $context = []): ?string
     {
@@ -43,6 +44,19 @@ class DummyExtractor implements PropertyListExtractorInterface, PropertyDescript
     public function getType($class, $property, array $context = []): ?Type
     {
         return Type::int();
+    }
+
+    public function getAttributes($class, $property, array $context = []): ?array
+    {
+        return [
+            [
+                'name' => \stdClass::class,
+                'arguments' => [
+                    'foo' => 'bar',
+                    'baz' => 'qux',
+                ],
+            ],
+        ];
     }
 
     public function getTypesFromConstructor(string $class, string $property): ?array

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithAttributes.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class DummyWithAttributes
+{
+    #[DummyAttribute(type: 'foo', name: 'nameA', version: 1)]
+    public $a;
+
+    #[DummyAttribute(type: 'bar', name: 'nameB', version: 2)]
+    public $b;
+
+    #[DummyAttribute(type: 'baz', name: 'nameC', version: 3)]
+    public $c;
+
+    #[DummyAttribute('foo', 'nameD', 4)]
+    public $d;
+
+    #[DummyAttribute(type: 'foo', name: 'nameE1', version: 5)]
+    #[DummyAttribute(type: 'foo', name: 'nameE2', version: 10)]
+    public $e;
+
+    public $f;
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyAttributesExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
@@ -23,7 +24,7 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class NullExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface
+class NullExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, PropertyAttributesExtractorInterface
 {
     public function getShortDescription($class, $property, array $context = []): ?string
     {
@@ -50,6 +51,14 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     }
 
     public function getType($class, $property, array $context = []): ?Type
+    {
+        $this->assertIsString($class);
+        $this->assertIsString($property);
+
+        return null;
+    }
+
+    public function getAttributes($class, $property, array $context = []): ?array
     {
         $this->assertIsString($class);
         $this->assertIsString($property);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

While the PropertyInfo component works great for extracting property annotations, in its current state it does not support extracting attributes. This means there's a necessity to use `ReflectionClass` on the target class to extract attributes, and that it's not possible to leverage `PropertyInfoCacheExtractor` to cache the results.

This PR adds a separate `PropertyAttributesExtractorInterface` interface that does just that, which is implemented by the existing `ReflectionExtractor` class.