### PR TITLE
[Mime] Precise `RawMessage` constructor's `iterable` argument

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -19,12 +19,12 @@ use Symfony\Component\Mime\Exception\LogicException;
 class RawMessage implements \Serializable
 {
     /**
-     * @var iterable|string
+     * @var iterable<string>|string
      */
     private $message;
 
     /**
-     * @param iterable|string $message
+     * @param iterable<string>|string $message
      */
     public function __construct($message)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Following https://github.com/symfony/symfony/pull/57896#discussion_r1699068148