### PR TITLE
[Console] Remove a redundant check in `ErrorListener`

### DIFF
--- a/src/Symfony/Component/Console/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/Console/EventListener/ErrorListener.php
@@ -75,19 +75,15 @@ class ErrorListener implements EventSubscriberInterface
         ];
     }
 
-    private static function getInputString(ConsoleEvent $event): ?string
+    private static function getInputString(ConsoleEvent $event): string
     {
         $commandName = $event->getCommand()?->getName();
-        $input = $event->getInput();
+        $inputString = (string) $event->getInput();
 
-        if ($input instanceof \Stringable) {
-            if ($commandName) {
-                return str_replace(["'$commandName'", "\"$commandName\""], $commandName, (string) $input);
-            }
-
-            return (string) $input;
+        if ($commandName) {
+            return str_replace(["'$commandName'", "\"$commandName\""], $commandName, $inputString);
         }
 
-        return $commandName;
+        return $inputString;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

If a class defines `__toString()` method, an object created from it will also be an instance of `\Stringable` interface.

This case, the `$input` object is an implementation of `Symfony\Component\Console\Input\InputInterface` that has `__toString()` method. So, `$input instanceof \Stringable` check is always true.

You may try this code sample for more details.

```php
<?php

require __DIR__.'/vendor/autoload.php';

var_dump(new \Symfony\Component\Console\Input\ArgvInput() instanceof \Stringable); // bool(true)
var_dump(new \Symfony\Component\Console\Input\ArrayInput([]) instanceof \Stringable); // bool(true)
var_dump(new \Symfony\Component\Console\Input\StringInput('') instanceof \Stringable); // bool(true)

readonly class Person
{
    public function __construct(private string $name) {}

    public function __toString(): string
    {
        return "Hello, I am {$this->name}.";
    }
}

$person = new Person("John Doe");

var_dump($person instanceof \Stringable); // bool(true)

```
