### PR TITLE
[DependencyInjection] Add `#[Constructor]` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeChildClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeChildClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\TestClasses;
+
+class ConstructorAttributeChildClass extends ConstructorAttributeValidClass
+{
+    public static function childStaticConstructor(): self
+    {
+        return new self();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeChildOverrideClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeChildOverrideClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\TestClasses;
+
+use Symfony\Component\DependencyInjection\Attribute\Constructor;
+
+class ConstructorAttributeChildOverrideClass extends ConstructorAttributeValidClass
+{
+    #[Constructor]
+    public static function childStaticConstructor(): self
+    {
+        return new self();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeMultipleOnSameClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeMultipleOnSameClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\TestClasses;
+
+use Symfony\Component\DependencyInjection\Attribute\Constructor;
+
+class ConstructorAttributeMultipleOnSameClass
+{
+    #[Constructor]
+    public function staticConstructor(): self
+    {
+        return new self();
+    }
+
+    #[Constructor]
+    public function staticConstructor2(): self
+    {
+        return new self();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeOnNonStaticClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeOnNonStaticClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\TestClasses;
+
+use Symfony\Component\DependencyInjection\Attribute\Constructor;
+
+class ConstructorAttributeOnNonStaticClass
+{
+    #[Constructor]
+    public function nonStaticConstructor(): self
+    {
+        return new self();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeValidClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/TestClasses/ConstructorAttributeValidClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\TestClasses;
+
+use Symfony\Component\DependencyInjection\Attribute\Constructor;
+
+class ConstructorAttributeValidClass
+{
+    #[Constructor]
+    public static function staticConstructor(): self
+    {
+        return new self();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/Constructor.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Constructor.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to define a static method as the service constructor.
+ *
+ * @author Maelan Le Borgne <maelan.leborgne@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class Constructor
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/53605#issuecomment-1905781277
| License       | MIT

## Description

This PR introduces a new `#[Constructor]` attribute to simplify the factory declaration using attributes.  
Right now to declare a factory using attributes, you have to use `#[Autoconfigure(constructor: 'staticMethod')]` on the class.  
This new `#[Constructor]`, applied to a static method, will set it as the factory of the declaring class.

## Example
```php
class MyService
{
    #[Constructor]
    public static function create(/*...*/): self
    {
        /*...*/
    }
    /*....*/
}
```

## Todo

I had some trouble finding a way to test this. There aren't many tests on autoconfiguration callbacks and most of them are copy/paste ([AsMessageHandler autoconfiguration](https://github.com/symfony/symfony/blob/e64bf4e695f84abf4bde17207a52b745cf7ebd74/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L684) and [its test](https://github.com/symfony/symfony/blob/e64bf4e695f84abf4bde17207a52b745cf7ebd74/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php#L797) for example). Any input on how to tests this or where the tests should live would be appreciated.

- [ ] Update CHANGELOG.md
- [ ] Add documentation
- [ ] Cleanup tests