### PR TITLE
[Cache] Stop defaulting to `igbinary` in `DefaultMarshaller`

### DIFF
--- a/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
@@ -20,17 +20,15 @@ use Symfony\Component\Cache\Exception\CacheException;
  */
 class DefaultMarshaller implements MarshallerInterface
 {
-    private bool $useIgbinarySerialize = true;
+    private bool $useIgbinarySerialize = false;
     private bool $throwOnSerializationFailure = false;
 
     public function __construct(?bool $useIgbinarySerialize = null, bool $throwOnSerializationFailure = false)
     {
-        if (null === $useIgbinarySerialize) {
-            $useIgbinarySerialize = \extension_loaded('igbinary') && version_compare('3.1.6', phpversion('igbinary'), '<=');
-        } elseif ($useIgbinarySerialize && (!\extension_loaded('igbinary') || version_compare('3.1.6', phpversion('igbinary'), '>'))) {
+        if ($useIgbinarySerialize && (!\extension_loaded('igbinary') || version_compare('3.1.6', phpversion('igbinary'), '>'))) {
             throw new CacheException(\extension_loaded('igbinary') ? 'Please upgrade the "igbinary" PHP extension to v3.1.6 or higher.' : 'The "igbinary" PHP extension is not loaded.');
         }
-        $this->useIgbinarySerialize = $useIgbinarySerialize;
+        $this->useIgbinarySerialize = true === $useIgbinarySerialize;
         $this->throwOnSerializationFailure = $throwOnSerializationFailure;
     }
 

--- a/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
@@ -24,7 +24,27 @@ class DefaultMarshallerTest extends TestCase
             'b' => function () {},
         ];
 
-        $expected = ['a' => \extension_loaded('igbinary') && (version_compare('3.1.6', phpversion('igbinary'), '<=')) ? igbinary_serialize(123) : serialize(123)];
+        $expected = ['a' => serialize(123)];
+        $this->assertSame($expected, $marshaller->marshall($values, $failed));
+        $this->assertSame(['b'], $failed);
+    }
+
+    /**
+     * @requires extension igbinary
+     */
+    public function testIgbinarySerialize()
+    {
+        if (version_compare('3.1.6', phpversion('igbinary'), '>')) {
+            $this->markTestSkipped('igbinary needs to be v3.1.6 or higher.');
+        }
+
+        $marshaller = new DefaultMarshaller(true);
+        $values = [
+            'a' => 123,
+            'b' => function () {},
+        ];
+
+        $expected = ['a' => igbinary_serialize(123)];
         $this->assertSame($expected, $marshaller->marshall($values, $failed));
         $this->assertSame(['b'], $failed);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Issues        | Fix #52391
| License       | MIT

igbinary used to be a drop in replacement for PHP's `serialize` but recent changes (in PHP 7.4) to the handling of uninitialized properties in `serialize` have not made it into igbinary, so it no longer is a simple drop in replacement.

This only removes igbinary as the default serializer, code can still opt-in through the first constructor argument.

This may result in a performance regression on systems with igbinary as it would no longer be used by default.

Fixes #52391