### PR TITLE
[Routing] Discard in-memory cache of routes when writing the file-based cache

### DIFF
--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -294,6 +294,7 @@ class Router implements RouterInterface, RequestMatcherInterface
                 }
 
                 $cache->write($dumper->dump(), $this->getRouteCollection()->getResources());
+                unset(self::$cache[$cache->getPath()]);
             }
         );
 
@@ -325,6 +326,7 @@ class Router implements RouterInterface, RequestMatcherInterface
                     $dumper = $this->getGeneratorDumperInstance();
 
                     $cache->write($dumper->dump(), $this->getRouteCollection()->getResources());
+                    unset(self::$cache[$cache->getPath()]);
                 }
             );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57640
| License       | MIT

The `Router` has a `private static ?array $cache` field that it uses to cache compiled route collections in the case that OpCache is not available to cache the file-based cache already. This is somewhat [a poor man's Opcache replacement](https://github.com/symfony/symfony/issues/57640#issuecomment-2208373009), useful e. g. for speedups during (functional) tests.

`\Symfony\Component\Config\ResourceCheckerConfigCache::write` contains special code to make sure the OpCache will reload files after they have been written, but the `static` property kind of "hides" this feature.

With this PR, the `static` cache entry is cleared as well.