### PR TITLE
[Security] Do not remove existing session on stateless requests

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -175,7 +175,7 @@ class ContextListener extends AbstractListener
 
         $request = $event->getRequest();
 
-        if (!$request->hasSession() || $request->attributes->get('_security_firewall_run') !== $this->sessionKey) {
+        if (!$request->hasSession() || $request->attributes->getBoolean('_stateless') || $request->attributes->get('_security_firewall_run') !== $this->sessionKey) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -146,6 +146,29 @@ class ContextListenerTest extends TestCase
         $this->assertFalse($session->isStarted());
     }
 
+    public function testOnKernelResponseWithStatelessAndPreviousSession()
+    {
+        $request = new Request();
+        $request->attributes->set('_security_firewall_run', '_security_session');
+        $request->attributes->set('_stateless', true);
+
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $event = new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response()
+        );
+
+        $listener = new ContextListener(new TokenStorage(), [], 'session', null, new EventDispatcher());
+        $listener->onKernelResponse($event);
+
+        $this->assertFalse($session->isStarted());
+    }
+
     /**
      * @dataProvider provideInvalidToken
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #57851 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This fixes the bug where an existing session was removed on stateless requests, forcing the user to reauthenticate after visiting a route with `stateless: true`.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
