### PR TITLE
replace `uniqid()` with `random_bytes()` to create identifiers

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -397,7 +397,7 @@ class ConnectionTest extends TestCase
     {
         yield 'No delay' => ['/^THE_MESSAGE_ID$/', 0, 'xadd', 'THE_MESSAGE_ID'];
 
-        yield '100ms delay' => ['/^\w+\.\d+$/', 100, 'rawCommand', '1'];
+        yield '100ms delay' => ['/^[a-f\d]+$/', 100, 'rawCommand', '1'];
     }
 
     public function testInvalidSentinelMasterName()

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -521,7 +521,7 @@ class Connection
 
         try {
             if ($delayInMs > 0) { // the delay is <= 0 for queued messages
-                $id = uniqid('', true);
+                $id = bin2hex(random_bytes(4));
                 $message = json_encode([
                     'body' => $body,
                     'headers' => $headers,

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
@@ -61,7 +61,7 @@ final class IqsmsTransport extends AbstractTransport
                         'phone' => $message->getPhone(),
                         'text' => $message->getSubject(),
                         'sender' => $message->getFrom() ?: $this->from,
-                        'clientId' => uniqid('', true),
+                        'clientId' => bin2hex(random_bytes(4)),
                     ],
                 ],
                 'login' => $this->login,

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1543,7 +1543,7 @@ class Process implements \IteratorAggregate
     private function prepareWindowsCommandLine(string|array $cmd, array &$env): string
     {
         $cmd = $this->buildShellCommandline($cmd);
-        $uid = uniqid('', true);
+        $uid = bin2hex(random_bytes(4));
         $cmd = preg_replace_callback(
             '/"(?:(
                 [^"%!^]*+

--- a/src/Symfony/Component/VarDumper/Command/Descriptor/HtmlDescriptor.php
+++ b/src/Symfony/Component/VarDumper/Command/Descriptor/HtmlDescriptor.php
@@ -50,7 +50,7 @@ class HtmlDescriptor implements DumpDescriptorInterface
             $title = '<code>$ </code>'.$context['cli']['command_line'];
             $dedupIdentifier = $context['cli']['identifier'];
         } else {
-            $dedupIdentifier = uniqid('', true);
+            $dedupIdentifier = bin2hex(random_bytes(4));
         }
 
         $sourceDescription = '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57588
| License       | MIT
