### PR TITLE
[Lock] Add `$prefix` parameter to avoid collision with `FlockStore`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2009,7 +2009,7 @@ class FrameworkExtension extends Extension
                 $storeDefinition = new Definition(PersistingStoreInterface::class);
                 $storeDefinition
                     ->setFactory([StoreFactory::class, 'createStore'])
-                    ->setArguments([$resourceStore])
+                    ->setArguments([$resourceStore, new Parameter('kernel.secret')])
                     ->addTag('lock.store');
 
                 $container->setDefinition($storeDefinitionId = '.lock.'.$resourceName.'.store.'.$container->hash($storeDsn), $storeDefinition);

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add parameter `$prefix` to `FlockStore::__construct()`
+
 7.0
 ---
 

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -24,7 +24,7 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  */
 class StoreFactory
 {
-    public static function createStore(#[\SensitiveParameter] object|string $connection): PersistingStoreInterface
+    public static function createStore(#[\SensitiveParameter] object|string $connection, #[\SensitiveParameter] ?string $secret = null): PersistingStoreInterface
     {
         switch (true) {
             case $connection instanceof \Redis:
@@ -53,6 +53,9 @@ class StoreFactory
                 throw new InvalidArgumentException(\sprintf('Unsupported Connection: "%s".', get_debug_type($connection)));
             case 'flock' === $connection:
                 return new FlockStore();
+
+            case str_starts_with($connection, 'flock+exclusive://'):
+                return new FlockStore(substr($connection, 15), $secret);
 
             case str_starts_with($connection, 'flock://'):
                 return new FlockStore(substr($connection, 8));

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -25,9 +25,9 @@ class FlockStoreTest extends AbstractStoreTestCase
     use SharedLockStoreTestTrait;
     use UnserializableTestTrait;
 
-    protected function getStore(): PersistingStoreInterface
+    protected function getStore(?string $prefix = null): PersistingStoreInterface
     {
-        return new FlockStore();
+        return new FlockStore(null, $prefix);
     }
 
     public function testConstructWhenRepositoryCannotBeCreated()
@@ -89,6 +89,27 @@ class FlockStoreTest extends AbstractStoreTestCase
 
         $file = \sprintf(
             '%s/sf.Symfony-Component-Lock-Tests-Store-FlockStoreTestS.%s.lock',
+            sys_get_temp_dir(),
+            strtr(substr(base64_encode(hash('sha256', $key, true)), 0, 7), '/', '_')
+        );
+        // ensure the file does not exist before the store
+        @unlink($file);
+
+        $store->save($key);
+
+        $this->assertFileExists($file);
+
+        $store->delete($key);
+    }
+
+    public function testSavePrefix()
+    {
+        $store = $this->getStore('FlockSecret');
+
+        $key = new Key(__CLASS__);
+
+        $file = \sprintf(
+            '%s/sf.FlockSecret.Symfony-Component-Lock-Tests-Store-FlockStoreTest.%s.lock',
             sys_get_temp_dir(),
             strtr(substr(base64_encode(hash('sha256', $key, true)), 0, 7), '/', '_')
         );

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -92,5 +92,6 @@ class StoreFactoryTest extends TestCase
 
         yield ['flock', FlockStore::class];
         yield ['flock://'.sys_get_temp_dir(), FlockStore::class];
+        yield ['flock+exclusive://'.sys_get_temp_dir(), FlockStore::class];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently if two Symfony projects are hosted on the same server and used the same key for a lock using the default `FlockStore`, the two applications shared the same lock.

So I suggest adding a prefix in the `FlockStore` constructor to isolate the lock to the current project and avoid collision.

This prefix could be initialized with the `kernel.secret` parameter by default.

To avoid BC, I add the  `flock-exclusive` lock key configuration.

I know this could be done by changing the path a the `FlockStore`, but this "exclusive lock" could be the default behaviour of Symfony in the next major release.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
