### PR TITLE
[Validator] Add `setGroupProvider` to `AttributeLoader`

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
@@ -37,6 +37,7 @@ class AttributeLoader implements LoaderInterface
             if ($constraint instanceof GroupSequence) {
                 $metadata->setGroupSequence($constraint->groups);
             } elseif ($constraint instanceof GroupSequenceProvider) {
+                $metadata->setGroupProvider($constraint->provider);
                 $metadata->setGroupSequenceProvider(true);
             } elseif ($constraint instanceof Constraint) {
                 $metadata->addConstraint($constraint);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -210,6 +210,22 @@ class AttributeLoaderTest extends TestCase
         $this->assertEquals($expected, $metadata);
     }
 
+    public function testLoadExternalGroupSequenceProvider()
+    {
+        $loader = $this->createAttributeLoader();
+        $namespace = $this->getFixtureAttributeNamespace();
+
+        $metadata = new ClassMetadata($namespace.'\GroupProviderDto');
+        $loader->loadClassMetadata($metadata);
+
+        $expected = new ClassMetadata($namespace.'\GroupProviderDto');
+        $expected->setGroupProvider('Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider');
+        $expected->setGroupSequenceProvider(true);
+        $expected->getReflectionClass();
+
+        $this->assertEquals($expected, $metadata);
+    }
+
     protected function createAttributeLoader(): AttributeLoader
     {
         return new AttributeLoader();
@@ -218,5 +234,10 @@ class AttributeLoaderTest extends TestCase
     protected function getFixtureNamespace(): string
     {
         return 'Symfony\Component\Validator\Tests\Fixtures\NestedAttribute';
+    }
+
+    protected function getFixtureAttributeNamespace(): string
+    {
+        return 'Symfony\Component\Validator\Tests\Fixtures\Attribute';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #57677 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Was introduced in `AnnotationLoader` and got removed during the 6.4->7.0 switch to the `AttributeLoader`. Fixes issue [#57677](https://github.com/symfony/symfony/issues/57677).

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
