### PR TITLE
[PropertyInfo]  add tests for TypeInfo types

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -571,6 +571,7 @@ class PhpDocExtractorTest extends TestCase
         yield ['arrayOfMixed', Type::dict(Type::mixed()), null, null];
         yield ['listOfStrings', Type::list(Type::string()), null, null];
         yield ['self', Type::object(Dummy::class), null, null];
+        yield ['collectionAsObject', Type::collection(Type::object(DummyCollection::class), Type::string(), Type::int()), null, null];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -594,6 +594,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['self', Type::object(Dummy::class)];
         yield ['rootDummyItems', Type::list(Type::object(RootDummyItem::class))];
         yield ['rootDummyItem', Type::object(RootDummyItem::class)];
+        yield ['collectionAsObject', Type::collection(Type::object(DummyCollection::class), Type::string(), Type::int())];
     }
 
     public function testParamTagTypeIsOmitted()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This change ensures that the tests that have been added in #57617 are also applied when the types from the TypeInfo component are used instead of the Type class that is built into the PropertyInfo component.