### PR TITLE
Release v7.0.10

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -7,6 +7,34 @@ in 7.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.0.0...v7.0.1
 
+* 7.0.10 (2024-07-26)
+
+ * bug #57803 [FrameworkBundle] move adding detailed JSON error messages to the validate phase (xabbuh)
+ * bug #57815 [Console][PhpUnitBridge][VarDumper] Fix `NO_COLOR` empty value handling (alexandre-daubois)
+ * bug #57828 [Translation] Fix CSV escape char in `CsvFileLoader` on PHP >= 7.4 (alexandre-daubois)
+ * bug #57812 [Validator] treat uninitialized properties referenced by property paths as null (xabbuh)
+ * bug #57816 [DoctrineBridge] fix messenger bus dispatch inside an active transaction (IndraGunawan)
+ * bug #57799 [ErrorHandler][VarDumper] Remove PHP 8.4 deprecations (alexandre-daubois)
+ * bug #57772 [WebProfilerBundle] Add word wrap in tables in dialog to see all the text in workflow listeners dialog (SpartakusMd)
+ * bug #57802 [PropertyInfo] Fix nullable value returned from extractFromMutator on CollectionType (benjilebon)
+ * bug #57832 [DependencyInjection] Do not try to load default method name on interface (lyrixx)
+ * bug #57748 [SecurityBundle] use firewall-specific user checkers when manually logging in users (xabbuh)
+ * bug #57753 [ErrorHandler] restrict the maximum length of the X-Debug-Exception header (xabbuh)
+ * bug #57646 [Serializer] Raise correct exception in `ArrayDenormalizer` when called without a nested denormalizer (derrabus)
+ * bug #57674 [Cache] Improve `dbindex` DSN parameter parsing (constantable)
+ * bug #57678 [Validator] Add `setGroupProvider` to `AttributeLoader` (Maximilian Zumbansen)
+ * bug #57679 [WebProfilerBundle] Change incorrect check for the `stateless` request attribute (themasch)
+ * bug #57663 [Cache] use copy() instead of rename() on Windows (xabbuh)
+ * bug #57617 [PropertyInfo] Handle collection in PhpStan same as PhpDoc (mtarld)
+ * bug #54057 [Messenger] Passing actual `Envelope` to `WorkerMessageRetriedEvent`  (daffoxdev)
+ * bug #57645 [Routing] Discard in-memory cache of routes when writing the file-based cache (mpdude)
+ * bug #57621 [Mailer]  force HTTP 1.1 for Mailgun API requests (xabbuh)
+ * bug #57616 [String] Revert "Fixed u()->snake(), b()->snake() and s()->snake() methods" (nicolas-grekas)
+ * bug #57593 [SecurityBundle] Compare paths after realpath() has been applied to both (xabbuh)
+ * bug #57594 [String] Normalize underscores in snake() (xabbuh)
+ * bug #57585 [HttpFoundation] Fix MockArraySessionStorage to generate more conform ids (Seldaek)
+ * bug #57589 [FrameworkBundle] fix AssetMapper usage without assets enabled (xabbuh)
+
 * 7.0.9 (2024-06-28)
 
  * bug #57345 [DependencyInjection] Fix regression in ordering service locators by priority (longwave)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.0.10-DEV';
+    public const VERSION = '7.0.10';
     public const VERSION_ID = 70010;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 10;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2024';
     public const END_OF_LIFE = '07/2024';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.0.9...v7.0.10)

 * bug #57803 [FrameworkBundle] move adding detailed JSON error messages to the validate phase (@xabbuh)
 * bug #57815 [Console][PhpUnitBridge][VarDumper] Fix `NO_COLOR` empty value handling (@alexandre-daubois)
 * bug #57828 [Translation] Fix CSV escape char in `CsvFileLoader` on PHP >= 7.4 (@alexandre-daubois)
 * bug #57812 [Validator] treat uninitialized properties referenced by property paths as null (@xabbuh)
 * bug #57816 [DoctrineBridge] fix messenger bus dispatch inside an active transaction (@IndraGunawan)
 * bug #57799 [ErrorHandler][VarDumper] Remove PHP 8.4 deprecations (@alexandre-daubois)
 * bug #57772 [WebProfilerBundle] Add word wrap in tables in dialog to see all the text in workflow listeners dialog (@SpartakusMd)
 * bug #57802 [PropertyInfo] Fix nullable value returned from extractFromMutator on CollectionType (@benjilebon)
 * bug #57832 [DependencyInjection] Do not try to load default method name on interface (@lyrixx)
 * bug #57748 [SecurityBundle] use firewall-specific user checkers when manually logging in users (@xabbuh)
 * bug #57753 [ErrorHandler] restrict the maximum length of the X-Debug-Exception header (@xabbuh)
 * bug #57646 [Serializer] Raise correct exception in `ArrayDenormalizer` when called without a nested denormalizer (@derrabus)
 * bug #57674 [Cache] Improve `dbindex` DSN parameter parsing (@constantable)
 * bug #57678 [Validator] Add `setGroupProvider` to `AttributeLoader` (Maximilian Zumbansen)
 * bug #57679 [WebProfilerBundle] Change incorrect check for the `stateless` request attribute (@themasch)
 * bug #57663 [Cache] use copy() instead of rename() on Windows (@xabbuh)
 * bug #57617 [PropertyInfo] Handle collection in PhpStan same as PhpDoc (@mtarld)
 * bug #54057 [Messenger] Passing actual `Envelope` to `WorkerMessageRetriedEvent`  (@daffoxdev)
 * bug #57645 [Routing] Discard in-memory cache of routes when writing the file-based cache (@mpdude)
 * bug #57621 [Mailer]  force HTTP 1.1 for Mailgun API requests (@xabbuh)
 * bug #57616 [String] Revert "Fixed u()->snake(), b()->snake() and s()->snake() methods" (@nicolas-grekas)
 * bug #57593 [SecurityBundle] Compare paths after realpath() has been applied to both (@xabbuh)
 * bug #57594 [String] Normalize underscores in snake() (@xabbuh)
 * bug #57585 [HttpFoundation] Fix MockArraySessionStorage to generate more conform ids (@Seldaek)
 * bug #57589 [FrameworkBundle] fix AssetMapper usage without assets enabled (@xabbuh)
