### PR TITLE
[HttpKernel] Fatal Error when using `#[MapUploadedFile]` with non-array/non-variadic argument

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -170,7 +170,14 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 };
             }
 
-            $arguments[$i] = $payload;
+            if ($argument->metadata->isVariadic()) {
+                if (!(is_array($payload) && array_is_list($payload))) {
+                    throw HttpException::fromStatusCode(422);
+                }
+                array_splice($arguments, $i, count($payload), $payload);
+            } else {
+                $arguments[$i] = $payload;
+            }
         }
 
         $event->setArguments($arguments);

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -171,10 +171,10 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             }
 
             if ($argument->metadata->isVariadic()) {
-                if (!(is_array($payload) && array_is_list($payload))) {
-                    throw HttpException::fromStatusCode(422);
+                if (!\is_array($payload) || !\array_is_list($payload)) {
+                    throw HttpException::fromStatusCode($validationFailedCode);
                 }
-                array_splice($arguments, $i, count($payload), $payload);
+                \array_splice($arguments, $i, \count($payload), $payload);
             } else {
                 $arguments[$i] = $payload;
             }
@@ -241,7 +241,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
     private function mapUploadedFile(Request $request, ArgumentMetadata $argument, MapUploadedFile $attribute): UploadedFile|array|null
     {
         $default = null;
-        if ($argument->isVariadic() || "array" === $argument->getType()) {
+        if ($argument->isVariadic() || 'array' === $argument->getType()) {
             $default = [];
         }
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -233,6 +233,11 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function mapUploadedFile(Request $request, ArgumentMetadata $argument, MapUploadedFile $attribute): UploadedFile|array|null
     {
-        return $request->files->get($attribute->name ?? $argument->getName(), []);
+        $default = null;
+        if ($argument->isVariadic() || "array" === $argument->getType()) {
+            $default = [];
+        }
+
+        return $request->files->get($attribute->name ?? $argument->getName(), $default);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -327,7 +327,7 @@ class UploadedFileValueResolverTest extends TestCase
         $resolver->onKernelControllerArguments($event);
 
         /** @var UploadedFile[] $data */
-        $data = $event->getArguments()[0];
+        $data = $event->getArguments();
 
         $this->assertCount(2, $data);
         $this->assertSame('file-small.txt', $data[0]->getFilename());

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -68,7 +68,7 @@ class UploadedFileValueResolverTest extends TestCase
         $attribute = new MapUploadedFile();
         $argument = new ArgumentMetadata(
             'qux',
-            "array",
+            'array',
             false,
             false,
             null,

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -68,6 +68,35 @@ class UploadedFileValueResolverTest extends TestCase
         $attribute = new MapUploadedFile();
         $argument = new ArgumentMetadata(
             'qux',
+            "array",
+            false,
+            false,
+            null,
+            false,
+            [$attribute::class => $attribute]
+        );
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            static function () {},
+            $resolver->resolve($request, $argument),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $resolver->onKernelControllerArguments($event);
+        $data = $event->getArguments()[0];
+
+        $this->assertEmpty($data);
+    }
+
+    /**
+     * @dataProvider provideContext
+     */
+    public function testNotNullableFile(RequestPayloadValueResolver $resolver, Request $request)
+    {
+        $attribute = new MapUploadedFile();
+        $argument = new ArgumentMetadata(
+            'qux',
             UploadedFile::class,
             false,
             false,
@@ -82,10 +111,39 @@ class UploadedFileValueResolverTest extends TestCase
             $request,
             HttpKernelInterface::MAIN_REQUEST
         );
+
+        $this->expectException(HttpException::class);
+
+        $resolver->onKernelControllerArguments($event);
+    }
+
+    /**
+     * @dataProvider provideContext
+     */
+    public function testNullableFile(RequestPayloadValueResolver $resolver, Request $request)
+    {
+        $attribute = new MapUploadedFile();
+        $argument = new ArgumentMetadata(
+            'qux',
+            UploadedFile::class,
+            false,
+            true,
+            null,
+            true,
+            [$attribute::class => $attribute]
+        );
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            static function () {},
+            $resolver->resolve($request, $argument),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
         $resolver->onKernelControllerArguments($event);
         $data = $event->getArguments()[0];
 
-        $this->assertEmpty($data);
+        $this->assertNull($data);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Having a simple controller with `MapUploadedFile` as non-array.
When the `file` is omitted in request, symfony throws `ValueError` because resolver returns an empty array and it doesn't match with `UploadedFile $file`.

In my opinion, the HttpException should be thrown in this case.
For array argument the behaviour stays the same.

```php
#[AsController]
#[Route(path: "/upload", methods: ["post"])]
final class Upload
{
    public function __invoke(
        #[MapUploadedFile()]
        UploadedFile $file,
    ): Response {
        ...
    }
}
```


#### Example with omitted `file` - `ValueError` occurs here
```
POST /upload HTTP/1.1
Content-Type: multipart/form-data; charset=utf-8; boundary=__X_PAW_BOUNDARY__
```

#### Error example
```
App\Controller\Upload::__invoke(): 
Argument #2 ($file) must be of type Symfony\Component\HttpFoundation\File\UploadedFile, array given, 
called in /app/vendor/symfony/http-kernel/HttpKernel.php on line 183 (500 Internal Server Error)
```