### PR TITLE
[ExpressionLanguage] Allow passing any iterable as `$providers` list

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add support for null-coalescing unknown variables
  * Add support for comments using `/*` & `*/`
+ * Allow passing any iterable as `$providers` list to `ExpressionLanguage` constructor
 
 7.1
 ---

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -32,9 +32,9 @@ class ExpressionLanguage
     protected array $functions = [];
 
     /**
-     * @param ExpressionFunctionProviderInterface[] $providers
+     * @param iterable<ExpressionFunctionProviderInterface> $providers
      */
-    public function __construct(?CacheItemPoolInterface $cache = null, array $providers = [])
+    public function __construct(?CacheItemPoolInterface $cache = null, iterable $providers = [])
     {
         $this->cache = $cache ?? new ArrayAdapter();
         $this->registerFunctions();

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -137,9 +137,12 @@ class ExpressionLanguageTest extends TestCase
         $this->assertSame(FooBackedEnum::Bar, $result);
     }
 
-    public function testProviders()
+    /**
+     * @dataProvider providerTestCases
+     */
+    public function testProviders(iterable $providers)
     {
-        $expressionLanguage = new ExpressionLanguage(null, [new TestProvider()]);
+        $expressionLanguage = new ExpressionLanguage(null, $providers);
         $this->assertEquals('foo', $expressionLanguage->evaluate('identity("foo")'));
         $this->assertEquals('"foo"', $expressionLanguage->compile('identity("foo")'));
         $this->assertEquals('FOO', $expressionLanguage->evaluate('strtoupper("foo")'));
@@ -148,6 +151,14 @@ class ExpressionLanguageTest extends TestCase
         $this->assertEquals('\strtolower("FOO")', $expressionLanguage->compile('strtolower("FOO")'));
         $this->assertTrue($expressionLanguage->evaluate('fn_namespaced()'));
         $this->assertEquals('\Symfony\Component\ExpressionLanguage\Tests\Fixtures\fn_namespaced()', $expressionLanguage->compile('fn_namespaced()'));
+    }
+
+    public static function providerTestCases(): iterable
+    {
+        yield 'array' => [[new TestProvider()]];
+        yield 'Traversable' => [(function () {
+            yield new TestProvider();
+        })()];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This would make it possible to register expression function providers using tagged iterators:

```yaml
my.expression_lang:
    class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
    arguments:
        $providers: !tagged_iterator my.tag
```