### PR TITLE
[Serializer][Translation] Deprecate passing an non-empty CSV escape char

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -19,6 +19,11 @@ Security
  * Add `$token` argument to `UserCheckerInterface::checkPostAuth()`
  * Deprecate argument `$secret` of `RememberMeToken` and `RememberMeAuthenticator`
 
+Serializer
+----------
+
+ * Deprecate passing a non-empty escape character to the `csv_escape_char` option of `CsvEncoder`
+
 String
 ------
 
@@ -26,6 +31,11 @@ String
    * `TruncateMode::Char` is equivalent to `true` value ;
    * `TruncateMode::WordAfter` is equivalent to `false` value ;
    * `TruncateMode::WordBefore` is a new mode that will cut the sentence on the last word before the limit is reached.
+
+Translation
+-----------
+
+ * Deprecate passing an escape character to `CsvFileLoader::setCsvControl()`
 
 Yaml
 ----

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Deprecate passing a non-empty escape character to the `csv_escape_char` option of `CsvEncoder`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -54,6 +54,10 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
     public function __construct(array $defaultContext = [])
     {
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
+
+        if ('' !== $this->defaultContext[self::ESCAPE_CHAR_KEY]) {
+            trigger_deprecation('symfony/serializer', '7.2', 'Setting the "csv_escape_char" option to a non-empty string is deprecated. The option will be removed in Symfony 8.0.');
+        }
     }
 
     public function encode(mixed $data, string $format, array $context = []): string

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
  */
 class CsvEncoderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private CsvEncoder $encoder;
 
     protected function setUp(): void
@@ -149,7 +152,6 @@ CSV
         $this->encoder = new CsvEncoder([
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => "'",
-            CsvEncoder::ESCAPE_CHAR_KEY => '|',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
         ]);
 
@@ -175,7 +177,6 @@ CSV
             , $this->encoder->encode($value, 'csv', [
                 CsvEncoder::DELIMITER_KEY => ';',
                 CsvEncoder::ENCLOSURE_KEY => "'",
-                CsvEncoder::ESCAPE_CHAR_KEY => '|',
                 CsvEncoder::KEY_SEPARATOR_KEY => '-',
             ]));
     }
@@ -185,7 +186,6 @@ CSV
         $encoder = new CsvEncoder([
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => "'",
-            CsvEncoder::ESCAPE_CHAR_KEY => '|',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
         ]);
         $value = ['a' => 'he\'llo', 'c' => ['d' => 'foo']];
@@ -574,7 +574,6 @@ CSV
         $this->encoder = new CsvEncoder([
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => "'",
-            CsvEncoder::ESCAPE_CHAR_KEY => '|',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
         ]);
 
@@ -596,7 +595,6 @@ CSV
             , 'csv', [
                 CsvEncoder::DELIMITER_KEY => ';',
                 CsvEncoder::ENCLOSURE_KEY => "'",
-                CsvEncoder::ESCAPE_CHAR_KEY => '|',
                 CsvEncoder::KEY_SEPARATOR_KEY => '-',
             ]));
     }
@@ -606,7 +604,6 @@ CSV
         $encoder = new CsvEncoder([
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => "'",
-            CsvEncoder::ESCAPE_CHAR_KEY => '|',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
             CsvEncoder::AS_COLLECTION_KEY => true, // Can be removed in 5.0
         ]);
@@ -709,5 +706,14 @@ CSV;
 
         $encoder = new CsvEncoder([CsvEncoder::END_OF_LINE => "\r\n"]);
         $this->assertSame("foo,bar\r\nhello,test\r\n", $encoder->encode($value, 'csv'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testPassingAnNonEmptyEscapeCharIsDeprecated()
+    {
+        $this->expectDeprecation('Since symfony/serializer 7.2: Setting the "csv_escape_char" option to a non-empty string is deprecated. The option will be removed in Symfony 8.0.');
+        new CsvEncoder([CsvEncoder::ESCAPE_CHAR_KEY => '\\']);
     }
 }

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `lint:translations` command
+ * Deprecate passing an escape character to `CsvFileLoader::setCsvControl()`
 
 7.1
 ---

--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -22,7 +22,10 @@ class CsvFileLoader extends FileLoader
 {
     private string $delimiter = ';';
     private string $enclosure = '"';
-    private string $escape = '\\';
+    /**
+     * @deprecated since Symfony 7.2, to be removed in 8.0
+     */
+    private string $escape = '';
 
     protected function loadResource(string $resource): array
     {
@@ -53,10 +56,16 @@ class CsvFileLoader extends FileLoader
     /**
      * Sets the delimiter, enclosure, and escape character for CSV.
      */
-    public function setCsvControl(string $delimiter = ';', string $enclosure = '"', string $escape = '\\'): void
+    public function setCsvControl(string $delimiter = ';', string $enclosure = '"'): void
     {
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
-        $this->escape = $escape;
+        $escape = func_num_args() > 2 ? func_get_arg(2) : null;
+
+        if (null !== $escape) {
+            trigger_deprecation('symfony/translation', '7.2', 'The "escape" parameter of the "%s" method is deprecated. It will be removed in 8.0.', __METHOD__);
+        }
+
+        $this->escape = $escape ?? '\\';
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Exception\InvalidResourceException;
 use Symfony\Component\Translation\Exception\NotFoundResourceException;
@@ -19,6 +20,8 @@ use Symfony\Component\Translation\Loader\CsvFileLoader;
 
 class CsvFileLoaderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testLoad()
     {
         $loader = new CsvFileLoader();
@@ -53,5 +56,16 @@ class CsvFileLoaderTest extends TestCase
         $this->expectException(InvalidResourceException::class);
 
         (new CsvFileLoader())->load('http://example.com/resources.csv', 'en', 'domain1');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testEscapeCharInCsvControlIsDeprecated()
+    {
+        $loader = new CsvFileLoader();
+
+        $this->expectDeprecation('Since symfony/translation 7.2: The "escape" parameter of the "Symfony\Component\Translation\Loader\CsvFileLoader::setCsvControl" method is deprecated. It will be removed in 8.0.');
+        $loader->setCsvControl(';', '"', '\\');
     }
 }

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=8.2",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^2.5|^3.0"
+        "symfony/translation-contracts": "^2.5|^3.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "nikic/php-parser": "^4.18|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

Using a non-empty string for CSV escape char [will be deprecated](https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism) in 8.4. Let's deprecate where relevant in the codebase?