### PR TITLE
[Serializer] Raise correct exception in `ArrayDenormalizer` when called without a nested denormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -42,7 +42,7 @@ class ArrayDenormalizer implements DenormalizerInterface, DenormalizerAwareInter
      */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): array
     {
-        if (null === $this->denormalizer) {
+        if (!isset($this->denormalizer)) {
             throw new BadMethodCallException('Please set a denormalizer before calling denormalize()!');
         }
         if (!\is_array($data)) {
@@ -72,7 +72,7 @@ class ArrayDenormalizer implements DenormalizerInterface, DenormalizerAwareInter
 
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        if (null === $this->denormalizer) {
+        if (!isset($this->denormalizer)) {
             throw new BadMethodCallException(sprintf('The nested denormalizer needs to be set to allow "%s()" to be used.', __METHOD__));
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -108,6 +108,22 @@ class ArrayDenormalizerTest extends TestCase
             )
         );
     }
+
+    public function testDenormalizeWithoutDenormalizer()
+    {
+        $arrayDenormalizer = new ArrayDenormalizer();
+
+        $this->expectException(\BadMethodCallException::class);
+        $arrayDenormalizer->denormalize([], 'string[]');
+    }
+
+    public function testSupportsDenormalizationWithoutDenormalizer()
+    {
+        $arrayDenormalizer = new ArrayDenormalizer();
+
+        $this->expectException(\BadMethodCallException::class);
+        $arrayDenormalizer->supportsDenormalization([], 'string[]');
+    }
 }
 
 class ArrayDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The `$denormalizer` property is not nullable and will be uninitialized by default. Because of that, the check that makes sure that the ArrayDenormalizer is not used before setting a nested denormalizer will produce an obscure error instead of raising the proper exception.