### PR TITLE
[Validator] treat uninitialized properties referenced by property paths as null

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
@@ -56,6 +57,8 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
                 $comparedValue = $this->getPropertyAccessor()->getValue($object, $path);
             } catch (NoSuchPropertyException $e) {
                 throw new ConstraintDefinitionException(sprintf('Invalid property path "%s" provided to "%s" constraint: ', $path, get_debug_type($constraint)).$e->getMessage(), 0, $e);
+            } catch (UninitializedPropertyException $e) {
+                $comparedValue = null;
             }
         } else {
             $comparedValue = $constraint->value;

--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Validator\Constraint;
@@ -130,6 +131,8 @@ class BicValidator extends ConstraintValidator
                 $iban = $this->getPropertyAccessor()->getValue($object, $path);
             } catch (NoSuchPropertyException $e) {
                 throw new ConstraintDefinitionException(sprintf('Invalid property path "%s" provided to "%s" constraint: ', $path, get_debug_type($constraint)).$e->getMessage(), 0, $e);
+            } catch (UninitializedPropertyException $e) {
+                $iban = null;
             }
         }
         if (!$iban) {

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
@@ -178,6 +179,8 @@ class RangeValidator extends ConstraintValidator
             return $this->getPropertyAccessor()->getValue($object, $propertyPath);
         } catch (NoSuchPropertyException $e) {
             throw new ConstraintDefinitionException(sprintf('Invalid property path "%s" provided to "%s" constraint: ', $propertyPath, get_debug_type($constraint)).$e->getMessage(), 0, $e);
+        } catch (UninitializedPropertyException $e) {
+            return null;
         }
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\AbstractComparison;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\TypedDummy;
 
 class ComparisonTest_Class
 {
@@ -260,6 +261,33 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         $this->setObject($object);
 
         $this->validator->validate($dirtyValue, $constraint);
+
+        if ($isValid) {
+            $this->assertNoViolation();
+        } else {
+            $this->buildViolation('Constraint Message')
+                ->setParameter('{{ value }}', $dirtyValueAsString)
+                ->setParameter('{{ compared_value }}', 'null')
+                ->setParameter('{{ compared_value_type }}', 'null')
+                ->setParameter('{{ compared_value_path }}', 'value')
+                ->setCode($this->getErrorCode())
+                ->assertRaised();
+        }
+    }
+
+    /**
+     * @requires PHP 7.4
+     *
+     * @dataProvider provideComparisonsToNullValueAtPropertyPath
+     */
+    public function testCompareWithUninitializedPropertyAtPropertyPath($dirtyValue, $dirtyValueAsString, $isValid)
+    {
+        $this->setObject(new TypedDummy());
+
+        $this->validator->validate($dirtyValue, $this->createConstraint([
+            'message' => 'Constraint Message',
+            'propertyPath' => 'value',
+        ]));
 
         if ($isValid) {
             $this->assertNoViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\BicTypedDummy;
 
 class BicValidatorTest extends ConstraintValidatorTestCase
 {
@@ -90,6 +91,18 @@ class BicValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ iban }}', 'FR14 2004 1010 0505 0001 3M02 606')
             ->setCode(Bic::INVALID_IBAN_COUNTRY_CODE_ERROR)
             ->assertRaised();
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testPropertyPathReferencingUninitializedProperty()
+    {
+        $this->setObject(new BicTypedDummy());
+
+        $this->validator->validate('UNCRIT2B912', new Bic(['ibanPropertyPath' => 'iban']));
+
+        $this->assertNoViolation();
     }
 
     public function testValidComparisonToValue()

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/BicTypedDummy.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/BicTypedDummy.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints\Fixtures;
+
+class BicTypedDummy
+{
+    public string $iban;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/MinMaxTyped.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/MinMaxTyped.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints\Fixtures;
+
+class MinMaxTyped
+{
+    public int $min;
+    public int $max;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/TypedDummy.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/TypedDummy.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints\Fixtures;
+
+class TypedDummy
+{
+    public mixed $value;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -121,6 +121,16 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
         $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
+    /**
+     * @requires PHP 7.4
+     *
+     * @dataProvider provideComparisonsToNullValueAtPropertyPath
+     */
+    public function testCompareWithUninitializedPropertyAtPropertyPath($dirtyValue, $dirtyValueAsString, $isValid)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+    }
+
     public static function throwsOnInvalidStringDatesProvider(): array
     {
         self::markTestSkipped('The "value" option cannot be used in the NegativeOrZero constraint');

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -121,6 +121,16 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
         $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
+    /**
+     * @requires PHP 7.4
+     *
+     * @dataProvider provideComparisonsToNullValueAtPropertyPath
+     */
+    public function testCompareWithUninitializedPropertyAtPropertyPath($dirtyValue, $dirtyValueAsString, $isValid)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+    }
+
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
         $this->markTestSkipped('PropertyPath option is not used in Negative constraint');

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\RangeValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\MinMaxTyped;
 use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
 
 class RangeValidatorTest extends ConstraintValidatorTestCase
@@ -1040,6 +1041,34 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ min_limit_path }}', 'min')
             ->setCode(Range::NOT_IN_RANGE_ERROR)
             ->assertRaised();
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testMinPropertyPathReferencingUninitializedProperty()
+    {
+        $object = new MinMaxTyped();
+        $object->max = 5;
+        $this->setObject($object);
+
+        $this->validator->validate(5, new Range(['minPropertyPath' => 'min', 'maxPropertyPath' => 'max']));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testMaxPropertyPathReferencingUninitializedProperty()
+    {
+        $object = new MinMaxTyped();
+        $object->min = 5;
+        $this->setObject($object);
+
+        $this->validator->validate(5, new Range(['minPropertyPath' => 'min', 'maxPropertyPath' => 'max']));
+
+        $this->assertNoViolation();
     }
 
     public static function provideMessageIfMinAndMaxSet(): array

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -38,7 +38,7 @@
         "symfony/expression-language": "^5.1|^6.0",
         "symfony/cache": "^4.4|^5.0|^6.0",
         "symfony/mime": "^4.4|^5.0|^6.0",
-        "symfony/property-access": "^4.4|^5.0|^6.0",
+        "symfony/property-access": "^5.4|^6.0",
         "symfony/property-info": "^5.3|^6.0",
         "symfony/translation": "^5.4.35|~6.3.12|^6.4.3",
         "doctrine/annotations": "^1.13|^2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #46347
| License       | MIT