### PR TITLE
[HttpFoundation] Add `Request::isStateless` method

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -66,8 +66,8 @@ class FirewallMap implements FirewallMapInterface
                 /** @var FirewallContext $context */
                 $context = $this->container->get($contextId);
 
-                if ($context->getConfig()?->isStateless() && !$request->attributes->has('_stateless')) {
-                    $request->attributes->set('_stateless', true);
+                if ($context->getConfig()?->isStateless() && null === $request->isStateless()) {
+                    $request->setStateless();
                 }
 
                 return $context;

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -66,7 +66,7 @@ class FirewallMap implements FirewallMapInterface
                 /** @var FirewallContext $context */
                 $context = $this->container->get($contextId);
 
-                if ($context->getConfig()?->isStateless() && null === $request->isStateless()) {
+                if ($context->getConfig()?->isStateless() && !$request->attributes->has('_stateless')) {
                     $request->setStateless();
                 }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -88,7 +88,7 @@ class FirewallMapTest extends TestCase
         $this->assertEquals([[$listener], $exceptionListener, $logoutListener], $firewallMap->getListeners($request));
         $this->assertEquals($firewallConfig, $firewallMap->getFirewallConfig($request));
         $this->assertEquals('security.firewall.map.context.foo', $request->attributes->get(self::ATTRIBUTE_FIREWALL_CONTEXT));
-        $this->assertEquals($expectedState, $request->attributes->get('_stateless'));
+        $this->assertEquals($expectedState, $request->isStateless());
     }
 
     public static function providesStatefulStatelessRequests(): \Generator

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -54,7 +54,7 @@ class FirewallMapTest extends TestCase
         $this->assertEquals([[], null, null], $firewallMap->getListeners($request));
         $this->assertNull($firewallMap->getFirewallConfig($request));
         $this->assertFalse($request->attributes->has(self::ATTRIBUTE_FIREWALL_CONTEXT));
-        $this->assertNull($request->isStateless());
+        $this->assertFalse($request->attributes->has('_stateless'));
     }
 
     /** @dataProvider providesStatefulStatelessRequests */

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -54,7 +54,7 @@ class FirewallMapTest extends TestCase
         $this->assertEquals([[], null, null], $firewallMap->getListeners($request));
         $this->assertNull($firewallMap->getFirewallConfig($request));
         $this->assertFalse($request->attributes->has(self::ATTRIBUTE_FIREWALL_CONTEXT));
-        $this->assertFalse($request->attributes->has('_stateless'));
+        $this->assertNull($request->isStateless());
     }
 
     /** @dataProvider providesStatefulStatelessRequests */
@@ -88,7 +88,7 @@ class FirewallMapTest extends TestCase
         $this->assertEquals([[$listener], $exceptionListener, $logoutListener], $firewallMap->getListeners($request));
         $this->assertEquals($firewallConfig, $firewallMap->getFirewallConfig($request));
         $this->assertEquals('security.firewall.map.context.foo', $request->attributes->get(self::ATTRIBUTE_FIREWALL_CONTEXT));
-        $this->assertEquals($expectedState, method_exists($request, 'isStateless') ? $request->isStateless() : $request->attributes->get('_stateless'));
+        $this->assertEquals($expectedState, $request->isStateless());
     }
 
     public static function providesStatefulStatelessRequests(): \Generator

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -88,7 +88,7 @@ class FirewallMapTest extends TestCase
         $this->assertEquals([[$listener], $exceptionListener, $logoutListener], $firewallMap->getListeners($request));
         $this->assertEquals($firewallConfig, $firewallMap->getFirewallConfig($request));
         $this->assertEquals('security.firewall.map.context.foo', $request->attributes->get(self::ATTRIBUTE_FIREWALL_CONTEXT));
-        $this->assertEquals($expectedState, $request->isStateless());
+        $this->assertEquals($expectedState, method_exists($request, 'isStateless') ? $request->isStateless() : $request->attributes->get('_stateless'));
     }
 
     public static function providesStatefulStatelessRequests(): \Generator

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -24,7 +24,7 @@
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
-        "symfony/http-foundation": "^6.4|^7.0",
+        "symfony/http-foundation": "^7.2",
         "symfony/password-hasher": "^6.4|^7.0",
         "symfony/security-core": "^7.2",
         "symfony/security-csrf": "^6.4|^7.0",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -24,7 +24,7 @@
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
-        "symfony/http-foundation": "^7.2",
+        "symfony/http-foundation": "^6.4|^7.0",
         "symfony/password-hasher": "^6.4|^7.0",
         "symfony/security-core": "^7.2",
         "symfony/security-csrf": "^6.4|^7.0",

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -127,7 +127,7 @@ class ProfilerController
             throw new NotFoundHttpException('The profiler must be enabled.');
         }
 
-        if (!$request->attributes->getBoolean('_stateless') && $request->hasSession()
+        if (!$request->isStateless() && $request->hasSession()
             && ($session = $request->getSession())->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag
         ) {
             // keep current flashes for one more request if using AutoExpireFlashBag
@@ -174,7 +174,7 @@ class ProfilerController
         $this->cspHandler?->disableCsp();
 
         $session = null;
-        if (!$request->attributes->getBoolean('_stateless') && $request->hasSession()) {
+        if (!$request->isStateless() && $request->hasSession()) {
             $session = $request->getSession();
         }
 
@@ -254,7 +254,7 @@ class ProfilerController
         $token = $request->query->get('token');
         $profileType = $request->query->get('type', 'request');
 
-        if (!$request->attributes->getBoolean('_stateless') && $request->hasSession()) {
+        if (!$request->isStateless() && $request->hasSession()) {
             $session = $request->getSession();
 
             $session->set('_profiler_search_ip', $ip);

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -20,6 +20,7 @@
         "symfony/config": "^6.4|^7.0",
         "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
+        "symfony/http-foundation": "^7.2",
         "symfony/routing": "^6.4|^7.0",
         "symfony/twig-bundle": "^6.4|^7.0",
         "twig/twig": "^3.10"

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add optional `$requests` argument to `RequestStack::__construct()`
+ * Add `Request::isStateless()`
 
 7.1
 ---

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add optional `$requests` argument to `RequestStack::__construct()`
- * Add `Request::isStateless()`
+ * Add `Request::isStateless()` and `Request::setStateless()`
 
 7.1
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -651,8 +651,17 @@ class Request
         return $default;
     }
 
-    public function isStateless(): bool
+    public function setStateless(bool $stateless = true): void
     {
+        $this->attributes->set('_stateless', $stateless);
+    }
+
+    public function isStateless(): ?bool
+    {
+        if (!$this->attributes->has('_stateless')) {
+            return null;
+        }
+
         return $this->attributes->getBoolean('_stateless');
     }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -651,6 +651,11 @@ class Request
         return $default;
     }
 
+    public function isStateless(): bool
+    {
+        return $this->attributes->getBoolean('_stateless');
+    }
+
     /**
      * Gets the Session.
      *

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -656,12 +656,8 @@ class Request
         $this->attributes->set('_stateless', $stateless);
     }
 
-    public function isStateless(): ?bool
+    public function isStateless(): bool
     {
-        if (!$this->attributes->has('_stateless')) {
-            return null;
-        }
-
         return $this->attributes->getBoolean('_stateless');
     }
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -106,7 +106,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             'session_metadata' => $sessionMetadata,
             'session_attributes' => $sessionAttributes,
             'session_usages' => array_values($this->sessionUsages),
-            'stateless_check' => $this->requestStack?->getMainRequest()?->attributes->get('_stateless') ?? false,
+            'stateless_check' => $this->requestStack?->getMainRequest()?->isStateless() ?? false,
             'flashes' => $flashes,
             'path_info' => $request->getPathInfo(),
             'controller' => 'n/a',

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -62,7 +62,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $sessionMetadata = [];
         $sessionAttributes = [];
         $flashes = [];
-        if (!$request->attributes->getBoolean('_stateless') && $request->hasSession()) {
+        if (!$request->isStateless() && $request->hasSession()) {
             $session = $request->getSession();
             if ($session->isStarted()) {
                 $sessionMetadata['Created'] = date(\DATE_RFC822, $session->getMetadataBag()->getCreated());

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -206,7 +206,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
                 ->headers->addCacheControlDirective('must-revalidate');
         }
 
-        if (!$event->getRequest()->attributes->get('_stateless', false)) {
+        if (!$event->getRequest()->isStateless()) {
             return;
         }
 
@@ -239,7 +239,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
         $stateless = false;
         $clonedRequestStack = clone $requestStack;
         while (null !== ($request = $clonedRequestStack->pop()) && !$stateless) {
-            $stateless = $request->attributes->get('_stateless');
+            $stateless = $request->isStateless();
         }
 
         if (!$stateless) {

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -91,7 +91,7 @@ class ProfilerListener implements EventSubscriberInterface
             return;
         }
 
-        $session = !$request->attributes->getBoolean('_stateless') && $request->hasPreviousSession() ? $request->getSession() : null;
+        $session = !$request->isStateless() && $request->hasPreviousSession() ? $request->getSession() : null;
 
         if ($session instanceof Session) {
             $usageIndexValue = $usageIndexReference = &$session->getUsageIndex();

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -124,7 +124,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         if ($request->getDefaultLocale() !== $request->getLocale()) {
             $subRequest->setLocale($request->getLocale());
         }
-        if (null !== $request->isStateless()) {
+        if ($request->attributes->has('_stateless')) {
             $subRequest->setStateless($request->isStateless());
         }
         if ($request->attributes->has('_check_controller_is_allowed')) {

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -124,8 +124,8 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         if ($request->getDefaultLocale() !== $request->getLocale()) {
             $subRequest->setLocale($request->getLocale());
         }
-        if ($request->attributes->has('_stateless')) {
-            $subRequest->attributes->set('_stateless', $request->attributes->get('_stateless'));
+        if (null !== $request->isStateless()) {
+            $subRequest->setStateless($request->isStateless());
         }
         if ($request->attributes->has('_check_controller_is_allowed')) {
             $subRequest->attributes->set('_check_controller_is_allowed', $request->attributes->get('_check_controller_is_allowed'));

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -318,7 +318,7 @@ class RequestDataCollectorTest extends TestCase
 
         $requestStack = new RequestStack();
         $request = $this->createRequest();
-        $request->attributes->set('_stateless', true);
+        $request->setStateless();
         $requestStack->push($request);
 
         $collector = new RequestDataCollector($requestStack);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -753,7 +753,7 @@ class SessionListenerTest extends TestCase
         $kernel = $this->createMock(HttpKernelInterface::class);
 
         $request = new Request();
-        $request->attributes->set('_stateless', true);
+        $request->setStateless();
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
         $request->getSession();
 
@@ -780,7 +780,7 @@ class SessionListenerTest extends TestCase
         $kernel = $this->createMock(HttpKernelInterface::class);
 
         $request = new Request();
-        $request->attributes->set('_stateless', true);
+        $request->setStateless();
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
         $request->getSession();
 
@@ -805,7 +805,7 @@ class SessionListenerTest extends TestCase
         $kernel = $this->createMock(HttpKernelInterface::class);
 
         $request = new Request();
-        $request->attributes->set('_stateless', true);
+        $request->setStateless();
 
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
         $request->getSession();
@@ -824,7 +824,7 @@ class SessionListenerTest extends TestCase
         $requestStack = new RequestStack();
 
         $request = new Request();
-        $request->attributes->set('_stateless', true);
+        $request->setStateless();
 
         $requestStack->push(new Request());
         $requestStack->push($request);
@@ -849,7 +849,7 @@ class SessionListenerTest extends TestCase
         $session->expects($this->exactly(0))->method('save');
 
         $request = new Request();
-        $request->attributes->set('_stateless', true);
+        $request->setStateless();
 
         $requestStack = new RequestStack();
         $requestStack->push($request);

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -281,7 +281,7 @@ class InlineFragmentRendererTest extends TestCase
         $kernel
             ->expects($this->once())
             ->method('handle')
-            ->with($this->callback(static fn (Request $subRequest) => $subRequest->attributes->get('_stateless')))
+            ->with($this->callback(static fn (Request $subRequest) => $subRequest->isStateless()))
         ;
         $strategy = new InlineFragmentRenderer($kernel);
         $strategy->render('/', $request);
@@ -296,7 +296,7 @@ class InlineFragmentRendererTest extends TestCase
         $kernel
             ->expects($this->once())
             ->method('handle')
-            ->with($this->callback(static fn (Request $subRequest) => !$subRequest->attributes->get('_stateless')))
+            ->with($this->callback(static fn (Request $subRequest) => !$subRequest->isStateless()))
         ;
         $strategy = new InlineFragmentRenderer($kernel);
         $strategy->render(new ControllerReference('main_controller', ['_stateless' => false]), $request);

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -275,7 +275,7 @@ class InlineFragmentRendererTest extends TestCase
     public function testStatelessAttributeIsForwardedByDefault()
     {
         $request = Request::create('/');
-        $request->attributes->set('_stateless', true);
+        $request->setStateless();
 
         $kernel = $this->createMock(HttpKernelInterface::class);
         $kernel
@@ -290,7 +290,7 @@ class InlineFragmentRendererTest extends TestCase
     public function testStatelessAttributeCanBeDisabled()
     {
         $request = Request::create('/');
-        $request->attributes->set('_stateless', true);
+        $request->setStateless();
 
         $kernel = $this->createMock(HttpKernelInterface::class);
         $kernel

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -20,7 +20,7 @@
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^6.4|^7.0",
         "symfony/event-dispatcher": "^6.4|^7.0",
-        "symfony/http-foundation": "^6.4|^7.0",
+        "symfony/http-foundation": "^7.2",
         "symfony/polyfill-ctype": "^1.8",
         "psr/log": "^1|^2|^3"
     },

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -86,7 +86,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
 
         $this->logger?->debug('Authentication failure, redirect triggered.', ['failure_path' => $options['failure_path']]);
 
-        if (!$request->attributes->getBoolean('_stateless')) {
+        if (!$request->isStateless()) {
             $request->getSession()->set(SecurityRequestAttributes::AUTHENTICATION_ERROR, $exception);
         }
 

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -99,7 +99,7 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
         }
 
         $firewallName = $this->getFirewallName();
-        if (null !== $firewallName && !$request->attributes->getBoolean('_stateless') && $targetUrl = $this->getTargetPath($request->getSession(), $firewallName)) {
+        if (null !== $firewallName && !$request->isStateless() && $targetUrl = $this->getTargetPath($request->getSession(), $firewallName)) {
             $this->removeTargetPath($request->getSession(), $firewallName);
 
             return $targetUrl;

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -85,7 +85,7 @@ class ContextListener extends AbstractListener
         }
 
         $request = $event->getRequest();
-        $session = !$request->attributes->getBoolean('_stateless') && $request->hasPreviousSession() ? $request->getSession() : null;
+        $session = !$request->isStateless() && $request->hasPreviousSession() ? $request->getSession() : null;
 
         $request->attributes->set('_security_firewall_run', $this->sessionKey);
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -47,7 +47,6 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
         $this->session = $this->createMock(SessionInterface::class);
         $this->request = $this->createMock(Request::class);
-        $this->request->attributes = new ParameterBag(['_stateless' => false]);
         $this->request->expects($this->any())->method('getSession')->willReturn($this->session);
         $this->exception = $this->getMockBuilder(AuthenticationException::class)->onlyMethods(['getMessage'])->getMock();
     }
@@ -93,7 +92,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
     public function testExceptionIsNotPersistedInSessionOnStatelessRequest()
     {
-        $this->request->attributes = new ParameterBag(['_stateless' => true]);
+        $this->request->method('isStateless')->willReturn(true);
 
         $this->session->expects($this->never())
             ->method('set')->with(SecurityRequestAttributes::AUTHENTICATION_ERROR, $this->exception);

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -63,7 +63,7 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
         $session->expects($this->never())->method('remove')->with('_security.admin.target_path');
         $statelessRequest = Request::create('/');
         $statelessRequest->setSession($session);
-        $statelessRequest->attributes->set('_stateless', true);
+        $statelessRequest->setStateless();
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects($this->any())->method('generate')->willReturn('http://localhost/login');

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/http-foundation": "^6.4|^7.0",
+        "symfony/http-foundation": "^7.2",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/property-access": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Related to #57502 but does not fix it
| License       | MIT

I think asking the user to check everywhere in his code for 
```
$request->attributes->get('_stateless')
```
before accessing `getSession` is kinda verbose and rely on some internal knowledge about how symfony describe the request as stateless.

It's easier for the developer to write
```
if (!$request->isStateless() && $request->hasSession()) {
```
rather than having to know the "internal attribute" to check
```
if (!$request->attributes->getBoolean('_stateless') && $request->hasSession()) {
```

So I propose to introduce this method as a facade to the internal attribute.