### PR TITLE
[Validator] properly set up constraint options

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -23,7 +23,7 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
 {
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new PositiveOrZero();
+        return new PositiveOrZero($options);
     }
 
     /**
@@ -92,10 +92,20 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
         $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 
+    public static function provideAllValidComparisons(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the PositiveOrZero constraint');
+    }
+
     /**
      * @dataProvider provideValidComparisonsToPropertyPath
      */
     public function testValidComparisonToPropertyPath($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
+    }
+
+    public function testNoViolationOnNullObjectWithPropertyPath()
     {
         $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
@@ -111,5 +121,20 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
         $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
+    }
+
+    public static function throwsOnInvalidStringDatesProvider(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the PositiveOrZero constraint');
+    }
+
+    public static function provideAllInvalidComparisons(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the Negative constraint');
+    }
+
+    public static function provideComparisonsToNullValueAtPropertyPath(): array
+    {
+        self::markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -23,7 +23,7 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
 {
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new Positive();
+        return new Positive($options);
     }
 
     /**
@@ -95,6 +95,11 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
         $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
 
+    public static function provideAllValidComparisons(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the Positive constraint');
+    }
+
     /**
      * @dataProvider provideValidComparisonsToPropertyPath
      */
@@ -114,5 +119,20 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
         $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+    }
+
+    public static function throwsOnInvalidStringDatesProvider(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the Positive constraint');
+    }
+
+    public static function provideAllInvalidComparisons(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the Positive constraint');
+    }
+
+    public static function provideComparisonsToNullValueAtPropertyPath(): array
+    {
+        self::markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -23,7 +23,7 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
 {
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new NegativeOrZero();
+        return new NegativeOrZero($options);
     }
 
     /**
@@ -95,6 +95,11 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
         $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
+    public static function provideAllValidComparisons(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the NegativeOrZero constraint');
+    }
+
     /**
      * @dataProvider provideValidComparisonsToPropertyPath
      */
@@ -103,12 +108,9 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
         $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
-    /**
-     * @dataProvider throwsOnInvalidStringDatesProvider
-     */
-    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
+    public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
-        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
+        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
     /**
@@ -119,8 +121,13 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
         $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
-    public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
+    public static function throwsOnInvalidStringDatesProvider(): array
     {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+        self::markTestSkipped('The "value" option cannot be used in the NegativeOrZero constraint');
+    }
+
+    public static function provideAllInvalidComparisons(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the NegativeOrZero constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -23,7 +23,7 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
 {
     protected static function createConstraint(?array $options = null): Constraint
     {
-        return new Negative();
+        return new Negative($options);
     }
 
     /**
@@ -95,6 +95,11 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
         $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
+    public static function provideAllValidComparisons(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the Negative constraint');
+    }
+
     /**
      * @dataProvider provideValidComparisonsToPropertyPath
      */
@@ -103,12 +108,9 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
         $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
-    /**
-     * @dataProvider throwsOnInvalidStringDatesProvider
-     */
-    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
+    public static function throwsOnInvalidStringDatesProvider(): array
     {
-        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
+        self::markTestSkipped('The "value" option cannot be used in the Negative constraint');
     }
 
     /**
@@ -122,5 +124,10 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
         $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+    }
+
+    public static function provideAllInvalidComparisons(): array
+    {
+        self::markTestSkipped('The "value" option cannot be used in the Negative constraint');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

while working on #57812 I noticed that we did not properly set up some of the constraints which means that tests making use of constraint options were never tested correctly
