### PR TITLE
[Security] pass the current token to the `checkPostAuth()` method of user checkers

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -11,6 +11,7 @@ If you're upgrading from a version below 7.1, follow the [7.1 upgrade guide](UPG
 Security
 --------
 
+ * Add `$token` argument to `UserCheckerInterface::checkPostAuth()`
  * Deprecate argument `$secret` of `RememberMeToken` and `RememberMeAuthenticator`
 
 String

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * Add `$token` argument to `UserCheckerInterface::checkPostAuth()`
  * Deprecate argument `$secret` of `RememberMeToken`
 
 7.0

--- a/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\User;
 
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
 final class ChainUserChecker implements UserCheckerInterface
 {
     /**
@@ -27,10 +29,16 @@ final class ChainUserChecker implements UserCheckerInterface
         }
     }
 
-    public function checkPostAuth(UserInterface $user): void
+    public function checkPostAuth(UserInterface $user /*, TokenInterface $token*/): void
     {
+        $token = 1 < \func_num_args() ? func_get_arg(1) : null;
+
         foreach ($this->checkers as $checker) {
-            $checker->checkPostAuth($user);
+            if ($token instanceof TokenInterface) {
+                $checker->checkPostAuth($user, $token);
+            } else {
+                $checker->checkPostAuth($user);
+            }
         }
     }
 }

--- a/src/Symfony/Component/Security/Core/User/UserCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserCheckerInterface.php
@@ -35,5 +35,5 @@ interface UserCheckerInterface
      *
      * @throws AccountStatusException
      */
-    public function checkPostAuth(UserInterface $user): void;
+    public function checkPostAuth(UserInterface $user /*, TokenInterface $token*/): void;
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * Pass the current token to the `checkPostAuth()` method of user checkers
  * Deprecate argument `$secret` of `RememberMeAuthenticator`
 
 7.1

--- a/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
@@ -47,7 +47,7 @@ class UserCheckerListener implements EventSubscriberInterface
             return;
         }
 
-        $this->userChecker->checkPostAuth($user);
+        $this->userChecker->checkPostAuth($user, $event->getAuthenticationToken());
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -163,7 +163,7 @@ class SwitchUserListener extends AbstractListener
 
         $this->logger?->info('Attempting to switch to user.', ['username' => $username]);
 
-        $this->userChecker->checkPostAuth($user);
+        $this->userChecker->checkPostAuth($user, $token);
 
         $roles = $user->getRoles();
         $originatedFromUri = str_replace('/&', '/?', preg_replace('#[&?]'.$this->usernameParameter.'=[^&]*#', '', $request->getRequestUri()));

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/UserCheckerListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/UserCheckerListenerTest.php
@@ -58,6 +58,14 @@ class UserCheckerListenerTest extends TestCase
         $this->listener->postCheckCredentials(new AuthenticationSuccessEvent(new PostAuthenticationToken($this->user, 'main', [])));
     }
 
+    public function testTokenIsPassedToPost()
+    {
+        $token = new PostAuthenticationToken($this->user, 'main', []);
+        $this->userChecker->expects($this->once())->method('checkPostAuth')->with($this->user, $token);
+
+        $this->listener->postCheckCredentials(new AuthenticationSuccessEvent($token));
+    }
+
     private function createCheckPassportEvent($passport = null)
     {
         $passport ??= new SelfValidatingPassport(new UserBadge('test', fn () => $this->user));

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -184,7 +184,7 @@ class SwitchUserListenerTest extends TestCase
             ->willReturn(true);
 
         $this->userChecker->expects($this->once())
-            ->method('checkPostAuth')->with($this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier()));
+            ->method('checkPostAuth')->with($this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier()), $token);
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener($this->event);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #50650
| License       | MIT