### PR TITLE
[SecurityBundle] Update web-token/jwt-library version and adjust checker parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,7 @@
         "twig/cssinliner-extra": "^2.12|^3",
         "twig/inky-extra": "^2.12|^3",
         "twig/markdown-extra": "^2.12|^3",
-        "web-token/jwt-library": "^3.3.2"
+        "web-token/jwt-library": "^3.3.2|^4.0"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -51,7 +51,7 @@
         "symfony/validator": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0",
         "twig/twig": "^3.0.4",
-        "web-token/jwt-library": "^3.3.2"
+        "web-token/jwt-library": "^3.3.2|^4.0"
     },
     "conflict": {
         "symfony/browser-kit": "<6.4",

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -86,9 +86,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
 
             // Verify the claims
             $checkers = [
-                new Checker\IssuedAtChecker(0, false, $this->clock),
-                new Checker\NotBeforeChecker(0, false, $this->clock),
-                new Checker\ExpirationTimeChecker(0, false, $this->clock),
+                new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: false),
+                new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: false),
+                new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: false),
                 new Checker\AudienceChecker($this->audience),
                 new Checker\IssuerChecker($this->issuers),
             ];

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -36,7 +36,7 @@
         "symfony/security-csrf": "^6.4|^7.0",
         "symfony/translation": "^6.4|^7.0",
         "psr/log": "^1|^2|^3",
-        "web-token/jwt-library": "^3.3.2"
+        "web-token/jwt-library": "^3.3.2|^4.0"
     },
     "conflict": {
         "symfony/clock": "<6.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix nothing
| License       | MIT

The web-token/jwt-library has been updated to allow versions up to 4.0 across multiple components. Additionally, the parameters for the IssuedAtChecker, NotBeforeChecker, and ExpirationTimeChecker in the OidcTokenHandler have been adjusted.