### PR TITLE
[Mime] Fix `RawMessage` constructor argument type

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -18,11 +18,14 @@ use Symfony\Component\Mime\Exception\LogicException;
  */
 class RawMessage
 {
-    /** @var iterable|string|resource */
+    /** @var iterable<string>|string|resource */
     private $message;
     private bool $isGeneratorClosed;
 
-    public function __construct(iterable|string $message)
+    /**
+     * @param iterable<string>|string|resource $message
+     */
+    public function __construct(mixed $message)
     {
         $this->message = $message;
     }

--- a/src/Symfony/Component/Mime/Tests/RawMessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/RawMessageTest.php
@@ -80,6 +80,25 @@ class RawMessageTest extends TestCase
         }
     }
 
+    public function testToIterableOnResourceRewindsAndYieldsLines()
+    {
+        $handle = \fopen('php://memory', 'r+');
+        \fwrite($handle, "line1\nline2\nline3\n");
+
+        $message = new RawMessage($handle);
+        $this->assertSame("line1\nline2\nline3\n", implode('', iterator_to_array($message->toIterable())));
+    }
+
+    public function testDestructClosesResource()
+    {
+        $handle = fopen('php://memory', 'r+');
+
+        $message = new RawMessage($handle);
+        unset($message);
+
+        $this->assertIsClosedResource($handle);
+    }
+
     public static function provideMessages(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`$this->message` can be a resource, and the current union type `iterable|string` make it impossible to pass a resource to the constructor.