### PR TITLE
[Contracts][HttpClient] Skip tests when zlib's `ob_gzhandler()` doesn't exist

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
@@ -37,6 +37,9 @@ class HttplugClientTest extends TestCase
         TestHttpServer::stop();
     }
 
+    /**
+     * @requires function ob_gzhandler
+     */
     public function testSendRequest()
     {
         $client = new HttplugClient(new NativeHttpClient());
@@ -51,6 +54,9 @@ class HttplugClientTest extends TestCase
         $this->assertSame('HTTP/1.1', $body['SERVER_PROTOCOL']);
     }
 
+    /**
+     * @requires function ob_gzhandler
+     */
     public function testSendAsyncRequest()
     {
         $client = new HttplugClient(new NativeHttpClient());

--- a/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
@@ -33,6 +33,9 @@ class Psr18ClientTest extends TestCase
         TestHttpServer::stop();
     }
 
+    /**
+     * @requires function ob_gzhandler
+     */
     public function testSendRequest()
     {
         $factory = new Psr17Factory();

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -25,6 +25,10 @@ abstract class HttpClientTestCase extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
+        if (!function_exists('ob_gzhandler')) {
+            static::markTestSkipped('The "ob_gzhandler" function is not available.');
+        }
+
         TestHttpServer::start();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using a minimal PHP binary without enabling special ext, `ob_gzhandler` may not be available making a lot of HttpClient's tests fail. The function is used here: https://github.com/symfony/symfony/blob/7.2/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php#L46