### PR TITLE
[Workflow] Clearer `NotEnabledTransitionException` message

### DIFF
--- a/src/Symfony/Component/Workflow/Exception/NotEnabledTransitionException.php
+++ b/src/Symfony/Component/Workflow/Exception/NotEnabledTransitionException.php
@@ -15,7 +15,7 @@ use Symfony\Component\Workflow\TransitionBlockerList;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
- * Thrown by Workflow when a not enabled transition is applied on a subject.
+ * Thrown when a transition cannot be applied on a subject.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
@@ -28,7 +28,7 @@ class NotEnabledTransitionException extends TransitionException
         private TransitionBlockerList $transitionBlockerList,
         array $context = [],
     ) {
-        parent::__construct($subject, $transitionName, $workflow, \sprintf('Transition "%s" is not enabled for workflow "%s".', $transitionName, $workflow->getName()), $context);
+        parent::__construct($subject, $transitionName, $workflow, \sprintf('Cannot apply transition "%s" on workflow "%s".', $transitionName, $workflow->getName()), $context);
     }
 
     public function getTransitionBlockerList(): TransitionBlockerList

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -286,7 +286,7 @@ class WorkflowTest extends TestCase
 
             $this->fail('Should throw an exception');
         } catch (NotEnabledTransitionException $e) {
-            $this->assertSame('Transition "t2" is not enabled for workflow "unnamed".', $e->getMessage());
+            $this->assertSame('Cannot apply transition "t2" on workflow "unnamed".', $e->getMessage());
             $this->assertCount(1, $e->getTransitionBlockerList());
             $list = iterator_to_array($e->getTransitionBlockerList());
             $this->assertSame('The marking does not enable the transition.', $list[0]->getMessage());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

The current exception message is somewhat confusing as it makes you think the transition is not enabled at all within the workflow. This can/does lead to people trying to debug a config issue. While the problem being encountered issue is that the transition can't be applied due to the current state of the supported class/object.

Hopefully, this makes it a bit clearer.