### PR TITLE
[Notifier] Fix KazInfoTeh package in UnsupportedSchemeException

### DIFF
--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -114,7 +114,7 @@ class UnsupportedSchemeException extends LogicException
         ],
         'kaz-info-teh' => [
             'class' => Bridge\KazInfoTeh\KazInfoTehTransportFactory::class,
-            'package' => 'symfony/symfony/kaz-info-teh-notifier',
+            'package' => 'symfony/kaz-info-teh-notifier',
         ],
         'lightsms' => [
             'class' => Bridge\LightSms\LightSmsTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

Fix typo in package name

`symfony/symfony/kaz-info-teh-notifier` => `symfony/kaz-info-teh-notifier`

