### PR TITLE
[Form] Deprecate VersionAwareTest trait

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -8,6 +8,11 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/7.2/
 
 If you're upgrading from a version below 7.1, follow the [7.1 upgrade guide](UPGRADE-7.1.md) first.
 
+Form
+----
+
+ * Deprecate the `VersionAwareTest` trait, use feature detection instead
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
@@ -2869,8 +2869,6 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 
     public function testWeekSingleText()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('holidays', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '1970-W01', [
             'input' => 'string',
             'widget' => 'single_text',
@@ -2889,8 +2887,6 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 
     public function testWeekSingleTextNoHtml5()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('holidays', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '1970-W01', [
             'input' => 'string',
             'widget' => 'single_text',
@@ -2910,8 +2906,6 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 
     public function testWeekChoices()
     {
-        $this->requiresFeatureSet(404);
-
         $data = ['year' => (int) date('Y'), 'week' => 1];
 
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\WeekType', $data, [
@@ -2938,8 +2932,6 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 
     public function testWeekText()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '2000-W01', [
             'input' => 'string',
             'widget' => 'text',

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
@@ -1842,8 +1842,6 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
 
     public function testWeekChoices()
     {
-        $this->requiresFeatureSet(404);
-
         $data = ['year' => (int) date('Y'), 'week' => 1];
 
         $form = $this->factory->createNamed('name', WeekType::class, $data, [

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -19,7 +19,6 @@ use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Tests\VersionAwareTest;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatableInterface;
@@ -27,8 +26,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 {
-    use VersionAwareTest;
-
     protected MockObject&CsrfTokenManagerInterface $csrfTokenManager;
     protected array $testableFeatures = [];
 
@@ -676,8 +673,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testSingleChoiceWithPreferred()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'preferred_choices' => ['&b'],
@@ -702,8 +697,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testSingleChoiceWithPreferredAndNoSeparator()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'preferred_choices' => ['&b'],
@@ -727,8 +720,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'preferred_choices' => ['&b'],
@@ -753,8 +744,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testChoiceWithOnlyPreferred()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'preferred_choices' => ['&a', '&b'],
@@ -1818,8 +1807,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testRenderNumberWithHtml5NumberType()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\NumberType', 1234.56, [
             'html5' => true,
         ]);
@@ -1836,8 +1823,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testRenderNumberWithHtml5NumberTypeAndStepAttribute()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\NumberType', 1234.56, [
             'html5' => true,
             'attr' => ['step' => '0.1'],
@@ -1912,8 +1897,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testPercentNoSymbol()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => false, 'rounding_mode' => \NumberFormatter::ROUND_CEILING]);
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -1927,8 +1910,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testPercentCustomSymbol()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => '‱', 'rounding_mode' => \NumberFormatter::ROUND_CEILING]);
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2606,8 +2587,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testLabelWithTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), 'Address is %address%', [
             'label_translation_parameters' => [
@@ -2625,8 +2604,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testHelpWithTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
             'help' => 'for company %company%',
             'help_translation_parameters' => [
@@ -2697,8 +2674,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testAttributesWithTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
             'attr' => [
                 'title' => 'Message to %company%',
@@ -2720,8 +2695,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testButtonWithTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamedBuilder('myform')
             ->add('mybutton', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', [
                 'label' => 'Submit to %company%',
@@ -2745,8 +2718,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
      */
     public function testSubmitFormNoValidate(bool $validate)
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->create(SubmitType::class, null, [
             'validate' => $validate,
         ]);
@@ -2776,8 +2747,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testWeekSingleText()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('holidays', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '1970-W01', [
             'input' => 'string',
             'widget' => 'single_text',
@@ -2795,8 +2764,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testWeekSingleTextNoHtml5()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('holidays', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '1970-W01', [
             'input' => 'string',
             'widget' => 'single_text',
@@ -2815,8 +2782,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testWeekChoices()
     {
-        $this->requiresFeatureSet(404);
-
         $data = ['year' => (int) date('Y'), 'week' => 1];
 
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\WeekType', $data, [
@@ -2841,8 +2806,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testWeekText()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '2000-W01', [
             'input' => 'string',
             'widget' => 'text',

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Deprecate the `VersionAwareTest` trait, use feature detection instead
+
 7.1
 ---
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTestCase.php
@@ -114,8 +114,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testPassLabelTranslationParametersToView()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
             'label_translation_parameters' => ['%param%' => 'value'],
         ]))
@@ -126,8 +124,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testPassAttrTranslationParametersToView()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
             'attr_translation_parameters' => ['%param%' => 'value'],
         ]))
@@ -138,8 +134,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testInheritLabelTranslationParametersFromParent()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'label_translation_parameters' => ['%param%' => 'value'],
@@ -153,8 +147,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testInheritAttrTranslationParametersFromParent()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'attr_translation_parameters' => ['%param%' => 'value'],
@@ -168,8 +160,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testPreferOwnLabelTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'label_translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
@@ -185,8 +175,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testPreferOwnAttrTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'attr_translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
@@ -202,8 +190,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testDefaultLabelTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
             ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
@@ -214,8 +200,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testDefaultAttrTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
             ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()

--- a/src/Symfony/Component/Form/Tests/VersionAwareTest.php
+++ b/src/Symfony/Component/Form/Tests/VersionAwareTest.php
@@ -11,12 +11,20 @@
 
 namespace Symfony\Component\Form\Tests;
 
+/**
+ * @deprecated since Symfony 7.2, use feature detection instead.
+ */
 trait VersionAwareTest
 {
     protected static int $supportedFeatureSetVersion = 404;
 
+    /**
+     * @deprecated since Symfony 7.2, use feature detection instead.
+     */
     protected function requiresFeatureSet(int $requiredFeatureSetVersion)
     {
+        trigger_deprecation('symfony/form', '7.2', 'The "%s" trait is deprecated, use feature detection instead.', VersionAwareTest::class);
+
         if ($requiredFeatureSetVersion > static::$supportedFeatureSetVersion) {
             $this->markTestSkipped(\sprintf('Test requires features from symfony/form %.2f but only version %.2f is supported.', $requiredFeatureSetVersion / 100, static::$supportedFeatureSetVersion / 100));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

With this trait, downstream projects can check if they have at least Symfony Form 4.4 installed. That check should really be a no-op these days.

I haven't removed the usages of this trait since downstream code might still rely on its presence. But I could eliminate all calls to the method that the trait provides.