### PR TITLE
[HttpClient] Disable HTTP/2 PUSH by default when using curl

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -67,7 +67,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
      *
      * @see HttpClientInterface::OPTIONS_DEFAULTS for available options
      */
-    public function __construct(array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 50)
+    public function __construct(array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 0)
     {
         if (!\extension_loaded('curl')) {
             throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\CurlHttpClient" as the "curl" extension is not installed.');

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -22,17 +22,19 @@ class CurlHttpClientTest extends HttpClientTestCase
 {
     protected function getHttpClient(string $testCase): HttpClientInterface
     {
-        if (false !== strpos($testCase, 'Push')) {
-            if (\PHP_VERSION_ID >= 70300 && \PHP_VERSION_ID < 70304) {
-                $this->markTestSkipped('PHP 7.3.0 to 7.3.3 don\'t support HTTP/2 PUSH');
-            }
-
-            if (!\defined('CURLMOPT_PUSHFUNCTION') || 0x073D00 > ($v = curl_version())['version_number'] || !(\CURL_VERSION_HTTP2 & $v['features'])) {
-                $this->markTestSkipped('curl <7.61 is used or it is not compiled with support for HTTP/2 PUSH');
-            }
+        if (!str_contains($testCase, 'Push')) {
+            return new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
         }
 
-        return new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        if (\PHP_VERSION_ID >= 70300 && \PHP_VERSION_ID < 70304) {
+            $this->markTestSkipped('PHP 7.3.0 to 7.3.3 don\'t support HTTP/2 PUSH');
+        }
+
+        if (!\defined('CURLMOPT_PUSHFUNCTION') || 0x073D00 > ($v = curl_version())['version_number'] || !(\CURL_VERSION_HTTP2 & $v['features'])) {
+            $this->markTestSkipped('curl <7.61 is used or it is not compiled with support for HTTP/2 PUSH');
+        }
+
+        return new CurlHttpClient(['verify_peer' => false, 'verify_host' => false], 6, 50);
     }
 
     public function testBindToPort()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57681
| License       | MIT

I propose to disable HTTP/2 PUSH by default when using curl. Amp still supports it out of the box, but support in curl is too fragile (it segfaults, see linked issue).

We have to balance:
- seeing a perf downgrade for apps that might benefit from pushes
- vs putting every users at risk with a possible segfault when a server sends PUSH frames

Preventing this possible segfault is the most important here IMHO. Apps that leverage PUSH should be rare, and can re-enable if they really want to.