### PR TITLE
[Routing] Remove dead `is_object()` check

### DIFF
--- a/src/Symfony/Component/Routing/Loader/ObjectLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectLoader.php
@@ -44,10 +44,6 @@ abstract class ObjectLoader extends Loader
 
         $loaderObject = $this->getObject($parts[0]);
 
-        if (!\is_object($loaderObject)) {
-            throw new \TypeError(\sprintf('"%s:getObject()" must return an object: "%s" returned.', static::class, get_debug_type($loaderObject)));
-        }
-
         if (!\is_callable([$loaderObject, $method])) {
             throw new \BadMethodCallException(\sprintf('Method "%s" not found on "%s" when importing routing resource "%s".', $method, get_debug_type($loaderObject), $resource));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Right after we call `ObjectLoader::getObject()`, we check if the returned value is actually an object. Since 6.0 (#42509), that method has a native return type of `object`, so we can be pretty sure that we won't ever not hold an object in our hands here.