### PR TITLE
[SecurityBundle] use firewall-specific user checkers when manually logging in users

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -579,6 +579,9 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         $container->setAlias('security.user_checker.'.$id, new Alias($firewall['user_checker'], false));
 
+        $userCheckerLocator = $container->getDefinition('security.user_checker_locator');
+        $userCheckerLocator->replaceArgument(0, array_merge($userCheckerLocator->getArgument(0), [$id => new ServiceClosureArgument(new Reference('security.user_checker.'.$id))]));
+
         foreach ($this->getSortedFactories() as $factory) {
             $key = str_replace('-', '_', $factory->getKey());
             if ('custom_authenticators' !== $key && \array_key_exists($key, $firewall)) {

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
 use Symfony\Component\Ldap\Security\LdapUserProvider;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
@@ -88,7 +89,7 @@ return static function (ContainerConfigurator $container) {
                     'security.authenticator.managers_locator' => service('security.authenticator.managers_locator')->ignoreOnInvalid(),
                     'request_stack' => service('request_stack'),
                     'security.firewall.map' => service('security.firewall.map'),
-                    'security.user_checker' => service('security.user_checker'),
+                    'security.user_checker_locator' => service('security.user_checker_locator'),
                     'security.firewall.event_dispatcher_locator' => service('security.firewall.event_dispatcher_locator'),
                     'security.csrf.token_manager' => service('security.csrf.token_manager')->ignoreOnInvalid(),
                 ]),
@@ -124,6 +125,8 @@ return static function (ContainerConfigurator $container) {
             ->args(['none'])
 
         ->set('security.user_checker', InMemoryUserChecker::class)
+        ->set('security.user_checker_locator', ServiceLocator::class)
+            ->args([[]])
 
         ->set('security.expression_language', ExpressionLanguage::class)
             ->args([service('cache.security_expression_language')->nullOnInvalid()])

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -127,7 +127,8 @@ class Security extends InternalSecurity implements AuthorizationCheckerInterface
 
         $authenticator = $this->getAuthenticator($authenticatorName, $firewallName);
 
-        $this->container->get('security.user_checker')->checkPreAuth($user);
+        $userCheckerLocator = $this->container->get('security.user_checker_locator');
+        $userCheckerLocator->get($firewallName)->checkPreAuth($user);
 
         return $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request, $badges);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
@@ -142,7 +142,7 @@ class SecurityTest extends TestCase
                 ['request_stack', $requestStack],
                 ['security.firewall.map', $firewallMap],
                 ['security.authenticator.managers_locator', $this->createContainer('main', $userAuthenticator)],
-                ['security.user_checker', $userChecker],
+                ['security.user_checker_locator', $this->createContainer('main', $userChecker)],
             ])
         ;
 
@@ -188,7 +188,7 @@ class SecurityTest extends TestCase
                 ['request_stack', $requestStack],
                 ['security.firewall.map', $firewallMap],
                 ['security.authenticator.managers_locator', $this->createContainer('main', $userAuthenticator)],
-                ['security.user_checker', $userChecker],
+                ['security.user_checker_locator', $this->createContainer('main', $userChecker)],
             ])
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57706
| License       | MIT
