### PR TITLE
[Cache] use copy() instead of rename() on Windows

### DIFF
--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -114,8 +114,13 @@ trait FilesystemCommonTrait
                 touch($this->tmp, $expiresAt ?: time() + 31556952); // 1 year in seconds
             }
 
-            $success = rename($this->tmp, $file);
-            $unlink = !$success;
+            if ('\\' === \DIRECTORY_SEPARATOR) {
+                $success = copy($this->tmp, $file);
+                $unlink = true;
+            } else {
+                $success = rename($this->tmp, $file);
+                $unlink = !$success;
+            }
 
             return $success;
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50326
| License       | MIT

On Windows depending on the PHP version `rename()` can fail if the target file is being executed. Since the source file is not used by another process using `copy()` instead should be safe to be used.
