### PR TITLE
[Mailer]  force HTTP 1.1 for Mailgun API requests

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -61,6 +61,7 @@ class MailgunApiTransport extends AbstractApiTransport
 
         $endpoint = sprintf('%s/v3/%s/messages', $this->getEndpoint(), urlencode($this->domain));
         $response = $this->client->request('POST', 'https://'.$endpoint, [
+            'http_version' => '1.1',
             'auth_basic' => 'api:'.$this->key,
             'headers' => $headers,
             'body' => $body->bodyToIterable(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57544, Fix https://github.com/symfony/symfony/pull/57569#issuecomment-2200588448
| License       | MIT
