### PR TITLE
Use first class callable syntax

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -77,7 +77,7 @@ class DoctrineDataCollector extends DataCollector
 
     public function getQueryCount(): int
     {
-        return array_sum(array_map('count', $this->data['queries']));
+        return array_sum(array_map(count(...), $this->data['queries']));
     }
 
     public function getQueries(): array

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -804,7 +804,7 @@ class EntityTypeTest extends BaseTypeTestCase
         $field->submit(1);
 
         $unitOfWorkIdentityMap = $this->em->getUnitOfWork()->getIdentityMap();
-        $managedEntitiesNames = array_map('strval', $unitOfWorkIdentityMap['Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity']);
+        $managedEntitiesNames = array_map(strval(...), $unitOfWorkIdentityMap['Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity']);
 
         $this->assertContains((string) $entity1, $managedEntitiesNames);
         $this->assertNotContains((string) $entity2, $managedEntitiesNames);

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -28,7 +28,7 @@ final class HttpKernelExtension extends AbstractExtension
             new TwigFunction('render', [HttpKernelRuntime::class, 'renderFragment'], ['is_safe' => ['html']]),
             new TwigFunction('render_*', [HttpKernelRuntime::class, 'renderFragmentStrategy'], ['is_safe' => ['html']]),
             new TwigFunction('fragment_uri', [HttpKernelRuntime::class, 'generateFragmentUri']),
-            new TwigFunction('controller', [self::class, 'controller']),
+            new TwigFunction('controller', self::controller(...)),
         ];
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -381,7 +381,7 @@ EOF
 
     private function filterDuplicateTransPaths(array $transPaths): array
     {
-        $transPaths = array_filter(array_map('realpath', $transPaths));
+        $transPaths = array_filter(array_map(realpath(...), $transPaths));
 
         sort($transPaths);
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -121,7 +121,7 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('trusted_header')
                     ->performNoDeepMerging()
                     ->defaultValue(['x-forwarded-for', 'x-forwarded-port', 'x-forwarded-proto'])
-                    ->beforeNormalization()->ifString()->then(fn ($v) => $v ? array_map('trim', explode(',', $v)) : [])->end()
+                    ->beforeNormalization()->ifString()->then(fn ($v) => $v ? array_map(trim(...), explode(',', $v)) : [])->end()
                     ->enumPrototype()
                         ->values([
                             'forwarded',
@@ -2076,7 +2076,7 @@ class Configuration implements ConfigurationInterface
                                 ->arrayNode('methods')
                                     ->beforeNormalization()
                                     ->ifArray()
-                                        ->then(fn ($v) => array_map('strtoupper', $v))
+                                        ->then(fn ($v) => array_map(strtoupper(...), $v))
                                     ->end()
                                     ->prototype('scalar')->end()
                                     ->info('A list of HTTP methods that triggers a retry for this status code. When empty, all methods are retried')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1176,7 +1176,7 @@ class FrameworkExtension extends Extension
         }
 
         if ($enabledLocales) {
-            $enabledLocales = implode('|', array_map('preg_quote', $enabledLocales));
+            $enabledLocales = implode('|', array_map(preg_quote(...), $enabledLocales));
             $container->getDefinition('routing.loader')->replaceArgument(2, ['_locale' => $enabledLocales]);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1122,7 +1122,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertArrayHasKey('cache_dir', $options);
         $this->assertSame($container->getParameter('kernel.cache_dir').'/translations', $options['cache_dir']);
 
-        $files = array_map('realpath', $options['resource_files']['en']);
+        $files = array_map(realpath(...), $options['resource_files']['en']);
         $ref = new \ReflectionClass(Validation::class);
         $this->assertContains(
             strtr(\dirname($ref->getFileName()).'/Resources/translations/validators.en.xlf', '/', \DIRECTORY_SEPARATOR),
@@ -2341,7 +2341,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         $container = $this->createContainerFromFile('trusted_proxies_private_ranges');
 
-        $this->assertSame(IpUtils::PRIVATE_SUBNETS, array_map('trim', explode(',', $container->getParameter('kernel.trusted_proxies'))));
+        $this->assertSame(IpUtils::PRIVATE_SUBNETS, array_map(trim(...), explode(',', $container->getParameter('kernel.trusted_proxies'))));
     }
 
     public function testWebhook()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -558,7 +558,7 @@ class RouterTest extends TestCase
             $this->assertTrue($cache->isFresh());
         } finally {
             if (is_dir($cacheDir)) {
-                array_map('unlink', glob($cacheDir.\DIRECTORY_SEPARATOR.'*'));
+                array_map(unlink(...), glob($cacheDir.\DIRECTORY_SEPARATOR.'*'));
                 rmdir($cacheDir);
             }
         }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -239,7 +239,7 @@ class MainConfiguration implements ConfigurationInterface
                     ->booleanNode('invalidate_session')->defaultTrue()->end()
                     ->arrayNode('clear_site_data')
                         ->performNoDeepMerging()
-                        ->beforeNormalization()->ifString()->then(fn ($v) => $v ? array_map('trim', explode(',', $v)) : [])->end()
+                        ->beforeNormalization()->ifString()->then(fn ($v) => $v ? array_map(trim(...), explode(',', $v)) : [])->end()
                         ->enumPrototype()
                             ->values([
                                 '*', 'cache', 'cookies', 'storage', 'executionContexts',

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -933,7 +933,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
     private function createRequestMatcher(ContainerBuilder $container, ?string $path = null, ?string $host = null, ?int $port = null, array $methods = [], ?array $ips = null, array $attributes = []): Reference
     {
         if ($methods) {
-            $methods = array_map('strtoupper', $methods);
+            $methods = array_map(strtoupper(...), $methods);
         }
 
         if ($ips) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
@@ -123,7 +123,7 @@ abstract class CompleteConfigurationTestCase extends TestCase
         foreach (array_keys($arguments[1]->getValues()) as $contextId) {
             $contextDef = $container->getDefinition($contextId);
             $arguments = $contextDef->getArguments();
-            $listeners[] = array_map('strval', $arguments[0]->getValues());
+            $listeners[] = array_map(strval(...), $arguments[0]->getValues());
 
             $configDef = $container->getDefinition((string) $arguments[3]);
             $configs[] = array_values($configDef->getArguments());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -711,7 +711,7 @@ class SecurityExtensionTest extends TestCase
 
         $container->compile();
 
-        $this->assertEquals($expectedAuthenticators, array_map('strval', $container->getDefinition('security.authenticator.manager.main')->getArgument(0)));
+        $this->assertEquals($expectedAuthenticators, array_map(strval(...), $container->getDefinition('security.authenticator.manager.main')->getArgument(0)));
     }
 
     public static function provideConfigureCustomAuthenticatorData(): iterable
@@ -816,7 +816,7 @@ class SecurityExtensionTest extends TestCase
 
         /** @var IteratorArgument $listenersIteratorArgument */
         $listenersIteratorArgument = $container->getDefinition('security.firewall.map.context.main')->getArgument(0);
-        $firewallListeners = array_map('strval', $listenersIteratorArgument->getValues());
+        $firewallListeners = array_map(strval(...), $listenersIteratorArgument->getValues());
         $this->assertContains('custom_firewall_listener_id', $firewallListeners);
     }
 

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperRepositoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperRepositoryTest.php
@@ -91,7 +91,7 @@ class AssetMapperRepositoryTest extends TestCase
         $this->assertCount(8, $actualAllAssets);
 
         // use realpath to normalize slashes on Windows for comparison
-        $expectedAllAssets = array_map('realpath', [
+        $expectedAllAssets = array_map(realpath(...), [
             'file1.css' => __DIR__.'/Fixtures/dir1/file1.css',
             'file2.js' => __DIR__.'/Fixtures/dir1/file2.js',
             'already-abcdefVWXYZ0123456789.digested.css' => __DIR__.'/Fixtures/dir2/already-abcdefVWXYZ0123456789.digested.css',
@@ -101,7 +101,7 @@ class AssetMapperRepositoryTest extends TestCase
             'subdir/file6.js' => __DIR__.'/Fixtures/dir2/subdir/file6.js',
             'test.gif.foo' => __DIR__.'/Fixtures/dir3/test.gif.foo',
         ]);
-        $this->assertEquals($expectedAllAssets, array_map('realpath', $actualAllAssets));
+        $this->assertEquals($expectedAllAssets, array_map(realpath(...), $actualAllAssets));
     }
 
     public function testAllWithNamespaces()
@@ -123,10 +123,10 @@ class AssetMapperRepositoryTest extends TestCase
             'dir3_namespace/test.gif.foo' => __DIR__.'/Fixtures/dir3/test.gif.foo',
         ];
 
-        $normalizedExpectedAllAssets = array_map('realpath', $expectedAllAssets);
+        $normalizedExpectedAllAssets = array_map(realpath(...), $expectedAllAssets);
 
         $actualAssets = $repository->all();
-        $normalizedActualAssets = array_map('realpath', $actualAssets);
+        $normalizedActualAssets = array_map(realpath(...), $actualAssets);
 
         $this->assertEquals($normalizedExpectedAllAssets, $normalizedActualAssets);
     }

--- a/src/Symfony/Component/Cache/Marshaller/DeflateMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/DeflateMarshaller.php
@@ -30,7 +30,7 @@ class DeflateMarshaller implements MarshallerInterface
 
     public function marshall(array $values, ?array &$failed): array
     {
-        return array_map('gzdeflate', $this->marshaller->marshall($values, $failed));
+        return array_map(gzdeflate(...), $this->marshaller->marshall($values, $failed));
     }
 
     public function unmarshall(string $value): mixed

--- a/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
+++ b/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
@@ -23,7 +23,7 @@ class LockRegistryTest extends TestCase
         }
         $lockFiles = LockRegistry::setFiles([]);
         LockRegistry::setFiles($lockFiles);
-        $expected = array_map('realpath', glob(__DIR__.'/../Adapter/*.php'));
+        $expected = array_map(realpath(...), glob(__DIR__.'/../Adapter/*.php'));
         $this->assertSame($expected, $lockFiles);
     }
 }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -617,7 +617,7 @@ class Application implements ResetInterface
     public function findNamespace(string $namespace): string
     {
         $allNamespaces = $this->getNamespaces();
-        $expr = implode('[^:]*:', array_map('preg_quote', explode(':', $namespace))).'[^:]*';
+        $expr = implode('[^:]*:', array_map(preg_quote(...), explode(':', $namespace))).'[^:]*';
         $namespaces = preg_grep('{^'.$expr.'}', $allNamespaces);
 
         if (!$namespaces) {
@@ -671,7 +671,7 @@ class Application implements ResetInterface
         }
 
         $allCommands = $this->commandLoader ? array_merge($this->commandLoader->getNames(), array_keys($this->commands)) : array_keys($this->commands);
-        $expr = implode('[^:]*:', array_map('preg_quote', explode(':', $name))).'[^:]*';
+        $expr = implode('[^:]*:', array_map(preg_quote(...), explode(':', $name))).'[^:]*';
         $commands = preg_grep('{^'.$expr.'}', $allCommands);
 
         if (!$commands) {

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -88,7 +88,7 @@ class InputOption
                 $shortcut = implode('|', $shortcut);
             }
             $shortcuts = preg_split('{(\|)-?}', ltrim($shortcut, '-'));
-            $shortcuts = array_filter($shortcuts, 'strlen');
+            $shortcuts = array_filter($shortcuts, strlen(...));
             $shortcut = implode('|', $shortcuts);
 
             if ('' === $shortcut) {

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -260,7 +260,7 @@ class Question
 
     protected function isAssoc(array $array): bool
     {
-        return (bool) \count(array_filter(array_keys($array), 'is_string'));
+        return (bool) \count(array_filter(array_keys($array), is_string(...)));
     }
 
     public function isTrimmable(): bool

--- a/src/Symfony/Component/Console/Tester/CommandCompletionTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandCompletionTester.php
@@ -49,6 +49,6 @@ class CommandCompletionTester
             $options[] = '--'.$option->getName();
         }
 
-        return array_map('strval', array_merge($options, $suggestions->getValueSuggestions()));
+        return array_map(strval(...), array_merge($options, $suggestions->getValueSuggestions()));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -662,7 +662,7 @@ class AutowirePass extends AbstractRecursivePass
             return \sprintf(' Did you mean to target%s "%s" instead?', 1 < \count($autowiringAliases) ? ' one of' : '', implode('", "', $autowiringAliases));
         }
 
-        if (!$container->has($type) && false !== $key = array_search(strtolower($type), array_map('strtolower', $servicesAndAliases))) {
+        if (!$container->has($type) && false !== $key = array_search(strtolower($type), array_map(strtolower(...), $servicesAndAliases))) {
             return \sprintf(' Did you mean "%s"?', $servicesAndAliases[$key]);
         } elseif (isset($this->ambiguousServiceTypes[$type])) {
             $message = \sprintf('one of these existing services: "%s"', implode('", "', $this->ambiguousServiceTypes[$type]));

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -298,7 +298,7 @@ class Container implements ContainerInterface, ResetInterface
      */
     public function getServiceIds(): array
     {
-        return array_map('strval', array_unique(array_merge(['service_container'], array_keys($this->fileMap), array_keys($this->methodMap), array_keys($this->aliases), array_keys($this->services))));
+        return array_map(strval(...), array_unique(array_merge(['service_container'], array_keys($this->fileMap), array_keys($this->methodMap), array_keys($this->aliases), array_keys($this->services))));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -781,7 +781,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
     public function getServiceIds(): array
     {
-        return array_map('strval', array_unique(array_merge(array_keys($this->getDefinitions()), array_keys($this->aliasDefinitions), parent::getServiceIds())));
+        return array_map(strval(...), array_unique(array_merge(array_keys($this->getDefinitions()), array_keys($this->aliasDefinitions), parent::getServiceIds())));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -720,7 +720,7 @@ class XmlFileLoader extends FileLoader
                 $locationstart = '';
             }
             $drive = '\\' === \DIRECTORY_SEPARATOR ? array_shift($parts).'/' : '';
-            $location = $locationstart.$drive.implode('/', array_map('rawurlencode', $parts));
+            $location = $locationstart.$drive.implode('/', array_map(rawurlencode(...), $parts));
 
             $imports .= \sprintf('  <xsd:import namespace="%s" schemaLocation="%s" />'."\n", $namespace, $location);
         }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -71,7 +71,7 @@ class ParameterBag implements ParameterBagInterface
 
             $nonNestedAlternative = null;
             if (!\count($alternatives) && str_contains($name, '.')) {
-                $namePartsLength = array_map('strlen', explode('.', $name));
+                $namePartsLength = array_map(strlen(...), explode('.', $name));
                 $key = substr($name, 0, -1 * (1 + array_pop($namePartsLength)));
                 while (\count($namePartsLength)) {
                     if ($this->has($key)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -781,7 +781,7 @@ class XmlFileLoaderTest extends TestCase
         sort($ids);
         $this->assertSame([Prototype\Foo::class, Prototype\NotFoo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
-        $resources = array_map('strval', $container->getResources());
+        $resources = array_map(strval(...), $container->getResources());
 
         $fixturesDir = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Fixtures'.\DIRECTORY_SEPARATOR;
         $this->assertContains((string) new FileResource($fixturesDir.'xml'.\DIRECTORY_SEPARATOR.'services_prototype.xml'), $resources);
@@ -818,7 +818,7 @@ class XmlFileLoaderTest extends TestCase
         sort($ids);
         $this->assertSame([Prototype\Foo::class, Prototype\NotFoo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
-        $resources = array_map('strval', $container->getResources());
+        $resources = array_map(strval(...), $container->getResources());
 
         $fixturesDir = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Fixtures'.\DIRECTORY_SEPARATOR;
         $this->assertContains((string) new FileResource($fixturesDir.'xml'.\DIRECTORY_SEPARATOR.$fileName), $resources);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -553,7 +553,7 @@ class YamlFileLoaderTest extends TestCase
         sort($ids);
         $this->assertSame([Prototype\Foo::class, Prototype\NotFoo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
-        $resources = array_map('strval', $container->getResources());
+        $resources = array_map(strval(...), $container->getResources());
 
         $fixturesDir = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Fixtures'.\DIRECTORY_SEPARATOR;
         $this->assertContains((string) new FileResource($fixturesDir.'yaml'.\DIRECTORY_SEPARATOR.'services_prototype.yml'), $resources);

--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -170,7 +170,7 @@ EOT
         $filePath = $_SERVER['SYMFONY_DOTENV_PATH'] ?? $this->projectDirectory.\DIRECTORY_SEPARATOR.'.env';
         $envFiles = $this->getEnvFiles($filePath);
 
-        return array_keys($this->getVariables(array_filter($envFiles, 'is_file'), null));
+        return array_keys($this->getVariables(array_filter($envFiles, is_file(...)), null));
     }
 
     private function getEnvFiles(string $filePath): array

--- a/src/Symfony/Component/Emoji/Resources/bin/build.php
+++ b/src/Symfony/Component/Emoji/Resources/bin/build.php
@@ -94,7 +94,7 @@ final class Builder
                     continue;
                 }
                 $parts = preg_split('//u', $emoji, -1, \PREG_SPLIT_NO_EMPTY);
-                $emojiCodePoints = strtoupper(implode('-', array_map('dechex', array_map('mb_ord', $parts))));
+                $emojiCodePoints = strtoupper(implode('-', array_map(dechex(...), array_map(mb_ord(...), $parts))));
                 if (!array_key_exists($emojiCodePoints, $emojisCodePoints)) {
                     continue;
                 }

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -575,7 +575,7 @@ class ErrorHandler
         $sameHandlerLimit = 10;
 
         while (!\is_array($handler) || !$handler[0] instanceof self) {
-            $handler = set_exception_handler('is_int');
+            $handler = set_exception_handler(is_int(...));
             restore_exception_handler();
 
             if (!$handler) {

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/ClassNotFoundErrorEnhancerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/ClassNotFoundErrorEnhancerTest.php
@@ -53,7 +53,7 @@ class ClassNotFoundErrorEnhancerTest extends TestCase
                 // Unregister all autoloaders to ensure the custom provided
                 // autoloader is the only one to be used during the test run.
                 $autoloaders = spl_autoload_functions();
-                array_map('spl_autoload_unregister', $autoloaders);
+                array_map(spl_autoload_unregister(...), $autoloaders);
                 spl_autoload_register($autoloader);
             }
 
@@ -62,7 +62,7 @@ class ClassNotFoundErrorEnhancerTest extends TestCase
         } finally {
             if ($autoloader) {
                 spl_autoload_unregister($autoloader);
-                array_map('spl_autoload_register', $autoloaders);
+                array_map(spl_autoload_register(...), $autoloaders);
             }
         }
 

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -581,7 +581,7 @@ class ErrorHandlerTest extends TestCase
     {
         try {
             if ($previousHandlerWasDefined) {
-                set_error_handler('count');
+                set_error_handler(count(...));
             }
 
             $logger = $loggerSetsAnotherHandler ? new LoggerThatSetAnErrorHandler() : new NullLogger();

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
@@ -38,9 +38,8 @@ class WrappedListenerTest extends TestCase
             [['Symfony\Component\EventDispatcher\Tests\Debug\FooListener', 'invalidMethod'], 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::invalidMethod'],
             ['var_dump', 'var_dump'],
             [function () {}, 'closure'],
-            [\Closure::fromCallable([new FooListener(), 'listen']), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listen'],
-            [\Closure::fromCallable(['Symfony\Component\EventDispatcher\Tests\Debug\FooListener', 'listenStatic']), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listenStatic'],
-            [\Closure::fromCallable(function () {}), 'closure'],
+            [(new FooListener())->listen(...), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listen'],
+            [FooListener::listenStatic(...), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listenStatic'],
             [[#[\Closure(name: FooListener::class)] static fn () => new FooListener(), 'listen'], 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listen'],
         ];
     }

--- a/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
+++ b/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
@@ -14,7 +14,7 @@ if ('cli' !== \PHP_SAPI) {
 }
 
 $operators = ['not', '!', 'or', '||', '&&', 'and', '|', '^', '&', '==', '===', '!=', '!==', '<', '>', '>=', '<=', 'not in', 'in', '..', '+', '-', '~', '*', '/', '%', 'contains', 'starts with', 'ends with', 'matches', '**'];
-$operators = array_combine($operators, array_map('strlen', $operators));
+$operators = array_combine($operators, array_map(strlen(...), $operators));
 arsort($operators);
 
 $regex = [];

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1178,7 +1178,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         $finder = $this->buildFinder();
         $a = iterator_to_array($finder->directories()->in(self::$tmpDir));
-        $a = array_values(array_map('strval', $a));
+        $a = array_values(array_map(strval(...), $a));
         sort($a);
         $this->assertEquals($expected, $a, 'implements the \IteratorAggregate interface');
     }

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -87,7 +87,7 @@ class ArrayChoiceList implements ChoiceListInterface
 
     public function getValues(): array
     {
-        return array_map('strval', array_keys($this->choices));
+        return array_map(strval(...), array_keys($this->choices));
     }
 
     public function getStructuredValues(): array

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -271,7 +271,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             return;
         }
 
-        $groupLabels = \is_array($groupLabels) ? array_map('strval', $groupLabels) : [(string) $groupLabels];
+        $groupLabels = \is_array($groupLabels) ? array_map(strval(...), $groupLabels) : [(string) $groupLabels];
 
         foreach ($groupLabels as $groupLabel) {
             // Initialize the group views if necessary. Unnecessarily built group

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/FilterChoiceLoaderDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/FilterChoiceLoaderDecoratorTest.php
@@ -78,7 +78,7 @@ class FilterChoiceLoaderDecoratorTest extends TestCase
     public function testLoadChoicesForValues()
     {
         $evenChoices = [1 => 2, 3 => 4];
-        $values = array_map('strval', range(1, 4));
+        $values = array_map(strval(...), range(1, 4));
 
         $filter = fn ($choice) => 0 === $choice % 2;
 

--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -141,7 +141,7 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
 
         if ('' !== $request->getUri()->getUserInfo() && !$request->hasHeader('authorization')) {
             $auth = explode(':', $request->getUri()->getUserInfo(), 2);
-            $auth = array_map('rawurldecode', $auth) + [1 => ''];
+            $auth = array_map(rawurldecode(...), $auth) + [1 => ''];
             $request->setHeader('Authorization', 'Basic '.base64_encode(implode(':', $auth)));
         }
 

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -388,7 +388,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
             }
 
             if (\function_exists('openssl_x509_read') && $certinfo = curl_getinfo($ch, \CURLINFO_CERTINFO)) {
-                $info['peer_certificate_chain'] = array_map('openssl_x509_read', array_column($certinfo, 'Cert'));
+                $info['peer_certificate_chain'] = array_map(openssl_x509_read(...), array_column($certinfo, 'Cert'));
             }
 
             if (300 <= $info['http_code'] && $info['http_code'] < 400) {

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -46,7 +46,7 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
         }
 
         ksort($headers);
-        $max = max(array_map('strlen', array_keys($headers))) + 1;
+        $max = max(array_map(strlen(...), array_keys($headers))) + 1;
         $content = '';
         foreach ($headers as $name => $values) {
             $name = ucwords($name, '-');

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1658,7 +1658,7 @@ class Request
      */
     public function getCharsets(): array
     {
-        return $this->charsets ??= array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept-Charset'))->all()));
+        return $this->charsets ??= array_map(strval(...), array_keys(AcceptHeader::fromString($this->headers->get('Accept-Charset'))->all()));
     }
 
     /**
@@ -1668,7 +1668,7 @@ class Request
      */
     public function getEncodings(): array
     {
-        return $this->encodings ??= array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept-Encoding'))->all()));
+        return $this->encodings ??= array_map(strval(...), array_keys(AcceptHeader::fromString($this->headers->get('Accept-Encoding'))->all()));
     }
 
     /**
@@ -1678,7 +1678,7 @@ class Request
      */
     public function getAcceptableContentTypes(): array
     {
-        return $this->acceptableContentTypes ??= array_map('strval', array_keys(AcceptHeader::fromString($this->headers->get('Accept'))->all()));
+        return $this->acceptableContentTypes ??= array_map(strval(...), array_keys(AcceptHeader::fromString($this->headers->get('Accept'))->all()));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/MethodRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/MethodRequestMatcher.php
@@ -32,7 +32,7 @@ class MethodRequestMatcher implements RequestMatcherInterface
      */
     public function __construct(array|string $methods)
     {
-        $this->methods = array_reduce(array_map('strtoupper', (array) $methods), static fn (array $methods, string $method) => array_merge($methods, preg_split('/\s*,\s*/', $method)), []);
+        $this->methods = array_reduce(array_map(strtoupper(...), (array) $methods), static fn (array $methods, string $method) => array_merge($methods, preg_split('/\s*,\s*/', $method)), []);
     }
 
     public function matches(Request $request): bool

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/SchemeRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/SchemeRequestMatcher.php
@@ -32,7 +32,7 @@ class SchemeRequestMatcher implements RequestMatcherInterface
      */
     public function __construct(array|string $schemes)
     {
-        $this->schemes = array_reduce(array_map('strtolower', (array) $schemes), static fn (array $schemes, string $scheme) => array_merge($schemes, preg_split('/\s*,\s*/', $scheme)), []);
+        $this->schemes = array_reduce(array_map(strtolower(...), (array) $schemes), static fn (array $schemes, string $scheme) => array_merge($schemes, preg_split('/\s*,\s*/', $scheme)), []);
     }
 
     public function matches(Request $request): bool

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -87,7 +87,7 @@ class ResponseHeaderBag extends HeaderBag
         if (null !== $key) {
             $key = strtr($key, self::UPPER, self::LOWER);
 
-            return 'set-cookie' !== $key ? $headers[$key] ?? [] : array_map('strval', $this->getCookies());
+            return 'set-cookie' !== $key ? $headers[$key] ?? [] : array_map(strval(...), $this->getCookies());
         }
 
         foreach ($this->getCookies() as $cookie) {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -442,7 +442,7 @@ class PdoSessionHandler extends AbstractSessionHandler
             return $dsnOrUrl; // If the URL is not valid, let's assume it might be a DSN already.
         }
 
-        $params = array_map('rawurldecode', $params);
+        $params = array_map(rawurldecode(...), $params);
 
         // Override the default username and password. Values passed through options will still win over these in the constructor.
         if (isset($params['user'])) {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -35,7 +35,7 @@ class MockFileSessionStorageTest extends TestCase
 
     protected function tearDown(): void
     {
-        array_map('unlink', glob($this->sessionDir.'/*'));
+        array_map(unlink(...), glob($this->sessionDir.'/*'));
         if (is_dir($this->sessionDir)) {
             @rmdir($this->sessionDir);
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -50,7 +50,7 @@ class NativeSessionStorageTest extends TestCase
     protected function tearDown(): void
     {
         session_write_close();
-        array_map('unlink', glob($this->savePath.'/*'));
+        array_map(unlink(...), glob($this->savePath.'/*'));
         if (is_dir($this->savePath)) {
             @rmdir($this->savePath);
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -46,7 +46,7 @@ class PhpBridgeSessionStorageTest extends TestCase
     protected function tearDown(): void
     {
         session_write_close();
-        array_map('unlink', glob($this->savePath.'/*'));
+        array_map(unlink(...), glob($this->savePath.'/*'));
         if (is_dir($this->savePath)) {
             @rmdir($this->savePath);
         }

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -47,7 +47,7 @@ class DebugHandlersListener implements EventSubscriberInterface
             // BC with Symfony 5
             $webMode = null;
         }
-        $handler = set_exception_handler('is_int');
+        $handler = set_exception_handler(is_int(...));
         $this->earlyHandler = \is_array($handler) ? $handler[0] : null;
         restore_exception_handler();
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -684,7 +684,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             'inline_factories' => $buildParameters['.container.dumper.inline_factories'] ?? false,
             'inline_class_loader' => $buildParameters['.container.dumper.inline_class_loader'] ?? $this->debug,
             'build_time' => $container->hasParameter('kernel.container_build_time') ? $container->getParameter('kernel.container_build_time') : time(),
-            'preload_classes' => array_map('get_class', $this->bundles),
+            'preload_classes' => array_map(get_class(...), $this->bundles),
         ]);
 
         $rootCode = array_pop($content);
@@ -746,7 +746,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         }
 
         if ($container->hasParameter('kernel.trusted_proxies') && $container->hasParameter('kernel.trusted_headers') && $trustedProxies = $container->getParameter('kernel.trusted_proxies')) {
-            Request::setTrustedProxies(\is_array($trustedProxies) ? $trustedProxies : array_map('trim', explode(',', $trustedProxies)), $container->getParameter('kernel.trusted_headers'));
+            Request::setTrustedProxies(\is_array($trustedProxies) ? $trustedProxies : array_map(trim(...), explode(',', $trustedProxies)), $container->getParameter('kernel.trusted_headers'));
         }
 
         return $container;

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
@@ -73,7 +73,7 @@ class TextBundleWriter implements BundleWriterInterface
         }
 
         if (\is_array($value)) {
-            $intValues = \count($value) === \count(array_filter($value, 'is_int'));
+            $intValues = \count($value) === \count(array_filter($value, is_int(...)));
 
             // check that the keys are 0-indexed and ascending
             $intKeys = array_is_list($value);

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -118,7 +118,7 @@ class Connection extends AbstractConnection
         $resolver->setDefault('referrals', false);
         $resolver->setAllowedTypes('referrals', 'bool');
         $resolver->setDefault('options', function (OptionsResolver $options, Options $parent) {
-            $options->setDefined(array_map('strtolower', array_keys((new \ReflectionClass(ConnectionOptions::class))->getConstants())));
+            $options->setDefined(array_map(strtolower(...), array_keys((new \ReflectionClass(ConnectionOptions::class))->getConstants())));
 
             if (true === $parent['debug']) {
                 $options->setDefault('debug_level', 7);

--- a/src/Symfony/Component/Mailer/Bridge/Mailomat/Transport/MailomatApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailomat/Transport/MailomatApiTransport.php
@@ -85,7 +85,7 @@ final class MailomatApiTransport extends AbstractApiTransport
     {
         $payload = [
             'from' => $this->addressToPayload($envelope->getSender()),
-            'to' => array_map([$this, 'addressToPayload'], $email->getTo()),
+            'to' => array_map($this->addressToPayload(...), $email->getTo()),
             'subject' => $email->getSubject(),
             'text' => $email->getTextBody(),
             'html' => $email->getHtmlBody(),
@@ -93,15 +93,15 @@ final class MailomatApiTransport extends AbstractApiTransport
         ];
 
         if ($email->getCc()) {
-            $payload['cc'] = array_map([$this, 'addressToPayload'], $email->getCc());
+            $payload['cc'] = array_map($this->addressToPayload(...), $email->getCc());
         }
 
         if ($email->getBcc()) {
-            $payload['bcc'] = array_map([$this, 'addressToPayload'], $email->getBcc());
+            $payload['bcc'] = array_map($this->addressToPayload(...), $email->getBcc());
         }
 
         if ($email->getReplyTo()) {
-            $payload['replyTo'] = array_map([$this, 'addressToPayload'], $email->getReplyTo());
+            $payload['replyTo'] = array_map($this->addressToPayload(...), $email->getReplyTo());
         }
 
         return $payload;

--- a/src/Symfony/Component/Mailer/EventListener/MessengerTransportListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessengerTransportListener.php
@@ -35,7 +35,7 @@ final class MessengerTransportListener implements EventSubscriberInterface
         }
 
         $names = $message->getHeaders()->get('X-Bus-Transport')->getBody();
-        $names = array_map('trim', explode(',', $names));
+        $names = array_map(trim(...), explode(',', $names));
         $event->addStamp(new TransportNamesStamp($names));
         $message->getHeaders()->remove('X-Bus-Transport');
     }

--- a/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
@@ -63,7 +63,7 @@ class RoundRobinTransport implements TransportInterface
 
     public function __toString(): string
     {
-        return $this->getNameSymbol().'('.implode(' ', array_map('strval', $this->transports)).')';
+        return $this->getNameSymbol().'('.implode(' ', array_map(strval(...), $this->transports)).')';
     }
 
     /**

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -204,7 +204,7 @@ class EsmtpTransport extends SmtpTransport
         $code = null;
         $authNames = [];
         $errors = [];
-        $modes = array_map('strtolower', $modes);
+        $modes = array_map(strtolower(...), $modes);
         foreach ($this->authenticators as $authenticator) {
             if (!\in_array(strtolower($authenticator->getAuthKeyword()), $modes, true)) {
                 continue;

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandleDescriptorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandleDescriptorTest.php
@@ -30,15 +30,15 @@ class HandleDescriptorTest extends TestCase
     public static function provideHandlers(): iterable
     {
         yield [function () {}, 'Closure'];
-        yield ['var_dump', 'var_dump'];
+        yield [var_dump(...), 'var_dump'];
         yield [new DummyCommandHandler(), DummyCommandHandler::class.'::__invoke'];
         yield [
             [new DummyCommandHandlerWithSpecificMethod(), 'handle'],
             DummyCommandHandlerWithSpecificMethod::class.'::handle',
         ];
-        yield [\Closure::fromCallable(function () {}), 'Closure'];
-        yield [\Closure::fromCallable(new DummyCommandHandler()), DummyCommandHandler::class.'::__invoke'];
-        yield [\Closure::bind(\Closure::fromCallable(function () {}), new \stdClass()), 'Closure'];
+        yield [(function () {})(...), 'Closure'];
+        yield [(new DummyCommandHandler())(...), DummyCommandHandler::class.'::__invoke'];
+        yield [\Closure::bind((function () {})(...), new \stdClass()), 'Closure'];
         yield [new class() {
             public function __invoke()
             {

--- a/src/Symfony/Component/Mime/CharacterStream.php
+++ b/src/Symfony/Component/Mime/CharacterStream.php
@@ -135,7 +135,7 @@ final class CharacterStream
     public function readBytes(int $length): ?array
     {
         if (null !== $read = $this->read($length)) {
-            return array_map('ord', str_split($read, 1));
+            return array_map(ord(...), str_split($read, 1));
         }
 
         return null;

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
@@ -91,7 +91,7 @@ final class TwitterTransport extends AbstractTransport
 
         $oauth['oauth_signature'] = base64_encode(hash_hmac(
             'sha1',
-            implode('&', array_map('rawurlencode', [
+            implode('&', array_map(rawurlencode(...), [
                 $method,
                 $url,
                 implode('&', array_map(fn ($k) => rawurlencode($k).'='.rawurlencode($sign[$k]), array_keys($sign))),

--- a/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php
@@ -48,7 +48,7 @@ class RoundRobinTransport implements TransportInterface
 
     public function __toString(): string
     {
-        return implode(' '.$this->getNameSymbol().' ', array_map('strval', $this->transports));
+        return implode(' '.$this->getNameSymbol().' ', array_map(strval(...), $this->transports));
     }
 
     public function supports(MessageInterface $message): bool

--- a/src/Symfony/Component/Process/PhpSubprocess.php
+++ b/src/Symfony/Component/Process/PhpSubprocess.php
@@ -156,7 +156,7 @@ class PhpSubprocess extends Process
         $paths = [(string) php_ini_loaded_file()];
 
         if (false !== $scanned = php_ini_scanned_files()) {
-            $paths = array_merge($paths, array_map('trim', explode(',', $scanned)));
+            $paths = array_merge($paths, array_map(trim(...), explode(',', $scanned)));
         }
 
         return $paths;

--- a/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
+++ b/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
@@ -27,7 +27,7 @@ class MethodNotAllowedException extends \RuntimeException implements ExceptionIn
      */
     public function __construct(array $allowedMethods, string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
-        $this->allowedMethods = array_map('strtoupper', $allowedMethods);
+        $this->allowedMethods = array_map(strtoupper(...), $allowedMethods);
 
         parent::__construct($message, $code, $previous);
     }

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -164,7 +164,7 @@ class Route implements \Serializable
      */
     public function setSchemes(string|array $schemes): static
     {
-        $this->schemes = array_map('strtolower', (array) $schemes);
+        $this->schemes = array_map(strtolower(...), (array) $schemes);
         $this->compiled = null;
 
         return $this;
@@ -199,7 +199,7 @@ class Route implements \Serializable
      */
     public function setMethods(string|array $methods): static
     {
-        $this->methods = array_map('strtoupper', (array) $methods);
+        $this->methods = array_map(strtoupper(...), (array) $methods);
         $this->compiled = null;
 
         return $this;

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -43,7 +43,7 @@ class RouterTest extends TestCase
     protected function tearDown(): void
     {
         if (is_dir($this->cacheDir)) {
-            array_map('unlink', glob($this->cacheDir.\DIRECTORY_SEPARATOR.'*'));
+            array_map(unlink(...), glob($this->cacheDir.\DIRECTORY_SEPARATOR.'*'));
             @rmdir($this->cacheDir);
         }
     }

--- a/src/Symfony/Component/Security/Core/User/InMemoryUser.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUser.php
@@ -88,8 +88,8 @@ final class InMemoryUser implements UserInterface, PasswordAuthenticatedUserInte
             return false;
         }
 
-        $currentRoles = array_map('strval', (array) $this->getRoles());
-        $newRoles = array_map('strval', (array) $user->getRoles());
+        $currentRoles = array_map(strval(...), (array) $this->getRoles());
+        $newRoles = array_map(strval(...), (array) $user->getRoles());
         $rolesChanged = \count($currentRoles) !== \count($newRoles) || \count($currentRoles) !== \count(array_intersect($currentRoles, $newRoles));
         if ($rolesChanged) {
             return false;

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -298,7 +298,7 @@ class ContextListener extends AbstractListener
             }
         }
 
-        $userRoles = array_map('strval', (array) $refreshedUser->getRoles());
+        $userRoles = array_map(strval(...), (array) $refreshedUser->getRoles());
 
         if (
             \count($userRoles) !== \count($refreshedToken->getRoleNames())

--- a/src/Symfony/Component/Serializer/DataCollector/SerializerDataCollector.php
+++ b/src/Symfony/Component/Serializer/DataCollector/SerializerDataCollector.php
@@ -50,7 +50,7 @@ class SerializerDataCollector extends DataCollector implements LateDataCollector
 
     public function getHandledCount(): int
     {
-        return array_sum(array_map('count', $this->data));
+        return array_sum(array_map(count(...), $this->data));
     }
 
     public function getTotalTime(): float

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CacheableObjectAttributesTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CacheableObjectAttributesTestTrait.php
@@ -48,7 +48,7 @@ trait CacheableObjectAttributesTestTrait
      */
     public function testReversedObjectCollectionNormalization()
     {
-        [$collection, $expectedArray] = array_map('array_reverse', $this->getObjectCollectionWithExpectedArray());
+        [$collection, $expectedArray] = array_map(array_reverse(...), $this->getObjectCollectionWithExpectedArray());
         $this->assertCollectionNormalizedProperly($collection, $expectedArray);
     }
 

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -433,7 +433,7 @@ abstract class AbstractUnicodeString extends AbstractString
             $prefix = $prefix->string;
         }
 
-        $prefix = implode('|', array_map('preg_quote', (array) $prefix));
+        $prefix = implode('|', array_map(preg_quote(...), (array) $prefix));
         $str->string = preg_replace("{^(?:$prefix)}iuD", '', $this->string);
 
         return $str;
@@ -466,7 +466,7 @@ abstract class AbstractUnicodeString extends AbstractString
             $suffix = $suffix->string;
         }
 
-        $suffix = implode('|', array_map('preg_quote', (array) $suffix));
+        $suffix = implode('|', array_map(preg_quote(...), (array) $suffix));
         $str->string = preg_replace("{(?:$suffix)$}iuD", '', $this->string);
 
         return $str;

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -26,7 +26,7 @@ class LazyString implements \Stringable, \JsonSerializable
     public static function fromCallable(callable|array $callback, mixed ...$arguments): static
     {
         if (\is_array($callback) && !\is_callable($callback) && !(($callback[0] ?? null) instanceof \Closure || 2 < \count($callback))) {
-            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be a callable or a [Closure, method] lazy-callable, "%s" given.', __METHOD__, '['.implode(', ', array_map('get_debug_type', $callback)).']'));
+            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be a callable or a [Closure, method] lazy-callable, "%s" given.', __METHOD__, '['.implode(', ', array_map(get_debug_type(...), $callback)).']'));
         }
 
         $lazyString = new static();

--- a/src/Symfony/Component/Translation/Dumper/MoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/MoFileDumper.php
@@ -28,7 +28,7 @@ class MoFileDumper extends FileDumper
         $size = 0;
 
         foreach ($messages->all($domain) as $source => $target) {
-            $offsets[] = array_map('strlen', [$sources, $source, $targets, $target]);
+            $offsets[] = array_map(strlen(...), [$sources, $source, $targets, $target]);
             $sources .= "\0".$source;
             $targets .= "\0".$target;
             ++$size;

--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -82,7 +82,7 @@ class PoFileLoader extends FileLoader
                 $item = $defaults;
                 $flags = [];
             } elseif (str_starts_with($line, '#,')) {
-                $flags = array_map('trim', explode(',', substr($line, 2)));
+                $flags = array_map(trim(...), explode(',', substr($line, 2)));
             } elseif (str_starts_with($line, 'msgid "')) {
                 // We start a new msg so save previous
                 // TODO: this fails when comments or contexts are added

--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -209,7 +209,7 @@ function printTable($translations, $verboseOutput, bool $includeCompletedLanguag
 
         return;
     }
-    $longestLocaleNameLength = max(array_map('strlen', array_keys($translations)));
+    $longestLocaleNameLength = max(array_map(strlen(...), array_keys($translations)));
 
     foreach ($translations as $locale => $translation) {
         if (!$includeCompletedLanguages && $translation['is_completed']) {

--- a/src/Symfony/Component/Translation/Util/XliffUtils.php
+++ b/src/Symfony/Component/Translation/Util/XliffUtils.php
@@ -161,7 +161,7 @@ class XliffUtils
         }
 
         $drive = '\\' === \DIRECTORY_SEPARATOR ? array_shift($parts).'/' : '';
-        $newPath = $locationstart.$drive.implode('/', array_map('rawurlencode', $parts));
+        $newPath = $locationstart.$drive.implode('/', array_map(rawurlencode(...), $parts));
 
         return str_replace($xmlUri, $newPath, $schemaSource);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
@@ -49,9 +49,9 @@ class EmailTest extends TestCase
 
     public function testNormalizerCanBeSet()
     {
-        $email = new Email(['normalizer' => 'trim']);
+        $email = new Email(['normalizer' => trim(...)]);
 
-        $this->assertEquals('trim', $email->normalizer);
+        $this->assertEquals(trim(...), $email->normalizer);
     }
 
     public function testInvalidNormalizerThrowsException()

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -84,7 +84,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidNormalizedEmails($email)
     {
-        $this->validator->validate($email, new Email(['normalizer' => 'trim']));
+        $this->validator->validate($email, new Email(['normalizer' => trim(...)]));
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpTest.php
@@ -24,9 +24,9 @@ class IpTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $ip = new Ip(['normalizer' => 'trim']);
+        $ip = new Ip(['normalizer' => trim(...)]);
 
-        $this->assertEquals('trim', $ip->normalizer);
+        $this->assertEquals(trim(...), $ip->normalizer);
     }
 
     public function testInvalidNormalizerThrowsException()

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
@@ -24,9 +24,9 @@ class LengthTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $length = new Length(['min' => 0, 'max' => 10, 'normalizer' => 'trim']);
+        $length = new Length(['min' => 0, 'max' => 10, 'normalizer' => trim(...)]);
 
-        $this->assertEquals('trim', $length->normalizer);
+        $this->assertEquals(trim(...), $length->normalizer);
     }
 
     public function testInvalidNormalizerThrowsException()

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -151,7 +151,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidNormalizedValues($value)
     {
-        $constraint = new Length(['min' => 3, 'max' => 3, 'normalizer' => 'trim']);
+        $constraint = new Length(['min' => 3, 'max' => 3, 'normalizer' => trim(...)]);
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/MacAddressTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MacAddressTest.php
@@ -23,7 +23,7 @@ class MacAddressTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $mac = new MacAddress(normalizer: 'trim');
+        $mac = new MacAddress(normalizer: trim(...));
 
         $this->assertEquals(trim(...), $mac->normalizer);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/MacAddressValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MacAddressValidatorTest.php
@@ -493,7 +493,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidMacsWithWhitespaces($mac)
     {
-        $this->validator->validate($mac, new MacAddress(normalizer: 'trim'));
+        $this->validator->validate($mac, new MacAddress(normalizer: trim(...)));
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankTest.php
@@ -24,9 +24,9 @@ class NotBlankTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $notBlank = new NotBlank(['normalizer' => 'trim']);
+        $notBlank = new NotBlank(['normalizer' => trim(...)]);
 
-        $this->assertEquals('trim', $notBlank->normalizer);
+        $this->assertEquals(trim(...), $notBlank->normalizer);
     }
 
     public function testAttributes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -132,7 +132,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new NotBlank([
             'message' => 'myMessage',
-            'normalizer' => 'trim',
+            'normalizer' => trim(...),
         ]);
 
         $this->validator->validate($value, $constraint);

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexTest.php
@@ -91,9 +91,9 @@ class RegexTest extends TestCase
 
     public function testNormalizerCanBeSet()
     {
-        $regex = new Regex(['pattern' => '/^[0-9]+$/', 'normalizer' => 'trim']);
+        $regex = new Regex(['pattern' => '/^[0-9]+$/', 'normalizer' => trim(...)]);
 
-        $this->assertEquals('trim', $regex->normalizer);
+        $this->assertEquals(trim(...), $regex->normalizer);
     }
 
     public function testInvalidNormalizerThrowsException()

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -59,7 +59,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValuesWithWhitespaces($value)
     {
-        $constraint = new Regex(['pattern' => '/^[0-9]+$/', 'normalizer' => 'trim']);
+        $constraint = new Regex(['pattern' => '/^[0-9]+$/', 'normalizer' => trim(...)]);
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -70,7 +70,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValuesWithWhitespacesNamed($value)
     {
-        $constraint = new Regex(pattern: '/^[0-9]+$/', normalizer: 'trim');
+        $constraint = new Regex(pattern: '/^[0-9]+$/', normalizer: trim(...));
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
@@ -24,9 +24,9 @@ class UrlTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $url = new Url(['normalizer' => 'trim', 'requireTld' => true]);
+        $url = new Url(['normalizer' => trim(...), 'requireTld' => true]);
 
-        $this->assertEquals('trim', $url->normalizer);
+        $this->assertEquals(trim(...), $url->normalizer);
     }
 
     public function testInvalidNormalizerThrowsException()

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -66,7 +66,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     public function testValidUrlsWithWhitespaces($url)
     {
         $this->validator->validate($url, new Url([
-            'normalizer' => 'trim',
+            'normalizer' => trim(...),
             'requireTld' => true,
         ]));
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidTest.php
@@ -24,9 +24,9 @@ class UuidTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $uuid = new Uuid(['normalizer' => 'trim']);
+        $uuid = new Uuid(['normalizer' => trim(...)]);
 
-        $this->assertEquals('trim', $uuid->normalizer);
+        $this->assertEquals(trim(...), $uuid->normalizer);
     }
 
     public function testInvalidNormalizerThrowsException()

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -93,7 +93,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidStrictUuidsWithWhitespaces($uuid, $versions = null)
     {
-        $constraint = new Uuid(['normalizer' => 'trim']);
+        $constraint = new Uuid(['normalizer' => trim(...)]);
 
         if (null !== $versions) {
             $constraint->versions = $versions;
@@ -120,7 +120,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
     {
         $this->validator->validate(
             "\x09\x09216fff40-98d9-11e3-a5e2-0800200c9a66",
-            new Uuid(normalizer: 'trim', versions: [Uuid::V1_MAC])
+            new Uuid(versions: [Uuid::V1_MAC], normalizer: trim(...))
         );
 
         $this->assertNoViolation();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | on
| Deprecations? | no
| Issues        | -
| License       | MIT

This was done in Twig (https://github.com/twigphp/Twig/pull/4137), I think it would be nice to convert occurrences where possible in the Symfony codebase as well