### PR TITLE
[VarDumper] Add support for virtual properties

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `FORCE_COLOR` environment variable
+ * Add support for virtual properties
 
 7.1
 ---

--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -190,7 +190,7 @@ class Caster
                 $p->isPublic() => $p->name,
                 $p->isProtected() => self::PREFIX_PROTECTED.$p->name,
                 default => "\0".$className."\0".$p->name,
-            }] = new UninitializedStub($p);
+            }] = \PHP_VERSION_ID >= 80400 && $p->isVirtual() ? new VirtualStub($p) : new UninitializedStub($p);
         }
 
         return $classProperties;

--- a/src/Symfony/Component/VarDumper/Caster/VirtualStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/VirtualStub.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+class VirtualStub extends ConstStub
+{
+    public function __construct(\ReflectionProperty $property)
+    {
+        parent::__construct('~'.($property->hasType() ? ' '.$property->getType() : ''), 'Virtual property');
+        $this->attr['virtual'] = true;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -33,12 +33,13 @@ class CliDumper extends AbstractDumper
         'default' => '0;38;5;208',
         'num' => '1;38;5;38',
         'const' => '1;38;5;208',
+        'virtual' => '3',
         'str' => '1;38;5;113',
         'note' => '38;5;38',
         'ref' => '38;5;247',
-        'public' => '',
-        'protected' => '',
-        'private' => '',
+        'public' => '39',
+        'protected' => '39',
+        'private' => '39',
         'meta' => '38;5;170',
         'key' => '38;5;113',
         'index' => '38;5;38',
@@ -347,7 +348,10 @@ class CliDumper extends AbstractDumper
             if ($cursor->hashKeyIsBinary) {
                 $key = $this->utf8Encode($key);
             }
-            $attr = ['binary' => $cursor->hashKeyIsBinary];
+            $attr = [
+                'binary' => $cursor->hashKeyIsBinary,
+                'virtual' => $cursor->attr['virtual'] ?? false,
+            ];
             $bin = $cursor->hashKeyIsBinary ? 'b' : '';
             $style = 'key';
             switch ($cursor->hashType) {
@@ -371,7 +375,7 @@ class CliDumper extends AbstractDumper
                     // no break
                 case Cursor::HASH_OBJECT:
                     if (!isset($key[0]) || "\0" !== $key[0]) {
-                        $this->line .= '+'.$bin.$this->style('public', $key).': ';
+                        $this->line .= '+'.$bin.$this->style('public', $key, $attr).': ';
                     } elseif (0 < strpos($key, "\0", 1)) {
                         $key = explode("\0", substr($key, 1), 2);
 
@@ -505,6 +509,9 @@ class CliDumper extends AbstractDumper
 
         if ('label' === $style && '' !== $value) {
             $value .= ' ';
+        }
+        if ($this->colors && ($attr['virtual'] ?? false)) {
+            $value = "\033[{$this->styles['virtual']}m".$value;
         }
 
         return $value;

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -29,6 +29,7 @@ class HtmlDumper extends CliDumper
             'default' => 'background-color:#18171B; color:#FF8400; line-height:1.2em; font:12px Menlo, Monaco, Consolas, monospace; word-wrap: break-word; white-space: pre-wrap; position:relative; z-index:99999; word-break: break-all',
             'num' => 'font-weight:bold; color:#1299DA',
             'const' => 'font-weight:bold',
+            'virtual' => 'font-style:italic',
             'str' => 'font-weight:bold; color:#56DB3A',
             'note' => 'color:#1299DA',
             'ref' => 'color:#A0A0A0',
@@ -45,6 +46,7 @@ class HtmlDumper extends CliDumper
             'default' => 'background:none; color:#CC7832; line-height:1.2em; font:12px Menlo, Monaco, Consolas, monospace; word-wrap: break-word; white-space: pre-wrap; position:relative; z-index:99999; word-break: break-all',
             'num' => 'font-weight:bold; color:#1299DA',
             'const' => 'font-weight:bold',
+            'virtual' => 'font-style:italic',
             'str' => 'font-weight:bold; color:#629755;',
             'note' => 'color:#6897BB',
             'ref' => 'color:#6E6E6E',
@@ -920,6 +922,9 @@ EOHTML
         }
         if ('label' === $style) {
             $v .= ' ';
+        }
+        if ($attr['virtual'] ?? false) {
+            $v = '<span class=sf-dump-virtual>'.$v.'</span>';
         }
 
         return $v;

--- a/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
@@ -16,10 +16,12 @@ use Symfony\Component\VarDumper\Caster\ArgsStub;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Caster\LinkStub;
 use Symfony\Component\VarDumper\Caster\ScalarStub;
+use Symfony\Component\VarDumper\Caster\VirtualStub;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 use Symfony\Component\VarDumper\Tests\Fixtures\FooInterface;
+use Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty;
 
 class StubCasterTest extends TestCase
 {
@@ -95,6 +97,40 @@ EODUMP;
         $expectedDump = <<<'EODUMP'
 array:1 [
   0 => 🐛
+]
+EODUMP;
+
+        $this->assertDumpMatchesFormat($expectedDump, $args);
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testVirtualPropertyStub()
+    {
+        $class = new \ReflectionClass(VirtualProperty::class);
+        $args = [new VirtualStub($class->getProperty('fullName'))];
+
+        $expectedDump = <<<'EODUMP'
+array:1 [
+  0 => ~ string
+]
+EODUMP;
+
+        $this->assertDumpMatchesFormat($expectedDump, $args);
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testVirtualPropertyWithoutTypeStub()
+    {
+        $class = new \ReflectionClass(VirtualProperty::class);
+        $args = [new VirtualStub($class->getProperty('noType'))];
+
+        $expectedDump = <<<'EODUMP'
+array:1 [
+  0 => ~
 ]
 EODUMP;
 
@@ -217,7 +253,7 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 <foo></foo><bar><span class=sf-dump-note>array:1</span> [<samp data-depth=1 class=sf-dump-expanded>
-  <span class=sf-dump-index>0</span> => "<a href="%sStubCasterTest.php:209" rel="noopener noreferrer"><span class=sf-dump-str title="19 characters">Exception@anonymous</span></a>"
+  <span class=sf-dump-index>0</span> => "<a href="%sStubCasterTest.php:245" rel="noopener noreferrer"><span class=sf-dump-str title="19 characters">Exception@anonymous</span></a>"
 </samp>]
 </bar>
 EODUMP;

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\AbstractDumper;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+use Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -302,6 +303,21 @@ EOTXT
 
         putenv('DUMP_LIGHT_ARRAY=');
         putenv('DUMP_STRING_LENGTH=');
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testVirtualProperties()
+    {
+        $this->assertDumpEquals(<<<EODUMP
+            Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty {
+              +firstName: "John"
+              +lastName: "Doe"
+              +fullName: ~ string
+              -noType: ~
+            }
+            EODUMP, new VirtualProperty());
     }
 
     public function testThrowingCaster()

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarDumper\Caster\ImgStub;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -115,6 +116,30 @@ EOTXT
 
             $out
         );
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testVirtualProperties()
+    {
+        $dumper = new HtmlDumper('php://output');
+        $dumper->setDumpHeader('<foo></foo>');
+        $dumper->setDumpBoundaries('<bar>', '</bar>');
+        $cloner = new VarCloner();
+
+        $data = $cloner->cloneVar(new VirtualProperty());
+        $out = $dumper->dump($data, true);
+
+        $this->assertStringMatchesFormat(<<<EODUMP
+            <foo></foo><bar><span class=sf-dump-note>Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty</span> {<a class=sf-dump-ref>#%i</a><samp data-depth=1 class=sf-dump-expanded>
+              +<span class=sf-dump-public title="Public property">firstName</span>: "<span class=sf-dump-str title="4 characters">John</span>"
+              +<span class=sf-dump-public title="Public property">lastName</span>: "<span class=sf-dump-str title="3 characters">Doe</span>"
+              +<span class=sf-dump-virtual><span class=sf-dump-public title="Public property">fullName</span></span>: <span class=sf-dump-virtual><span class=sf-dump-const title="Virtual property">~ string</span></span>
+              -<span class=sf-dump-virtual><span class=sf-dump-private title="Private property defined in class:&#10;`Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty`">noType</span></span>: <span class=sf-dump-virtual><span class=sf-dump-const title="Virtual property">~</span></span>
+            </samp>}
+            </bar>
+            EODUMP, $out);
     }
 
     public function testCharset()

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/VirtualProperty.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/VirtualProperty.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\VarDumper\Tests\Fixtures;
+
+class VirtualProperty
+{
+    public string $firstName = 'John';
+    public string $lastName = 'Doe';
+
+    public string $fullName {
+        get {
+            return $this->firstName.' '.$this->lastName;
+        }
+    }
+
+    private $noType {
+        get {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This brings support for hooked virtual properties. Given the following code:

```php
class VirtualHookedClass
{
    public string $firstName = 'John';
    private string $lastName = 'Doe';

    public string $fullName {
        get {
            return $this->firstName . ' ' . $this->lastName;
        }
    }

    private $untypedFullName {
        get {
            return $this->firstName . ' ' . $this->lastName;
        }
    }
}

dd(new VirtualHookedClass());
```

The following is dumped:

![image](https://github.com/user-attachments/assets/34a2f1c6-febf-469f-bf5b-186348fc3ebe)

Currently, it dumps the property as an uninitialized one, as `+fullName: ? string`. I think it would be nice to know that more than being uninitialized, it's actually a virtual property.

Given that hooks contain arbitrary code, I'm not sure it would be a good idea to try to display the resulting value in the dump of the virtual property.