### PR TITLE
Support for PHP-CS-Fixer's parallel runner

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -23,6 +23,8 @@ file that was distributed with this source code.
 EOF;
 
 return (new PhpCsFixer\Config())
+    // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@PHP71Migration' => true,
         '@PHPUnit75Migration:risky' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | n/a
| Deprecations? | no
| Issues        | n/a
| License       | MIT

In PHP-CS-Fixer/PHP-CS-Fixer#7777 parallel runner was introduced, which drastically improves analysis time. I believe Symfony should take advantage of it too 🙂. Tested on Symfony project itself using:

```shell
$ docker run -it --rm -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3 check --using-cache=no
```

Running with 1 core (current setup):

```
Running analysis on 1 core sequentially.
...
Found 74 of 6306 files that can be fixed in 378.418 seconds, 40.00 MB memory used
```

Running with CPU auto-detection (7 CPU for me, because my Docker is limited to this number):

```
Running analysis on 7 cores with 10 files per process.
...
Found 74 of 6306 files that can be fixed in 56.836 seconds, 22.00 MB memory used
```

`378.418 seconds` vs `56.836 seconds` 😎. With this improvement you can consider running Fixer against the whole codebase in every pipeline, not only for modified files (which I believe you do now, correct me if I'm wrong).

### Why `if` condition

~~Parallel runner was introduced in Fixer 3.57.0 and since Symfony does not require it in any way for local development (it assumes developer has it installed as PHAR file) we can't be sure each dev has up-to-date version available.~~ Removed after [discussion](https://github.com/symfony/symfony/pull/57687#discussion_r1670560208).