### PR TITLE
[Filesystem][Messenger][PsrHttpMessageBridge] do not use uniqid() in tests

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Factory/HttpFoundationFactoryTest.php
@@ -172,15 +172,15 @@ class HttpFoundationFactoryTest extends TestCase
         $symfonyUploadedFile = $this->callCreateUploadedFile($uploadedFile);
         $size = $symfonyUploadedFile->getSize();
 
-        $uniqid = uniqid();
-        $symfonyUploadedFile->move($this->tmpDir, $uniqid);
+        $filename = 'upload';
+        $symfonyUploadedFile->move($this->tmpDir, $filename);
 
         $this->assertEquals($uploadedFile->getSize(), $size);
         $this->assertEquals(\UPLOAD_ERR_OK, $symfonyUploadedFile->getError());
         $this->assertEquals('myfile.txt', $symfonyUploadedFile->getClientOriginalName());
         $this->assertEquals('txt', $symfonyUploadedFile->getClientOriginalExtension());
         $this->assertEquals('text/plain', $symfonyUploadedFile->getClientMimeType());
-        $this->assertEquals('An uploaded file.', file_get_contents($this->tmpDir.'/'.$uniqid));
+        $this->assertEquals('An uploaded file.', file_get_contents($this->tmpDir.'/'.$filename));
     }
 
     public function testCreateUploadedFileWithError()

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -863,7 +863,7 @@ class FilesystemTest extends FilesystemTestCase
     public function testRenameThrowsExceptionOnError()
     {
         $this->expectException(IOException::class);
-        $file = $this->workspace.\DIRECTORY_SEPARATOR.uniqid('fs_test_', true);
+        $file = $this->workspace.\DIRECTORY_SEPARATOR.'does-not-exist';
         $newPath = $this->workspace.\DIRECTORY_SEPARATOR.'new_file';
 
         $this->filesystem->rename($file, $newPath);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -413,7 +413,7 @@ class ConnectionTest extends TestCase
         }
 
         $master = getenv('MESSENGER_REDIS_DSN');
-        $uid = uniqid('sentinel_');
+        $uid = random_int(1, PHP_INT_MAX);
 
         $exp = explode('://', $master, 2)[1];
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | part of #57588
| License       | MIT

updates the remaining tests that were not covered by #57665