### PR TITLE
use more entropy with uniqid()

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/log_file.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/log_file.phpt
@@ -2,7 +2,7 @@
 Test DeprecationErrorHandler with log file
 --FILE--
 <?php
-$filename = tempnam(sys_get_temp_dir(), 'sf-').uniqid();
+$filename = tempnam(sys_get_temp_dir(), 'sf-').uniqid('', true);
 $k = 'SYMFONY_DEPRECATIONS_HELPER';
 putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'logFile='.$filename);
 putenv('ANSICON');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -28,7 +28,7 @@ class AnnotationsCacheWarmerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->cacheDir = sys_get_temp_dir().'/'.uniqid();
+        $this->cacheDir = sys_get_temp_dir().'/'.uniqid('', true);
         $fs = new Filesystem();
         $fs->mkdir($this->cacheDir);
         parent::setUp();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
@@ -36,7 +36,7 @@ class ConfigBuilderCacheWarmerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->varDir = sys_get_temp_dir().'/'.uniqid();
+        $this->varDir = sys_get_temp_dir().'/'.uniqid('', true);
         $fs = new Filesystem();
         $fs->mkdir($this->varDir);
     }

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
@@ -64,7 +64,7 @@ final class IqsmsTransport extends AbstractTransport
                         'phone' => $message->getPhone(),
                         'text' => $message->getSubject(),
                         'sender' => $this->from,
-                        'clientId' => uniqid(),
+                        'clientId' => uniqid('', true),
                     ],
                 ],
                 'login' => $this->login,

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -33,7 +33,7 @@ class CompiledUrlMatcherDumperTest extends TestCase
     {
         parent::setUp();
 
-        $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_matcher.'.uniqid('CompiledUrlMatcher').'.php';
+        $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_matcher.'.uniqid('CompiledUrlMatcher', true).'.php';
     }
 
     protected function tearDown(): void

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
@@ -29,7 +29,7 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_serializer_metadata.'.uniqid('CompiledClassMetadataFactory').'.php';
+        $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_serializer_metadata.'.uniqid('CompiledClassMetadataFactory', true).'.php';
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

It looked like using `uniqid()` without opting for more entropy slipped in after #20132 and #20137.
