### PR TITLE
Code style change in `@PER-CS2.0` affecting `@Symfony` (parentheses for anonymous classes)

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -37,6 +37,7 @@ return (new PhpCsFixer\Config())
         'nullable_type_declaration' => true,
         'nullable_type_declaration_for_default_null_value' => true,
         'trailing_comma_in_multiline' => ['elements' => ['arrays', 'match', 'parameters']],
+        'new_with_parentheses' => ['anonymous_class' => false],
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -29,7 +29,7 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
 
     protected function setUp(): void
     {
-        $this->logger = new class() extends AbstractLogger {
+        $this->logger = new class extends AbstractLogger {
             public array $logs = [];
 
             public function log($level, $message, $context = []): void

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -926,7 +926,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity = new SingleIntIdEntity(1, 'foo');
 
         return [
-            [$entity, new class() implements \Iterator {
+            [$entity, new class implements \Iterator {
                 public function current(): mixed
                 {
                     return null;
@@ -950,7 +950,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
                 {
                 }
             }],
-            [$entity, new class() implements \Iterator {
+            [$entity, new class implements \Iterator {
                 public function current(): mixed
                 {
                     return false;

--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -47,7 +47,7 @@ final class TranslationExtension extends AbstractExtension
                 throw new \LogicException(\sprintf('You cannot use the "%s" if the Translation Contracts are not available. Try running "composer require symfony/translation".', __CLASS__));
             }
 
-            $this->translator = new class() implements TranslatorInterface {
+            $this->translator = new class implements TranslatorInterface {
                 use TranslatorTrait;
             };
         }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -2652,7 +2652,7 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testHelpWithTranslatableInterface()
     {
-        $message = new class() implements TranslatableInterface {
+        $message = new class implements TranslatableInterface {
             public function trans(TranslatorInterface $translator, ?string $locale = null): string
             {
                 return $translator->trans('foo');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
@@ -189,7 +189,7 @@ class ConfigBuilderCacheWarmerTest extends TestCase
         $kernel = new class($this->varDir) extends TestKernel {
             protected function build(ContainerBuilder $container): void
             {
-                $container->registerExtension(new class() extends Extension implements ConfigurationInterface {
+                $container->registerExtension(new class extends Extension implements ConfigurationInterface {
                     public function load(array $configs, ContainerBuilder $container): void
                     {
                     }
@@ -276,7 +276,7 @@ class ConfigBuilderCacheWarmerTest extends TestCase
             {
                 /** @var TestSecurityExtension $extension */
                 $extension = $container->getExtension('test_security');
-                $extension->addAuthenticatorFactory(new class() implements TestAuthenticatorFactoryInterface {
+                $extension->addAuthenticatorFactory(new class implements TestAuthenticatorFactoryInterface {
                     public function getKey(): string
                     {
                         return 'token';
@@ -292,19 +292,19 @@ class ConfigBuilderCacheWarmerTest extends TestCase
             {
                 yield from parent::registerBundles();
 
-                yield new class() extends Bundle {
+                yield new class extends Bundle {
                     public function getContainerExtension(): ExtensionInterface
                     {
                         return new TestSecurityExtension();
                     }
                 };
 
-                yield new class() extends Bundle {
+                yield new class extends Bundle {
                     public function build(ContainerBuilder $container): void
                     {
                         /** @var TestSecurityExtension $extension */
                         $extension = $container->getExtension('test_security');
-                        $extension->addAuthenticatorFactory(new class() implements TestAuthenticatorFactoryInterface {
+                        $extension->addAuthenticatorFactory(new class implements TestAuthenticatorFactoryInterface {
                             public function getKey(): string
                             {
                                 return 'form-login';

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -66,7 +66,7 @@ class ProfilerPassTest extends TestCase
 
     public static function provideValidCollectorWithTemplateUsingAutoconfigure(): \Generator
     {
-        yield [new class() implements TemplateAwareDataCollectorInterface {
+        yield [new class implements TemplateAwareDataCollectorInterface {
             public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
             {
             }
@@ -86,7 +86,7 @@ class ProfilerPassTest extends TestCase
             }
         }];
 
-        yield [new class() extends AbstractDataCollector {
+        yield [new class extends AbstractDataCollector {
             public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
             {
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -388,7 +388,7 @@ class WebTestCaseTest extends TestCase
 
     private function getTester(KernelBrowser $client): WebTestCase
     {
-        $tester = new class() extends WebTestCase {
+        $tester = new class extends WebTestCase {
             use WebTestAssertionsTrait {
                 getClient as public;
             }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -226,7 +226,7 @@ class SecurityDataCollectorTest extends TestCase
         $voter1 = new DummyVoter();
         $voter2 = new DummyVoter();
 
-        $decoratedVoter1 = new TraceableVoter($voter1, new class() implements EventDispatcherInterface {
+        $decoratedVoter1 = new TraceableVoter($voter1, new class implements EventDispatcherInterface {
             public function dispatch(object $event, ?string $eventName = null): object
             {
                 return new \stdClass();
@@ -301,7 +301,7 @@ class SecurityDataCollectorTest extends TestCase
         $voter1 = new DummyVoter();
         $voter2 = new DummyVoter();
 
-        $decoratedVoter1 = new TraceableVoter($voter1, new class() implements EventDispatcherInterface {
+        $decoratedVoter1 = new TraceableVoter($voter1, new class implements EventDispatcherInterface {
             public function dispatch(object $event, ?string $eventName = null): object
             {
                 return new \stdClass();

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperCompilerTest.php
@@ -21,7 +21,7 @@ class AssetMapperCompilerTest extends TestCase
 {
     public function testCompile()
     {
-        $compiler1 = new class() implements AssetCompilerInterface {
+        $compiler1 = new class implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return 'css' === $asset->publicExtension;
@@ -33,7 +33,7 @@ class AssetMapperCompilerTest extends TestCase
             }
         };
 
-        $compiler2 = new class() implements AssetCompilerInterface {
+        $compiler2 = new class implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return 'js' === $asset->publicExtension;
@@ -45,7 +45,7 @@ class AssetMapperCompilerTest extends TestCase
             }
         };
 
-        $compiler3 = new class() implements AssetCompilerInterface {
+        $compiler3 = new class implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return 'js' === $asset->publicExtension;

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -50,7 +50,7 @@ class MappedAssetFactoryTest extends TestCase
 
     public function testCreateMappedAssetWithContentThatChanged()
     {
-        $file1Compiler = new class() implements AssetCompilerInterface {
+        $file1Compiler = new class implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return true;
@@ -92,7 +92,7 @@ class MappedAssetFactoryTest extends TestCase
 
     public function testCreateMappedAssetWithDigest()
     {
-        $file6Compiler = new class() implements AssetCompilerInterface {
+        $file6Compiler = new class implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return true;

--- a/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationDispatcherTest.php
+++ b/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationDispatcherTest.php
@@ -41,7 +41,7 @@ class EarlyExpirationDispatcherTest extends TestCase
 
         $item = $pool->getItem('foo');
 
-        $computationService = new class() {
+        $computationService = new class {
             public function __invoke(CacheItem $item)
             {
                 return 123;
@@ -90,7 +90,7 @@ class EarlyExpirationDispatcherTest extends TestCase
         $pool->save($item->set(789));
         $item = $pool->getItem('foo');
 
-        $computationService = new class() {
+        $computationService = new class {
             public function __invoke(CacheItem $item)
             {
                 return 123;

--- a/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationHandlerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationHandlerTest.php
@@ -38,7 +38,7 @@ class EarlyExpirationHandlerTest extends TestCase
         $item = $pool->getItem('foo');
         $item->set(234);
 
-        $computationService = new class() implements CallbackInterface {
+        $computationService = new class implements CallbackInterface {
             public function __invoke(CacheItemInterface $item, bool &$save): mixed
             {
                 usleep(30000);

--- a/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationMessageTest.php
+++ b/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationMessageTest.php
@@ -27,7 +27,7 @@ class EarlyExpirationMessageTest extends TestCase
         $item = $pool->getItem('foo');
         $item->set(234);
 
-        $computationService = new class() {
+        $computationService = new class {
             public function __invoke(CacheItem $item)
             {
                 return 123;

--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -32,7 +32,7 @@ class RedisTraitTest extends TestCase
             self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
 
-        $mock = new class() {
+        $mock = new class {
             use RedisTrait;
         };
         $connection = $mock::createConnection($dsn);
@@ -46,7 +46,7 @@ class RedisTraitTest extends TestCase
             self::markTestSkipped('REDIS_AUTHENTICATED_HOST env var is not defined.');
         }
 
-        $mock = new class() {
+        $mock = new class {
             use RedisTrait;
         };
         $connection = $mock::createConnection('redis://:p%40ssword@'.getenv('REDIS_AUTHENTICATED_HOST'));
@@ -105,7 +105,7 @@ class RedisTraitTest extends TestCase
         }
 
         try {
-            $mock = new class() {
+            $mock = new class {
                 use RedisTrait;
             };
 
@@ -143,7 +143,7 @@ class RedisTraitTest extends TestCase
             self::markTestSkipped('REDIS_AUTHENTICATED_HOST env var is not defined.');
         }
 
-        $mock = new class () {
+        $mock = new class {
             use RedisTrait;
         };
         $connection = $mock::createConnection($dsn);
@@ -190,7 +190,7 @@ class RedisTraitTest extends TestCase
         }
         $this->expectException(InvalidArgumentException::class);
 
-        $mock = new class () {
+        $mock = new class {
             use RedisTrait;
         };
         $mock::createConnection($dsn);

--- a/src/Symfony/Component/Clock/Tests/ClockTest.php
+++ b/src/Symfony/Component/Clock/Tests/ClockTest.php
@@ -74,7 +74,7 @@ class ClockTest extends TestCase
 
     public function testPsrClock()
     {
-        $psrClock = new class() implements ClockInterface {
+        $psrClock = new class implements ClockInterface {
             public function now(): \DateTimeImmutable
             {
                 return new \DateTimeImmutable('@1234567');

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -965,7 +965,7 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('foo')->setCode(function () {
-            throw new \InvalidArgumentException(\sprintf('Dummy type "%s" is invalid.', (new class() {})::class));
+            throw new \InvalidArgumentException(\sprintf('Dummy type "%s" is invalid.', (new class {})::class));
         });
         $tester = new ApplicationTester($application);
 
@@ -991,7 +991,7 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('foo')->setCode(function () {
-            throw new \InvalidArgumentException(\sprintf('Dummy type "%s" is invalid.', (new class() {})::class));
+            throw new \InvalidArgumentException(\sprintf('Dummy type "%s" is invalid.', (new class {})::class));
         });
         $tester = new ApplicationTester($application);
 

--- a/src/Symfony/Component/Console/Tests/Command/SingleCommandApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/SingleCommandApplicationTest.php
@@ -21,7 +21,7 @@ class SingleCommandApplicationTest extends TestCase
 {
     public function testRun()
     {
-        $command = new class() extends SingleCommandApplication {
+        $command = new class extends SingleCommandApplication {
             protected function execute(InputInterface $input, OutputInterface $output): int
             {
                 return 0;

--- a/src/Symfony/Component/Console/Tests/Messenger/RunCommandMessageHandlerTest.php
+++ b/src/Symfony/Component/Console/Tests/Messenger/RunCommandMessageHandlerTest.php
@@ -86,7 +86,7 @@ final class RunCommandMessageHandlerTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->addCommands([
-            new class() extends Command {
+            new class extends Command {
                 public function configure(): void
                 {
                     $this

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -50,7 +50,7 @@ class AutowirePass extends AbstractRecursivePass
     public function __construct(
         private bool $throwOnAutowiringException = true,
     ) {
-        $this->defaultArgument = new class() {
+        $this->defaultArgument = new class {
             public $value;
             public $names;
             public $bag;

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
@@ -98,7 +98,7 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
             }
         }
 
-        $pass = new class() extends AbstractRecursivePass {
+        $pass = new class extends AbstractRecursivePass {
             public Reference $ref;
             public string $sourceId;
             public array $alternatives;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AbstractRecursivePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AbstractRecursivePassTest.php
@@ -35,7 +35,7 @@ class AbstractRecursivePassTest extends TestCase
             ->register('foo', \stdClass::class)
             ->setFactory([new Reference('child'), 'createFactory']);
 
-        $pass = new class() extends AbstractRecursivePass {
+        $pass = new class extends AbstractRecursivePass {
             public \ReflectionMethod $actual;
 
             protected function processValue($value, $isRoot = false): mixed
@@ -61,7 +61,7 @@ class AbstractRecursivePassTest extends TestCase
             ->setAbstract(true);
         $container->setDefinition('foo', new ChildDefinition('parent'));
 
-        $pass = new class() extends AbstractRecursivePass {
+        $pass = new class extends AbstractRecursivePass {
             public \ReflectionMethod $actual;
 
             protected function processValue($value, $isRoot = false): mixed
@@ -87,7 +87,7 @@ class AbstractRecursivePassTest extends TestCase
             ->setAbstract(true);
         $container->setDefinition('foo', new ChildDefinition('parent'));
 
-        $pass = new class() extends AbstractRecursivePass {
+        $pass = new class extends AbstractRecursivePass {
             public \ReflectionMethod $actual;
 
             protected function processValue($value, $isRoot = false): mixed
@@ -113,7 +113,7 @@ class AbstractRecursivePassTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid service "foo": the class is not set.');
 
-        (new class() extends AbstractRecursivePass {
+        (new class extends AbstractRecursivePass {
             protected function processValue($value, $isRoot = false): mixed
             {
                 if ($value instanceof Definition && 'foo' === $this->currentId) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -108,17 +108,17 @@ class CheckDefinitionValidityPassTest extends TestCase
         $message = 'A "tags" attribute must be of a scalar-type for service "a", tag "%s", attribute "%s".';
         yield 'object attribute value' => [
             'foo',
-            ['bar' => new class() {}],
+            ['bar' => new class {}],
             \sprintf($message, 'foo', 'bar'),
         ];
         yield 'nested object attribute value' => [
             'foo',
-            ['bar' => ['baz' => new class() {}]],
+            ['bar' => ['baz' => new class {}]],
             \sprintf($message, 'foo', 'bar.baz'),
         ];
         yield 'deeply nested object attribute value' => [
             'foo',
-            ['bar' => ['baz' => ['qux' => new class() {}]]],
+            ['bar' => ['baz' => ['qux' => new class {}]]],
             \sprintf($message, 'foo', 'bar.baz.qux'),
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CustomExpressionLanguageFunctionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CustomExpressionLanguageFunctionTest.php
@@ -27,7 +27,7 @@ class CustomExpressionLanguageFunctionTest extends TestCase
             ->setPublic(true)
             ->setArguments([new Expression('custom_func("foobar")')]);
 
-        $container->addExpressionLanguageProvider(new class() implements ExpressionFunctionProviderInterface {
+        $container->addExpressionLanguageProvider(new class implements ExpressionFunctionProviderInterface {
             public function getFunctions(): array
             {
                 return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -257,7 +257,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             $this->markTestSkipped('SubscribedService attribute not available.');
         }
 
-        $subscriber = new class() implements ServiceSubscriberInterface {
+        $subscriber = new class implements ServiceSubscriberInterface {
             use ServiceMethodsSubscriberTrait;
 
             #[SubscribedService]
@@ -277,7 +277,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             $this->markTestSkipped('SubscribedService attribute not available.');
         }
 
-        $subscriber = new class() implements ServiceSubscriberInterface {
+        $subscriber = new class implements ServiceSubscriberInterface {
             use ServiceMethodsSubscriberTrait;
 
             #[SubscribedService]
@@ -297,7 +297,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             $this->markTestSkipped('SubscribedService attribute not available.');
         }
 
-        $subscriber = new class() implements ServiceSubscriberInterface {
+        $subscriber = new class implements ServiceSubscriberInterface {
             use ServiceMethodsSubscriberTrait;
 
             #[SubscribedService]
@@ -368,7 +368,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $subscriber = new class() implements ServiceSubscriberInterface {
+        $subscriber = new class implements ServiceSubscriberInterface {
             public static function getSubscribedServices(): array
             {
                 return [
@@ -413,7 +413,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $subscriber = new class() implements ServiceSubscriberInterface {
+        $subscriber = new class implements ServiceSubscriberInterface {
             public static function getSubscribedServices(): array
             {
                 return [
@@ -465,7 +465,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $subscriber = new class() implements ServiceSubscriberInterface {
+        $subscriber = new class implements ServiceSubscriberInterface {
             public static function getSubscribedServices(): array
             {
                 return [

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -151,7 +151,7 @@ class ContainerBuilderTest extends TestCase
 
     public function testDeprecateParameterThrowsWhenParameterBagIsNotInternal()
     {
-        $builder = new ContainerBuilder(new class() implements ParameterBagInterface {
+        $builder = new ContainerBuilder(new class implements ParameterBagInterface {
             public function clear(): void
             {
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -320,7 +320,7 @@ class ContainerTest extends TestCase
     public function testReset()
     {
         $c = new Container();
-        $c->set('bar', $bar = new class() implements ResetInterface {
+        $c->set('bar', $bar = new class implements ResetInterface {
             public int $resetCounter = 0;
 
             public function reset(): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1061,7 +1061,7 @@ class PhpDumperTest extends TestCase
 
         $container->register(TestDefinition1::class, TestDefinition1::class)->setPublic(true);
 
-        $container->addCompilerPass(new class() implements CompilerPassInterface {
+        $container->addCompilerPass(new class implements CompilerPassInterface {
             public function process(ContainerBuilder $container): void
             {
                 $container->setDefinition('late_alias', new Definition(TestDefinition1::class))->setPublic(true);

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -143,7 +143,7 @@ class EnvVarProcessorTest extends TestCase
         $GLOBALS['ENV_FOO'] = 'value';
 
         $loaders = function () {
-            yield new class() implements EnvVarLoaderInterface {
+            yield new class implements EnvVarLoaderInterface {
                 public function loadEnvVars(): array
                 {
                     return ['FOO' => $GLOBALS['ENV_FOO']];
@@ -173,7 +173,7 @@ class EnvVarProcessorTest extends TestCase
         $GLOBALS['ENV_FOO'] = 'value';
 
         $loaders = function () {
-            yield new class() implements EnvVarLoaderInterface {
+            yield new class implements EnvVarLoaderInterface {
                 public function loadEnvVars(): array
                 {
                     return ['FOO' => $GLOBALS['ENV_FOO']];
@@ -864,13 +864,13 @@ CSV;
         $_ENV['BUZ_ENV_LOADER'] = '';
 
         $loaders = function () {
-            yield new class() implements EnvVarLoaderInterface {
+            yield new class implements EnvVarLoaderInterface {
                 public function loadEnvVars(): array
                 {
                     return [
                         'FOO_ENV_LOADER' => '123',
                         'BAZ_ENV_LOADER' => '',
-                        'LAZY_ENV_LOADER' => new class() {
+                        'LAZY_ENV_LOADER' => new class {
                             public function __toString(): string
                             {
                                 return '';
@@ -880,14 +880,14 @@ CSV;
                 }
             };
 
-            yield new class() implements EnvVarLoaderInterface {
+            yield new class implements EnvVarLoaderInterface {
                 public function loadEnvVars(): array
                 {
                     return [
                         'FOO_ENV_LOADER' => '234',
                         'BAR_ENV_LOADER' => '456',
                         'BAZ_ENV_LOADER' => '567',
-                        'LAZY_ENV_LOADER' => new class() {
+                        'LAZY_ENV_LOADER' => new class {
                             public function __toString(): string
                             {
                                 return '678';
@@ -934,7 +934,7 @@ CSV;
                 throw new ParameterCircularReferenceException(['FOO_CONTAINER']);
             }
 
-            yield new class() implements EnvVarLoaderInterface {
+            yield new class implements EnvVarLoaderInterface {
                 public function loadEnvVars(): array
                 {
                     return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Extension/AbstractExtensionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Extension/AbstractExtensionTest.php
@@ -27,7 +27,7 @@ class AbstractExtensionTest extends TestCase
 {
     public function testConfiguration()
     {
-        $extension = new class() extends AbstractExtension {
+        $extension = new class extends AbstractExtension {
             public function configure(DefinitionConfigurator $definition): void
             {
                 // load one
@@ -56,7 +56,7 @@ class AbstractExtensionTest extends TestCase
 
     public function testPrependExtensionConfig()
     {
-        $extension = new class() extends AbstractExtension {
+        $extension = new class extends AbstractExtension {
             public function configure(DefinitionConfigurator $definition): void
             {
                 $definition->rootNode()
@@ -107,7 +107,7 @@ class AbstractExtensionTest extends TestCase
 
     public function testLoadExtension()
     {
-        $extension = new class() extends AbstractExtension {
+        $extension = new class extends AbstractExtension {
             public function configure(DefinitionConfigurator $definition): void
             {
                 $definition->import('../Fixtures/config/definition/foo.php');
@@ -148,7 +148,7 @@ class AbstractExtensionTest extends TestCase
 
     protected function processPrependExtension(PrependExtensionInterface $extension): ContainerBuilder
     {
-        $thirdExtension = new class() extends AbstractExtension {
+        $thirdExtension = new class extends AbstractExtension {
             public function configure(DefinitionConfigurator $definition): void
             {
                 $definition->import('../Fixtures/config/definition/foo.php');

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -194,7 +194,7 @@ class ErrorHandler
             $traceReflector->setValue($e, $trace);
             $e->file = $file ?? $e->file;
             $e->line = $line ?? $e->line;
-        }, null, new class() extends \Exception {
+        }, null, new class extends \Exception {
         });
     }
 

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
@@ -26,7 +26,7 @@ class CliErrorRenderer implements ErrorRendererInterface
     public function render(\Throwable $exception): FlattenException
     {
         $cloner = new VarCloner();
-        $dumper = new class() extends CliDumper {
+        $dumper = new class extends CliDumper {
             protected function supportsColors(): bool
             {
                 $outputStream = $this->outputStream;

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -333,7 +333,7 @@ class ErrorHandlerTest extends TestCase
 
     public function testHandleErrorWithAnonymousClass()
     {
-        $anonymousObject = new class() extends \stdClass {
+        $anonymousObject = new class extends \stdClass {
         };
 
         $handler = ErrorHandler::register();
@@ -422,7 +422,7 @@ class ErrorHandlerTest extends TestCase
             ['Uncaught Exception: foo', new \Exception('foo')],
             ['Uncaught Exception: foo', new class('foo') extends \RuntimeException {
             }],
-            ['Uncaught Exception: foo stdClass@anonymous bar', new \RuntimeException('foo '.(new class() extends \stdClass {
+            ['Uncaught Exception: foo stdClass@anonymous bar', new \RuntimeException('foo '.(new class extends \stdClass {
             })::class.' bar')],
             ['Uncaught Error: bar', new \Error('bar')],
             ['Uncaught ccc', new \ErrorException('ccc')],

--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -245,7 +245,7 @@ class FlattenExceptionTest extends TestCase
 
     public function testAnonymousClass()
     {
-        $flattened = FlattenException::createFromThrowable(new class() extends \RuntimeException {
+        $flattened = FlattenException::createFromThrowable(new class extends \RuntimeException {
         });
 
         $this->assertSame('RuntimeException@anonymous', $flattened->getClass());
@@ -255,7 +255,7 @@ class FlattenExceptionTest extends TestCase
 
         $this->assertSame('Symfony\Component\HttpKernel\Exception\NotFoundHttpException@anonymous', $flattened->getClass());
 
-        $flattened = FlattenException::createFromThrowable(new \Exception(\sprintf('Class "%s" blah.', (new class() extends \RuntimeException {
+        $flattened = FlattenException::createFromThrowable(new \Exception(\sprintf('Class "%s" blah.', (new class extends \RuntimeException {
         })::class)));
 
         $this->assertSame('Class "RuntimeException@anonymous" blah.', $flattened->getMessage());

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -202,14 +202,14 @@ class RegisterListenersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->setParameter('event_dispatcher.event_aliases', [AliasedEvent::class => 'aliased_event']);
 
-        $container->register('foo', \get_class(new class() {
+        $container->register('foo', \get_class(new class {
             public function onFooBar()
             {
             }
         }))->addTag('kernel.event_listener', ['event' => 'foo.bar']);
         $container->register('bar', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => 'foo.bar']);
         $container->register('baz', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => 'event']);
-        $container->register('zar', \get_class(new class() {
+        $container->register('zar', \get_class(new class {
             public function onFooBarZar()
             {
             }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -346,7 +346,7 @@ class ExpressionLanguageTest extends TestCase
 
     public static function provideNullSafe()
     {
-        $foo = new class() extends \stdClass {
+        $foo = new class extends \stdClass {
             public function bar()
             {
                 return null;
@@ -437,7 +437,7 @@ class ExpressionLanguageTest extends TestCase
 
     public static function provideNullCoalescing()
     {
-        $foo = new class() extends \stdClass {
+        $foo = new class extends \stdClass {
             public function bar()
             {
                 return null;

--- a/src/Symfony/Component/Finder/Tests/Iterator/VfsIteratorTestTrait.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/VfsIteratorTestTrait.php
@@ -29,7 +29,7 @@ trait VfsIteratorTestTrait
 
         $this->vfsScheme = 'symfony-finder-vfs-test-'.++self::$vfsNextSchemeIndex;
 
-        $vfsWrapperClass = \get_class(new class() {
+        $vfsWrapperClass = \get_class(new class {
             /** @var array<string, \Closure(string, 'list_dir_open'|'list_dir_rewind'|'is_dir'): (list<string>|bool)> */
             public static array $vfsProviders = [];
 

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -39,7 +39,7 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->serverParams = new class() extends ServerParams {
+        $this->serverParams = new class extends ServerParams {
             public ?int $contentLength = null;
             public string $postMaxSize = '';
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -728,7 +728,7 @@ class DefaultChoiceListFactoryTest extends TestCase
 
     public function testPassTranslatableInterfaceAsLabelDoesntCastItToString()
     {
-        $message = new class() implements TranslatableInterface {
+        $message = new class implements TranslatableInterface {
             public function trans(TranslatorInterface $translator, ?string $locale = null): string
             {
                 return 'my_message';

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerConfigTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerConfigTest.php
@@ -269,7 +269,7 @@ class HtmlSanitizerConfigTest extends TestCase
     {
         $config = new HtmlSanitizerConfig();
 
-        $sanitizer = new class() implements AttributeSanitizerInterface {
+        $sanitizer = new class implements AttributeSanitizerInterface {
             public function getSupportedElements(): ?array
             {
                 return null;

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
@@ -397,7 +397,7 @@ class HtmlSanitizerCustomTest extends TestCase
     {
         $config = (new HtmlSanitizerConfig())
             ->allowElement('div', ['data-attr'])
-            ->withAttributeSanitizer(new class() implements AttributeSanitizerInterface {
+            ->withAttributeSanitizer(new class implements AttributeSanitizerInterface {
                 public function getSupportedElements(): ?array
                 {
                     return ['div'];

--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -52,7 +52,7 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
 
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
-        $state = new class() {
+        $state = new class {
             public ?string $buffer = null;
             public ?string $lastEventId = null;
             public float $reconnectionTime;

--- a/src/Symfony/Component/HttpClient/Internal/AmpClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpClientState.php
@@ -141,7 +141,7 @@ final class AmpClientState extends ClientState
         $options['capture_peer_cert_chain'] && $context = $context->withPeerCapturing();
         $options['crypto_method'] && $context = $context->withMinimumVersion($options['crypto_method']);
 
-        $connector = $handleConnector = new class() implements Connector {
+        $connector = $handleConnector = new class implements Connector {
             public DnsConnector $connector;
             public string $uri;
             /** @var resource|null */

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -292,7 +292,7 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
                 return $response;
             }
 
-            $urlResolver = new class() {
+            $urlResolver = new class {
                 use HttpClientTrait {
                     parseUrl as public;
                     resolveUrl as public;

--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -273,7 +273,7 @@ class HttpClientDataCollectorTest extends TestCase
                             'fooprop' => 'foopropval',
                             'barprop' => 'barpropval',
                         ],
-                        'tostring' => new class() {
+                        'tostring' => new class {
                             public function __toString(): string
                             {
                                 return 'tostringval';

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -518,7 +518,7 @@ class MockHttpClientTest extends HttpClientTestCase
     {
         $client = new MockHttpClient();
 
-        $param = new class() {
+        $param = new class {
             public function __toString(): string
             {
                 return 'bar';

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -215,7 +215,7 @@ class RetryableHttpClientTest extends TestCase
             ]),
             new GenericRetryStrategy(),
             1,
-            $logger = new class() extends TestLogger {
+            $logger = new class extends TestLogger {
                 public array $context = [];
 
                 public function log($level, $message, array $context = []): void
@@ -259,7 +259,7 @@ class RetryableHttpClientTest extends TestCase
 
         TestHttpServer::start();
 
-        $strategy = new class() implements RetryStrategyInterface {
+        $strategy = new class implements RetryStrategyInterface {
             public $isCalled = false;
 
             public function shouldRetry(AsyncContext $context, ?string $responseContent, ?TransportExceptionInterface $exception): ?bool

--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -20,7 +20,7 @@ class InputBagTest extends TestCase
 {
     public function testGet()
     {
-        $bag = new InputBag(['foo' => 'bar', 'null' => null, 'int' => 1, 'float' => 1.0, 'bool' => false, 'stringable' => new class() implements \Stringable {
+        $bag = new InputBag(['foo' => 'bar', 'null' => null, 'int' => 1, 'float' => 1.0, 'bool' => false, 'stringable' => new class implements \Stringable {
             public function __toString(): string
             {
                 return 'strval';
@@ -58,7 +58,7 @@ class InputBagTest extends TestCase
 
     public function testGetString()
     {
-        $bag = new InputBag(['integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class() implements \Stringable {
+        $bag = new InputBag(['integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class implements \Stringable {
             public function __toString(): string
             {
                 return 'strval';

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -171,7 +171,7 @@ class JsonResponseTest extends TestCase
 
     public function testConstructorWithObjectWithToStringMethod()
     {
-        $class = new class() {
+        $class = new class {
             public function __toString(): string
             {
                 return '{}';

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -206,7 +206,7 @@ class ParameterBagTest extends TestCase
 
     public function testGetString()
     {
-        $bag = new ParameterBag(['integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class() implements \Stringable {
+        $bag = new ParameterBag(['integer' => 123, 'bool_true' => true, 'bool_false' => false, 'string' => 'abc', 'stringable' => new class implements \Stringable {
             public function __toString(): string
             {
                 return 'strval';

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2213,7 +2213,7 @@ class RequestTest extends TestCase
 
     public function testFactoryCallable()
     {
-        $requestFactory = new class() {
+        $requestFactory = new class {
             public function createRequest(): Request
             {
                 return new NewRequest();

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -27,7 +27,7 @@ class AbstractProxyTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->proxy = new class() extends AbstractProxy {};
+        $this->proxy = new class extends AbstractProxy {};
     }
 
     public function testGetSaveHandlerName()

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedJsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedJsonResponseTest.php
@@ -132,14 +132,14 @@ class StreamedJsonResponseTest extends TestCase
     {
         $arrayObject = new \ArrayObject(['__symfony_json__' => '__symfony_json__']);
 
-        $iteratorAggregate = new class() implements \IteratorAggregate {
+        $iteratorAggregate = new class implements \IteratorAggregate {
             public function getIterator(): \Traversable
             {
                 return new \ArrayIterator(['__symfony_json__']);
             }
         };
 
-        $jsonSerializable = new class() implements \IteratorAggregate, \JsonSerializable {
+        $jsonSerializable = new class implements \IteratorAggregate, \JsonSerializable {
             public function getIterator(): \Traversable
             {
                 return new \ArrayIterator(['This should be ignored']);
@@ -187,7 +187,7 @@ class StreamedJsonResponseTest extends TestCase
 
     public function testPlaceholderAsObjectStructure()
     {
-        $object = new class() {
+        $object = new class {
             public $__symfony_json__ = 'foo';
             public $bar = '__symfony_json__';
         };

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -350,7 +350,7 @@ class ArgumentResolverTest extends TestCase
 
     public function testResolversChainCompletionWhenResolverThrowsSpecialException()
     {
-        $failingValueResolver = new class() implements ValueResolverInterface {
+        $failingValueResolver = new class implements ValueResolverInterface {
             public function resolve(Request $request, ArgumentMetadata $argument): iterable
             {
                 throw new NearMissValueResolverException('This resolver throws an exception');
@@ -370,7 +370,7 @@ class ArgumentResolverTest extends TestCase
 
     public function testExceptionListSingle()
     {
-        $failingValueResolverOne = new class() implements ValueResolverInterface {
+        $failingValueResolverOne = new class implements ValueResolverInterface {
             public function resolve(Request $request, ArgumentMetadata $argument): iterable
             {
                 throw new NearMissValueResolverException('Some reason why value could not be resolved.');
@@ -388,13 +388,13 @@ class ArgumentResolverTest extends TestCase
 
     public function testExceptionListMultiple()
     {
-        $failingValueResolverOne = new class() implements ValueResolverInterface {
+        $failingValueResolverOne = new class implements ValueResolverInterface {
             public function resolve(Request $request, ArgumentMetadata $argument): iterable
             {
                 throw new NearMissValueResolverException('Some reason why value could not be resolved.');
             }
         };
-        $failingValueResolverTwo = new class() implements ValueResolverInterface {
+        $failingValueResolverTwo = new class implements ValueResolverInterface {
             public function resolve(Request $request, ArgumentMetadata $argument): iterable
             {
                 throw new NearMissValueResolverException('Another reason why value could not be resolved.');

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/TraceableArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/TraceableArgumentResolverTest.php
@@ -28,7 +28,7 @@ class TraceableArgumentResolverTest extends TestCase
         $stopwatch = $this->createStub(Stopwatch::class);
         $stopwatch->method('start')->willReturn($stopwatchEvent);
 
-        $resolver = new class() implements ArgumentResolverInterface {
+        $resolver = new class implements ArgumentResolverInterface {
             public function getArguments(Request $request, callable $controller, ?\ReflectionFunctionAbstract $reflector = null): array
             {
                 throw new \Exception();

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/TraceableControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/TraceableControllerResolverTest.php
@@ -28,7 +28,7 @@ class TraceableControllerResolverTest extends TestCase
         $stopwatch = $this->createStub(Stopwatch::class);
         $stopwatch->method('start')->willReturn($stopwatchEvent);
 
-        $resolver = new class() implements ControllerResolverInterface {
+        $resolver = new class implements ControllerResolverInterface {
             public function getController(Request $request): callable|false
             {
                 throw new \Exception();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -336,7 +336,7 @@ class SessionListenerTest extends TestCase
 
     public function testOnlyTriggeredOnMainRequest()
     {
-        $listener = new class() extends AbstractSessionListener {
+        $listener = new class extends AbstractSessionListener {
             protected function getSession(): ?SessionInterface
             {
                 return null;

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -412,7 +412,7 @@ class KernelTest extends TestCase
 
     public function testKernelExtension()
     {
-        $kernel = new class() extends CustomProjectDirKernel implements ExtensionInterface {
+        $kernel = new class extends CustomProjectDirKernel implements ExtensionInterface {
             public function load(array $configs, ContainerBuilder $container): void
             {
                 $container->setParameter('test.extension-registered', true);

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -373,7 +373,7 @@ class LockTest extends TestCase
     {
         $key = new Key((string) random_int(100, 1000));
         $store = new InMemoryStore();
-        $logger = new class() extends AbstractLogger {
+        $logger = new class extends AbstractLogger {
             private array $logs = [];
 
             public function log($level, $message, array $context = []): void
@@ -468,7 +468,7 @@ class LockTest extends TestCase
     public function testAcquireReadTwiceWithExpiration()
     {
         $key = new Key(__METHOD__);
-        $store = new class() implements PersistingStoreInterface {
+        $store = new class implements PersistingStoreInterface {
             use ExpiringStoreTrait;
             private array $keys = [];
             private int $initialTtl = 30;
@@ -512,7 +512,7 @@ class LockTest extends TestCase
     public function testAcquireTwiceWithExpiration()
     {
         $key = new Key(__METHOD__);
-        $store = new class() implements PersistingStoreInterface {
+        $store = new class implements PersistingStoreInterface {
             use ExpiringStoreTrait;
             private array $keys = [];
             private int $initialTtl = 30;

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -41,7 +41,7 @@ class MailerTest extends TestCase
 
     public function testSendMessageToBus()
     {
-        $bus = new class() implements MessageBusInterface {
+        $bus = new class implements MessageBusInterface {
             public array $messages = [];
             public array $stamps = [];
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -63,7 +63,7 @@ class PostgreSqlConnectionTest extends TestCase
             ->method('createQueryBuilder')
             ->willReturn(new QueryBuilder($driverConnection));
 
-        $wrappedConnection = new class() {
+        $wrappedConnection = new class {
             private int $notifyCalls = 0;
 
             public function pgsqlGetNotify()

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnCustomStopExceptionListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnCustomStopExceptionListenerTest.php
@@ -28,7 +28,7 @@ class StopWorkerOnCustomStopExceptionListenerTest extends TestCase
         yield 'it should not stop (1)' => [new \Exception(), false];
         yield 'it should not stop (2)' => [new HandlerFailedException(new Envelope(new \stdClass()), [new \Exception()]), false];
 
-        $t = new class() extends \Exception implements StopWorkerExceptionInterface {};
+        $t = new class extends \Exception implements StopWorkerExceptionInterface {};
         yield 'it should stop with custom exception' => [$t, true];
         yield 'it should stop with core exception' => [new StopWorkerException(), true];
 

--- a/src/Symfony/Component/Messenger/Tests/Exception/HandlerFailedExceptionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Exception/HandlerFailedExceptionTest.php
@@ -23,7 +23,7 @@ class HandlerFailedExceptionTest extends TestCase
     public function testThatStringErrorCodeConvertsToInteger()
     {
         $envelope = new Envelope(new \stdClass());
-        $exception = new class() extends \RuntimeException {
+        $exception = new class extends \RuntimeException {
             public function __construct()
             {
                 $this->code = 'HY000';

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandleDescriptorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandleDescriptorTest.php
@@ -39,7 +39,7 @@ class HandleDescriptorTest extends TestCase
         yield [\Closure::fromCallable(function () {}), 'Closure'];
         yield [\Closure::fromCallable(new DummyCommandHandler()), DummyCommandHandler::class.'::__invoke'];
         yield [\Closure::bind(\Closure::fromCallable(function () {}), new \stdClass()), 'Closure'];
-        yield [new class() {
+        yield [new class {
             public function __invoke()
             {
             }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -51,7 +51,7 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
     {
         $message = new DummyMessage('Hey');
         $envelope = new Envelope($message);
-        $handler = new class() {
+        $handler = new class {
             public function __invoke()
             {
                 throw new \Exception('failed');
@@ -100,7 +100,7 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
 
     public static function itAddsHandledStampsProvider(): iterable
     {
-        $first = new class() extends HandleMessageMiddlewareTestCallable {
+        $first = new class extends HandleMessageMiddlewareTestCallable {
             public function __invoke()
             {
                 return 'first result';
@@ -108,7 +108,7 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         };
         $firstClass = $first::class;
 
-        $second = new class() extends HandleMessageMiddlewareTestCallable {
+        $second = new class extends HandleMessageMiddlewareTestCallable {
             public function __invoke()
             {
                 return null;
@@ -116,7 +116,7 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         };
         $secondClass = $second::class;
 
-        $failing = new class() extends HandleMessageMiddlewareTestCallable {
+        $failing = new class extends HandleMessageMiddlewareTestCallable {
             public function __invoke()
             {
                 throw new \Exception('handler failed.');
@@ -199,7 +199,7 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
 
     public function testBatchHandler()
     {
-        $handler = new class() implements BatchHandlerInterface {
+        $handler = new class implements BatchHandlerInterface {
             public array $processedMessages;
 
             use BatchHandlerTrait;
@@ -255,7 +255,7 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
 
     public function testBatchHandlerNoAck()
     {
-        $handler = new class() implements BatchHandlerInterface {
+        $handler = new class implements BatchHandlerInterface {
             use BatchHandlerTrait;
 
             public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
@@ -290,7 +290,7 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
 
     public function testBatchHandlerNoBatch()
     {
-        $handler = new class() implements BatchHandlerInterface {
+        $handler = new class implements BatchHandlerInterface {
             public array $processedMessages;
 
             use BatchHandlerTrait;

--- a/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
@@ -32,7 +32,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
         $busId = 'command_bus';
         $envelope = new Envelope(new DummyMessage('Hello'));
 
-        $middleware = new class() implements MiddlewareInterface {
+        $middleware = new class implements MiddlewareInterface {
             public int $calls = 0;
 
             public function handle(Envelope $envelope, StackInterface $stack): Envelope

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -72,7 +72,7 @@ class WorkerTest extends TestCase
                 return $envelopes[] = $envelope;
             });
 
-        $dispatcher = new class() implements EventDispatcherInterface {
+        $dispatcher = new class implements EventDispatcherInterface {
             private StopWorkerOnMessageLimitListener $listener;
 
             public function __construct()
@@ -417,7 +417,7 @@ class WorkerTest extends TestCase
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
 
-        $stamp = new class() implements StampInterface {
+        $stamp = new class implements StampInterface {
         };
         $listener = function (WorkerMessageReceivedEvent $event) use ($stamp) {
             $event->addStamps($stamp);

--- a/src/Symfony/Component/Mime/Tests/MimeTypesTest.php
+++ b/src/Symfony/Component/Mime/Tests/MimeTypesTest.php
@@ -28,7 +28,7 @@ class MimeTypesTest extends AbstractMimeTypeGuesserTestCase
     public function testUnsupportedGuesser()
     {
         $guesser = $this->getGuesser();
-        $guesser->registerGuesser(new class() implements MimeTypeGuesserInterface {
+        $guesser->registerGuesser(new class implements MimeTypeGuesserInterface {
             public function isGuesserSupported(): bool
             {
                 return false;

--- a/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
@@ -117,7 +117,7 @@ class TextPartTest extends TestCase
 
     public function testCustomEncoding()
     {
-        TextPart::addEncoder('upper_encoder', new class() implements ContentEncoderInterface {
+        TextPart::addEncoder('upper_encoder', new class implements ContentEncoderInterface {
             public function encodeByteStream($stream, int $maxLineLength = 0): iterable
             {
                 $filter = stream_filter_append($stream, 'string.toupper', \STREAM_FILTER_READ);

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -147,7 +147,7 @@ class PropertyAccessorTest extends TestCase
 
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetterOfAnonymousClass()
     {
-        $object = new class() {
+        $object = new class {
             private $uninitialized;
 
             public function getUninitialized(): array
@@ -164,7 +164,7 @@ class PropertyAccessorTest extends TestCase
 
     public function testGetValueThrowsExceptionIfUninitializedNotNullablePropertyWithGetterOfAnonymousClass()
     {
-        $object = new class() {
+        $object = new class {
             private string $uninitialized;
 
             public function getUninitialized(): string
@@ -181,7 +181,7 @@ class PropertyAccessorTest extends TestCase
 
     public function testGetValueThrowsExceptionIfUninitializedPropertyOfAnonymousClass()
     {
-        $object = new class() {
+        $object = new class {
             public string $uninitialized;
         };
 
@@ -209,7 +209,7 @@ class PropertyAccessorTest extends TestCase
 
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetterOfAnonymousStdClass()
     {
-        $object = new class() extends \stdClass {
+        $object = new class extends \stdClass {
             private $uninitialized;
 
             public function getUninitialized(): array
@@ -226,7 +226,7 @@ class PropertyAccessorTest extends TestCase
 
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetterOfAnonymousChildClass()
     {
-        $object = new class() extends UninitializedPrivateProperty {
+        $object = new class extends UninitializedPrivateProperty {
         };
 
         $this->expectException(UninitializedPropertyException::class);

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -336,7 +336,7 @@ class PhpFileLoaderTest extends TestCase
         new LoaderResolver([
             $loader = new PhpFileLoader($locator),
             new Psr4DirectoryLoader($locator),
-            new class() extends AttributeClassLoader {
+            new class extends AttributeClassLoader {
                 protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
@@ -361,7 +361,7 @@ class PhpFileLoaderTest extends TestCase
     {
         new LoaderResolver([
             $loader = new PhpFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
-            new class() extends AttributeClassLoader {
+            new class extends AttributeClassLoader {
                 protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());

--- a/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
@@ -105,7 +105,7 @@ class Psr4DirectoryLoaderTest extends TestCase
         return new DelegatingLoader(
             new LoaderResolver([
                 new Psr4DirectoryLoader($locator),
-                new class() extends AttributeClassLoader {
+                new class extends AttributeClassLoader {
                     protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                     {
                         $route->setDefault('_controller', $class->getName().'::'.$method->getName());

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -616,7 +616,7 @@ class XmlFileLoaderTest extends TestCase
         new LoaderResolver([
             $loader = new XmlFileLoader($locator),
             new Psr4DirectoryLoader($locator),
-            new class() extends AttributeClassLoader {
+            new class extends AttributeClassLoader {
                 protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
@@ -641,7 +641,7 @@ class XmlFileLoaderTest extends TestCase
     {
         new LoaderResolver([
             $loader = new XmlFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
-            new class() extends AttributeClassLoader {
+            new class extends AttributeClassLoader {
                 protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -474,7 +474,7 @@ class YamlFileLoaderTest extends TestCase
     {
         new LoaderResolver([
             $loader = new YamlFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures/localized')),
-            new class() extends AttributeClassLoader {
+            new class extends AttributeClassLoader {
                 protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
@@ -498,7 +498,7 @@ class YamlFileLoaderTest extends TestCase
         new LoaderResolver([
             $loader = new YamlFileLoader($locator),
             new Psr4DirectoryLoader($locator),
-            new class() extends AttributeClassLoader {
+            new class extends AttributeClassLoader {
                 protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());
@@ -523,7 +523,7 @@ class YamlFileLoaderTest extends TestCase
     {
         new LoaderResolver([
             $loader = new YamlFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
-            new class() extends AttributeClassLoader {
+            new class extends AttributeClassLoader {
                 protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot): void
                 {
                     $route->setDefault('_controller', $class->getName().'::'.$method->getName());

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -287,7 +287,7 @@ class MessageGeneratorTest extends TestCase
                 '22:12:01' => [],
             ],
             'schedule' => [
-                RecurringMessage::trigger(new class() implements TriggerInterface {
+                RecurringMessage::trigger(new class implements TriggerInterface {
                     public function __toString(): string
                     {
                         return 'foo';

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -39,7 +39,7 @@ class AccessDecisionManagerTest extends TestCase
             $this->getUnexpectedVoter(),
         ];
 
-        $strategy = new class() implements AccessDecisionStrategyInterface {
+        $strategy = new class implements AccessDecisionStrategyInterface {
             public function decide(\Traversable $results): bool
             {
                 $i = 0;

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -90,7 +90,7 @@ class AuthenticatedVoterTest extends TestCase
         $user = new InMemoryUser('wouter', '', ['ROLE_USER']);
 
         if ('fully' === $authenticated) {
-            $token = new class() extends AbstractToken {
+            $token = new class extends AbstractToken {
                 public function getCredentials()
                 {
                 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -41,7 +41,7 @@ class VoterTest extends TestCase
 
             [$voter, ['DELETE'], VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if no attribute is supported'],
 
-            [$voter, ['EDIT'], VoterInterface::ACCESS_ABSTAIN, new class() {}, 'ACCESS_ABSTAIN if class is not supported'],
+            [$voter, ['EDIT'], VoterInterface::ACCESS_ABSTAIN, new class {}, 'ACCESS_ABSTAIN if class is not supported'],
 
             [$voter, ['EDIT'], VoterInterface::ACCESS_ABSTAIN, null, 'ACCESS_ABSTAIN if object is null'],
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -343,7 +343,7 @@ class AuthenticatorManagerTest extends TestCase
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
 
-        $logger = new class() extends AbstractLogger {
+        $logger = new class extends AbstractLogger {
             public array $logContexts = [];
 
             public function log($level, $message, array $context = []): void

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -175,7 +175,7 @@ class FormLoginAuthenticatorTest extends TestCase
      */
     public function testHandleNonStringPasswordWithToString(bool $postOnly)
     {
-        $passwordObject = new class() {
+        $passwordObject = new class {
             public function __toString(): string
             {
                 return 's$cr$t';

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
@@ -156,7 +156,7 @@ class JsonLoginAuthenticatorTest extends TestCase
     {
         $this->setUpAuthenticator();
 
-        $response = $this->authenticator->onAuthenticationFailure(new Request(), new class() extends AuthenticationException {
+        $response = $this->authenticator->onAuthenticationFailure(new Request(), new class extends AuthenticationException {
             public function getMessageData(): array
             {
                 return ['%failed_attempts%' => 3];

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -42,7 +42,7 @@ class AccessListenerTest extends TestCase
             ->willReturn([['foo' => 'bar'], null])
         ;
 
-        $token = new class() extends AbstractToken {
+        $token = new class extends AbstractToken {
             public function getCredentials(): mixed
             {
             }

--- a/src/Symfony/Component/Serializer/Tests/Context/ContextBuilderTraitTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/ContextBuilderTraitTest.php
@@ -22,7 +22,7 @@ class ContextBuilderTraitTest extends TestCase
 {
     public function testWithContext()
     {
-        $contextBuilder = new class() implements ContextBuilderInterface {
+        $contextBuilder = new class implements ContextBuilderInterface {
             use ContextBuilderTrait;
         };
 
@@ -37,7 +37,7 @@ class ContextBuilderTraitTest extends TestCase
 
     public function testWith()
     {
-        $contextBuilder = new class() {
+        $contextBuilder = new class {
             use ContextBuilderTrait;
 
             public function withFoo(string $value): static

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
@@ -25,7 +25,7 @@ class AbstractNormalizerContextBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->contextBuilder = new class() extends AbstractNormalizerContextBuilder {};
+        $this->contextBuilder = new class extends AbstractNormalizerContextBuilder {};
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractObjectNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractObjectNormalizerContextBuilderTest.php
@@ -25,7 +25,7 @@ class AbstractObjectNormalizerContextBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->contextBuilder = new class() extends AbstractObjectNormalizerContextBuilder {};
+        $this->contextBuilder = new class extends AbstractObjectNormalizerContextBuilder {};
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
@@ -68,7 +68,7 @@ class CacheMetadataFactoryTest extends TestCase
 
     public function testAnonymousClass()
     {
-        $anonymousObject = new class() {
+        $anonymousObject = new class {
         };
 
         $metadata = new ClassMetadata($anonymousObject::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -271,7 +271,7 @@ class AbstractNormalizerTest extends TestCase
     public static function getNormalizerWithCustomNameConverter()
     {
         $extractor = new PhpDocExtractor();
-        $nameConverter = new class() implements NameConverterInterface {
+        $nameConverter = new class implements NameConverterInterface {
             public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
             {
                 return ucfirst($propertyName);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -526,7 +526,7 @@ class AbstractObjectNormalizerTest extends TestCase
     {
         $factory = new ClassMetadataFactory(new AttributeLoader());
 
-        $loaderMock = new class() implements ClassMetadataFactoryInterface {
+        $loaderMock = new class implements ClassMetadataFactoryInterface {
             public function getMetadataFor($value): ClassMetadataInterface
             {
                 if (AbstractDummy::class === $value) {
@@ -561,7 +561,7 @@ class AbstractObjectNormalizerTest extends TestCase
     {
         $factory = new ClassMetadataFactory(new AttributeLoader());
 
-        $loaderMock = new class() implements ClassMetadataFactoryInterface {
+        $loaderMock = new class implements ClassMetadataFactoryInterface {
             public function getMetadataFor($value): ClassMetadataInterface
             {
                 if (AbstractDummy::class === $value) {
@@ -614,7 +614,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeWithNestedDiscriminatorMap()
     {
-        $classDiscriminatorResolver = new class() implements ClassDiscriminatorResolverInterface {
+        $classDiscriminatorResolver = new class implements ClassDiscriminatorResolverInterface {
             public function getMappingForClass(string $class): ?ClassDiscriminatorMapping
             {
                 return match ($class) {
@@ -867,7 +867,7 @@ class AbstractObjectNormalizerTest extends TestCase
             '99' => 'baz',
         ];
 
-        $obj = new class() {
+        $obj = new class {
             #[SerializedName('1')]
             public $foo;
 
@@ -891,7 +891,7 @@ class AbstractObjectNormalizerTest extends TestCase
             ],
         ];
 
-        $obj = new class() {
+        $obj = new class {
             #[SerializedPath('[data][id]')]
             public $id;
         };
@@ -902,7 +902,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testNormalizeBasedOnAllowedAttributes()
     {
-        $normalizer = new class() extends AbstractObjectNormalizer {
+        $normalizer = new class extends AbstractObjectNormalizer {
             public function getSupportedTypes(?string $format): array
             {
                 return ['*' => false];
@@ -982,7 +982,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar->bar = 'bar';
         $foobar->baz = 'baz';
 
-        $normalizer = new class() extends AbstractObjectNormalizerDummy {
+        $normalizer = new class extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;
 
             protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
@@ -1022,7 +1022,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar->bar = 'bar';
         $foobar->baz = 'baz';
 
-        $normalizer = new class() extends AbstractObjectNormalizerDummy {
+        $normalizer = new class extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;
 
             protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
@@ -1057,7 +1057,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar->bar = 'bar';
         $foobar->baz = 'baz';
 
-        $normalizer = new class() extends AbstractObjectNormalizerDummy {
+        $normalizer = new class extends AbstractObjectNormalizerDummy {
             public $childContextCacheKey;
 
             protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
@@ -1087,7 +1087,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeXmlScalar()
     {
-        $normalizer = new class() extends AbstractObjectNormalizer {
+        $normalizer = new class extends AbstractObjectNormalizer {
             public function __construct()
             {
                 parent::__construct(null, new MetadataAwareNameConverter(new ClassMetadataFactory(new AttributeLoader())));

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
@@ -59,7 +59,7 @@ trait CallbacksTestTrait
     {
         $normalizer = $this->getNormalizerForCallbacksWithPropertyTypeExtractor();
 
-        $obj = new class() extends CallbacksObject {
+        $obj = new class extends CallbacksObject {
             public function __construct()
             {
             }
@@ -101,7 +101,7 @@ trait CallbacksTestTrait
     {
         $normalizer = $this->getNormalizerForCallbacksWithPropertyTypeExtractor();
 
-        $objWithNoConstructorArgument = new class() extends CallbacksObject {
+        $objWithNoConstructorArgument = new class extends CallbacksObject {
             public function __construct()
             {
             }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/MapDenormalizationTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/MapDenormalizationTest.php
@@ -187,7 +187,7 @@ class MapDenormalizationTest extends TestCase
 
     private function getSerializer()
     {
-        $loaderMock = new class() implements ClassMetadataFactoryInterface {
+        $loaderMock = new class implements ClassMetadataFactoryInterface {
             public function getMetadataFor($value): ClassMetadataInterface
             {
                 if (AbstractDummyValue::class === $value) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -749,7 +749,7 @@ class ObjectNormalizerTest extends TestCase
         $normalizer = new ObjectNormalizer(null, null, null, $extractor);
         $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
 
-        $this->assertSame('bar', $serializer->denormalize(['foo' => 'bar'], (new class() {
+        $this->assertSame('bar', $serializer->denormalize(['foo' => 'bar'], (new class {
             /** @var self::*|null */
             public $foo;
         })::class)->foo);
@@ -784,7 +784,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testAdvancedNameConverter()
     {
-        $nameConverter = new class() implements AdvancedNameConverterInterface {
+        $nameConverter = new class implements AdvancedNameConverterInterface {
             public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
             {
                 return \sprintf('%s-%s-%s-%s', $propertyName, $class, $format, $context['foo']);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -426,7 +426,7 @@ class SerializerTest extends TestCase
         $example = new AbstractDummyFirstChild('foo-value', 'bar-value');
         $example->setQuux(new DummyFirstChildQuux('quux'));
 
-        $loaderMock = new class() implements ClassMetadataFactoryInterface {
+        $loaderMock = new class implements ClassMetadataFactoryInterface {
             public function getMetadataFor($value): ClassMetadataInterface
             {
                 if (AbstractDummy::class === $value) {
@@ -607,10 +607,10 @@ class SerializerTest extends TestCase
         $data['c2'] = new \ArrayObject(['nested' => new \ArrayObject(['k' => 'v'])]);
         $data['d1'] = new \ArrayObject(['nested' => []]);
         $data['d2'] = new \ArrayObject(['nested' => ['k' => 'v']]);
-        $data['e1'] = new class() {
+        $data['e1'] = new class {
             public $map = [];
         };
-        $data['e2'] = new class() {
+        $data['e2'] = new class {
             public $map = ['k' => 'v'];
         };
         $data['f1'] = new class(new \ArrayObject()) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
@@ -189,7 +189,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
     public function testContextIsPropagatedToNestedConstraints()
     {
         $validator = Validation::createValidatorBuilder()
-            ->setMetadataFactory(new class() implements MetadataFactoryInterface {
+            ->setMetadataFactory(new class implements MetadataFactoryInterface {
                 public function getMetadataFor($classOrObject): MetadataInterface
                 {
                     return (new ClassMetadata(ExpressionConstraintNested::class))
@@ -215,7 +215,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
     public function testEmbeddedMessageTakenFromFailingConstraint()
     {
         $validator = Validation::createValidatorBuilder()
-            ->setMetadataFactory(new class() implements MetadataFactoryInterface {
+            ->setMetadataFactory(new class implements MetadataFactoryInterface {
                 public function getMetadataFor($classOrObject): MetadataInterface
                 {
                     return (new ClassMetadata(Data::class))
@@ -265,7 +265,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
 
     public function testTranslatorIsCalledOnConstraintBaseMessageAndViolations()
     {
-        $translator = new class() implements TranslatorInterface, LocaleAwareInterface {
+        $translator = new class implements TranslatorInterface, LocaleAwareInterface {
             use TranslatorTrait;
 
             public function trans(?string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -83,7 +83,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
             ['0'],
             ['090909'],
             [90909],
-            [new class() {
+            [new class {
                 public function __toString(): string
                 {
                     return '090909';
@@ -144,7 +144,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
         return [
             ['abcd'],
             ['090foo'],
-            [new class() {
+            [new class {
                 public function __toString(): string
                 {
                     return 'abcd';

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -58,7 +58,7 @@ class PropertyInfoLoaderTest extends TestCase
             ])
         ;
 
-        $propertyTypeExtractor = new class() implements PropertyTypeExtractorInterface {
+        $propertyTypeExtractor = new class implements PropertyTypeExtractorInterface {
             private int $i = 0;
             private int $j = 0;
             private array $types;
@@ -234,7 +234,7 @@ class PropertyInfoLoaderTest extends TestCase
             ->willReturn(['string'])
         ;
 
-        $propertyTypeExtractor = new class() implements PropertyTypeExtractorInterface {
+        $propertyTypeExtractor = new class implements PropertyTypeExtractorInterface {
             public function getType(string $class, string $property, array $context = []): ?Type
             {
                 return Type::string();
@@ -273,7 +273,7 @@ class PropertyInfoLoaderTest extends TestCase
                 ->willReturn(['string', 'autoMappingExplicitlyEnabled'])
             ;
 
-            $propertyTypeExtractor = new class() implements PropertyTypeExtractorInterface {
+            $propertyTypeExtractor = new class implements PropertyTypeExtractorInterface {
                 public function getType(string $class, string $property, array $context = []): ?Type
                 {
                     return Type::string();

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -352,7 +352,7 @@ class ValidatorBuilder
         $translator = $this->translator;
 
         if (null === $translator) {
-            $translator = new class() implements TranslatorInterface, LocaleAwareInterface {
+            $translator = new class implements TranslatorInterface, LocaleAwareInterface {
                 use TranslatorTrait;
             };
             // Force the locale to be 'en' when no translator is provided rather than relying on the Intl default locale

--- a/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
@@ -178,7 +178,7 @@ EOTXT
 
     public function testTypeErrorInDebugInfo()
     {
-        $this->assertDumpMatchesFormat('class@anonymous {}', new class() {
+        $this->assertDumpMatchesFormat('class@anonymous {}', new class {
             public function __debugInfo(): array
             {
                 return ['class' => \get_class(null)];

--- a/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
@@ -206,7 +206,7 @@ EODUMP;
 
     public function testClassStubWithAnonymousClass()
     {
-        $var = [new ClassStub((new class() extends \Exception {
+        $var = [new ClassStub((new class extends \Exception {
         })::class)];
 
         $cloner = new VarCloner();

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
@@ -49,7 +49,7 @@ class ServerDumperTest extends TestCase
         $cloner = new VarCloner();
         $data = $cloner->cloneVar('foo');
         $dumper = new ServerDumper(self::VAR_DUMPER_SERVER, $wrappedDumper, [
-            'foo_provider' => new class() implements ContextProviderInterface {
+            'foo_provider' => new class implements ContextProviderInterface {
                 public function getContext(): ?array
                 {
                     return ['foo'];

--- a/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
@@ -31,7 +31,7 @@ class ConnectionTest extends TestCase
         $cloner = new VarCloner();
         $data = $cloner->cloneVar('foo');
         $connection = new Connection(self::VAR_DUMPER_SERVER, [
-            'foo_provider' => new class() implements ContextProviderInterface {
+            'foo_provider' => new class implements ContextProviderInterface {
                 public function getContext(): ?array
                 {
                     return ['foo'];

--- a/src/Symfony/Component/VarExporter/Internal/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Internal/Hydrator.php
@@ -64,11 +64,11 @@ class Hydrator
                 return $baseHydrator;
 
             case 'ErrorException':
-                return $baseHydrator->bindTo(null, new class() extends \ErrorException {
+                return $baseHydrator->bindTo(null, new class extends \ErrorException {
                 });
 
             case 'TypeError':
-                return $baseHydrator->bindTo(null, new class() extends \Error {
+                return $baseHydrator->bindTo(null, new class extends \Error {
                 });
 
             case 'SplObjectStorage':
@@ -166,11 +166,11 @@ class Hydrator
                 return $baseHydrator;
 
             case 'ErrorException':
-                return $baseHydrator->bindTo(new \stdClass(), new class() extends \ErrorException {
+                return $baseHydrator->bindTo(new \stdClass(), new class extends \ErrorException {
                 });
 
             case 'TypeError':
-                return $baseHydrator->bindTo(new \stdClass(), new class() extends \Error {
+                return $baseHydrator->bindTo(new \stdClass(), new class extends \Error {
                 });
 
             case 'SplObjectStorage':

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -225,7 +225,7 @@ class LazyGhostTraitTest extends TestCase
 
     public function testIndirectModification()
     {
-        $obj = new class() {
+        $obj = new class {
             public array $foo;
         };
         $proxy = $this->createLazyGhost($obj::class, fn () => null);

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -205,7 +205,7 @@ class LazyProxyTraitTest extends TestCase
 
     public function testWither()
     {
-        $obj = new class() {
+        $obj = new class {
             public $foo = 123;
 
             public function withFoo($foo): static
@@ -226,7 +226,7 @@ class LazyProxyTraitTest extends TestCase
 
     public function testFluent()
     {
-        $obj = new class() {
+        $obj = new class {
             public $foo = 123;
 
             public function setFoo($foo): static
@@ -244,7 +244,7 @@ class LazyProxyTraitTest extends TestCase
 
     public function testIndirectModification()
     {
-        $obj = new class() {
+        $obj = new class {
             public array $foo;
         };
         $proxy = $this->createLazyProxy($obj::class, fn () => $obj);
@@ -268,7 +268,7 @@ class LazyProxyTraitTest extends TestCase
 
     public function testLazyDecoratorClass()
     {
-        $obj = new class() extends TestClass {
+        $obj = new class extends TestClass {
             use LazyProxyTrait {
                 createLazyProxy as private;
             }

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -170,7 +170,7 @@ class ProxyHelperTest extends TestCase
 
     public static function classWithUnserializeMagicMethodProvider(): iterable
     {
-        yield 'not type hinted __unserialize method' => [new class() {
+        yield 'not type hinted __unserialize method' => [new class {
             public function __unserialize($array)
             {
             }
@@ -190,7 +190,7 @@ class ProxyHelperTest extends TestCase
         }
         EOPHP];
 
-        yield 'type hinted __unserialize method' => [new class() {
+        yield 'type hinted __unserialize method' => [new class {
             public function __unserialize(array $array)
             {
             }
@@ -220,7 +220,7 @@ class ProxyHelperTest extends TestCase
 
         EOPHP;
 
-        $class = new \ReflectionClass(new class() {
+        $class = new \ReflectionClass(new class {
             #[SomeAttribute]
             public function foo(#[\SensitiveParameter, AnotherAttribute] $a): int
             {

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -65,7 +65,7 @@ class VarExporterTest extends TestCase
         yield [$h = fopen(__FILE__, 'r')];
         yield [[$h]];
 
-        $a = new class() {
+        $a = new class {
         };
 
         yield [$a];

--- a/src/Symfony/Contracts/Tests/Service/ServiceMethodsSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceMethodsSubscriberTraitTest.php
@@ -46,7 +46,7 @@ class ServiceMethodsSubscriberTraitTest extends TestCase
         $container = new class([]) implements ContainerInterface {
             use ServiceLocatorTrait;
         };
-        $service = new class() extends ParentWithMagicCall {
+        $service = new class extends ParentWithMagicCall {
             use ServiceMethodsSubscriberTrait;
         };
 
@@ -59,7 +59,7 @@ class ServiceMethodsSubscriberTraitTest extends TestCase
         $container = new class([]) implements ContainerInterface {
             use ServiceLocatorTrait;
         };
-        $service = new class() {
+        $service = new class {
             use ServiceMethodsSubscriberTrait;
         };
 

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -54,7 +54,7 @@ class ServiceSubscriberTraitTest extends TestCase
         $container = new class([]) implements ContainerInterface {
             use ServiceLocatorTrait;
         };
-        $service = new class() extends ParentWithMagicCall {
+        $service = new class extends ParentWithMagicCall {
             use ServiceSubscriberTrait;
         };
 
@@ -67,7 +67,7 @@ class ServiceSubscriberTraitTest extends TestCase
         $container = new class([]) implements ContainerInterface {
             use ServiceLocatorTrait;
         };
-        $service = new class() {
+        $service = new class {
             use ServiceSubscriberTrait;
         };
 
@@ -82,7 +82,7 @@ class ServiceSubscriberTraitTest extends TestCase
         };
         $container2 = clone $container1;
 
-        $testService = new class() extends LegacyParentTestService2 implements ServiceSubscriberInterface {
+        $testService = new class extends LegacyParentTestService2 implements ServiceSubscriberInterface {
             use ServiceSubscriberTrait;
         };
         $this->assertNull($testService->setContainer($container1));

--- a/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
+++ b/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
@@ -45,7 +45,7 @@ class TranslatorTest extends TestCase
 
     public function getTranslator(): TranslatorInterface
     {
-        return new class() implements TranslatorInterface {
+        return new class implements TranslatorInterface {
             use TranslatorTrait;
         };
     }
@@ -366,7 +366,7 @@ class TranslatorTest extends TestCase
 
     protected function generateTestData($langCodes)
     {
-        $translator = new class() {
+        $translator = new class {
             use TranslatorTrait {
                 getPluralizationRule as public;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I have created a PR (https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8140) in the PHP-CS-Fixer repo to bring the `@PER-CS2.0` ruleset in line with the specifications on the `new_with_parentheses` rule for anonymous classes. Since the `@Symfony` ruleset builds upon the `@PER-CS2.0` ruleset, they would like confirmation that the Symfony community is OK with this change affecting the Symfony ruleset as well. Should it not be, I'll push another commit there ensuring that the change does not affect `@Symfony`.

Therefore, this PR is not meant to be merged, but function as an RFC to get your opinion and show the effect it would have when applied to the Symfony source.