### PR TITLE
[String] test: kebab-case to snake_case

### DIFF
--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1070,6 +1070,8 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['x_y', 'x_y'],
             ['x_y', 'X_Y'],
             ['xu_yo', 'xu_yo'],
+            ['symfony_is_great', 'symfony-is-great'],
+            ['symfony_is_great', 'symfony.is.great'],
             ['symfony_is_great', 'symfonyIsGreat'],
             ['symfony5_is_great', 'symfony5IsGreat'],
             ['symfony5is_great', 'symfony5isGreat'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes?
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In Symfony 7.1.1, `kebab-case` strings casted to `snake_case` properly. The changes made in 7.1.2 broke this functionality and kept it `kebab-case`.

It would be nice to have a `kebab-case` test added to the list to clearly define the expected behavior.

Relates to: #57497, #57612, #57616
