### PR TITLE
[Serializer][Translation] Deprecate passing a non-empty CSV escape char

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -40,6 +40,12 @@ Security
  * Add `$token` argument to `UserCheckerInterface::checkPostAuth()`
  * Deprecate argument `$secret` of `RememberMeToken` and `RememberMeAuthenticator`
 
+Serializer
+----------
+
+ * Deprecate the `csv_escape_char` context option of `CsvEncoder` and the `CsvEncoder::ESCAPE_CHAR_KEY` constant
+ * Deprecate `CsvEncoderContextBuilder::withEscapeChar()` method
+
 String
 ------
 
@@ -47,6 +53,11 @@ String
    * `TruncateMode::Char` is equivalent to `true` value ;
    * `TruncateMode::WordAfter` is equivalent to `false` value ;
    * `TruncateMode::WordBefore` is a new mode that will cut the sentence on the last word before the limit is reached.
+
+Translation
+-----------
+
+ * Deprecate passing an escape character to `CsvFileLoader::setCsvControl()`
 
 Yaml
 ----

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Deprecate the `csv_escape_char` context option of `CsvEncoder` and the `CsvEncoder::ESCAPE_CHAR_KEY` constant
+ * Deprecate `CsvEncoderContextBuilder::withEscapeChar()` method
+
 7.1
 ---
 

--- a/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
@@ -62,10 +62,14 @@ final class CsvEncoderContextBuilder implements ContextBuilderInterface
      *
      * Must be empty or a single character.
      *
+     * @deprecated since Symfony 7.2, to be removed in 8.0
+     *
      * @throws InvalidArgumentException
      */
     public function withEscapeChar(?string $escapeChar): static
     {
+        trigger_deprecation('symfony/serializer', '7.2', 'The "%s" method is deprecated. It will be removed in 8.0.', __METHOD__);
+
         if (null !== $escapeChar && \strlen($escapeChar) > 1) {
             throw new InvalidArgumentException(\sprintf('The "%s" escape character must be empty or a single character.', $escapeChar));
         }

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -25,6 +25,9 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
     public const FORMAT = 'csv';
     public const DELIMITER_KEY = 'csv_delimiter';
     public const ENCLOSURE_KEY = 'csv_enclosure';
+    /**
+     * @deprecated since Symfony 7.2, to be removed in 8.0
+     */
     public const ESCAPE_CHAR_KEY = 'csv_escape_char';
     public const KEY_SEPARATOR_KEY = 'csv_key_separator';
     public const HEADERS_KEY = 'csv_headers';
@@ -53,6 +56,10 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
     public function __construct(array $defaultContext = [])
     {
+        if (\array_key_exists(self::ESCAPE_CHAR_KEY, $defaultContext)) {
+            trigger_deprecation('symfony/serializer', '7.2', 'Setting the "csv_escape_char" option is deprecated. The option will be removed in 8.0.');
+        }
+
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Context\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Serializer\Context\Encoder\CsvEncoderContextBuilder;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
@@ -21,6 +22,8 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  */
 class CsvEncoderContextBuilderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private CsvEncoderContextBuilder $contextBuilder;
 
     protected function setUp(): void
@@ -38,7 +41,6 @@ class CsvEncoderContextBuilderTest extends TestCase
         $context = $this->contextBuilder
             ->withDelimiter($values[CsvEncoder::DELIMITER_KEY])
             ->withEnclosure($values[CsvEncoder::ENCLOSURE_KEY])
-            ->withEscapeChar($values[CsvEncoder::ESCAPE_CHAR_KEY])
             ->withKeySeparator($values[CsvEncoder::KEY_SEPARATOR_KEY])
             ->withHeaders($values[CsvEncoder::HEADERS_KEY])
             ->withEscapedFormulas($values[CsvEncoder::ESCAPE_FORMULAS_KEY])
@@ -59,7 +61,6 @@ class CsvEncoderContextBuilderTest extends TestCase
         yield 'With values' => [[
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => '"',
-            CsvEncoder::ESCAPE_CHAR_KEY => '\\',
             CsvEncoder::KEY_SEPARATOR_KEY => '_',
             CsvEncoder::HEADERS_KEY => ['h1', 'h2'],
             CsvEncoder::ESCAPE_FORMULAS_KEY => true,
@@ -72,7 +73,6 @@ class CsvEncoderContextBuilderTest extends TestCase
         yield 'With null values' => [[
             CsvEncoder::DELIMITER_KEY => null,
             CsvEncoder::ENCLOSURE_KEY => null,
-            CsvEncoder::ESCAPE_CHAR_KEY => null,
             CsvEncoder::KEY_SEPARATOR_KEY => null,
             CsvEncoder::HEADERS_KEY => null,
             CsvEncoder::ESCAPE_FORMULAS_KEY => null,
@@ -88,7 +88,6 @@ class CsvEncoderContextBuilderTest extends TestCase
         $context = $this->contextBuilder
             ->withDelimiter(null)
             ->withEnclosure(null)
-            ->withEscapeChar(null)
             ->withKeySeparator(null)
             ->withHeaders(null)
             ->withEscapedFormulas(null)
@@ -101,7 +100,6 @@ class CsvEncoderContextBuilderTest extends TestCase
         $this->assertSame([
             CsvEncoder::DELIMITER_KEY => null,
             CsvEncoder::ENCLOSURE_KEY => null,
-            CsvEncoder::ESCAPE_CHAR_KEY => null,
             CsvEncoder::KEY_SEPARATOR_KEY => null,
             CsvEncoder::HEADERS_KEY => null,
             CsvEncoder::ESCAPE_FORMULAS_KEY => null,
@@ -124,9 +122,25 @@ class CsvEncoderContextBuilderTest extends TestCase
         $this->contextBuilder->withEnclosure('ọ');
     }
 
+    /**
+     * @group legacy
+     */
     public function testCannotSetMultipleBytesAsEscapeChar()
     {
+        $this->expectDeprecation('Since symfony/serializer 7.2: The "Symfony\Component\Serializer\Context\Encoder\CsvEncoderContextBuilder::withEscapeChar" method is deprecated. It will be removed in 8.0.');
+
         $this->expectException(InvalidArgumentException::class);
         $this->contextBuilder->withEscapeChar('ọ');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testWithEscapeCharIsDeprecated()
+    {
+        $this->expectDeprecation('Since symfony/serializer 7.2: The "Symfony\Component\Serializer\Context\Encoder\CsvEncoderContextBuilder::withEscapeChar" method is deprecated. It will be removed in 8.0.');
+        $context = $this->contextBuilder->withEscapeChar('\\');
+
+        $this->assertSame(['csv_escape_char' => '\\'], $context->toArray());
     }
 }

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `lint:translations` command
+ * Deprecate passing an escape character to `CsvFileLoader::setCsvControl()`
 
 7.1
 ---

--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -22,6 +22,9 @@ class CsvFileLoader extends FileLoader
 {
     private string $delimiter = ';';
     private string $enclosure = '"';
+    /**
+     * @deprecated since Symfony 7.2, to be removed in 8.0
+     */
     private string $escape = '';
 
     protected function loadResource(string $resource): array
@@ -57,6 +60,10 @@ class CsvFileLoader extends FileLoader
     {
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
+        if ('' !== $escape) {
+            trigger_deprecation('symfony/translation', '7.2', 'The "escape" parameter of the "%s" method is deprecated. It will be removed in 8.0.', __METHOD__);
+        }
+
         $this->escape = $escape;
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Exception\InvalidResourceException;
 use Symfony\Component\Translation\Exception\NotFoundResourceException;
@@ -19,6 +20,8 @@ use Symfony\Component\Translation\Loader\CsvFileLoader;
 
 class CsvFileLoaderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testLoad()
     {
         $loader = new CsvFileLoader();
@@ -53,5 +56,16 @@ class CsvFileLoaderTest extends TestCase
         $this->expectException(InvalidResourceException::class);
 
         (new CsvFileLoader())->load('http://example.com/resources.csv', 'en', 'domain1');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testEscapeCharInCsvControlIsDeprecated()
+    {
+        $loader = new CsvFileLoader();
+
+        $this->expectDeprecation('Since symfony/translation 7.2: The "escape" parameter of the "Symfony\Component\Translation\Loader\CsvFileLoader::setCsvControl" method is deprecated. It will be removed in 8.0.');
+        $loader->setCsvControl(';', '"', '\\');
     }
 }

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=8.2",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^2.5|^3.0"
+        "symfony/translation-contracts": "^2.5|^3.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "nikic/php-parser": "^4.18|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

Using a non-empty string for CSV escape char [will be deprecated](https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism) in 8.4. Let's deprecate where relevant in the codebase?