### PR TITLE
[DoctrineBridge] fix messenger bus dispatch inside an active transaction

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineOpenTransactionLoggerMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineOpenTransactionLoggerMiddleware.php
@@ -43,11 +43,12 @@ class DoctrineOpenTransactionLoggerMiddleware extends AbstractDoctrineMiddleware
         }
 
         $this->isHandling = true;
+        $initialTransactionLevel = $entityManager->getConnection()->getTransactionNestingLevel();
 
         try {
             return $stack->next()->handle($envelope, $stack);
         } finally {
-            if ($entityManager->getConnection()->isTransactionActive()) {
+            if ($entityManager->getConnection()->getTransactionNestingLevel() > $initialTransactionLevel) {
                 $this->logger->error('A handler opened a transaction but did not close it.', [
                     'message' => $envelope->getMessage(),
                 ]);

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -50,9 +50,9 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
 
     public function testMiddlewareWrapsInTransactionAndFlushes()
     {
-        $this->connection->expects($this->exactly(1))
-            ->method('isTransactionActive')
-            ->willReturn(true, true, false)
+        $this->connection->expects($this->exactly(2))
+            ->method('getTransactionNestingLevel')
+            ->willReturn(0, 1)
         ;
 
         $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

it was working fine with the below config and command.

```yaml
# config/packages/messenger.yaml
framework:
    messenger:
        buses:
            sync_bus:
                middleware:
                    - validation
                    - doctrine_ping_connection
                    - doctrine_close_connection
                    - doctrine_open_transaction_logger
                    - doctrine_transaction
        routing:
            App\Message\SyncJob: sync
```

```php
<?php
// src/Command/TestComand.php

namespace App\Command;

use App\Message\SyncJob;
use Doctrine\ORM\EntityManagerInterface;
// use ...

#[AsCommand(
    name: 'app:test',
    description: 'Add a short description for your command',
)]
class TestCommand extends Command
{
    public function __construct(
        private readonly EntityManagerInterface $em,
        private readonly MessageBusInterface $bus,
    )
    {
        parent::__construct();
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $io = new SymfonyStyle($input, $output);

        $this->bus->dispatch(new SyncJob('someone'));

        $io->success('You have a new command! Now make it your own! Pass --help to see your options.');

        return Command::SUCCESS;
    }
}

```

An issue occurs if I dispatch the message inside a transaction
```php
$this->em->wrapInTransaction(function ($em) {
        // another process here
        $this->bus->dispatch(new SyncJob('someone'));
});
```

an error comes up

```
ERROR     [app] A handler opened a transaction but did not close it.
```

This PR aims to fix this issue without changing the existing behaviour