### PR TITLE
[Process] Fix ProcessTest - testIgnoringSignal for local

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1669,7 +1669,7 @@ class ProcessTest extends TestCase
             $this->markTestSkipped('pnctl extension is required.');
         }
 
-        $process = $this->getProcess('sleep 10');
+        $process = $this->getProcess(['sleep', '10']);
         $process->setIgnoredSignals([\SIGTERM]);
 
         $process->start();
@@ -1685,7 +1685,7 @@ class ProcessTest extends TestCase
             $this->markTestSkipped('pnctl extension is required.');
         }
 
-        $process = $this->getProcess('sleep 10');
+        $process = $this->getProcess(['sleep', '10']);
 
         $process->start();
         $process->stop(timeout: 0.2);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix Process test (testIgnoringSignal)
| License       | MIT

Fix ProcessTest : testIgnoringSignal().
Tests on 2 independant env. The test was failed.
Have to pass an array instead of string in the getProcess()