### PR TITLE
[DoctrineBridge] Make `EntityValueResolver` return `null` if a composite ID value is `null`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -104,6 +104,9 @@ final class EntityValueResolver implements ValueResolverInterface
         if (false === $id || null === $id) {
             return $id;
         }
+        if (\is_array($id) && \in_array(null, $id, true)) {
+            return null;
+        }
 
         if ($options->evictCache && $manager instanceof EntityManagerInterface) {
             $cacheProvider = $manager->getCache();

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -144,6 +144,20 @@ class EntityValueResolverTest extends TestCase
         $this->assertSame([null], $resolver->resolve($request, $argument));
     }
 
+    public function testResolveWithArrayIdNullValue()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('nullValue', null);
+
+        $argument = $this->createArgument(entity: new MapEntity(id: ['nullValue']), isNullable: true,);
+
+        $this->assertSame([null], $resolver->resolve($request, $argument));
+    }
+
     public function testResolveWithConversionFailedException()
     {
         $manager = $this->getMockBuilder(ObjectManager::class)->getMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

My use-case is the upsert of an entity identified by two values. I have an `update` route with these two values as route parameters, and a `create` route with only one. In that case the second value is `null` but the `EntityValueResolver` will still call the repository’s `find` method, resulting in a `MissingIdentifierField` exception:

> The identifier [VALUE] is missing for a query of [ENTITY]

This PR makes the `EntityValueResolver` return `null` in this case, like when a scalar ID is `null`.