### PR TITLE
[String] Revert "Fixed u()->snake(), b()->snake() and s()->snake() methods"

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -162,7 +162,7 @@ abstract class AbstractUnicodeString extends AbstractString
     public function camel(): parent
     {
         $str = clone $this;
-        $str->string = str_replace(' ', '', preg_replace_callback('/\b.(?![A-Z]{2,})/u', static function ($m) use (&$i) {
+        $str->string = str_replace(' ', '', preg_replace_callback('/\b.(?!\p{Lu})/u', static function ($m) use (&$i) {
             return 1 === ++$i ? ('İ' === $m[0] ? 'i̇' : mb_strtolower($m[0], 'UTF-8')) : mb_convert_case($m[0], \MB_CASE_TITLE, 'UTF-8');
         }, preg_replace('/[^\pL0-9]++/u', ' ', $this->string)));
 
@@ -366,8 +366,8 @@ abstract class AbstractUnicodeString extends AbstractString
 
     public function snake(): parent
     {
-        $str = clone $this;
-        $str->string = preg_replace('/[ _]+/', '_', mb_strtolower(preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1 \2', $str->string), 'UTF-8'));
+        $str = $this->camel();
+        $str->string = mb_strtolower(preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1_\2', $str->string), 'UTF-8');
 
         return $str;
     }

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -366,8 +366,8 @@ class ByteString extends AbstractString
 
     public function snake(): parent
     {
-        $str = clone $this;
-        $str->string = preg_replace('/[ _]+/', '_', strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1 \2', $str->string)));
+        $str = $this->camel();
+        $str->string = strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1_\2', $str->string));
 
         return $str;
     }

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1046,6 +1046,7 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfonyIsGreat', 'symfony_is_great'],
             ['symfony5IsGreat', 'symfony_5_is_great'],
             ['symfonyIsGreat', 'Symfony is great'],
+            ['SYMFONYISGREAT', 'SYMFONY_IS_GREAT'],
             ['symfonyIsAGreatFramework', 'Symfony is a great framework'],
             ['symfonyIsGREAT', '*Symfony* is GREAT!!'],
             ['SYMFONY', 'SYMFONY'],
@@ -1077,11 +1078,12 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfony_is_great', 'symfonyIsGREAT'],
             ['symfony_is_really_great', 'symfonyIsREALLYGreat'],
             ['symfony', 'SYMFONY'],
-            ['symfony_is_great', 'SYMFONY IS GREAT'],
-            ['symfony_is_great', 'SYMFONY_IS_GREAT'],
+            ['symfonyisgreat', 'SYMFONY IS GREAT'],
+            ['symfonyisgreat', 'SYMFONY_IS_GREAT'],
             ['symfony_is_great', 'symfony    is     great'],
-            ['symfony_is_great', 'SYMFONY    IS     GREAT'],
-            ['symfony_is_great', 'SYMFONY _ IS _ GREAT'],
+            ['symfonyisgreat', 'SYMFONY    IS     GREAT'],
+            ['symfonyisgreat', 'SYMFONY _ IS _ GREAT'],
+            ['symfony_isgreat', 'Symfony IS GREAT!'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57612
| License       | MIT

This PR reverts #57497 for BC reasons, but keeps the test cases we added in the process. Those test cases allowed to spot a real issue where the ascii and unicode implementations didn't agree on the resulting camel case for `SYMFONY IS GREAT`. Both implementations now result in `SYMFONYISGREAT` (likely introduced in #47423).