### PR TITLE
[WebProfilerBundle] Change incorrect check for the `stateless` request attribute

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -180,7 +180,7 @@ class ProfilerController
         $this->cspHandler?->disableCsp();
 
         $session = null;
-        if ($request->attributes->getBoolean('_stateless') && $request->hasSession()) {
+        if (!$request->attributes->getBoolean('_stateless') && $request->hasSession()) {
             $session = $request->getSession();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Issues        | 
| License       | MIT

When upgrading our project from 5.4 to 6.4 (yep..we're late) we encountered an "Session was used while the request was declared stateless." exception when opening the profiler. Our `main` firewall sets `stateless: true` as its only used for API requests (and the profiler). Debugging to find what caused the session to be initialized I ended up in the `ProfilerController::searchBarAction`, which gets the session *only if the `_stateless` attribute is `true`*. 

According to my understanding an the discussion here  https://github.com/symfony/symfony/pull/50218/files#r1668401248 this seems to be incorrect. 

We only want to use the session if the request is **not** `stateless`. 
