### PR TITLE
[Cache] Add optional `ClockInterface` to `ArrayAdapter`

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add optional `Psr\Clock\ClockInterface` parameter to `ArrayAdapter`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Tests\Fixtures\TestEnum;
+use Symfony\Component\Clock\MockClock;
 
 /**
  * @group time-sensitive
@@ -101,5 +102,18 @@ class ArrayAdapterTest extends AdapterTestCase
         $cache->save($item);
 
         $this->assertSame(TestEnum::Foo, $cache->getItem('foo')->get());
+    }
+
+    public function testClockAware()
+    {
+        $clock = new MockClock();
+        $cache = new ArrayAdapter(10, false, 0, 0, $clock);
+
+        $cache->save($cache->getItem('foo'));
+        $this->assertTrue($cache->hasItem('foo'));
+
+        $clock->modify('+11 seconds');
+
+        $this->assertFalse($cache->hasItem('foo'));
     }
 }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -34,6 +34,7 @@
         "doctrine/dbal": "^3.6|^4",
         "predis/predis": "^1.1|^2.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
+        "symfony/clock": "^6.4|^7.0",
         "symfony/config": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/filesystem": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | none
| License       | MIT

Hello.
It is common to use `ArrayAdapter` as a cache adapter in test environments. Unfortunately, currently cache item expiration is untestable. On the other hand, `Psr\Clock\ClockInterface` and Symfony Clock component are available for some time. I think it would be great if we make use of `ClockInterface` in `ArrayAdapter`.
