### PR TITLE
[Messenger] Allow setting retry delay by `RecoverableExceptionInterface`

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -23,6 +23,11 @@ FrameworkBundle
 
  * [BC BREAK] The `secrets:decrypt-to-local` command terminates with a non-zero exit code when a secret could not be read
 
+Messenger
+---------
+
+ * Add `getRetryDelay()` method to `RecoverableExceptionInterface`
+
 Security
 --------
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * `WrappedExceptionsInterface` now extends PHP's `Throwable` interface
  * Add `#[AsMessage]` attribute with `$transport` parameter for message routing
  * Add `--format` option to the `messenger:stats` command
+ * Add `getRetryDelay()` method to `RecoverableExceptionInterface`
 
 7.1
 ---

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -63,7 +63,12 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
             ++$retryCount;
 
-            $delay = $retryStrategy->getWaitingTime($envelope, $throwable);
+            $delay = null;
+            if ($throwable instanceof RecoverableExceptionInterface && method_exists($throwable, 'getRetryDelay')) {
+                $delay = $throwable->getRetryDelay();
+            }
+
+            $delay ??= $retryStrategy->getWaitingTime($envelope, $throwable);
 
             $this->logger?->warning('Error thrown while handling message {class}. Sending for retry #{retryCount} using {delay} ms delay. Error: "{error}"', $context + ['retryCount' => $retryCount, 'delay' => $delay, 'error' => $throwable->getMessage(), 'exception' => $throwable]);
 

--- a/src/Symfony/Component/Messenger/Exception/RecoverableExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/RecoverableExceptionInterface.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\Messenger\Exception;
  * and the message should be retried, a handler can throw such an exception.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @method int|null getRetryDelay() The time to wait in milliseconds
  */
 interface RecoverableExceptionInterface extends \Throwable
 {

--- a/src/Symfony/Component/Messenger/Exception/RecoverableMessageHandlingException.php
+++ b/src/Symfony/Component/Messenger/Exception/RecoverableMessageHandlingException.php
@@ -18,4 +18,13 @@ namespace Symfony\Component\Messenger\Exception;
  */
 class RecoverableMessageHandlingException extends RuntimeException implements RecoverableExceptionInterface
 {
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, private readonly ?int $retryDelay = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getRetryDelay(): ?int
+    {
+        return $this->retryDelay;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57756
| License       | MIT

Allow overriding retry delay from the retry strategy by providing it in the exception. Example use case is retrying http request based on `Retry-After` header.