### PR TITLE
[Messenger] Let WrappedExceptionsInterface extend the native Throwable interface

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * `WrappedExceptionsInterface` now extends PHP's `Throwable` interface
  * Add `#[AsMessage]` attribute with `$transport` parameter for message routing
  * Add `--format` option to the `messenger:stats` command
 

--- a/src/Symfony/Component/Messenger/Exception/WrappedExceptionsInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/WrappedExceptionsInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Messenger\Exception;
  *
  * @author Jeroen <https://github.com/Jeroeny>
  */
-interface WrappedExceptionsInterface
+interface WrappedExceptionsInterface extends \Throwable
 {
     /**
      * @return \Throwable[]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57667
| License       | MIT

We already did that in the past for `ExceptionInterface` in #28307.