### PR TITLE
[Translation] Fix CSV escape char in `CsvFileLoader` on PHP >= 7.4

### DIFF
--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -22,7 +22,7 @@ class CsvFileLoader extends FileLoader
 {
     private $delimiter = ';';
     private $enclosure = '"';
-    private $escape = '\\';
+    private $escape = '';
 
     /**
      * {@inheritdoc}
@@ -38,7 +38,7 @@ class CsvFileLoader extends FileLoader
         }
 
         $file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::SKIP_EMPTY);
-        $file->setCsvControl($this->delimiter, $this->enclosure, $this->escape);
+        $file->setCsvControl($this->delimiter, $this->enclosure, '' === $this->escape && \PHP_VERSION_ID < 70400 ? '\\' : $this->escape);
 
         foreach ($file as $data) {
             if (false === $data) {
@@ -56,10 +56,10 @@ class CsvFileLoader extends FileLoader
     /**
      * Sets the delimiter, enclosure, and escape character for CSV.
      */
-    public function setCsvControl(string $delimiter = ';', string $enclosure = '"', string $escape = '\\')
+    public function setCsvControl(string $delimiter = ';', string $enclosure = '"', string $escape = '')
     {
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
-        $this->escape = $escape;
+        $this->escape = '' === $escape && \PHP_VERSION_ID < 70400 ? '\\' : $escape;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Related to https://github.com/symfony/symfony/pull/57827. This check has already been done in other places like:

https://github.com/symfony/symfony/blob/4a176ceb4b67d1f17cdfb88ecc0946e47a807f65/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php#L310