### PR TITLE
[VarDumper] Add clickable links in `HtmlDumper`

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add clickable links in `HtmlDumper`
+
 7.1
 ---
 

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -681,6 +681,9 @@ pre.sf-dump code {
     padding:0;
     background:none;
 }
+.sf-dump-link .sf-dump-str:hover {
+    text-decoration: underline;
+}
 .sf-dump-public.sf-dump-highlight,
 .sf-dump-protected.sf-dump-highlight,
 .sf-dump-private.sf-dump-highlight,
@@ -779,6 +782,10 @@ EOHTML
             $this->line .= $this->indentPad;
             $this->line .= \sprintf('<img src="data:%s;base64,%s" /></samp>', $cursor->attr['content-type'], base64_encode($cursor->attr['img-data']));
             $this->endValue($cursor);
+        } elseif (filter_var($str, FILTER_VALIDATE_URL)) {
+            $this->line .= \sprintf('<a href=%s target=_blank class=sf-dump-link>', $str);
+            parent::dumpString($cursor, $str, $bin, $cut);
+            $this->line .= '</a>';
         } else {
             parent::dumpString($cursor, $str, $bin, $cut);
         }

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -186,6 +186,7 @@ EOTXT
         return [
             [['dummy' => new ImgStub('dummy', 'img/png', '100em')], '<img src="data:img/png;base64,ZHVtbXk=" />'],
             ['foo', '<span class=sf-dump-str title="3 characters">foo</span>'],
+            ['https://symfony.com', "<a href=https://symfony.com target=_blank class=sf-dump-link>\"<span class=sf-dump-str title=\"19 characters\">https://symfony.com</span>\"\n</a>"],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | No
| New feature?  | Yes
| Deprecations? | No
| Issues        | None
| License       | MIT

This is a small DX feature that makes dumped links clickable.
This feature is already supported by the `CliDumper`.