### PR TITLE
[Console] Skip broken tests on OSX

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1977,6 +1977,7 @@ class ApplicationTest extends TestCase
 
     /**
      * @requires extension pcntl
+     * @requires OSFAMILY !Darwin
      */
     public function testSignalListener()
     {
@@ -2015,6 +2016,7 @@ class ApplicationTest extends TestCase
 
     /**
      * @requires extension pcntl
+     * @requires OSFAMILY !Darwin
      */
     public function testSignalSubscriber()
     {
@@ -2036,6 +2038,7 @@ class ApplicationTest extends TestCase
 
     /**
      * @requires extension pcntl
+     * @requires OSFAMILY !Darwin
      */
     public function testSignalDispatchWithoutEventToDispatch()
     {
@@ -2050,6 +2053,7 @@ class ApplicationTest extends TestCase
 
     /**
      * @requires extension pcntl
+     * @requires OSFAMILY !Darwin
      */
     public function testSignalDispatchWithoutEventDispatcher()
     {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 6.4 (and probably bellow)
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | ø <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT


On OSX running the following command results in the test being abrutply terminated:

```shell
./phpunit src/Symfony/Component/Console/
```

I could narrow it down to `src/Symfony/Component/Console/Tests/ApplicationTest.php`. I think this is a bug from the pcntl extensions as running any problematic test individual result in a successful test and I cannot find any static state that should interfere with this (at least at the Symfony code level). 

My observations are that the application instance, which is the `$this`, of [this closure](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Console/Application.php#L1035), changes when executing the whole test case.

I'm unsure where to start to report this to PHP and would appreciate some help there or at least to confirm this is not a Symfony issue but a PHP one.

Meanwhile I could observe this behaviour on different machines including @chalasr. So I'm proposing to disable those problematic tests for OSX meanwhile as otherwise the test suite is not even executable on OSX.

FWIW ran it with:

OSX: 14.5 (23F79) on M3
PHP: 8.3.8
pcntl enabled (compiled PHP with `--enable-pcntl`)
