### PR TITLE
[BrowserKit][HttpKernel] make use of the `@template` annotation to improve type information

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -29,6 +29,9 @@ use Symfony\Component\Process\PhpProcess;
  * you need to also implement the getScript() method.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @template TRequest of object
+ * @template TResponse of object
  */
 abstract class AbstractBrowser
 {
@@ -36,8 +39,10 @@ abstract class AbstractBrowser
     protected CookieJar $cookieJar;
     protected array $server = [];
     protected Request $internalRequest;
+    /** @psalm-var TRequest */
     protected object $request;
     protected Response $internalResponse;
+    /** @psalm-var TResponse */
     protected object $response;
     protected Crawler $crawler;
     protected bool $useHtml5Parser = true;
@@ -221,6 +226,8 @@ abstract class AbstractBrowser
      * The origin response is the response instance that is returned
      * by the code that handles requests.
      *
+     * @psalm-return TResponse
+     *
      * @see doRequest()
      */
     public function getResponse(): object
@@ -241,6 +248,8 @@ abstract class AbstractBrowser
      *
      * The origin request is the request instance that is sent
      * to the code that handles requests.
+     *
+     * @psalm-return TRequest
      *
      * @see doRequest()
      */
@@ -402,7 +411,9 @@ abstract class AbstractBrowser
     /**
      * Makes a request in another process.
      *
-     * @return object
+     * @psalm-param TRequest $request
+     *
+     * @psalm-return TResponse
      *
      * @throws \RuntimeException When processing returns exit code
      */
@@ -437,12 +448,16 @@ abstract class AbstractBrowser
     /**
      * Makes a request.
      *
-     * @return object
+     * @psalm-param TRequest $request
+     *
+     * @psalm-return TResponse
      */
     abstract protected function doRequest(object $request);
 
     /**
      * Returns the script to execute when the request must be insulated.
+     *
+     * @psalm-param TRequest $request
      *
      * @param object $request An origin request instance
      *
@@ -459,6 +474,8 @@ abstract class AbstractBrowser
      * Filters the BrowserKit request to the origin one.
      *
      * @return object
+     *
+     * @psalm-return TRequest
      */
     protected function filterRequest(Request $request)
     {
@@ -467,6 +484,8 @@ abstract class AbstractBrowser
 
     /**
      * Filters the origin response to the BrowserKit one.
+     *
+     * @psalm-param TResponse $response
      *
      * @return Response
      */

--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -24,6 +24,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * to make real HTTP requests.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @template-extends AbstractBrowser<Request, Response>
  */
 class HttpBrowser extends AbstractBrowser
 {

--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -25,8 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @method Request  getRequest()
- * @method Response getResponse()
+ * @template-extends AbstractBrowser<Request, Response>
  */
 class HttpKernelBrowser extends AbstractBrowser
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I was wondering why we had `@method` annotations in the `HttpKernelBrowser` class. It looks like they were introduced in #21537 to satisfy static analysis tools and to improve auto-completion in IDEs. Given that we have more than one subclass of the `AbstractBrowser` class I thought it might be good to properly make use of the `@template` annotation to cover all methods of that class without having to list them all explicitly in all child classes.