### PR TITLE
[TwigBridge]  Use constant var name to cache `trans_default_domain` expression result

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -30,6 +30,8 @@ use Twig\NodeVisitor\NodeVisitorInterface;
  */
 final class TranslationDefaultDomainNodeVisitor implements NodeVisitorInterface
 {
+    private const INTERNAL_VAR_NAME = '__internal_trans_default_domain';
+
     private Scope $scope;
 
     public function __construct()
@@ -49,9 +51,8 @@ final class TranslationDefaultDomainNodeVisitor implements NodeVisitorInterface
 
                 return $node;
             } else {
-                $var = $this->getVarName();
-                $name = new AssignNameExpression($var, $node->getTemplateLine());
-                $this->scope->set('domain', new NameExpression($var, $node->getTemplateLine()));
+                $name = new AssignNameExpression(self::INTERNAL_VAR_NAME, $node->getTemplateLine());
+                $this->scope->set('domain', new NameExpression(self::INTERNAL_VAR_NAME, $node->getTemplateLine()));
 
                 return new SetNode(false, new Node([$name]), new Node([$node->getNode('expr')]), $node->getTemplateLine());
             }
@@ -110,10 +111,5 @@ final class TranslationDefaultDomainNodeVisitor implements NodeVisitorInterface
         }
 
         return false;
-    }
-
-    private function getVarName(): string
-    {
-        return \sprintf('__internal_%s', hash('xxh128', uniqid(mt_rand(), true)));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #57588
| License       | MIT

When `trans_default_domain` is used with an expression, the result of the expression is cached into a variable and this variable is stored in the `Scope` to be used for each following usage of the `|trans` filter.

This var name doesn't need to be random:
- there is only 1 value in the scope, more than 1 variable at a time is never necessary.
- if `trans_default_domain` is called a second time, the same variable can be reassigned.

The only benefit of using a random var name would be to prevent usage in the template. The name `__internal_trans_default_domain` self-explains that it is not meant to be used.