### PR TITLE
[SecurityBundle] Link to the profile the token was (de)authenticated

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -181,6 +181,17 @@
                                 <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.authenticated ? 'yes' : 'no') ~ '.svg') }}</span>
                                 <span class="label">Authenticated</span>
                             </div>
+
+                            {% if collector.authProfileToken %}
+                                <div class="metric">
+                                    <span class="value">
+                                        <a href="{{ path('_profiler', {token: collector.authProfileToken, panel: 'security'}) }}">
+                                            {{- collector.authProfileToken -}}
+                                        </a>
+                                    </span>
+                                    <span class="label">From</span>
+                                </div>
+                            {% endif %}
                         </div>
 
                         <table>
@@ -219,7 +230,15 @@
                         </table>
                     {% elseif collector.enabled %}
                         <div class="empty">
-                            <p>There is no security token.</p>
+                            <p>
+                                There is no security token.
+                                {% if collector.deauthProfileToken %}
+                                    It was removed in
+                                    <a href="{{ path('_profiler', {token: collector.deauthProfileToken, panel: 'security'}) }}">
+                                        {{- collector.deauthProfileToken -}}
+                                    </a>.
+                                {% endif %}
+                            </p>
                         </div>
                     {% endif %}
                 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Part of #36668
| License       | MIT

When using a stateful firewall, this PR allows an easy access to the profile of the request where a user was

- authenticated: ![](https://github.com/symfony/symfony/assets/1898254/a3342407-2d2d-44ca-b271-ce35834297d4)
- de-authenticated: ![](https://github.com/symfony/symfony/assets/1898254/a279ba0f-3634-40ce-8d81-d2009729485b)
