### PR TITLE
do not use `uniqid()` for generating dev tool tokens

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
@@ -77,7 +77,7 @@ final class ConsoleProfilerListener implements EventSubscriberInterface
             return;
         }
 
-        $request->attributes->set('_stopwatch_token', substr(hash('xxh128', uniqid(mt_rand(), true)), 0, 6));
+        $request->attributes->set('_stopwatch_token', bin2hex(random_bytes(3)));
         $this->stopwatch->openSection();
     }
 

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -27,7 +27,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     {
         switch ($eventName) {
             case KernelEvents::REQUEST:
-                $event->getRequest()->attributes->set('_stopwatch_token', substr(hash('xxh128', uniqid(mt_rand(), true)), 0, 6));
+                $event->getRequest()->attributes->set('_stopwatch_token', bin2hex(random_bytes(3)));
                 $this->stopwatch->openSection();
                 break;
             case KernelEvents::VIEW:

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -133,7 +133,7 @@ class Profiler implements ResetInterface
             return null;
         }
 
-        $profile = new Profile(substr(hash('xxh128', uniqid(mt_rand(), true)), 0, 6));
+        $profile = new Profile(bin2hex(random_bytes(3)));
         $profile->setTime(time());
         $profile->setUrl($request->getUri());
         $profile->setMethod($request->getMethod());

--- a/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
@@ -37,7 +37,7 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
 
     public function serialize(mixed $data, string $format, array $context = []): string
     {
-        $context[self::DEBUG_TRACE_ID] = $traceId = uniqid('', true);
+        $context[self::DEBUG_TRACE_ID] = $traceId = bin2hex(random_bytes(4));
 
         $startTime = microtime(true);
         $result = $this->serializer->serialize($data, $format, $context);
@@ -52,7 +52,7 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
 
     public function deserialize(mixed $data, string $type, string $format, array $context = []): mixed
     {
-        $context[self::DEBUG_TRACE_ID] = $traceId = uniqid('', true);
+        $context[self::DEBUG_TRACE_ID] = $traceId = bin2hex(random_bytes(4));
 
         $startTime = microtime(true);
         $result = $this->serializer->deserialize($data, $type, $format, $context);
@@ -67,7 +67,7 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
 
     public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
-        $context[self::DEBUG_TRACE_ID] = $traceId = uniqid('', true);
+        $context[self::DEBUG_TRACE_ID] = $traceId = bin2hex(random_bytes(4));
 
         $startTime = microtime(true);
         $result = $this->serializer->normalize($object, $format, $context);
@@ -82,7 +82,7 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
 
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        $context[self::DEBUG_TRACE_ID] = $traceId = uniqid('', true);
+        $context[self::DEBUG_TRACE_ID] = $traceId = bin2hex(random_bytes(4));
 
         $startTime = microtime(true);
         $result = $this->serializer->denormalize($data, $type, $format, $context);
@@ -97,7 +97,7 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
 
     public function encode(mixed $data, string $format, array $context = []): string
     {
-        $context[self::DEBUG_TRACE_ID] = $traceId = uniqid('', true);
+        $context[self::DEBUG_TRACE_ID] = $traceId = bin2hex(random_bytes(4));
 
         $startTime = microtime(true);
         $result = $this->serializer->encode($data, $format, $context);
@@ -112,7 +112,7 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
 
     public function decode(string $data, string $format, array $context = []): mixed
     {
-        $context[self::DEBUG_TRACE_ID] = $traceId = uniqid('', true);
+        $context[self::DEBUG_TRACE_ID] = $traceId = bin2hex(random_bytes(4));
 
         $startTime = microtime(true);
         $result = $this->serializer->decode($data, $format, $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | part of #57588
| License       | MIT