### PR TITLE
[PropertyInfo] Check if property is nullable when using `ReflectionExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -202,7 +202,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 $type = $this->typeResolver->resolve($mutatorReflection->getParameters()[0]);
 
                 if (!$type instanceof CollectionType && \in_array($prefix, $this->arrayMutatorPrefixes, true)) {
-                    $type = Type::list($type);
+                    $type = $this->isNullableProperty($class, $property) ? Type::nullable(Type::list($type)) : Type::list($type);
                 }
 
                 return $type;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -164,6 +164,7 @@ class PhpDocExtractorTest extends TestCase
             ['listOfStrings', [new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, false, null, true, new LegacyType(LegacyType::BUILTIN_TYPE_INT), new LegacyType(LegacyType::BUILTIN_TYPE_STRING))], null, null],
             ['self', [new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, Dummy::class)], null, null],
             ['collectionAsObject', [new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, DummyCollection::class, true, [new LegacyType(LegacyType::BUILTIN_TYPE_INT)], [new LegacyType(LegacyType::BUILTIN_TYPE_STRING)])], null, null],
+            ['nullableTypedCollection', [new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, true, null, true, new LegacyType(LegacyType::BUILTIN_TYPE_INT), new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, Dummy::class))], null, null],
         ];
     }
 
@@ -548,6 +549,7 @@ class PhpDocExtractorTest extends TestCase
         yield ['collection', Type::list(Type::object(\DateTimeImmutable::class)), null, null];
         yield ['nestedCollection', Type::list(Type::list(Type::string())), null, null];
         yield ['mixedCollection', Type::array(), null, null];
+        yield ['nullableTypedCollection', Type::nullable(Type::list(Type::object(Dummy::class))), null, null];
         yield ['a', Type::int(), 'A.', null];
         yield ['b', Type::nullable(Type::object(ParentDummy::class)), 'B.', null];
         yield ['c', Type::nullable(Type::bool()), null, null];

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -76,6 +76,7 @@ class ReflectionExtractorTest extends TestCase
                 'listOfStrings',
                 'parentAnnotation',
                 'genericInterface',
+                'nullableTypedCollection',
                 'foo',
                 'foo2',
                 'foo3',
@@ -143,6 +144,7 @@ class ReflectionExtractorTest extends TestCase
                 'listOfStrings',
                 'parentAnnotation',
                 'genericInterface',
+                'nullableTypedCollection',
                 'foo',
                 'foo2',
                 'foo3',
@@ -199,6 +201,7 @@ class ReflectionExtractorTest extends TestCase
                 'listOfStrings',
                 'parentAnnotation',
                 'genericInterface',
+                'nullableTypedCollection',
                 'foo',
                 'foo2',
                 'foo3',
@@ -865,6 +868,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertEquals(Type::list(Type::string()), $this->extractor->getType(Php74Dummy::class, 'stringCollection'));
         $this->assertEquals(Type::nullable(Type::int()), $this->extractor->getType(Php74Dummy::class, 'nullableWithDefault'));
         $this->assertEquals(Type::array(), $this->extractor->getType(Php74Dummy::class, 'collection'));
+        $this->assertEquals(Type::nullable(Type::list(Type::object(Dummy::class))), $this->extractor->getType(Php74Dummy::class, 'nullableTypedCollection'));
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -177,6 +177,9 @@ class Dummy extends ParentDummy
      */
     public $genericInterface;
 
+    /** @var Dummy[]|null  */
+    public $nullableTypedCollection = null;
+
     public static function getStatic()
     {
     }
@@ -267,6 +270,10 @@ class Dummy extends ParentDummy
     }
 
     public function hasElement(string $element): bool
+    {
+    }
+
+    public function addNullableTypedCollection(Dummy $dummy): void
     {
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php74Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php74Dummy.php
@@ -23,11 +23,18 @@ class Php74Dummy
     private ?int $nullableWithDefault = 1;
     public array $collection = [];
 
+    /** @var Dummy[]|null  */
+    public ?array $nullableTypedCollection = null;
+
     public function addStringCollection(string $string): void
     {
     }
 
     public function removeStringCollection(string $string): void
+    {
+    }
+
+    public function addNullableTypedCollection(Dummy $dummy): void
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57707 
| License       | MIT

When `$type` was resolved into a `CollectionType` with an adder mutator on the given `$class`, the replaced $type ignored if the actual property was nullable or not, causing the returned Type to always report as non nullable even when given property was declared with a `null` union type or a `?` (`?array` for example)

See issue for more information and an example case

