### PR TITLE
[ErrorHandler][VarDumper] Remove PHP 8.4 deprecations

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -55,7 +55,6 @@ class ErrorHandler
         \E_USER_DEPRECATED => 'User Deprecated',
         \E_NOTICE => 'Notice',
         \E_USER_NOTICE => 'User Notice',
-        \E_STRICT => 'Runtime Notice',
         \E_WARNING => 'Warning',
         \E_USER_WARNING => 'User Warning',
         \E_COMPILE_WARNING => 'Compile Warning',
@@ -73,7 +72,6 @@ class ErrorHandler
         \E_USER_DEPRECATED => [null, LogLevel::INFO],
         \E_NOTICE => [null, LogLevel::WARNING],
         \E_USER_NOTICE => [null, LogLevel::WARNING],
-        \E_STRICT => [null, LogLevel::WARNING],
         \E_WARNING => [null, LogLevel::WARNING],
         \E_USER_WARNING => [null, LogLevel::WARNING],
         \E_COMPILE_WARNING => [null, LogLevel::WARNING],
@@ -183,6 +181,11 @@ class ErrorHandler
 
     public function __construct(?BufferingLogger $bootstrappingLogger = null, bool $debug = false)
     {
+        if (\PHP_VERSION_ID < 80400) {
+            $this->levels[\E_STRICT] = 'Runtime Notice';
+            $this->loggers[\E_STRICT] = [null, LogLevel::WARNING];
+        }
+
         if ($bootstrappingLogger) {
             $this->bootstrappingLogger = $bootstrappingLogger;
             $this->setDefaultLogger($bootstrappingLogger);

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -213,7 +213,6 @@ class ErrorHandlerTest extends TestCase
                 \E_USER_DEPRECATED => [null, LogLevel::INFO],
                 \E_NOTICE => [$logger, LogLevel::WARNING],
                 \E_USER_NOTICE => [$logger, LogLevel::CRITICAL],
-                \E_STRICT => [null, LogLevel::WARNING],
                 \E_WARNING => [null, LogLevel::WARNING],
                 \E_USER_WARNING => [null, LogLevel::WARNING],
                 \E_COMPILE_WARNING => [null, LogLevel::WARNING],
@@ -225,6 +224,11 @@ class ErrorHandlerTest extends TestCase
                 \E_ERROR => [null, LogLevel::CRITICAL],
                 \E_CORE_ERROR => [null, LogLevel::CRITICAL],
             ];
+
+            if (\PHP_VERSION_ID < 80400) {
+                $loggers[\E_STRICT] = [null, LogLevel::WARNING];
+            }
+
             $this->assertSame($loggers, $handler->setLoggers([]));
         } finally {
             restore_error_handler();
@@ -478,7 +482,6 @@ class ErrorHandlerTest extends TestCase
             \E_USER_DEPRECATED => [$bootLogger, LogLevel::INFO],
             \E_NOTICE => [$bootLogger, LogLevel::WARNING],
             \E_USER_NOTICE => [$bootLogger, LogLevel::WARNING],
-            \E_STRICT => [$bootLogger, LogLevel::WARNING],
             \E_WARNING => [$bootLogger, LogLevel::WARNING],
             \E_USER_WARNING => [$bootLogger, LogLevel::WARNING],
             \E_COMPILE_WARNING => [$bootLogger, LogLevel::WARNING],
@@ -490,6 +493,10 @@ class ErrorHandlerTest extends TestCase
             \E_ERROR => [$bootLogger, LogLevel::CRITICAL],
             \E_CORE_ERROR => [$bootLogger, LogLevel::CRITICAL],
         ];
+
+        if (\PHP_VERSION_ID < 80400) {
+            $loggers[\E_STRICT] = [$bootLogger, LogLevel::WARNING];
+        }
 
         $this->assertSame($loggers, $handler->setLoggers([]));
 

--- a/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
@@ -23,7 +23,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
 class DOMCaster
 {
     private const ERROR_CODES = [
-        \DOM_PHP_ERR => 'DOM_PHP_ERR',
+        0 => 'DOM_PHP_ERR',
         \DOM_INDEX_SIZE_ERR => 'DOM_INDEX_SIZE_ERR',
         \DOMSTRING_SIZE_ERR => 'DOMSTRING_SIZE_ERR',
         \DOM_HIERARCHY_REQUEST_ERR => 'DOM_HIERARCHY_REQUEST_ERR',
@@ -138,16 +138,12 @@ class DOMCaster
             'doctype' => $dom->doctype,
             'implementation' => $dom->implementation,
             'documentElement' => new CutStub($dom->documentElement),
-            'actualEncoding' => $dom->actualEncoding,
             'encoding' => $dom->encoding,
             'xmlEncoding' => $dom->xmlEncoding,
-            'standalone' => $dom->standalone,
             'xmlStandalone' => $dom->xmlStandalone,
-            'version' => $dom->version,
             'xmlVersion' => $dom->xmlVersion,
             'strictErrorChecking' => $dom->strictErrorChecking,
             'documentURI' => $dom->documentURI ? new LinkStub($dom->documentURI) : $dom->documentURI,
-            'config' => $dom->config,
             'formatOutput' => $dom->formatOutput,
             'validateOnParse' => $dom->validateOnParse,
             'resolveExternals' => $dom->resolveExternals,
@@ -275,9 +271,6 @@ class DOMCaster
             'publicId' => $dom->publicId,
             'systemId' => $dom->systemId,
             'notationName' => $dom->notationName,
-            'actualEncoding' => $dom->actualEncoding,
-            'encoding' => $dom->encoding,
-            'version' => $dom->version,
         ];
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -41,7 +41,7 @@ class ExceptionCaster
         \E_USER_ERROR => 'E_USER_ERROR',
         \E_USER_WARNING => 'E_USER_WARNING',
         \E_USER_NOTICE => 'E_USER_NOTICE',
-        \E_STRICT => 'E_STRICT',
+        2048 => 'E_STRICT',
     ];
 
     private static $framesCache = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

[A new batch of deprecations](https://wiki.php.net/rfc/deprecations_php_8_4) is coming with PHP 8.4. There's a few things in the code to remove to be completely deprecation free in 5.4. Even if the vote is not finished yet, most deprecations are likely to pass barring a major turn of events.