### PR TITLE
[WebProfilerBundle] Format workflow calls duration

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
@@ -319,7 +319,7 @@
                                             {% endif %}
                                         </td>
                                         <td>
-                                            {{ call.duration }}ms
+                                            {{ '%0.2f ms'|format(call.duration) }}
                                         </td>
                                     </tr>
                                 {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57673
| License       | MIT

Used the same format as the one used in `src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig`