### PR TITLE
[AssetMapper] Leverage Filesystem

### DIFF
--- a/src/Symfony/Component/AssetMapper/CompiledAssetMapperConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/CompiledAssetMapperConfigReader.php
@@ -40,8 +40,7 @@ class CompiledAssetMapperConfigReader
     public function saveConfig(string $filename, array $data): string
     {
         $path = Path::join($this->directory, $filename);
-        @mkdir(\dirname($path), 0777, true);
-        file_put_contents($path, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+        $this->filesystem->dumpFile($path, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
 
         return $path;
     }
@@ -51,7 +50,7 @@ class CompiledAssetMapperConfigReader
         $path = Path::join($this->directory, $filename);
 
         if (is_file($path)) {
-            unlink($path);
+            $this->filesystem->remove($path);
         }
     }
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\AssetMapper\ImportMap;
 
 use Symfony\Component\AssetMapper\Exception\RuntimeException;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\VarExporter\VarExporter;
 
@@ -23,11 +24,13 @@ use Symfony\Component\VarExporter\VarExporter;
 class ImportMapConfigReader
 {
     private ImportMapEntries $rootImportMapEntries;
+    private readonly Filesystem $filesystem;
 
     public function __construct(
         private readonly string $importMapConfigPath,
         private readonly RemotePackageStorage $remotePackageStorage,
     ) {
+        $this->filesystem = new Filesystem();
     }
 
     public function getEntries(): ImportMapEntries
@@ -101,7 +104,7 @@ class ImportMapConfigReader
         }
 
         $map = class_exists(VarExporter::class) ? VarExporter::export($importMapConfig) : var_export($importMapConfig, true);
-        file_put_contents($this->importMapConfigPath, <<<EOF
+        $this->filesystem->dumpFile($this->importMapConfigPath, <<<EOF
         <?php
 
         /**

--- a/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageDownloader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageDownloader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\AssetMapper\ImportMap;
 
 use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @final
@@ -20,11 +21,14 @@ class RemotePackageDownloader
 {
     private array $installed;
 
+    private readonly Filesystem $filesystem;
+
     public function __construct(
         private readonly RemotePackageStorage $remotePackageStorage,
         private readonly ImportMapConfigReader $importMapConfigReader,
         private readonly PackageResolverInterface $packageResolver,
     ) {
+        $this->filesystem = new Filesystem();
     }
 
     /**
@@ -146,7 +150,10 @@ class RemotePackageDownloader
     private function saveInstalled(array $installed): void
     {
         $this->installed = $installed;
-        file_put_contents($this->remotePackageStorage->getStorageDir().'/installed.php', \sprintf('<?php return %s;', var_export($installed, true)));
+        $this->filesystem->dumpFile(
+            $this->remotePackageStorage->getStorageDir().'/installed.php',
+            '<?php return '.var_export($installed, true).';',
+        );
     }
 
     private function areAllExtraFilesDownloaded(ImportMapEntry $entry, array $extraFilenames): bool

--- a/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageStorage.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageStorage.php
@@ -12,14 +12,19 @@
 namespace Symfony\Component\AssetMapper\ImportMap;
 
 use Symfony\Component\AssetMapper\Exception\RuntimeException;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Manages the local storage of remote/vendor importmap packages.
  */
 class RemotePackageStorage
 {
+    private readonly Filesystem $filesystem;
+
     public function __construct(private readonly string $vendorDir)
     {
+        $this->filesystem = new Filesystem();
     }
 
     public function getStorageDir(): string
@@ -53,9 +58,10 @@ class RemotePackageStorage
 
         $vendorPath = $this->getDownloadPath($entry->packageModuleSpecifier, $entry->type);
 
-        @mkdir(\dirname($vendorPath), 0777, true);
-        if (false === @file_put_contents($vendorPath, $contents)) {
-            throw new RuntimeException(error_get_last()['message'] ?? \sprintf('Failed to write file "%s".', $vendorPath));
+        try {
+            $this->filesystem->dumpFile($vendorPath, $contents);
+        } catch (IOException $e) {
+            throw new RuntimeException(\sprintf('Failed to write file "%s".', $vendorPath), 0, $e);
         }
     }
 
@@ -67,9 +73,10 @@ class RemotePackageStorage
 
         $vendorPath = $this->getExtraFileDownloadPath($entry, $extraFilename);
 
-        @mkdir(\dirname($vendorPath), 0777, true);
-        if (false === @file_put_contents($vendorPath, $contents)) {
-            throw new RuntimeException(error_get_last()['message'] ?? \sprintf('Failed to write file "%s".', $vendorPath));
+        try {
+            $this->filesystem->dumpFile($vendorPath, $contents);
+        } catch (IOException $e) {
+            throw new RuntimeException(\sprintf('Failed to write file "%s".', $vendorPath), 0, $e);
         }
     }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -409,11 +409,7 @@ class ImportMapManagerTest extends TestCase
 
     private function writeFile(string $filename, string $content): void
     {
-        $path = \dirname(self::$writableRoot.'/'.$filename);
-        if (!is_dir($path)) {
-            mkdir($path, 0777, true);
-        }
-        file_put_contents(self::$writableRoot.'/'.$filename, $content);
+        $this->filesystem->dumpFile(self::$writableRoot.'/'.$filename, $content);
     }
 
     private static function createLocalEntry(string $importName, string $path, ImportMapType $type = ImportMapType::JS, bool $isEntrypoint = false): ImportMapEntry

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageDownloaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageDownloaderTest.php
@@ -29,9 +29,7 @@ class RemotePackageDownloaderTest extends TestCase
     protected function setUp(): void
     {
         $this->filesystem = new Filesystem();
-        if (!file_exists(self::$writableRoot)) {
-            $this->filesystem->mkdir(self::$writableRoot);
-        }
+        $this->filesystem->mkdir(self::$writableRoot);
     }
 
     protected function tearDown(): void
@@ -106,9 +104,9 @@ class RemotePackageDownloaderTest extends TestCase
             'bar.js/file' => ['version' => '1.0.0', 'dependencies' => [], 'extraFiles' => []],
             'baz' => ['version' => '1.0.0', 'dependencies' => [], 'extraFiles' => []],
         ];
-        file_put_contents(
+        $this->filesystem->dumpFile(
             self::$writableRoot.'/assets/vendor/installed.php',
-            '<?php return '.var_export($installed, true).';'
+            '<?php return '.var_export($installed, true).';',
         );
 
         $configReader = $this->createMock(ImportMapConfigReader::class);
@@ -116,14 +114,12 @@ class RemotePackageDownloaderTest extends TestCase
 
         // matches installed version and file exists
         $entry1 = ImportMapEntry::createRemote('foo', ImportMapType::JS, path: '/any', version: '1.0.0', packageModuleSpecifier: 'foo', isEntrypoint: false);
-        @mkdir(self::$writableRoot.'/assets/vendor/foo', 0777, true);
-        file_put_contents(self::$writableRoot.'/assets/vendor/foo/foo.index.js', 'original foo content');
+        $this->filesystem->dumpFile(self::$writableRoot.'/assets/vendor/foo/foo.index.js', 'original foo content');
         // matches installed version but file does not exist
         $entry2 = ImportMapEntry::createRemote('bar.js/file', ImportMapType::JS, path: '/any', version: '1.0.0', packageModuleSpecifier: 'bar.js/file', isEntrypoint: false);
         // does not match installed version
         $entry3 = ImportMapEntry::createRemote('baz', ImportMapType::CSS, path: '/any', version: '1.1.0', packageModuleSpecifier: 'baz', isEntrypoint: false);
-        @mkdir(self::$writableRoot.'/assets/vendor/baz', 0777, true);
-        file_put_contents(self::$writableRoot.'/assets/vendor/baz/baz.index.css', 'original baz content');
+        $this->filesystem->dumpFile(self::$writableRoot.'/assets/vendor/baz/baz.index.css', 'original baz content');
         // matches installed & file exists, but has missing extra file
         $entry4 = ImportMapEntry::createRemote('has-missing-extra', ImportMapType::JS, path: '/any', version: '1.0.0', packageModuleSpecifier: 'has-missing-extra', isEntrypoint: false);
         $importMapEntries = new ImportMapEntries([$entry1, $entry2, $entry3, $entry4]);

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
@@ -46,18 +46,26 @@ class RemotePackageStorageTest extends TestCase
         $vendorDir = self::$writableRoot.'/assets/acme/vendor';
         $this->filesystem->mkdir($vendorDir.'/module_specifier');
         $this->filesystem->touch($vendorDir.'/module_specifier/module_specifier.index.js');
-        $this->filesystem->chmod($vendorDir.'/module_specifier/module_specifier.index.js', 0555);
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->filesystem->chmod($vendorDir.'/module_specifier/module_specifier.index.js', 0555);
+        } else {
+            $this->filesystem->chmod($vendorDir.'/module_specifier/', 0555);
+        }
 
         $storage = new RemotePackageStorage($vendorDir);
         $entry = ImportMapEntry::createRemote('foo', ImportMapType::JS, '/does/not/matter', '1.0.0', 'module_specifier', false);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('file_put_contents('.$vendorDir.'/module_specifier/module_specifier.index.js): Failed to open stream: Permission denied');
+        $this->expectExceptionMessage('Failed to write file "'.$vendorDir.'/module_specifier/module_specifier.index.js".');
 
         try {
             $storage->save($entry, 'any content');
         } finally {
-            $this->filesystem->chmod($vendorDir.'/module_specifier/module_specifier.index.js', 0777);
+            if ('\\' === \DIRECTORY_SEPARATOR) {
+                $this->filesystem->chmod($vendorDir.'/module_specifier/module_specifier.index.js', 0777);
+            } else {
+                $this->filesystem->chmod($vendorDir.'/module_specifier/', 0777);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

Continue the work started in #54173 & #54724 to replace php file functions  (`mkdir`, `file_get_contents` , `file_put_contents`, `unlink`) by Filesystem methods 