### PR TITLE
[HttpFoundation] Remove always false condition in `BinaryFileResponse`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -110,8 +110,8 @@ class BinaryFileResponse extends Response
      */
     public function setChunkSize(int $chunkSize): static
     {
-        if ($chunkSize < 1 || $chunkSize > \PHP_INT_MAX) {
-            throw new \LogicException('The chunk size of a BinaryFileResponse cannot be less than 1 or greater than PHP_INT_MAX.');
+        if ($chunkSize < 1) {
+            throw new \InvalidArgumentException('The chunk size of a BinaryFileResponse cannot be less than 1.');
         }
 
         $this->chunkSize = $chunkSize;

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -455,4 +455,14 @@ class BinaryFileResponseTest extends ResponseTestCase
         $string = ob_get_clean();
         $this->assertSame('foo,bar', $string);
     }
+
+    public function testSetChunkSizeTooSmall()
+    {
+        $response = new BinaryFileResponse(__DIR__.'/File/Fixtures/test.gif');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The chunk size of a BinaryFileResponse cannot be less than 1.');
+
+        $response->setChunkSize(0);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The condition is always false because the parameter is int typed. Passing `PHP_INT_MAX + 1` will result on a cast to float, making PHP complain about the parameter type.

Also, the exception raised should better be an `InvalidArgmuentException` to me, instead of a logic one.

I moved in this PR the test covering `setChunkSize` originally proposed in https://github.com/symfony/symfony/pull/57714.