### PR TITLE
[Console] Fix side-effects from running bash completions

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -7,7 +7,7 @@
 
 _sf_{{ COMMAND_NAME }}() {
     # Use newline as only separator to allow space in completion values
-    IFS=$'\n'
+    local IFS=$'\n'
     local sf_cmd="${COMP_WORDS[0]}"
 
     # for an alias, get the real script behind it


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/composer/composer/issues/12015
| License       | MIT

Fixes issues in symfony bash completions having side-effects for other completions. See https://github.com/composer/composer/issues/12015 for details.

I identified this IFS line as causing the issue.. But it was introduced here 
https://github.com/symfony/symfony/commit/e9e0c07f0b7bf79285934c937d68327f3ee50121 (cc @GromNaN) probably for a good reason. So I don't think this is mergeable as is, but we should see what can be done to set IFS where needed per process call and not change it globally like that.