### PR TITLE
[Form] NumberType: Fix parsing of numbers in exponential notation with negative exponent

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -143,7 +143,8 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
             $value = str_replace(',', $decSep, $value);
         }
 
-        if (str_contains($value, $decSep)) {
+        //If the value is in exponential notation with a negative exponent, we end up with a float value too
+        if (str_contains($value, $decSep) || false !== stripos($value, 'e-')) {
             $type = \NumberFormatter::TYPE_DOUBLE;
         } else {
             $type = \PHP_INT_SIZE === 8

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -632,4 +632,31 @@ class NumberToLocalizedStringTransformerTest extends TestCase
 
         $this->assertSame(1.0, $transformer->reverseTransform('1'));
     }
+
+    /**
+     * @dataProvider eNotationProvider
+     */
+    public function testReverseTransformENotation($output, $input)
+    {
+        \Locale::setDefault('en');
+
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->assertSame($output, $transformer->reverseTransform($input));
+    }
+
+    public static function eNotationProvider(): array
+    {
+        return [
+            [0.001, '1E-3'],
+            [0.001, '1.0E-3'],
+            [0.001, '1e-3'],
+            [0.001, '1.0e-03'],
+            [1000.0, '1E3'],
+            [1000.0, '1.0E3'],
+            [1000.0, '1e3'],
+            [1000.0, '1.0e3'],
+            [1232.0, '1.232e3'],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | See below
| License       | MIT

Currently, when inputting a string like "1E-3" into a NumberType leads incorrectly to a result of "0". The correct result would be "0.001", which is also the result, when inputting "1.0E-3".

This is caused by `NumberToLocalizedStringTransformer`, which assumes that the result must be a integer, if the string does not contain the decimal separator. However, this behavior is incorrect, if the string is in exponential notation with negative exponent.
The NumberFormatter can correctly parse this format, but it needs to be told that the result should be a double (otherwise its gets incorrectly rounded to 0)

To fix this behavior, I added a check for the negative exponential format, which then results in a double result.