### PR TITLE
[TwigBridge] Remove random file name for `lint:twig` output in case of error

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -89,7 +89,7 @@ EOF
         $this->format = $input->getOption('format') ?? (GithubActionReporter::isGithubActionEnvironment() ? 'github' : 'txt');
 
         if (['-'] === $filenames) {
-            return $this->display($input, $output, $io, [$this->validate(file_get_contents('php://stdin'), uniqid('sf_', true))]);
+            return $this->display($input, $output, $io, [$this->validate(file_get_contents('php://stdin'), 'Standard Input')]);
         }
 
         if (!$filenames) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #57588
| License       | MIT

In the `lint:twig`, `uniqid` is used to generate a file name when linting a template from STDIN.
- I don't find any reason to use a unique file name. The file name is never stored when the template is tokenized and compiled. The cache is not used.
- This meaningless file name is displayed in the output in case of error, which is better replaced by the text "Standard Input".

Before:
```
$ bin/console lint:twig - < vendor/symfony/twig-bridge/Resources/views/Email/zurb_2/notification/body.html.twig
  ERROR  in sf_6681e2dd64a2e2.02015003 (line -1)
  >> The "inky_to_html" filter is part of the InkyExtension, which is not installed/enabled; try running "composer require twig/inky-extra". 
 [WARNING] 0 Twig files have valid syntax and 1 contain errors.
```

After:
```
$ bin/console lint:twig - < vendor/symfony/twig-bridge/Resources/views/Email/zurb_2/notification/body.html.twig
  ERROR  in Standard Input (line -1)
  >> The "inky_to_html" filter is part of the InkyExtension, which is not installed/enabled; try running "composer require twig/inky-extra".                                                                                 
 [WARNING] 0 Twig files have valid syntax and 1 contain errors.                                                                                                 
```

Note: the `line -1` is due to the lack of context provided to  `Twig\Extra\TwigExtraBundle\MissingExtensionSuggestor::suggestFilter()`

For reference, this was introduced by https://github.com/symfony/symfony/pull/10843
