### PR TITLE
[WebProfilerBundle] Add word wrap in tables in dialog to see all the text in workflow listeners dialog

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
@@ -60,6 +60,7 @@
         dialog table td {
             padding: .625em;
             text-align: center;
+            word-wrap: break-word;
         }
 
         dialog table th {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | no <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

In the web profiler, when looking at the listeners for workflow, if reference to the listener is too big, it's not seen and the table is not horizontally scrollable. Added word wrap so that the whole text is seen.

**Before**
<img width="947" alt="before" src="https://github.com/user-attachments/assets/9491daa6-b58b-4cf7-b46d-be9d7d5fda07">

**After**
<img width="945" alt="after" src="https://github.com/user-attachments/assets/f7f7db7a-3657-4d99-a0af-9cc3a9961b83">


