### PR TITLE
[Validator] Fix constraints on `WordCount` properties

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/WordCount.php
+++ b/src/Symfony/Component/Validator/Constraints/WordCount.php
@@ -48,8 +48,8 @@ final class WordCount extends Constraint
             throw new MissingOptionsException(\sprintf('Either option "min" or "max" must be given for constraint "%s".', __CLASS__), ['min', 'max']);
         }
 
-        if (null !== $min && $min < 0) {
-            throw new ConstraintDefinitionException(\sprintf('The "%s" constraint requires the min word count to be a positive integer or 0 if set.', __CLASS__));
+        if (null !== $min && $min <= 0) {
+            throw new ConstraintDefinitionException(\sprintf('The "%s" constraint requires the min word count to be a positive integer if set.', __CLASS__));
         }
 
         if (null !== $max && $max <= 0) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/WordCountTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WordCountTest.php
@@ -48,15 +48,31 @@ class WordCountTest extends TestCase
         $this->assertNull($wordCount->locale);
     }
 
-    public function testMinMustBeNatural()
+    public function testMinIsNegative()
     {
         $this->expectException(ConstraintDefinitionException::class);
-        $this->expectExceptionMessage('The "Symfony\Component\Validator\Constraints\WordCount" constraint requires the min word count to be a positive integer or 0 if set.');
+        $this->expectExceptionMessage('The "Symfony\Component\Validator\Constraints\WordCount" constraint requires the min word count to be a positive integer if set.');
 
         new WordCount(-1);
     }
 
-    public function testMaxMustBePositive()
+    public function testMinIsZero()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Validator\Constraints\WordCount" constraint requires the min word count to be a positive integer if set.');
+
+        new WordCount(0);
+    }
+
+    public function testMaxIsNegative()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Validator\Constraints\WordCount" constraint requires the max word count to be a positive integer if set.');
+
+        new WordCount(max: -1);
+    }
+
+    public function testMaxIsZero()
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('The "Symfony\Component\Validator\Constraints\WordCount" constraint requires the max word count to be a positive integer if set.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

On second thought, it doesn't make sense to allow `min` to be set at 0 in `WordCount`. Minimum word count allowed should be 1 for the constraint to have a meaning, or `null` if no minimum is set.