### PR TITLE
[Cache] Use correct arguments for adapters within `ChainAdapter` pool

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -118,12 +118,12 @@ class CachePoolPass implements CompilerPassInterface
                         $chainedPool->replaceArgument($i++, new Reference(static::getServiceProvider($container, $chainedTags[0]['provider'])));
                     }
 
-                    if (isset($tags[0]['namespace']) && !\in_array($adapter->getClass(), [ArrayAdapter::class, NullAdapter::class], true)) {
-                        $chainedPool->replaceArgument($i++, $tags[0]['namespace']);
+                    if (isset($chainedTags[0]['namespace']) && !\in_array($adapter->getClass(), [ArrayAdapter::class, NullAdapter::class], true)) {
+                        $chainedPool->replaceArgument($i++, $chainedTags[0]['namespace']);
                     }
 
-                    if (isset($tags[0]['default_lifetime'])) {
-                        $chainedPool->replaceArgument($i++, $tags[0]['default_lifetime']);
+                    if (isset($chainedTags[0]['default_lifetime'])) {
+                        $chainedPool->replaceArgument($i++, $chainedTags[0]['default_lifetime']);
                     }
 
                     $adapters[] = $chainedPool;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no
| Issues        | Fix #57698
| License       | MIT

