### PR TITLE
[Notifier][Telegram] Add support for local API server

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add a DSN option/flag `sslmode=disable` to allow the disabling of bridge's default behavior of using `https` protocol
+
 7.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
@@ -7,12 +7,34 @@ DSN example
 -----------
 
 ```
-TELEGRAM_DSN=telegram://TOKEN@default?channel=CHAT_ID
+TELEGRAM_DSN=telegram://TOKEN@default?channel=CHAT_ID&sslmode=SSLMODE
 ```
 
 where:
  - `TOKEN` is your Telegram token
  - `CHAT_ID` is your Telegram chat id
+ - `SSLMODE` https is used by default. It can be changed by setting value to `disable`, http will be used
+
+Interacting with local API server instead of official Telegram API
+------------------------------------------------------------------
+
+If such a case is needed, you can replace the `default` keyword in the DSN
+with the desired domain/IP address of your local API server. You may also want to
+disable the bridge's default behavior of using `https` protocol as local API servers
+can only accept `http` traffic.
+
+Example:
+```
+TELEGRAM_DSN=telegram://TOKEN@localhost:5001?channel=CHAT_ID&sslmode=disable
+```
+
+Caution: Disabling the use of the `https` protocol can pose a security risk.
+You should only do this if your local API server is hosted somehow internally
+and the traffic will remain within a secure environment.
+
+Otherwise, you may want to implement a TLS-termination proxy in front of
+your server for handling the encryption and decryption of the traffic,
+So you can continue using it normally over `https` protocol.
 
 Adding Interactions to a Message
 --------------------------------

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -52,17 +52,25 @@ final class TelegramTransport extends AbstractTransport
         private ?string $chatChannel = null,
         ?HttpClientInterface $client = null,
         ?EventDispatcherInterface $dispatcher = null,
+        private readonly bool $disableHttps = false,
     ) {
         parent::__construct($client, $dispatcher);
     }
 
     public function __toString(): string
     {
-        if (null === $this->chatChannel) {
-            return \sprintf('telegram://%s', $this->getEndpoint());
+        $toString = \sprintf('telegram://%s', $this->getEndpoint());
+
+        $formattedOptions = http_build_query([
+            'channel' => $this->chatChannel,
+            'sslmode' => $this->disableHttps ? 'disable' : null,
+        ], '', '&');
+
+        if ('' !== $formattedOptions) {
+            $toString .= \sprintf('?%s', $formattedOptions);
         }
 
-        return \sprintf('telegram://%s?channel=%s', $this->getEndpoint(), $this->chatChannel);
+        return $toString;
     }
 
     public function supports(MessageInterface $message): bool
@@ -117,8 +125,9 @@ final class TelegramTransport extends AbstractTransport
         $method = $this->getPath($options);
         $this->ensureExclusiveOptionsNotDuplicated($options);
         $options = $this->expandOptions($options, 'contact', 'location', 'venue');
+        $protocolSchema = $this->disableHttps ? 'http' : 'https';
 
-        $endpoint = \sprintf('https://%s/bot%s/%s', $this->getEndpoint(), $this->token, $method);
+        $endpoint = \sprintf('%s://%s/bot%s/%s', $protocolSchema, $this->getEndpoint(), $this->token, $method);
 
         $response = $this->client->request('POST', $endpoint, [
             $optionsContainer => array_filter($options),

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
@@ -23,9 +23,7 @@ final class TelegramTransportFactory extends AbstractTransportFactory
 {
     public function create(Dsn $dsn): TelegramTransport
     {
-        $scheme = $dsn->getScheme();
-
-        if ('telegram' !== $scheme) {
+        if ('telegram' !== $dsn->getScheme()) {
             throw new UnsupportedSchemeException($dsn, 'telegram', $this->getSupportedSchemes());
         }
 
@@ -33,8 +31,9 @@ final class TelegramTransportFactory extends AbstractTransportFactory
         $channel = $dsn->getOption('channel');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
+        $disableHttps = 'disable' === $dsn->getOption('sslmode');
 
-        return (new TelegramTransport($token, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new TelegramTransport($token, $channel, $this->client, $this->dispatcher, $disableHttps))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
@@ -26,10 +26,10 @@ final class TelegramTransportFactoryTest extends AbstractTransportFactoryTestCas
 
     public static function createProvider(): iterable
     {
-        yield [
-            'telegram://host.test?channel=testChannel',
-            'telegram://user:password@host.test?channel=testChannel',
-        ];
+        yield ['telegram://host.test?channel=testChannel', 'telegram://user:password@host.test?channel=testChannel'];
+
+        // Tests for `sslmode` option
+        yield ['telegram://host.test?channel=testChannel&sslmode=disable', 'telegram://user:password@host.test?channel=testChannel&sslmode=disable'];
     }
 
     public static function supportsProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -31,15 +31,17 @@ final class TelegramTransportTest extends TransportTestCase
 {
     private const FIXTURE_FILE = __DIR__.'/Fixtures/image.png';
 
-    public static function createTransport(?HttpClientInterface $client = null, ?string $channel = null): TelegramTransport
+    public static function createTransport(?HttpClientInterface $client = null, ?string $channel = null, bool $disableHttps = false): TelegramTransport
     {
-        return new TelegramTransport('token', $channel, $client ?? new MockHttpClient());
+        return new TelegramTransport('token', $channel, $client ?? new MockHttpClient(), disableHttps: $disableHttps);
     }
 
     public static function toStringProvider(): iterable
     {
         yield ['telegram://api.telegram.org', self::createTransport()];
         yield ['telegram://api.telegram.org?channel=testChannel', self::createTransport(null, 'testChannel')];
+        yield ['telegram://api.telegram.org?sslmode=disable', self::createTransport(null, null, true)];
+        yield ['telegram://api.telegram.org?channel=testChannel&sslmode=disable', self::createTransport(null, 'testChannel', true)];
     }
 
     public static function supportedMessagesProvider(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57766
| License       | MIT

Since Telegram's [local API server](https://core.telegram.org/bots/api#using-a-local-bot-api-server) doesn't support HTTPS traffic natively, this PR introduces a new DSN option/flag to allow the disabling of bridge's default behavior of using `https` protocol