### PR TITLE
[Uid] Ensure UuidV1 is created in lowercase

### DIFF
--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -90,6 +90,15 @@ class UuidTest extends TestCase
         $this->assertSame('3499710062d0', $uuid->getNode());
     }
 
+    public function testV1IsLowerCase()
+    {
+        $uuid = new UuidV1();
+        $this->assertSame(strtolower((string) $uuid), (string) $uuid);
+
+        $uuid = new UuidV1('D9E7A184-5D5B-11EA-A62A-3499710062D0');
+        $this->assertSame(strtolower((string) $uuid), (string) $uuid);
+    }
+
     public function testV3()
     {
         $uuid = Uuid::v3(new UuidV4(self::A_UUID_V4), 'the name');

--- a/src/Symfony/Component/Uid/UuidV1.php
+++ b/src/Symfony/Component/Uid/UuidV1.php
@@ -25,7 +25,7 @@ class UuidV1 extends Uuid
     public function __construct(?string $uuid = null)
     {
         if (null === $uuid) {
-            $this->uid = uuid_create(static::TYPE);
+            $this->uid = strtolower(uuid_create(static::TYPE));
         } else {
             parent::__construct($uuid, true);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no 
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57878
| License       | MIT

Ensure `$this->uid` is in lowercase in UuidV1  (see #57878  for context)

(strtolower is already called in the parent::__construct... but not when $args is null. And the uuid extension generates uppercase values --at least sometimes--).

Not sure if should be considered a "bug" / which version to flag ?

