### PR TITLE
[HttpFoundation] Add tests for `MethodRequestMatcher` and `SchemeRequestMatcher`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/MethodRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/MethodRequestMatcherTest.php
@@ -27,6 +27,13 @@ class MethodRequestMatcherTest extends TestCase
         $this->assertSame($isMatch, $matcher->matches($request));
     }
 
+    public function testAlwaysMatchesOnEmptyMethod()
+    {
+        $matcher = new MethodRequestMatcher([]);
+        $request = Request::create('https://example.com', 'POST');
+        $this->assertTrue($matcher->matches($request));
+    }
+
     public static function getData()
     {
         return [

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/SchemeRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/SchemeRequestMatcherTest.php
@@ -42,6 +42,13 @@ class SchemeRequestMatcherTest extends TestCase
         }
     }
 
+    public function testAlwaysMatchesOnParamsHeaders()
+    {
+        $matcher = new SchemeRequestMatcher([]);
+        $request = Request::create('sftp://example.com');
+        $this->assertTrue($matcher->matches($request));
+    }
+
     public static function getData()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Following https://github.com/symfony/symfony/pull/57714 after rebasing on 5.4