### PR TITLE
[PsrHttpMessageBridge] Remove `uniqid()` from `tempnam()` calls

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Factory/HttpFoundationFactory.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Factory/HttpFoundationFactory.php
@@ -104,7 +104,7 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
      */
     protected function getTemporaryPath(): string
     {
-        return tempnam(sys_get_temp_dir(), uniqid('symfony', true));
+        return tempnam(sys_get_temp_dir(), 'symfony');
     }
 
     public function createResponse(ResponseInterface $psrResponse, bool $streamed = false): Response

--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/HttpFoundationFactoryTest.php
@@ -198,7 +198,7 @@ class HttpFoundationFactoryTest extends TestCase
 
     private function createUploadedFile(string $content, int $error, string $clientFileName, string $clientMediaType): UploadedFile
     {
-        $filePath = tempnam($this->tmpDir, uniqid());
+        $filePath = tempnam($this->tmpDir, 'sftest');
         file_put_contents($filePath, $content);
 
         return new UploadedFile($filePath, filesize($filePath), $error, $clientFileName, $clientMediaType);

--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/PsrHttpFactoryTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/PsrHttpFactoryTest.php
@@ -131,7 +131,7 @@ class PsrHttpFactoryTest extends TestCase
 
     private function createUploadedFile(string $content, string $originalName, string $mimeType, int $error): UploadedFile
     {
-        $path = tempnam($this->tmpDir, uniqid());
+        $path = $this->createTempFile();
         file_put_contents($path, $content);
 
         return new UploadedFile($path, $originalName, $mimeType, $error, true);
@@ -182,7 +182,7 @@ class PsrHttpFactoryTest extends TestCase
 
     public function testCreateResponseFromBinaryFile()
     {
-        $path = tempnam($this->tmpDir, uniqid());
+        $path = $this->createTempFile();
         file_put_contents($path, 'Binary');
 
         $response = new BinaryFileResponse($path);
@@ -194,7 +194,7 @@ class PsrHttpFactoryTest extends TestCase
 
     public function testCreateResponseFromBinaryFileWithRange()
     {
-        $path = tempnam($this->tmpDir, uniqid());
+        $path = $this->createTempFile();
         file_put_contents($path, 'Binary');
 
         $request = new Request();
@@ -286,5 +286,10 @@ class PsrHttpFactoryTest extends TestCase
         $factory = new Psr17Factory();
 
         return new PsrHttpFactory($factory, $factory, $factory, $factory);
+    }
+
+    private function createTempFile(): string
+    {
+        return tempnam($this->tmpDir, 'sftest');
     }
 }

--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Functional/CovertTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Functional/CovertTest.php
@@ -217,7 +217,7 @@ class CovertTest extends TestCase
 
     private static function createUploadedFile(string $content, string $originalName, string $mimeType, int $error): UploadedFile
     {
-        $path = tempnam(sys_get_temp_dir(), uniqid());
+        $path = tempnam(sys_get_temp_dir(), 'sftest');
         file_put_contents($path, $content);
 
         return new UploadedFile($path, $originalName, $mimeType, $error, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #57588
| License       | MIT

PHP's `tempnam()` function should already make sure we get a collision-free random temporary file. We should not need additional randomness from `uniqid()`.
