### PR TITLE
[PsrHttpMessageBridge] Remove a redundant check in HttpFoundationFactory class

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Factory/HttpFoundationFactory.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Factory/HttpFoundationFactory.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
-use Psr\Http\Message\UriInterface;
 use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,19 +39,17 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
         $server = [];
         $uri = $psrRequest->getUri();
 
-        if ($uri instanceof UriInterface) {
-            $server['SERVER_NAME'] = $uri->getHost();
-            $server['SERVER_PORT'] = $uri->getPort() ?: ('https' === $uri->getScheme() ? 443 : 80);
-            $server['REQUEST_URI'] = $uri->getPath();
-            $server['QUERY_STRING'] = $uri->getQuery();
+        $server['SERVER_NAME'] = $uri->getHost();
+        $server['SERVER_PORT'] = $uri->getPort() ?: ('https' === $uri->getScheme() ? 443 : 80);
+        $server['REQUEST_URI'] = $uri->getPath();
+        $server['QUERY_STRING'] = $uri->getQuery();
 
-            if ('' !== $server['QUERY_STRING']) {
-                $server['REQUEST_URI'] .= '?'.$server['QUERY_STRING'];
-            }
+        if ('' !== $server['QUERY_STRING']) {
+            $server['REQUEST_URI'] .= '?'.$server['QUERY_STRING'];
+        }
 
-            if ('https' === $uri->getScheme()) {
-                $server['HTTPS'] = 'on';
-            }
+        if ('https' === $uri->getScheme()) {
+            $server['HTTPS'] = 'on';
         }
 
         $server['REQUEST_METHOD'] = $psrRequest->getMethod();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

`HttpFoundationFactory::createRequest` method receives an implementation of `ServerRequestInterface` and it's `getUri` method must always return a `UriInterface` implementation. So, this check below is redundant.

```php
<?php
$uri = $psrRequest->getUri(); // absolutely is \Psr\Http\Message\UriInterface

if ($uri instanceof UriInterface) { // redundant check
    // Do something
}
```

### My Concern
I've checked Symfony roadmap/releases [here](https://symfony.com/releases). And I decided to create a PR to branch 6.4 because:
- PsrHttpMessage is included in v6.4 (not in 5.4).
- v6.4 is still maintained (v6.0, v6.1, v6.2 and v6.3 are "End of life" versions).
- It is not a breaking/major change.

Did I choose branch correctly? If not, please give me more references/posts about how to choose a right branch for a PR.