### PR TITLE
[FrameworkBundle]  terminate with non-zero exit code when a secret could not be read

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -8,6 +8,11 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/7.2/
 
 If you're upgrading from a version below 7.1, follow the [7.1 upgrade guide](UPGRADE-7.1.md) first.
 
+FrameworkBundle
+---------------
+
+ * [BC BREAK] The `secrets:decrypt-to-local` command terminates with a non-zero exit code when a secret could not be read
+
 Security
 --------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
  * Derivate `kernel.secret` from the decryption secret when its env var is not defined
  * Make the `config/` directory optional in `MicroKernelTrait`, add support for service arguments in the
    invokable Kernel class, and register `FrameworkBundle` by default when the `bundles.php` file is missing
- * Add `exit` option for `secrets:decrypt-to-local` command
+ * [BC BREAK] The `secrets:decrypt-to-local` command terminates with a non-zero exit code when a secret could not be read
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
@@ -38,7 +38,6 @@ final class SecretsDecryptToLocalCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('exit', null, InputOption::VALUE_NONE, 'Returns a non-zero exit code if any errors are encountered')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force overriding of secrets that already exist in the local vault')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command decrypts all secrets and copies them in the local vault.
@@ -48,10 +47,6 @@ The <info>%command.name%</info> command decrypts all secrets and copies them in 
 When the <info>--force</info> option is provided, secrets that already exist in the local vault are overridden.
 
     <info>%command.full_name% --force</info>
-
-When the <info>--exit</info> option is provided, the command will return a non-zero exit code if any errors are encountered.
-
-    <info>%command.full_name% --exit</info>
 EOF
             )
         ;
@@ -100,7 +95,7 @@ EOF
             $io->note($this->localVault->getLastMessage());
         }
 
-        if ($hadErrors && $input->getOption('exit'))  {
+        if ($hadErrors)  {
             return 1;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

The fix for #42038 did a bit too much. Not only did it fix the PHP error that
wasn't caught before, but also changed the exit code of the command. With this
change the PHP error will still be prevented, but the command will terminate
with a non-zero exit code to indicate the failure that occurred while reading
the stored secrets.