### PR TITLE
[Messenger] Resend failed messages to failure transport using a delay from retry strategy

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -186,6 +186,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('failure transports'),
                 service('logger')->ignoreOnInvalid(),
+                service('messenger.retry_strategy_locator'),
             ])
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'messenger'])

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/FailureTransportIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/FailureTransportIntegrationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Amqp\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Bridge\Amqp\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransport;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Retry\MultiplierRetryStrategy;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Worker;
+
+/**
+ * @requires extension amqp
+ *
+ * @group integration
+ */
+class FailureTransportIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!getenv('MESSENGER_AMQP_DSN')) {
+            $this->markTestSkipped('The "MESSENGER_AMQP_DSN" environment variable is required.');
+        }
+    }
+
+    public function testItDoesNotLoseMessagesFromTheFailedTransport()
+    {
+        $connection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'));
+        $connection->setup();
+        $connection->purgeQueues();
+
+        $failureConnection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'),
+            ['exchange' => [
+                'name' => 'failed',
+                'type' => 'fanout',
+            ], 'queues' => ['failed' => []]]
+        );
+        $failureConnection->setup();
+        $failureConnection->purgeQueues();
+
+        $originalTransport = new AmqpTransport($connection);
+        $failureTransport = new AmqpTransport($failureConnection);
+
+        $retryStrategy = new MultiplierRetryStrategy(1, 100, 2);
+        $retryStrategyLocator = $this->createStub(ContainerInterface::class);
+        $retryStrategyLocator->method('has')->willReturn(true);
+        $retryStrategyLocator->method('get')->willReturn($retryStrategy);
+
+        $sendersLocatorFailureTransport = new ServiceLocator([
+            'original' => static fn () => $failureTransport,
+        ]);
+
+        $transports = [
+            'original' => $originalTransport,
+            'failed' => $failureTransport,
+        ];
+
+        $locator = $this->createStub(ContainerInterface::class);
+        $locator->method('has')->willReturn(true);
+        $locator->method('get')->willReturnCallback(static fn ($transportName) => $transports[$transportName]);
+        $senderLocator = new SendersLocator(
+            [DummyMessage::class => ['original']],
+            $locator
+        );
+
+        $timesHandled = 0;
+
+        $handler = static function () use (&$timesHandled) {
+            ++$timesHandled;
+            throw new \Exception('Handler failed');
+        };
+
+        $handlerLocator = new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler, ['from_transport' => 'original'])],
+        ]);
+
+        $bus = new MessageBus([
+            new FailedMessageProcessingMiddleware(),
+            new SendMessageMiddleware($senderLocator),
+            new HandleMessageMiddleware($handlerLocator),
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new SendFailedMessageForRetryListener($locator, $retryStrategyLocator));
+        $dispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener(
+            $sendersLocatorFailureTransport, null, $retryStrategyLocator
+        ));
+        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+        $dispatcher->addSubscriber(new StopWorkerOnTimeLimitListener(2));
+
+        $originalTransport->send(Envelope::wrap(new DummyMessage('dummy')));
+
+        $runWorker = static function (string $transportName) use ($bus, $dispatcher, $transports): void {
+            (new Worker(
+                [$transportName => $transports[$transportName]],
+                $bus,
+                $dispatcher,
+            ))->run();
+        };
+
+        $runWorker('original');
+        $runWorker('original');
+        $runWorker('failed');
+        $runWorker('failed');
+
+        $this->assertSame(4, $timesHandled);
+        $failedMessage = $this->waitForFailedMessage($failureTransport, 2);
+        // 100 delay * 2 multiplier ^ 3 retries = 800 expected delay
+        $this->assertSame(800, $failedMessage->last(DelayStamp::class)->getDelay());
+        $this->assertSame(0, $failedMessage->last(RedeliveryStamp::class)->getRetryCount());
+        $this->assertCount(4, $failedMessage->all(RedeliveryStamp::class));
+        $this->assertCount(2, $failedMessage->all(SentToFailureTransportStamp::class));
+        foreach ($failedMessage->all(SentToFailureTransportStamp::class) as $stamp) {
+            $this->assertSame('original', $stamp->getOriginalReceiverName());
+        }
+    }
+
+    private function waitForFailedMessage(AmqpTransport $failureTransport, int $timeOutInS): Envelope
+    {
+        $start = microtime(true);
+        while (microtime(true) - $start < $timeOutInS) {
+            $envelopes = iterator_to_array($failureTransport->get());
+            if (\count($envelopes) > 0) {
+                foreach ($envelopes as $envelope) {
+                    $failureTransport->reject($envelope);
+                }
+
+                return $envelopes[0];
+            }
+            usleep(100 * 1000);
+        }
+        throw new \RuntimeException('Message was not received from failure transport within expected timeframe.');
+    }
+}

--- a/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
@@ -78,7 +78,7 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
      */
     public function getWaitingTime(Envelope $message, ?\Throwable $throwable = null): int
     {
-        $retries = RedeliveryStamp::getRetryCountFromEnvelope($message);
+        $retries = \count($message->all(RedeliveryStamp::class));
 
         $delay = $this->delayMilliseconds * $this->multiplier ** $retries;
 

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
@@ -27,6 +30,11 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $sender = $this->createMock(SenderInterface::class);
         $sender->expects($this->once())->method('send')->with($this->callback(function ($envelope) use ($receiverName) {
             $this->assertInstanceOf(Envelope::class, $envelope);
+
+            $delayStamp = $envelope->last(DelayStamp::class);
+            $this->assertNotNull($delayStamp);
+            $this->assertSame(5000, $delayStamp->getDelay());
+
             $sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class);
             $this->assertNotNull($sentToFailureTransportStamp);
             $this->assertSame($receiverName, $sentToFailureTransportStamp->getOriginalReceiverName());
@@ -35,8 +43,38 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         }))->willReturnArgument(0);
 
         $serviceLocator = new ServiceLocator([
-            $receiverName => fn () => $sender,
+            $receiverName => static fn () => $sender,
         ]);
+
+        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStrategy->expects($this->once())->method('getWaitingTime')->willReturn(5000);
+
+        $retryStrategyLocator = $this->createMock(ServiceLocator::class);
+        $retryStrategyLocator->expects($this->once())->method('has')->with($receiverName)->willReturn(true);
+        $retryStrategyLocator->expects($this->once())->method('get')->with($receiverName)->willReturn($retryStrategy);
+
+        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator, null, $retryStrategyLocator);
+
+        $exception = new \Exception('no!');
+        $envelope = new Envelope(new \stdClass());
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
+
+        $listener->onMessageFailed($event);
+    }
+
+    public function testItSendsToTheFailureTransportWithoutRetryStrategyLocator()
+    {
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->once())->method('send')->with($this->callback(function (Envelope $envelope) {
+            $this->assertSame(0, $envelope->last(DelayStamp::class)->getDelay());
+
+            return true;
+        }))->willReturnArgument(0);
+
+        $serviceLocator = $this->createStub(ServiceLocator::class);
+        $serviceLocator->method('has')->willReturn(true);
+        $serviceLocator->method('get')->willReturn($sender);
+
         $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);
 
         $exception = new \Exception('no!');
@@ -51,7 +89,8 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $sender = $this->createMock(SenderInterface::class);
         $sender->expects($this->never())->method('send');
 
-        $listener = new SendFailedMessageToFailureTransportListener(new ServiceLocator([]));
+        $retryStrategyLocator = $this->createStub(ServiceLocator::class);
+        $listener = new SendFailedMessageToFailureTransportListener(new ServiceLocator([]), null, $retryStrategyLocator);
 
         $envelope = new Envelope(new \stdClass());
         $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \Exception());
@@ -60,18 +99,41 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $listener->onMessageFailed($event);
     }
 
-    public function testDoNotRedeliverToFailedWithServiceLocator()
+    public function testDoRedeliverToFailedWithServiceLocator()
     {
         $receiverName = 'my_receiver';
+        $failedReceiver = 'failed_receiver';
 
         $sender = $this->createMock(SenderInterface::class);
-        $sender->expects($this->never())->method('send');
+        $sender->expects($this->once())->method('send')->with($this->callback(function (Envelope $envelope) use ($receiverName) {
+            $delayStamp = $envelope->last(DelayStamp::class);
+            $this->assertNotNull($delayStamp);
+            $this->assertSame(1000, $delayStamp->getDelay());
 
-        $listener = new SendFailedMessageToFailureTransportListener(new ServiceLocator([]));
+            $sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class);
+            $this->assertNotNull($sentToFailureTransportStamp);
+            $this->assertSame($receiverName, $sentToFailureTransportStamp->getOriginalReceiverName());
+
+            return true;
+        }))->willReturnArgument(0);
+
+        $serviceLocator = new ServiceLocator([
+            $receiverName => static fn () => $sender,
+        ]);
+
+        $retryStrategy = $this->createStub(RetryStrategyInterface::class);
+        $retryStrategy->method('getWaitingTime')->willReturn(1000);
+        $retryStrategyLocator = $this->createMock(ServiceLocator::class);
+        $retryStrategyLocator->expects($this->once())->method('has')->willReturn(true);
+        $retryStrategyLocator->expects($this->once())->method('get')->with($failedReceiver)->willReturn($retryStrategy);
+
+        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator, null, $retryStrategyLocator);
         $envelope = new Envelope(new \stdClass(), [
+            // the received stamp is assumed to be added by the FailedMessageProcessingMiddleware
+            new ReceivedStamp($receiverName),
             new SentToFailureTransportStamp($receiverName),
         ]);
-        $event = new WorkerMessageFailedEvent($envelope, $receiverName, new \Exception());
+        $event = new WorkerMessageFailedEvent($envelope, $failedReceiver, new \Exception());
 
         $listener->onMessageFailed($event);
     }
@@ -104,7 +166,7 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         }))->willReturnArgument(0);
 
         $serviceLocator = new ServiceLocator([
-            $receiverName => fn () => $sender,
+            $receiverName => static fn () => $sender,
         ]);
 
         $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);

--- a/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Messenger\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Psr\Log\NullLogger;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Messenger\Envelope;
@@ -56,8 +55,8 @@ class FailureIntegrationTest extends TestCase
         $transport2 = new DummyFailureTestSenderAndReceiver();
         $failureTransport = new DummyFailureTestSenderAndReceiver();
         $sendersLocatorFailureTransport = new ServiceLocator([
-            'transport1' => fn () => $failureTransport,
-            'transport2' => fn () => $failureTransport,
+            'transport1' => static fn () => $failureTransport,
+            'transport2' => static fn () => $failureTransport,
         ]);
 
         $transports = [
@@ -72,7 +71,7 @@ class FailureIntegrationTest extends TestCase
             ->willReturn(true);
         $locator->expects($this->any())
             ->method('get')
-            ->willReturnCallback(fn ($transportName) => $transports[$transportName]);
+            ->willReturnCallback(static fn ($transportName) => $transports[$transportName]);
         $senderLocator = new SendersLocator(
             [DummyMessage::class => ['transport1', 'transport2']],
             $locator
@@ -115,12 +114,16 @@ class FailureIntegrationTest extends TestCase
         $dispatcher->addSubscriber(new AddErrorDetailsStampListener());
         $dispatcher->addSubscriber(new SendFailedMessageForRetryListener($locator, $retryStrategyLocator));
 
-        $dispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener($sendersLocatorFailureTransport));
+        $dispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener(
+            $sendersLocatorFailureTransport,
+            null,
+            $retryStrategyLocator
+        ));
         $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
 
-        $runWorker = function (string $transportName) use ($transports, $bus, $dispatcher): ?\Throwable {
+        $runWorker = static function (string $transportName) use ($transports, $bus, $dispatcher): ?\Throwable {
             $throwable = null;
-            $failedListener = function (WorkerMessageFailedEvent $event) use (&$throwable) {
+            $failedListener = static function (WorkerMessageFailedEvent $event) use (&$throwable) {
                 $throwable = $event->getThrowable();
             };
             $dispatcher->addListener(WorkerMessageFailedEvent::class, $failedListener);
@@ -195,14 +198,14 @@ class FailureIntegrationTest extends TestCase
         $this->assertCount(1, $transport2->getMessagesWaitingToBeReceived());
 
         /*
-         * Message is retried on failure transport then discarded
+         * Message is retried on failure transport then re-queued
          */
         $runWorker('the_failure_transport');
         // only the "failed" handler is called a 4th time
         $this->assertSame(4, $transport1HandlerThatFails->getTimesCalled());
         $this->assertSame(1, $allTransportHandlerThatWorks->getTimesCalled());
-        // handling fails again, message is discarded
-        $this->assertCount(0, $failureTransport->getMessagesWaitingToBeReceived());
+        // handling fails again, message is re-queued with a delay
+        $this->assertCount(1, $failureTransport->getMessagesWaitingToBeReceived());
 
         /*
          * Execute handlers on transport2
@@ -214,10 +217,10 @@ class FailureIntegrationTest extends TestCase
         $this->assertSame(2, $allTransportHandlerThatWorks->getTimesCalled());
         // transport1 handler called for the first time
         $this->assertSame(1, $transport2HandlerThatWorks->getTimesCalled());
-        // all transport should be empty
+        // all original transports should be empty - failed queue still holds the message
         $this->assertEmpty($transport1->getMessagesWaitingToBeReceived());
         $this->assertEmpty($transport2->getMessagesWaitingToBeReceived());
-        $this->assertEmpty($failureTransport->getMessagesWaitingToBeReceived());
+        $this->assertCount(1, $failureTransport->getMessagesWaitingToBeReceived());
 
         /*
          * Dispatch the original message again
@@ -226,9 +229,18 @@ class FailureIntegrationTest extends TestCase
         // handle the failing message so it goes into the failure transport
         $runWorker('transport1');
         $runWorker('transport1');
+        $this->assertCount(2, $failureTransport->getMessagesWaitingToBeReceived());
         // now make the handler work!
         $transport1HandlerThatFails->setShouldThrow(false);
         $runWorker('the_failure_transport');
+        $runWorker('the_failure_transport');
+
+        // the message is now handled and the failure transport is empty
+        // transport1Handler is called 4 more times - 2 retries and twice successfully from failure transport
+        $this->assertSame(8, $transport1HandlerThatFails->getTimesCalled());
+        $this->assertSame(3, $allTransportHandlerThatWorks->getTimesCalled());
+        $this->assertSame(1, $transport2HandlerThatWorks->getTimesCalled());
+
         // the failure transport is empty because it worked
         $this->assertEmpty($failureTransport->getMessagesWaitingToBeReceived());
     }
@@ -241,8 +253,8 @@ class FailureIntegrationTest extends TestCase
         $failureTransport2 = new DummyFailureTestSenderAndReceiver();
 
         $sendersLocatorFailureTransport = new ServiceLocator([
-            'transport1' => fn () => $failureTransport1,
-            'transport2' => fn () => $failureTransport2,
+            'transport1' => static fn () => $failureTransport1,
+            'transport2' => static fn () => $failureTransport2,
         ]);
 
         $transports = [
@@ -258,7 +270,7 @@ class FailureIntegrationTest extends TestCase
             ->willReturn(true);
         $locator->expects($this->any())
             ->method('get')
-            ->willReturnCallback(fn ($transportName) => $transports[$transportName]);
+            ->willReturnCallback(static fn ($transportName) => $transports[$transportName]);
         $senderLocator = new SendersLocator(
             [DummyMessage::class => ['transport1', 'transport2']],
             $locator
@@ -297,13 +309,14 @@ class FailureIntegrationTest extends TestCase
         $dispatcher->addSubscriber(new SendFailedMessageForRetryListener($locator, $retryStrategyLocator));
         $dispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener(
             $sendersLocatorFailureTransport,
-            new NullLogger()
+            null,
+            $retryStrategyLocator,
         ));
         $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
 
-        $runWorker = function (string $transportName) use ($transports, $bus, $dispatcher): ?\Throwable {
+        $runWorker = static function (string $transportName) use ($transports, $bus, $dispatcher): ?\Throwable {
             $throwable = null;
-            $failedListener = function (WorkerMessageFailedEvent $event) use (&$throwable) {
+            $failedListener = static function (WorkerMessageFailedEvent $event) use (&$throwable) {
                 $throwable = $event->getThrowable();
             };
             $dispatcher->addListener(WorkerMessageFailedEvent::class, $failedListener);
@@ -342,7 +355,8 @@ class FailureIntegrationTest extends TestCase
         // "transport1" handler is called again from the "the_failed_transport1" and it fails
         $this->assertSame(2, $transport1HandlerThatFails->getTimesCalled());
         $this->assertSame(0, $transport2HandlerThatFails->getTimesCalled());
-        $this->assertCount(0, $failureTransport1->getMessagesWaitingToBeReceived());
+        // message is not discarded but remains in failed transport
+        $this->assertCount(1, $failureTransport1->getMessagesWaitingToBeReceived());
         $this->assertCount(0, $failureTransport2->getMessagesWaitingToBeReceived());
 
         // Receive the message from "transport2"
@@ -351,7 +365,7 @@ class FailureIntegrationTest extends TestCase
         $this->assertSame(2, $transport1HandlerThatFails->getTimesCalled());
         // handler for "transport2" is called
         $this->assertSame(1, $transport2HandlerThatFails->getTimesCalled());
-        $this->assertCount(0, $failureTransport1->getMessagesWaitingToBeReceived());
+        $this->assertCount(1, $failureTransport1->getMessagesWaitingToBeReceived());
         // the failure transport "the_failure_transport2" has 1 new message failed from "transport2"
         $this->assertCount(1, $failureTransport2->getMessagesWaitingToBeReceived());
 
@@ -360,9 +374,9 @@ class FailureIntegrationTest extends TestCase
         $this->assertSame(2, $transport1HandlerThatFails->getTimesCalled());
         // "transport2" handler is called again from the "the_failed_transport2" and it fails
         $this->assertSame(2, $transport2HandlerThatFails->getTimesCalled());
-        $this->assertCount(0, $failureTransport1->getMessagesWaitingToBeReceived());
-        // After the message fails again, the message is discarded from the "the_failure_transport2"
-        $this->assertCount(0, $failureTransport2->getMessagesWaitingToBeReceived());
+        $this->assertCount(1, $failureTransport1->getMessagesWaitingToBeReceived());
+        // After the message fails again, the message is re-queued to the "the_failure_transport2"
+        $this->assertCount(1, $failureTransport2->getMessagesWaitingToBeReceived());
     }
 
     public function testStampsAddedByMiddlewaresDontDisappearWhenDelayedMessageFails()
@@ -379,7 +393,7 @@ class FailureIntegrationTest extends TestCase
             ->willReturn(true);
         $locator->expects($this->any())
             ->method('get')
-            ->willReturnCallback(fn ($transportName) => $transports[$transportName]);
+            ->willReturnCallback(static fn ($transportName) => $transports[$transportName]);
         $senderLocator = new SendersLocator([], $locator);
 
         $retryStrategyLocator = $this->createMock(ContainerInterface::class);
@@ -400,7 +414,7 @@ class FailureIntegrationTest extends TestCase
 
         $bus = new MessageBus($middlewareStack);
 
-        $transport1Handler = fn () => $bus->dispatch(new \stdClass(), [new DispatchAfterCurrentBusStamp()]);
+        $transport1Handler = static fn () => $bus->dispatch(new \stdClass(), [new DispatchAfterCurrentBusStamp()]);
 
         $handlerLocator = new HandlersLocator([
             DummyMessage::class => [new HandlerDescriptor($transport1Handler)],
@@ -414,9 +428,9 @@ class FailureIntegrationTest extends TestCase
         $dispatcher->addSubscriber(new SendFailedMessageForRetryListener($locator, $retryStrategyLocator));
         $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
 
-        $runWorker = function (string $transportName) use ($transports, $bus, $dispatcher): ?\Throwable {
+        $runWorker = static function (string $transportName) use ($transports, $bus, $dispatcher): ?\Throwable {
             $throwable = null;
-            $failedListener = function (WorkerMessageFailedEvent $event) use (&$throwable) {
+            $failedListener = static function (WorkerMessageFailedEvent $event) use (&$throwable) {
                 $throwable = $event->getThrowable();
             };
             $dispatcher->addListener(WorkerMessageFailedEvent::class, $failedListener);
@@ -460,7 +474,7 @@ class FailureIntegrationTest extends TestCase
             ->willReturn(true);
         $locator->expects($this->any())
             ->method('get')
-            ->willReturnCallback(fn ($transportName) => $transports[$transportName]);
+            ->willReturnCallback(static fn ($transportName) => $transports[$transportName]);
         $senderLocator = new SendersLocator([], $locator);
 
         $retryStrategyLocator = $this->createMock(ContainerInterface::class);
@@ -483,7 +497,7 @@ class FailureIntegrationTest extends TestCase
 
         $bus = new MessageBus($middlewareStack);
 
-        $transport1Handler = fn () => $bus->dispatch(new \stdClass(), [new DispatchAfterCurrentBusStamp()]);
+        $transport1Handler = static fn () => $bus->dispatch(new \stdClass(), [new DispatchAfterCurrentBusStamp()]);
 
         $handlerLocator = new HandlersLocator([
             DummyMessage::class => [new HandlerDescriptor($transport1Handler)],
@@ -496,9 +510,9 @@ class FailureIntegrationTest extends TestCase
         $dispatcher->addSubscriber(new SendFailedMessageForRetryListener($locator, $retryStrategyLocator));
         $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
 
-        $runWorker = function (string $transportName) use ($transports, $bus, $dispatcher): ?\Throwable {
+        $runWorker = static function (string $transportName) use ($transports, $bus, $dispatcher): ?\Throwable {
             $throwable = null;
-            $failedListener = function (WorkerMessageFailedEvent $event) use (&$throwable) {
+            $failedListener = static function (WorkerMessageFailedEvent $event) use (&$throwable) {
                 $throwable = $event->getThrowable();
             };
             $dispatcher->addListener(WorkerMessageFailedEvent::class, $failedListener);

--- a/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
@@ -55,7 +55,10 @@ class MultiplierRetryStrategyTest extends TestCase
     public function testGetWaitTime(int $delay, float $multiplier, int $maxDelay, int $previousRetries, int $expectedDelay)
     {
         $strategy = new MultiplierRetryStrategy(10, $delay, $multiplier, $maxDelay);
-        $envelope = new Envelope(new \stdClass(), [new RedeliveryStamp($previousRetries)]);
+        $envelope = Envelope::wrap(new \stdClass());
+        for ($i = 0; $i < $previousRetries; ++$i) {
+            $envelope = $envelope->with(new RedeliveryStamp($i));
+        }
 
         $this->assertSame($expectedDelay, $strategy->getWaitingTime($envelope));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53216 #51815
| License       | MIT

This PR tries to fix #53216 and is a follow-up to #51815 
It is somewhat of a stretch to call this a fix, as it changes behavior ~~and especially breaks the BC promise~~.
My sole argumentation for a fix would be that discarding instead of retrying messages is unexpected behavior, but this is subjective.
With changed behavior, I am very much open for comments and suggestions.

**The changes are:**
- `SendFailedMessageToFailureTransportListener` does no longer discard messages if a message was already sent to a failure transport but uses a retry strategy to re-send it to the failure transport using an increasing delay
    - Messages will be retried indefinitely until successfully handled
- `SendFailedMessageToFailureTransportListener` uses the last `ReceivedStamp` in order to not lose information about the original transport
    - It is assumed that the `FailedMessageProcessingMiddleware` is used
    - Otherwise e.g. a handler that is only registered for a specific transport (`from_transport`) would not be considered as a handler when retrieving retries from a failure transport
- The default `MutliplierRetryStrategy` counts all `RedeliveryStamps` to determine the delay instead of the current retry loop
   - Reasons:
       - My argument would be that the delay should increase with every subsequent retrieval from the failure queue, regardless of the current retry in the retry strategy 
       - A retry strategy  with 0 retries would always use the default without increasing at all
- The `AmqpSender` does no longer default to where a message was previously received from as a routing key, when sending it to the failure transport
   - This did not really matter with the default `fanout` binding setup, but interferes with routing in the delay exchange

**Limitations:**
- counting `RedeliveryStamps` is not reliable as `SendFailedMessageForRetryListener` limits (removes) them
    - this could be solved by including a total instead of just the current in the `RedeliveryStamp`

Changing the retry behavior ~~and the public constructor~~ of the EventListener is definitely a breaking change. It's impossible to tell if a project relies on the fact that messages are discarded from the failure transport.
The constructor change is handled gracefully but it still requires some sort of default delay in order to not introduce the regression of an instant and infite retry loop.

Again, really happy for feedback!
