### PR TITLE
Remove useless `uniqid` in tempnam calls in tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/log_file.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/log_file.phpt
@@ -2,7 +2,7 @@
 Test DeprecationErrorHandler with log file
 --FILE--
 <?php
-$filename = tempnam(sys_get_temp_dir(), 'sf-').uniqid();
+$filename = tempnam(sys_get_temp_dir(), 'sf-');
 $k = 'SYMFONY_DEPRECATIONS_HELPER';
 putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'logFile='.$filename);
 putenv('ANSICON');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
@@ -37,8 +37,9 @@ class ConfigBuilderCacheWarmerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->varDir = sys_get_temp_dir().'/'.uniqid();
         $fs = new Filesystem();
+        $this->varDir = tempnam(sys_get_temp_dir(), 'sf_var_');
+        $fs->remove($this->varDir);
         $fs->mkdir($this->varDir);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -82,7 +82,8 @@ class TranslationDebugCommandTest extends TestCase
     {
         $this->fs->remove($this->translationDir);
         $this->fs = new Filesystem();
-        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
+        $this->translationDir = tempnam(sys_get_temp_dir(), 'sf_translation_');
+        $this->fs->remove($this->translationDir);
         $this->fs->mkdir($this->translationDir.'/translations');
         $this->fs->mkdir($this->translationDir.'/templates');
 
@@ -150,7 +151,8 @@ class TranslationDebugCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->fs = new Filesystem();
-        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
+        $this->translationDir = tempnam(sys_get_temp_dir(), 'sf_translation_');
+        $this->fs->remove($this->translationDir);
         $this->fs->mkdir($this->translationDir.'/translations');
         $this->fs->mkdir($this->translationDir.'/templates');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandCompletionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandCompletionTest.php
@@ -57,7 +57,8 @@ class TranslationUpdateCommandCompletionTest extends TestCase
     protected function setUp(): void
     {
         $this->fs = new Filesystem();
-        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
+        $this->translationDir = tempnam(sys_get_temp_dir(), 'sf_translation_');
+        $this->fs->remove($this->translationDir);
         $this->fs->mkdir($this->translationDir.'/translations');
         $this->fs->mkdir($this->translationDir.'/templates');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -78,11 +78,6 @@ class TranslationUpdateCommandTest extends TestCase
 
     public function testDumpMessagesAndCleanInRootDirectory()
     {
-        $this->fs->remove($this->translationDir);
-        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
-        $this->fs->mkdir($this->translationDir.'/translations');
-        $this->fs->mkdir($this->translationDir.'/templates');
-
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo']], [], null, [$this->translationDir.'/trans'], [$this->translationDir.'/views']);
         $tester->execute(['command' => 'translation:extract', 'locale' => 'en', '--dump-messages' => true, '--clean' => true]);
         $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
@@ -115,11 +110,6 @@ class TranslationUpdateCommandTest extends TestCase
 
     public function testWriteMessagesInRootDirectory()
     {
-        $this->fs->remove($this->translationDir);
-        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
-        $this->fs->mkdir($this->translationDir.'/translations');
-        $this->fs->mkdir($this->translationDir.'/templates');
-
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo']]);
         $tester->execute(['command' => 'translation:extract', 'locale' => 'en', '--force' => true]);
         $this->assertMatchesRegularExpression('/Translation files were successfully updated./', $tester->getDisplay());
@@ -174,7 +164,8 @@ class TranslationUpdateCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->fs = new Filesystem();
-        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
+        $this->translationDir = tempnam(sys_get_temp_dir(), 'sf_translation_');
+        $this->fs->remove($this->translationDir);
         $this->fs->mkdir($this->translationDir.'/translations');
         $this->fs->mkdir($this->translationDir.'/templates');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/BundlePathsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/BundlePathsTest.php
@@ -23,9 +23,10 @@ class BundlePathsTest extends AbstractWebTestCase
     public function testBundlePublicDir()
     {
         $kernel = static::bootKernel(['test_case' => 'BundlePaths']);
-        $projectDir = sys_get_temp_dir().'/'.uniqid('sf_bundle_paths', true);
+        $projectDir = tempnam(sys_get_temp_dir(), 'sf_bundle_paths_');
 
         $fs = new Filesystem();
+        $fs->remove($projectDir);
         $fs->mkdir($projectDir.'/public');
         $command = (new Application($kernel))->add(new AssetsInstallCommand($fs, $projectDir));
         $exitCode = (new CommandTester($command))->execute(['target' => $projectDir.'/public']);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -530,7 +530,9 @@ class RouterTest extends TestCase
      */
     public function testCacheValidityWithContainerParameters($parameter)
     {
-        $cacheDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('router_', true);
+        $cacheDir = tempnam(sys_get_temp_dir(), 'sf_router_');
+        unlink($cacheDir);
+        mkdir($cacheDir);
 
         try {
             $container = new Container();

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -92,7 +92,6 @@ class GeneratedConfigTest extends TestCase
         // $this->generateConfigBuilder('Symfony\\Component\\Config\\Tests\\Builder\\Fixtures\\'.$name, $expectedCode);
         // $this->markTestIncomplete('Re-comment the line above and relaunch the tests');
 
-        $outputDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('sf_config_builder', true);
         $configBuilder = $this->generateConfigBuilder('Symfony\\Component\\Config\\Tests\\Builder\\Fixtures\\'.$name, $outputDir);
         $callback($configBuilder);
 
@@ -162,12 +161,12 @@ class GeneratedConfigTest extends TestCase
     /**
      * Generate the ConfigBuilder or return an already generated instance.
      */
-    private function generateConfigBuilder(string $configurationClass, ?string $outputDir = null)
+    private function generateConfigBuilder(string $configurationClass, ?string &$outputDir = null)
     {
-        $outputDir ??= sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('sf_config_builder', true);
-        if (!str_contains($outputDir, __DIR__)) {
-            $this->tempDir[] = $outputDir;
-        }
+        $outputDir = tempnam(sys_get_temp_dir(), 'sf_config_builder_');
+        unlink($outputDir);
+        mkdir($outputDir);
+        $this->tempDir[] = $outputDir;
 
         $configuration = new $configurationClass();
         $rootNode = $configuration->getConfigTreeBuilder()->buildTree();

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -30,7 +30,7 @@ class CompiledUrlMatcherDumperTest extends TestCase
     {
         parent::setUp();
 
-        $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_matcher.'.uniqid('CompiledUrlMatcher').'.php';
+        $this->dumpPath = tempnam(sys_get_temp_dir(), 'sf_matcher_');
     }
 
     protected function tearDown(): void

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -35,7 +35,9 @@ class RouterTest extends TestCase
         $this->loader = $this->createMock(LoaderInterface::class);
         $this->router = new Router($this->loader, 'routing.yml');
 
-        $this->cacheDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('router_', true);
+        $this->cacheDir = tempnam(sys_get_temp_dir(), 'sf_router_');
+        unlink($this->cacheDir);
+        mkdir($this->cacheDir);
     }
 
     protected function tearDown(): void

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
@@ -27,7 +27,7 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_serializer_metadata.'.uniqid('CompiledClassMetadataFactory').'.php';
+        $this->dumpPath = tempnam(sys_get_temp_dir(), 'sf_serializer_metadata_');
     }
 
     protected function tearDown(): void

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationProviderTestCase.php
@@ -33,7 +33,8 @@ abstract class TranslationProviderTestCase extends TestCase
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
         $this->fs = new Filesystem();
-        $this->translationAppDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
+        $this->translationAppDir = tempnam(sys_get_temp_dir(), 'sf_translation_');
+        $this->fs->remove($this->translationAppDir);
         $this->fs->mkdir($this->translationAppDir.'/translations');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #57588
| License       | MIT

For creating a temporary directory, I use `tempnam` then remove the file and create the directory with the same name.