### PR TITLE
[Serializer] Remove `ArrayDenormalizer::setDenormalizer()`

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -29,11 +29,6 @@ class ArrayDenormalizer implements DenormalizerInterface, DenormalizerAwareInter
 {
     use DenormalizerAwareTrait;
 
-    public function setDenormalizer(DenormalizerInterface $denormalizer): void
-    {
-        $this->denormalizer = $denormalizer;
-    }
-
     public function getSupportedTypes(?string $format): array
     {
         return ['object' => null, '*' => false];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

`ArrayDenormalizer::setDenormalizer()` contains the same implementation as `DenormalizerAwareTrait::setDenormalizer()` which is why I believe we can safely remove the former.