### PR TITLE
[ErrorHandler] Fix `E_STRICT` logging level

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -181,7 +181,7 @@ class ErrorHandler
     {
         if (\PHP_VERSION_ID < 80400) {
             $this->levels[\E_STRICT] = 'Runtime Notice';
-            $this->loggers[\E_STRICT] = [null, LogLevel::WARNING];
+            $this->loggers[\E_STRICT] = [null, LogLevel::ERROR];
         }
 
         if ($bootstrappingLogger) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Following https://github.com/symfony/symfony/pull/57799. In more recent branches, E_* errors logging level were raised from warnings to errors.