### PR TITLE
[Messenger] SendFailedMessageToFailureTransportListener wont send messages to failure transport if RejectRedeliveredMessageException was thrown

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Exception\RejectRedeliveredMessageException;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
@@ -46,6 +47,10 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
     public function onMessageFailed(WorkerMessageFailedEvent $event)
     {
         if ($event->willRetry()) {
+            return;
+        }
+
+        if ($event->getThrowable() instanceof RejectRedeliveredMessageException) {
             return;
         }
 

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\Exception\RejectRedeliveredMessageException;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
@@ -101,6 +102,21 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $envelope = new Envelope(new \stdClass());
         $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \Exception());
         $event->setForRetry();
+
+        $listener->onMessageFailed($event);
+    }
+
+    public function testDoNothingIfRejectRedliverMessageExceptionWasThrown()
+    {
+        $receiverName = 'my_receiver';
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->never())->method('send');
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+
+        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);
+        $envelope = new Envelope(new \stdClass());
+        $event = new WorkerMessageFailedEvent($envelope, $receiverName, new RejectRedeliveredMessageException());
 
         $listener->onMessageFailed($event);
     }


### PR DESCRIPTION
SendFailedMessageToFailureTransportListener wont send messages to failure transport if RejectRedeliveredMessageException was thrown

| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57733
| License       | MIT
