### PR TITLE
[Config] Allow overriding array nodes and prototyped array nodes

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Allow overriding prototyped array nodes with using `!`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -22,6 +22,8 @@ use Symfony\Component\Config\Definition\Exception\UnsetKeyException;
  */
 class ArrayNode extends BaseNode implements PrototypeNodeInterface
 {
+    private const OVERRIDE_OPERATOR = '!';
+
     protected array $xmlRemappings = [];
     protected array $children = [];
     protected bool $allowFalse = false;
@@ -344,6 +346,13 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         }
 
         foreach ($rightSide as $k => $v) {
+            if (str_starts_with($k, self::OVERRIDE_OPERATOR)) {
+                $keyWithoutOverrideOperator = ltrim($k, self::OVERRIDE_OPERATOR);
+
+                $leftSide[$keyWithoutOverrideOperator] = $v;
+                continue;
+            }
+
             // no conflict
             if (!\array_key_exists($k, $leftSide)) {
                 if (!$this->allowNewKeys) {

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -23,6 +23,8 @@ use Symfony\Component\Config\Definition\Exception\UnsetKeyException;
  */
 class PrototypedArrayNode extends ArrayNode
 {
+    private const OVERRIDE_OPERATOR = '!';
+
     protected PrototypeNodeInterface $prototype;
     protected ?string $keyAttribute = null;
     protected bool $removeKeyAttribute = false;
@@ -259,6 +261,14 @@ class PrototypedArrayNode extends ArrayNode
 
         $isList = array_is_list($rightSide);
         foreach ($rightSide as $k => $v) {
+            // key starts with the '!' operator, so we override the left side
+            if (str_starts_with($k, self::OVERRIDE_OPERATOR)) {
+                $keyWithoutOverrideOperator = ltrim($k, self::OVERRIDE_OPERATOR);
+
+                $leftSide[$keyWithoutOverrideOperator] = $v;
+                continue;
+            }
+
             // prototype, and key is irrelevant there are no named keys, append the element
             if (null === $this->keyAttribute && $isList) {
                 $leftSide[] = $v;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This feature is inspired by https://docs.docker.com/compose/compose-file/13-merge/#replace-value. The idea is to allow fully override number-indexed keys. For example, we are not able to override workflows' `from` values, because they're merged.

Let's consider the following YAML configuration:
```yaml
framework:
    workflows:
        catalog_promotion:
            # ...
            transitions:
                process:
                    from:
                        - inactive
                        - active
                    to: processing
``` 

Currently, we are able to add new `from`, but we cannot remove any of existing. It's important from POV of projects like Sylius. Thanks to this PR, we can create the following configuration from the end-app level:

```yaml
framework:
    workflows:
        catalog_promotion:
            # ...
            transitions:
                process:
                    !from:
                        - semiactive
                        - active
```

The result is `from: semiactive, active`