### PR TITLE
[Security][SecurityBundle] Add encryption support to OIDC tokens

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -85,6 +85,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'routing.route_loader',
         'scheduler.schedule_provider',
         'scheduler.task',
+        'security.access_token_handler.oidc.encryption_algorithm',
         'security.access_token_handler.oidc.signature_algorithm',
         'security.authenticator.login_linker',
         'security.expression_language_provider',

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `Security::isGrantedForUser()` to test user authorization without relying on the session. For example, users not currently logged in, or while processing a message from a message queue
+ * Add encryption support to `OidcTokenHandler` (JWE)
 
 7.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -338,11 +338,27 @@
         <xsd:choice maxOccurs="unbounded">
             <xsd:element name="issuers" type="oidc_issuers" minOccurs="0" maxOccurs="1" />
             <xsd:element name="issuer" type="password_hasher" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="encryption" type="oidc_encryption" />
         </xsd:choice>
         <xsd:attribute name="claim" type="xsd:string" />
         <xsd:attribute name="audience" type="xsd:string" use="required" />
         <xsd:attribute name="algorithm" type="xsd:string" use="required" />
         <xsd:attribute name="key" type="xsd:string" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="oidc_encryption">
+        <xsd:choice maxOccurs="unbounded">
+            <xsd:element name="algorithms" type="oidc_encryption_algorithms" minOccurs="1" maxOccurs="1" />
+        </xsd:choice>
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="enforce" type="xsd:boolean" />
+        <xsd:attribute name="keyset" type="xsd:string" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="oidc_encryption_algorithms">
+        <xsd:sequence>
+            <xsd:element name="algorithm" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+        </xsd:sequence>
     </xsd:complexType>
 
     <xsd:complexType name="oidc_issuers">

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -15,6 +15,15 @@ use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\AlgorithmManagerFactory;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A128CBCHS256;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A128GCM;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A192CBCHS384;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A192GCM;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A256CBCHS512;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A256GCM;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHES;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHSS;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP;
 use Jose\Component\Signature\Algorithm\ES256;
 use Jose\Component\Signature\Algorithm\ES384;
 use Jose\Component\Signature\Algorithm\ES512;
@@ -135,5 +144,47 @@ return static function (ContainerConfigurator $container) {
 
         ->set('security.access_token_handler.oidc.signature.PS512', PS512::class)
             ->tag('security.access_token_handler.oidc.signature_algorithm')
+
+        // Encryption
+        // Note that - all xxxKW algorithms are not defined as an extra dependency is required
+        //           - The RSA_1.5 is missing as deprecated
+        ->set('security.access_token_handler.oidc.encryption_algorithm_manager_factory', AlgorithmManagerFactory::class)
+            ->args([
+                tagged_iterator('security.access_token_handler.oidc.encryption_algorithm'),
+            ])
+
+        ->set('security.access_token_handler.oidc.encryption', AlgorithmManager::class)
+            ->abstract()
+            ->factory([service('security.access_token_handler.oidc.encryption_algorithm_manager_factory'), 'create'])
+            ->args([
+                abstract_arg('encryption algorithms'),
+            ])
+
+        ->set('security.access_token_handler.oidc.encryption.RSAOAEP', RSAOAEP::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
+
+        ->set('security.access_token_handler.oidc.encryption.ECDHES', ECDHES::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
+
+        ->set('security.access_token_handler.oidc.encryption.ECDHSS', ECDHSS::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
+
+        ->set('security.access_token_handler.oidc.encryption.A128CBCHS256', A128CBCHS256::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
+
+        ->set('security.access_token_handler.oidc.encryption.A192CBCHS384', A192CBCHS384::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
+
+        ->set('security.access_token_handler.oidc.encryption.A256CBCHS512', A256CBCHS512::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
+
+        ->set('security.access_token_handler.oidc.encryption.A128GCM', A128GCM::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
+
+        ->set('security.access_token_handler.oidc.encryption.A192GCM', A192GCM::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
+
+        ->set('security.access_token_handler.oidc.encryption.A256GCM', A256GCM::class)
+            ->tag('security.access_token_handler.oidc.encryption_algorithm')
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
@@ -13,9 +13,13 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A128GCM;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHES;
+use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Encryption\Serializer\CompactSerializer as JweCompactSerializer;
 use Jose\Component\Signature\Algorithm\ES256;
 use Jose\Component\Signature\JWSBuilder;
-use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\CompactSerializer as JwsCompactSerializer;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -348,35 +352,10 @@ class AccessTokenTest extends AbstractWebTestCase
     }
 
     /**
-     * @requires extension openssl
+     * @dataProvider validAccessTokens
      */
-    public function testOidcSuccess()
+    public function testOidcSuccess(string $token)
     {
-        $time = time();
-        $claims = [
-            'iat' => $time,
-            'nbf' => $time,
-            'exp' => $time + 3600,
-            'iss' => 'https://www.example.com',
-            'aud' => 'Symfony OIDC',
-            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
-            'username' => 'dunglas',
-        ];
-        $token = (new CompactSerializer())->serialize((new JWSBuilder(new AlgorithmManager([
-            new ES256(),
-        ])))->create()
-            ->withPayload(json_encode($claims))
-            // tip: use https://mkjwk.org/ to generate a JWK
-            ->addSignature(new JWK([
-                'kty' => 'EC',
-                'crv' => 'P-256',
-                'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
-                'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
-                'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
-            ]), ['alg' => 'ES256'])
-            ->build()
-        );
-
         $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oidc.yml']);
         $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => \sprintf('Bearer %s', $token)]);
         $response = $client->getResponse();
@@ -384,6 +363,43 @@ class AccessTokenTest extends AbstractWebTestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(['message' => 'Welcome @dunglas!'], json_decode($response->getContent(), true));
+    }
+
+    /**
+     * @dataProvider invalidAccessTokens
+     */
+    public function testOidcFailure(string $token)
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oidc.yml']);
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => \sprintf('Bearer %s', $token)]);
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="invalid_token",error_description="Invalid credentials."', $response->headers->get('WWW-Authenticate'));
+    }
+
+    /**
+     * @requires extension openssl
+     */
+    public function testOidcFailureWithJweEnforced()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oidc_jwe.yml']);
+        $token = self::createJws([
+            'iat' => time() - 1,
+            'nbf' => time() - 1,
+            'exp' => time() + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => 'Symfony OIDC',
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+            'username' => 'dunglas',
+        ]);
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => \sprintf('Bearer %s', $token)]);
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="invalid_token",error_description="Invalid credentials."', $response->headers->get('WWW-Authenticate'));
     }
 
     public function testCasSuccess()
@@ -407,5 +423,98 @@ class AccessTokenTest extends AbstractWebTestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(['message' => 'Welcome @dunglas!'], json_decode($response->getContent(), true));
+    }
+
+    public function validAccessTokens(): array
+    {
+        if (!\extension_loaded('openssl')) {
+            return [];
+        }
+        $time = time();
+        $claims = [
+            'iat' => $time,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => 'Symfony OIDC',
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+            'username' => 'dunglas',
+        ];
+        $jws = $this->createJws($claims);
+        $jwe = $this->createJwe($jws);
+
+        return [
+            [$jws],
+            [$jwe],
+        ];
+    }
+
+    public static function invalidAccessTokens(): array
+    {
+        if (!\extension_loaded('openssl')) {
+            return [];
+        }
+        $time = time();
+        $claims = [
+            'iat' => $time,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => 'Symfony OIDC',
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+            'username' => 'dunglas',
+        ];
+
+        return [
+            [self::createJws([...$claims, 'aud' => 'Invalid Audience'])],
+            [self::createJws([...$claims, 'iss' => 'Invalid Issuer'])],
+            [self::createJws([...$claims, 'exp' => $time - 3600])],
+            [self::createJws([...$claims, 'nbf' => $time + 3600])],
+            [self::createJws([...$claims, 'iat' => $time + 3600])],
+            [self::createJws([...$claims, 'username' => 'Invalid Username'])],
+            [self::createJwe(self::createJws($claims), ['exp' => $time - 3600])],
+            [self::createJwe(self::createJws($claims), ['cty' => 'x-specific'])],
+        ];
+    }
+
+    private static function createJws(array $claims, array $header = []): string
+    {
+        return (new JwsCompactSerializer())->serialize((new JWSBuilder(new AlgorithmManager([
+            new ES256(),
+        ])))->create()
+            ->withPayload(json_encode($claims))
+            // tip: use https://mkjwk.org/ to generate a JWK
+            ->addSignature(new JWK([
+                'kty' => 'EC',
+                'crv' => 'P-256',
+                'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+                'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+                'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+            ]), [...$header, 'alg' => 'ES256'])
+            ->build()
+        );
+    }
+
+    private static function createJwe(string $input, array $header = []): string
+    {
+        $jwk = new JWK([
+            'kty' => 'EC',
+            'use' => 'enc',
+            'crv' => 'P-256',
+            'kid' => 'enc-1720876375',
+            'x' => '4P27-OB2s5ZP3Zt5ExxQ9uFrgnGaMK6wT1oqd5bJozQ',
+            'y' => 'CNh-ZbKJBvz6hJ8JOulXclACP2OuoO2PtqT6WC8tLcU',
+        ]);
+
+        return (new JweCompactSerializer())->serialize(
+            (new JWEBuilder(new AlgorithmManager([
+                new ECDHES(), new A128GCM(),
+            ])))->create()
+                ->withPayload($input)
+                ->withSharedProtectedHeader(['alg' => 'ECDH-ES', 'enc' => 'A128GCM', ...$header])
+                // tip: use https://mkjwk.org/ to generate a JWK
+                ->addRecipient($jwk)
+                ->build()
+        );
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc_jwe.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc_jwe.yml
@@ -29,6 +29,7 @@ security:
                         keyset: '{"keys":[{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}]}'
                         encryption:
                             enabled: true
+                            enforce: true
                             algorithms: ['ECDH-ES', 'A128GCM']
                             keyset: '{"keys": [{"kty": "EC","d": "YG0HnRsaYv2cUj7TpgHcRX1poL9l4cskIuOi1gXv0Dg","use": "enc","crv": "P-256","kid": "enc-1720876375","x": "4P27-OB2s5ZP3Zt5ExxQ9uFrgnGaMK6wT1oqd5bJozQ","y": "CNh-ZbKJBvz6hJ8JOulXclACP2OuoO2PtqT6WC8tLcU","alg": "ECDH-ES"}]}'
                 token_extractors: 'header'

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/password-hasher": "^6.4|^7.0",
         "symfony/security-core": "^7.3",
         "symfony/security-csrf": "^6.4|^7.0",
-        "symfony/security-http": "^7.2",
+        "symfony/security-http": "^7.3",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -17,9 +17,13 @@ use Jose\Component\Core\Algorithm;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\JWEDecrypter;
+use Jose\Component\Encryption\JWETokenSupport;
+use Jose\Component\Encryption\Serializer\CompactSerializer as JweCompactSerializer;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
 use Jose\Component\Signature\JWSTokenSupport;
 use Jose\Component\Signature\JWSVerifier;
-use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\CompactSerializer as JwsCompactSerializer;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
@@ -37,10 +41,13 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 final class OidcTokenHandler implements AccessTokenHandlerInterface
 {
     use OidcTrait;
+    private ?JWKSet $decryptionKeyset = null;
+    private ?AlgorithmManager $decryptionAlgorithms = null;
+    private bool $enforceEncryption = false;
 
     public function __construct(
         private Algorithm|AlgorithmManager $signatureAlgorithm,
-        private JWK|JWKSet $jwkset,
+        private JWK|JWKSet $signatureKeyset,
         private string $audience,
         private array $issuers,
         private string $claim = 'sub',
@@ -51,10 +58,17 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
             trigger_deprecation('symfony/security-http', '7.1', 'First argument must be instance of %s, %s given.', AlgorithmManager::class, Algorithm::class);
             $this->signatureAlgorithm = new AlgorithmManager([$signatureAlgorithm]);
         }
-        if ($jwkset instanceof JWK) {
+        if ($signatureKeyset instanceof JWK) {
             trigger_deprecation('symfony/security-http', '7.1', 'Second argument must be instance of %s, %s given.', JWKSet::class, JWK::class);
-            $this->jwkset = new JWKSet([$jwkset]);
+            $this->signatureKeyset = new JWKSet([$signatureKeyset]);
         }
+    }
+
+    public function enabledJweSupport(JWKSet $decryptionKeyset, AlgorithmManager $decryptionAlgorithms, bool $enforceEncryption): void
+    {
+        $this->decryptionKeyset = $decryptionKeyset;
+        $this->decryptionAlgorithms = $decryptionAlgorithms;
+        $this->enforceEncryption = $enforceEncryption;
     }
 
     public function getUserBadgeFrom(string $accessToken): UserBadge
@@ -64,37 +78,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         }
 
         try {
-            // Decode the token
-            $jwsVerifier = new JWSVerifier($this->signatureAlgorithm);
-            $serializerManager = new JWSSerializerManager([new CompactSerializer()]);
-            $jws = $serializerManager->unserialize($accessToken);
-            $claims = json_decode($jws->getPayload(), true);
-
-            // Verify the signature
-            if (!$jwsVerifier->verifyWithKeySet($jws, $this->jwkset, 0)) {
-                throw new InvalidSignatureException();
-            }
-
-            // Verify the headers
-            $headerCheckerManager = new Checker\HeaderCheckerManager([
-                new Checker\AlgorithmChecker($this->signatureAlgorithm->list()),
-            ], [
-                new JWSTokenSupport(),
-            ]);
-            // if this check fails, an InvalidHeaderException is thrown
-            $headerCheckerManager->check($jws, 0);
-
-            // Verify the claims
-            $checkers = [
-                new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: false),
-                new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: false),
-                new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: false),
-                new Checker\AudienceChecker($this->audience),
-                new Checker\IssuerChecker($this->issuers),
-            ];
-            $claimCheckerManager = new ClaimCheckerManager($checkers);
-            // if this check fails, an InvalidClaimException is thrown
-            $claimCheckerManager->check($claims);
+            $accessToken = $this->decryptIfNeeded($accessToken);
+            $claims = $this->loadAndVerifyJws($accessToken);
+            $this->verifyClaims($claims);
 
             if (empty($claims[$this->claim])) {
                 throw new MissingClaimException(\sprintf('"%s" claim not found.', $this->claim));
@@ -109,6 +95,94 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
             ]);
 
             throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
+        }
+    }
+
+    private function loadAndVerifyJws(string $accessToken): array
+    {
+        // Decode the token
+        $jwsVerifier = new JWSVerifier($this->signatureAlgorithm);
+        $serializerManager = new JWSSerializerManager([new JwsCompactSerializer()]);
+        $jws = $serializerManager->unserialize($accessToken);
+
+        // Verify the signature
+        if (!$jwsVerifier->verifyWithKeySet($jws, $this->signatureKeyset, 0)) {
+            throw new InvalidSignatureException();
+        }
+
+        $headerCheckerManager = new Checker\HeaderCheckerManager([
+            new Checker\AlgorithmChecker($this->signatureAlgorithm->list()),
+        ], [
+            new JWSTokenSupport(),
+        ]);
+        // if this check fails, an InvalidHeaderException is thrown
+        $headerCheckerManager->check($jws, 0);
+
+        return json_decode($jws->getPayload(), true);
+    }
+
+    private function verifyClaims(array $claims): array
+    {
+        // Verify the claims
+        $checkers = [
+            new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+            new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+            new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+            new Checker\AudienceChecker($this->audience),
+            new Checker\IssuerChecker($this->issuers),
+        ];
+        $claimCheckerManager = new ClaimCheckerManager($checkers);
+
+        // if this check fails, an InvalidClaimException is thrown
+        return $claimCheckerManager->check($claims);
+    }
+
+    private function decryptIfNeeded(string $accessToken): string
+    {
+        if (null === $this->decryptionKeyset || null === $this->decryptionAlgorithms) {
+            $this->logger?->debug('The encrypted tokens (JWE) are not supported. Skipping.');
+
+            return $accessToken;
+        }
+
+        $jweHeaderChecker = new Checker\HeaderCheckerManager(
+            [
+                new Checker\AlgorithmChecker($this->decryptionAlgorithms->list()),
+                new Checker\CallableChecker('enc', fn ($value) => \in_array($value, $this->decryptionAlgorithms->list())),
+                new Checker\CallableChecker('cty', fn ($value) => 'JWT' === $value),
+                new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+                new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+                new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+            ],
+            [new JWETokenSupport()]
+        );
+        $jweDecrypter = new JWEDecrypter($this->decryptionAlgorithms, null);
+        $serializerManager = new JWESerializerManager([new JweCompactSerializer()]);
+        try {
+            $jwe = $serializerManager->unserialize($accessToken);
+            $jweHeaderChecker->check($jwe, 0);
+            $result = $jweDecrypter->decryptUsingKeySet($jwe, $this->decryptionKeyset, 0);
+            if (false === $result) {
+                throw new \RuntimeException('The JWE could not be decrypted.');
+            }
+
+            $payload = $jwe->getPayload();
+            if (null === $payload) {
+                throw new \RuntimeException('The JWE payload is empty.');
+            }
+
+            return $payload;
+        } catch (\InvalidArgumentException|\RuntimeException $e) {
+            if ($this->enforceEncryption) {
+                $this->logger?->error('An error occurred while decrypting the token.', [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+                throw new BadCredentialsException('Encrypted token is required.', 0, $e);
+            }
+            $this->logger?->debug('The token decryption failed. Skipping as not mandatory.');
+
+            return $accessToken;
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add encryption support to `OidcTokenHandler` (JWE)
+
 7.2
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #50441
| License       | MIT

The changes add encryption support to OpenID Connect (OIDC) tokens in the Symfony Security Bundle. This is useful in making the application more secure. They also ensure the tokens are correctly decrypted and validated before use. Additionally, tests have been expanded to cover these new scenarios.

```yaml
security:
    firewalls:
        main:
            pattern: ^/
            access_token:
                token_handler:
                    oidc:
                        ...
                        encryption:
                            enabled: true
                            algorithms: [...]
                            keyset: '{"keys": [{...}]}'
```