### PR TITLE
[Clock] Add `ClockAwareInterface` that defines the contract for `ClockAwareTrait` implementation

### DIFF
--- a/src/Symfony/Component/Clock/CHANGELOG.md
+++ b/src/Symfony/Component/Clock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+* Add `ClockAwareInterface` that have to be used with `ClockAwareTrait`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Clock/ClockAwareInterface.php
+++ b/src/Symfony/Component/Clock/ClockAwareInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Clock;
+
+use Psr\Clock\ClockInterface;
+
+/**
+ * An interface to help write time-sensitive classes.
+ *
+ * @author Sergii Dolgushev <p@tchwork.com>
+ */
+interface ClockAwareInterface
+{
+    public function setClock(ClockInterface $clock): void;
+
+    public function now(): DatePoint;
+}

--- a/src/Symfony/Component/Clock/ClockAwareInterface.php
+++ b/src/Symfony/Component/Clock/ClockAwareInterface.php
@@ -21,6 +21,4 @@ use Psr\Clock\ClockInterface;
 interface ClockAwareInterface
 {
     public function setClock(ClockInterface $clock): void;
-
-    public function now(): DatePoint;
 }

--- a/src/Symfony/Component/Clock/ClockAwareInterface.php
+++ b/src/Symfony/Component/Clock/ClockAwareInterface.php
@@ -16,7 +16,7 @@ use Psr\Clock\ClockInterface;
 /**
  * An interface to help write time-sensitive classes.
  *
- * @author Sergii Dolgushev <p@tchwork.com>
+ * @author Sergii Dolgushev <dolgushev.serhey@gmail.com>
  */
 interface ClockAwareInterface
 {

--- a/src/Symfony/Component/Clock/ClockAwareTrait.php
+++ b/src/Symfony/Component/Clock/ClockAwareTrait.php
@@ -29,7 +29,7 @@ trait ClockAwareTrait
         $this->clock = $clock;
     }
 
-    protected function now(): DatePoint
+    public function now(): DatePoint
     {
         $now = ($this->clock ??= new Clock())->now();
 

--- a/src/Symfony/Component/Clock/ClockAwareTrait.php
+++ b/src/Symfony/Component/Clock/ClockAwareTrait.php
@@ -29,7 +29,7 @@ trait ClockAwareTrait
         $this->clock = $clock;
     }
 
-    public function now(): DatePoint
+    protected function now(): DatePoint
     {
         $now = ($this->clock ??= new Clock())->now();
 

--- a/src/Symfony/Component/Clock/Tests/ClockAwareTraitTest.php
+++ b/src/Symfony/Component/Clock/Tests/ClockAwareTraitTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Clock\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\ClockAwareInterface;
 use Symfony\Component\Clock\ClockAwareTrait;
 use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\Clock\MockClock;
@@ -21,11 +22,10 @@ class ClockAwareTraitTest extends TestCase
     public function testTrait()
     {
         $sut = new ClockAwareTestImplem();
-
         $this->assertInstanceOf(DatePoint::class, $sut->now());
 
         $clock = new MockClock();
-        $sut = new $sut();
+        $sut = new ClockAwareTestImplem();
         $sut->setClock($clock);
 
         $ts = $sut->now()->getTimestamp();
@@ -36,9 +36,7 @@ class ClockAwareTraitTest extends TestCase
     }
 }
 
-class ClockAwareTestImplem
+class ClockAwareTestImplem implements ClockAwareInterface
 {
-    use ClockAwareTrait {
-        now as public;
-    }
+    use ClockAwareTrait;
 }

--- a/src/Symfony/Component/Clock/Tests/ClockAwareTraitTest.php
+++ b/src/Symfony/Component/Clock/Tests/ClockAwareTraitTest.php
@@ -38,5 +38,7 @@ class ClockAwareTraitTest extends TestCase
 
 class ClockAwareTestImplem implements ClockAwareInterface
 {
-    use ClockAwareTrait;
+    use ClockAwareTrait {
+        now as public;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A 
| License       | MIT

Right now there is `ClockAwareTrait` that contains the implementations. This PR introduces `ClockAwareInterface` that defines the contract for methods already implemented in `ClockAwareTrait`.

So classes that are using `ClockAwareTrait` should in addition to implementing `ClockAwareInterface`. A good example is `ClockAwareTestImplem` in `ClockAwareTraitTest`:

```php
class ClockAwareTestImplem implements ClockAwareInterface
{
    use ClockAwareTrait;
}
```

