### PR TITLE
[TypeInfo] Add `PhpDocAwareReflectionTypeResolver`

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add `PhpDocAwareReflectionTypeResolver` resolver
+
 7.1
 ---
 

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpDoc.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpDoc.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+final class DummyWithPhpDoc
+{
+    /**
+     * @var array<Dummy>
+     */
+    public mixed $arrayOfDummies = [];
+
+    /**
+     * @param Dummy $dummy
+     *
+     * @return Dummy
+     */
+    public function getNextDummy(mixed $dummy): mixed
+    {
+        throw new \BadMethodCallException(sprintf('"%s" is not implemented.', __METHOD__));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/PhpDocAwareReflectionTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/PhpDocAwareReflectionTypeResolverTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPhpDoc;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\PhpDocAwareReflectionTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+
+class PhpDocAwareReflectionTypeResolverTest extends TestCase
+{
+    public function testReadPhpDoc()
+    {
+        $resolver = new PhpDocAwareReflectionTypeResolver(TypeResolver::create(), new StringTypeResolver(), new TypeContextFactory());
+        $reflection = new \ReflectionClass(DummyWithPhpDoc::class);
+
+        $this->assertEquals(Type::array(Type::object(Dummy::class)), $resolver->resolve($reflection->getProperty('arrayOfDummies')));
+        $this->assertEquals(Type::object(Dummy::class), $resolver->resolve($reflection->getMethod('getNextDummy')));
+        $this->assertEquals(Type::object(Dummy::class), $resolver->resolve($reflection->getMethod('getNextDummy')->getParameters()[0]));
+    }
+
+    public function testFallbackWhenNoPhpDoc()
+    {
+        $resolver = new PhpDocAwareReflectionTypeResolver(TypeResolver::create(), new StringTypeResolver(), new TypeContextFactory());
+        $reflection = new \ReflectionClass(Dummy::class);
+
+        $this->assertEquals(Type::int(), $resolver->resolve($reflection->getProperty('id')));
+        $this->assertEquals(Type::int(), $resolver->resolve($reflection->getMethod('getId')));
+        $this->assertEquals(Type::int(), $resolver->resolve($reflection->getMethod('setId')->getParameters()[0]));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/TypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/TypeResolverTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\TypeInfo\Type;
@@ -38,7 +37,7 @@ class TypeResolverTest extends TestCase
         $this->expectException(UnsupportedException::class);
         $this->expectExceptionMessage('Cannot find any resolver for "int" type.');
 
-        $resolver = new TypeResolver(new ServiceLocator([]));
+        $resolver = TypeResolver::create([]);
         $resolver->resolve(1);
     }
 
@@ -59,13 +58,13 @@ class TypeResolverTest extends TestCase
         $reflectionReturnTypeResolver = $this->createMock(TypeResolverInterface::class);
         $reflectionReturnTypeResolver->method('resolve')->willReturn(Type::template('REFLECTION_RETURN_TYPE'));
 
-        $resolver = new TypeResolver(new ServiceLocator([
-            'string' => fn () => $stringResolver,
-            \ReflectionType::class => fn () => $reflectionTypeResolver,
-            \ReflectionParameter::class => fn () => $reflectionParameterResolver,
-            \ReflectionProperty::class => fn () => $reflectionPropertyResolver,
-            \ReflectionFunctionAbstract::class => fn () => $reflectionReturnTypeResolver,
-        ]));
+        $resolver = TypeResolver::create([
+            'string' => $stringResolver,
+            \ReflectionType::class => $reflectionTypeResolver,
+            \ReflectionParameter::class => $reflectionParameterResolver,
+            \ReflectionProperty::class => $reflectionPropertyResolver,
+            \ReflectionFunctionAbstract::class => $reflectionReturnTypeResolver,
+        ]);
 
         $this->assertEquals(Type::template('STRING'), $resolver->resolve('foo'));
         $this->assertEquals(

--- a/src/Symfony/Component/TypeInfo/TypeResolver/PhpDocAwareReflectionTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/PhpDocAwareReflectionTypeResolver.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\TypeResolver;
+
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeContext\TypeContext;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolverInterface;
+
+/**
+ * Resolves type on reflection prioriziting PHP documentation.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @internal
+ */
+final readonly class PhpDocAwareReflectionTypeResolver implements TypeResolverInterface
+{
+    public function __construct(
+        private TypeResolverInterface $reflectionTypeResolver,
+        private TypeResolverInterface $stringTypeResolver,
+        private TypeContextFactory $typeContextFactory,
+        private PhpDocParser $phpDocParser = new PhpDocParser(new TypeParser(), new ConstExprParser()),
+        private Lexer $lexer = new Lexer(),
+    ) {
+    }
+
+    public function resolve(mixed $subject, ?TypeContext $typeContext = null): Type
+    {
+        if (!$subject instanceof \ReflectionProperty && !$subject instanceof \ReflectionParameter && !$subject instanceof \ReflectionFunctionAbstract) {
+            throw new UnsupportedException(sprintf('Expected subject to be a "ReflectionProperty", a "ReflectionParameter" or a "ReflectionFunctionAbstract", "%s" given.', get_debug_type($subject)), $subject);
+        }
+
+        $docComment = match (true) {
+            $subject instanceof \ReflectionProperty => $subject->getDocComment(),
+            $subject instanceof \ReflectionParameter => $subject->getDeclaringFunction()->getDocComment(),
+            $subject instanceof \ReflectionFunctionAbstract => $subject->getDocComment(),
+        };
+
+        if (!$docComment) {
+            return $this->reflectionTypeResolver->resolve($subject);
+        }
+
+        $typeContext ??= $this->typeContextFactory->createFromReflection($subject);
+
+        $tagName = match (true) {
+            $subject instanceof \ReflectionProperty => '@var',
+            $subject instanceof \ReflectionParameter => '@param',
+            $subject instanceof \ReflectionFunctionAbstract => '@return',
+        };
+
+        $tokens = new TokenIterator($this->lexer->tokenize($docComment));
+        $docNode = $this->phpDocParser->parse($tokens);
+
+        foreach ($docNode->getTagsByName($tagName) as $tag) {
+            $tagValue = $tag->value;
+
+            if (
+                $tagValue instanceof VarTagValueNode
+                || $tagValue instanceof ParamTagValueNode && $tagName && '$'.$subject->getName() === $tagValue->parameterName
+                || $tagValue instanceof ReturnTagValueNode
+            ) {
+                return $this->stringTypeResolver->resolve((string) $tagValue, $typeContext);
+            }
+        }
+
+        return $this->reflectionTypeResolver->resolve($subject);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -58,13 +58,10 @@ final class StringTypeResolver implements TypeResolverInterface
      */
     private static array $classExistCache = [];
 
-    private readonly Lexer $lexer;
-    private readonly TypeParser $parser;
-
-    public function __construct()
-    {
-        $this->lexer = new Lexer();
-        $this->parser = new TypeParser(new ConstExprParser());
+    public function __construct(
+        private Lexer $lexer = new Lexer(),
+        private TypeParser $parser = new TypeParser(new ConstExprParser()),
+    ) {
     }
 
     public function resolve(mixed $subject, ?TypeContext $typeContext = null): Type


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

Add a `PhpDocAwareReflectionTypeResolver` that resolves type on reflections prioritizing PHP documentation. 
The same feature already exists in the `PropertyInfo` component and improves DX a lot.
Installing `phpstan/phpdoc-parser` automatically enables this feature both using the type-info component standalone and the fullstack framework.