### PR TITLE
[Security] Throw a forbidden exception when the IsCsrfTokenValid attribute fails

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -30,6 +30,15 @@ HttpFoundation
 
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()`
 
+Security
+--------
+
+ * [BC BREAK] A failing `#[IsCsrfTokenValid]` attribute now throws
+   `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException`, which extends `HttpException` and
+   carries a 403 status, instead of `Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException`, which
+   extends `AuthenticationException`. The firewall no longer turns the failure into a login redirect or a 401, and
+   code catching the `Security\Core` exception for this case must catch the `Security\Http` one instead
+
 SecurityBundle
 --------------
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `allowed_time_drift` option to `OidcTokenHandler` to configure time tolerance for token validation (`iat`, `nbf`, `exp` claims)
+ * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
+use Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException;
 
 /**
  * Handles the IsCsrfTokenValid attribute on controllers.
@@ -70,7 +70,7 @@ final class IsCsrfTokenValidAttributeListener implements EventSubscriberInterfac
             null === $tokenValue
             || !$this->csrfTokenManager->isTokenValid(new CsrfToken($id, $tokenValue))
         ) {
-            throw new InvalidCsrfTokenException('Invalid CSRF token.');
+            throw new InvalidCsrfTokenException();
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Exception/InvalidCsrfTokenException.php
+++ b/src/Symfony/Component/Security/Http/Exception/InvalidCsrfTokenException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Thrown when the CSRF token checked by the #[IsCsrfTokenValid] attribute is invalid.
+ *
+ * Unlike its Security\Core counterpart, which reports an authentication failure, this one
+ * reports a forbidden request: the controller is reached by an already identified caller.
+ *
+ * @author Roman JOLY <eltharin18@outlook.fr>
+ */
+class InvalidCsrfTokenException extends HttpException
+{
+    public function __construct(string $message = 'Invalid CSRF token.', ?\Throwable $previous = null, int $code = 0, array $headers = [])
+    {
+        parent::__construct(403, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
@@ -22,11 +22,12 @@ use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 use Symfony\Component\Security\Http\EventListener\IsCsrfTokenValidAttributeListener;
+use Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsCsrfTokenValidAttributeController;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsCsrfTokenValidAttributeMethodsController;
 
@@ -224,6 +225,30 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
 
         $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
         $listener->onKernelControllerArguments($event);
+    }
+
+    public function testTheThrownExceptionCarriesA403StatusAndIsNotAnAuthenticationFailure()
+    {
+        $request = new Request([], ['_token' => 'bar']);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            [new IsCsrfTokenValidAttributeMethodsController(), 'withInvalidTokenKey'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($this->createStub(CsrfTokenManagerInterface::class));
+
+        try {
+            $listener->onKernelControllerArguments($event);
+            $this->fail('Expected an InvalidCsrfTokenException.');
+        } catch (InvalidCsrfTokenException $e) {
+            $this->assertSame(403, $e->getStatusCode());
+            // an AuthenticationException would be turned into a login redirect by the firewall
+            $this->assertNotInstanceOf(AuthenticationException::class, $e);
+        }
     }
 
     public function testIsCsrfTokenValidThrowExceptionWhenInvalidMatchingToken()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57343
| License       | MIT

`IsCsrfTokenValidAttributeListener` threw `Security\Core\Exception\InvalidCsrfTokenException`, which extends `AuthenticationException`. `Security\Http\Firewall\ExceptionListener` matches that before anything else and routes it to `startAuthentication()`, so a CSRF failure inside a controller redirected to the login page, or returned 401 when the firewall has no entry point.

The Core exception is the right one for the authentication-time check in `CsrfProtectionListener`, where the login form's token is verified. It is the wrong one for a controller attribute, which is reached by a caller who is already identified. That is the distinction @stof drew when the attribute was added.

A new `Security\Http\Exception\InvalidCsrfTokenException` extending `HttpException` with a 403 status replaces it, matching what `IsGrantedAttributeListener` already throws when a status code is configured.

Measured end to end with a real kernel, the real `ControllerAttributesListener`, the real firewall `ExceptionListener` and `debug=false`:

| firewall | before | after |
| --- | --- | --- |
| `form_login` entry point | 302 to /login | 403 |
| no entry point | 401 | 403 |
| `http_basic` entry point | 401 with `WWW-Authenticate` | 403 |
| no firewall exception listener | 401, from `#[WithHttpStatus]` | 403 |

No path produces a 500, and none produces a 401 afterwards. The exception message is unchanged and is not exposed any differently: hidden by both renderers when `debug=false`, and the JSON problem detail moves from `"Unauthorized"` to `"Forbidden"`, which is the status text rather than the message.

Changed during review:

* the CHANGELOG entry moved from `SecurityBundle` to `Security\Http`, where the changed class lives, and into the 8.2 section. It had landed in the 7.3 section after rebasing. This is what @kbond asked for;
* added the `[BC BREAK]` entry in `UPGRADE-8.2.md`. Two things need it: the old and new exceptions share no ancestor below `\RuntimeException`, so an application catching the `Security\Core` one for this case silently stops matching, and stateless firewalls move from 401 to 403;
* added a test for the behaviour rather than only the class name. The suite asserted which exception was thrown and nothing else, so reparenting the class onto something the firewall matches would have kept it green. The new test asserts the 403 status and that the exception is not an `AuthenticationException`, and it fails on a clean 8.2;
* the redundant explicit message at the call site is gone, and the two same-named exceptions no longer carry identical docblocks.

Left as is deliberately: the parent stays `HttpException` rather than the `BadRequestHttpException` suggested in review, because that class means 400 and the constructor would have to bypass its parent to force 403. @webda2l's request for a configurable `statusCode` like `IsGranted` is not implemented here.
