### PR TITLE
[HttpFoundation] Add `$requests` parameter to `RequestStack` constructor

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add optional `$requests` argument to `RequestStack::__construct()`
+
 7.1
 ---
 

--- a/src/Symfony/Component/HttpFoundation/RequestStack.php
+++ b/src/Symfony/Component/HttpFoundation/RequestStack.php
@@ -27,6 +27,16 @@ class RequestStack
     private array $requests = [];
 
     /**
+     * @param Request[] $requests
+     */
+    public function __construct(array $requests = [])
+    {
+        foreach ($requests as $request) {
+            $this->push($request);
+        }
+    }
+
+    /**
      * Pushes a Request on the stack.
      *
      * This method should generally not be called directly as the stack

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestStackTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestStackTest.php
@@ -17,6 +17,13 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class RequestStackTest extends TestCase
 {
+    public function testConstruct()
+    {
+        $request = Request::create('/foo');
+        $requestStack = new RequestStack([$request]);
+        $this->assertSame($request, $requestStack->getCurrentRequest());
+    }
+
     public function testGetCurrentRequest()
     {
         $requestStack = new RequestStack();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no 
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This change make it possible to directly give requests into the constructor. This way it make it easier to write Unit tests based on RequestStack like our own RequestAnalyzer service without the need to write the requestStack into an own variable e.g.

```diff
-$requestStack = new RequestStack();
-$requestStack->push(Request::create('/'));
-$requestAnalyzer = new RequestAnalyzer($requestStack);
+$requestAnalyzer = new RequestAnalyzer(new RequestStack([Request::create('/')]));
```

~~I updated also the Symfony core tests~~ (Undo because lowest deps then not working still for reference https://github.com/symfony/symfony/pull/57909/commits/e16fd501da59c21ca23398b86e8cbe5faea0f4af).

The change in the `RequestStack` is:

```diff
     /*
      * @var @param Request[]
      */
     private array $requests = [];

+    /**
+     * @param Request[] $requests
+     */
+    public function __construct(array $requests = [])
+    {
+        foreach ($requests as $request) {
+            $this->push($request);
+        }
+    }
+
```

For BC reasons I did go of calling the `push` if somebody extending the `RequestStack`.