### PR TITLE
[String] Fix the `snake` method behavior with uppercase strings and special characters

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -377,7 +377,7 @@ abstract class AbstractUnicodeString extends AbstractString
 
         $strings = array_map(
             function (string $matchedString) {
-                return mb_strtolower($matchedString);
+                return mb_strtolower($matchedString, 'UTF-8');
             },
             $matches[0] ?? []
         );

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -366,10 +366,23 @@ abstract class AbstractUnicodeString extends AbstractString
 
     public function snake(): parent
     {
-        $str = $this->camel();
-        $str->string = mb_strtolower(preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1_\2', $str->string), 'UTF-8');
+        $str = clone $this;
+        $matches = [];
 
-        return $str;
+        preg_match_all(
+            '/([\p{Ll}0-9]+(?=\p{Lu}))|(\p{Lu}[\p{Ll}0-9]+)|(\p{Lu}+(?=\p{Lu}\p{Ll}))|((?<=\w)?[\p{Ll}\p{Lu}0-9]+(?=\w)?)/u',
+            $str,
+            $matches
+        );
+
+        $strings = array_map(
+            function (string $matchedString) {
+                return mb_strtolower($matchedString);
+            },
+            $matches[0] ?? []
+        );
+
+        return new static(implode('_', $strings));
     }
 
     public function title(bool $allWords = false): parent

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -371,7 +371,7 @@ abstract class AbstractUnicodeString extends AbstractString
 
         preg_match_all(
             '/([\p{Ll}0-9]+(?=\p{Lu}))|(\p{Lu}[\p{Ll}0-9]+)|(\p{Lu}+(?=\p{Lu}\p{Ll}))|((?<=\w)?[\p{Ll}\p{Lu}0-9]+(?=\w)?)/u',
-            $str,
+            $str->string,
             $matches
         );
 
@@ -382,7 +382,9 @@ abstract class AbstractUnicodeString extends AbstractString
             $matches[0] ?? []
         );
 
-        return new static(implode('_', $strings));
+        $str->string = implode('_', $strings);
+
+        return $str;
     }
 
     public function title(bool $allWords = false): parent

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -366,10 +366,23 @@ class ByteString extends AbstractString
 
     public function snake(): parent
     {
-        $str = $this->camel();
-        $str->string = strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1_\2', $str->string));
+        $str = clone $this;
+        $matches = [];
 
-        return $str;
+        preg_match_all(
+            '/([a-z0-9]+(?=[A-Z]))|([A-Z][a-z0-9]+)|([A-Z]+(?=[A-Z][a-z]))|((?<=\w)?[a-zA-Z0-9]+(?=\w)?)/',
+            $str,
+            $matches
+        );
+
+        $strings = array_map(
+            function (string $matchedString) {
+                return mb_strtolower($matchedString);
+            },
+            $matches[0] ?? []
+        );
+
+        return new static(implode('_', $strings));
     }
 
     public function splice(string $replacement, int $start = 0, ?int $length = null): parent

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -377,7 +377,7 @@ class ByteString extends AbstractString
 
         $strings = array_map(
             function (string $matchedString) {
-                return mb_strtolower($matchedString);
+                return strtolower($matchedString);
             },
             $matches[0] ?? []
         );

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -371,7 +371,7 @@ class ByteString extends AbstractString
 
         preg_match_all(
             '/([a-z0-9]+(?=[A-Z]))|([A-Z][a-z0-9]+)|([A-Z]+(?=[A-Z][a-z]))|((?<=\w)?[a-zA-Z0-9]+(?=\w)?)/',
-            $str,
+            $str->string,
             $matches
         );
 
@@ -382,7 +382,9 @@ class ByteString extends AbstractString
             $matches[0] ?? []
         );
 
-        return new static(implode('_', $strings));
+        $str->string = implode('_', $strings);
+
+        return $str;
     }
 
     public function splice(string $replacement, int $start = 0, ?int $length = null): parent

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1080,12 +1080,14 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfony_is_great', 'symfonyIsGREAT'],
             ['symfony_is_really_great', 'symfonyIsREALLYGreat'],
             ['symfony', 'SYMFONY'],
-            ['symfonyisgreat', 'SYMFONY IS GREAT'],
-            ['symfonyisgreat', 'SYMFONY_IS_GREAT'],
+            ['symfony_is_great', 'SYMFONY IS GREAT'],
+            ['symfony_is_great', 'SYMFONY_IS_GREAT'],
             ['symfony_is_great', 'symfony    is     great'],
-            ['symfonyisgreat', 'SYMFONY    IS     GREAT'],
-            ['symfonyisgreat', 'SYMFONY _ IS _ GREAT'],
-            ['symfony_isgreat', 'Symfony IS GREAT!'],
+            ['symfony_is_great', 'SYMFONY    IS     GREAT'],
+            ['symfony_is_great', 'SYMFONY _ IS _ GREAT'],
+            ['symfony_is_great', 'Symfony IS GREAT!'],
+            ['123_customer_with_special_name', '123-customer,with/special#name'],
+            ['this_value_should_be_false', 'This value should be false.'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57782
| License       | MIT

The current implementation of the `snake` method is based on the `camel` method, which does not work correctly with uppercase strings. The `camel` method doesn't handle parts of the string in uppercase, which I believe is the correct behavior.

For example:
```php
'Symfony is GREAT' => 'symfonyIsGREAT'
'SYMFONY IS GREAT' => 'SYMFONYISGREAT'
```
The first example seems correct to me, but this behavior may cause unexpected results in the second example.

To fix the issue, I chose not to base the `snake` method on the `camel` method.

My proposal may also fix issues #57612 and #57464, and I hope it does not break anything.
