### PR TITLE
[FrameworkBundle] Add `exit` option to `secrets:decrypt-to-local` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Derivate `kernel.secret` from the decryption secret when its env var is not defined
  * Make the `config/` directory optional in `MicroKernelTrait`, add support for service arguments in the
    invokable Kernel class, and register `FrameworkBundle` by default when the `bundles.php` file is missing
+ * Add `exit` option for `secrets:decrypt-to-local` command
 
 7.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57539 
| License       | MIT

<!--
This merge requests adds a simple 'strict' option to the secrets:decrypt-to-local command which will spit out a non-zero exit code whenever errors happen during reading of a secret.
-->
