### PR TITLE
[HttpKernel] [WebProfileBundle] Fix Routing panel for URLs with a colon

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -83,10 +83,10 @@ class RouterController
      */
     private function getTraces(RequestDataCollector $request, string $method): array
     {
-        $traceRequest = Request::create(
-            $request->getPathInfo(),
-            $request->getRequestServer(true)->get('REQUEST_METHOD'),
-            \in_array($request->getMethod(), ['DELETE', 'PATCH', 'POST', 'PUT'], true) ? $request->getRequestRequest()->all() : $request->getRequestQuery()->all(),
+        $traceRequest = new Request(
+            $request->getRequestQuery()->all(),
+            $request->getRequestRequest()->all(),
+            $request->getRequestAttributes()->all(),
             $request->getRequestCookies(true)->all(),
             [],
             $request->getRequestServer(true)->all()

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/RouterControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/RouterControllerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\WebProfilerBundle\Tests\Functional\WebProfilerBundleKernel;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Routing\Route;
+
+class RouterControllerTest extends WebTestCase
+{
+    public function testFalseNegativeTrace()
+    {
+        $path = '/foo/bar:123/baz';
+
+        $kernel = new WebProfilerBundleKernel();
+        $client = new KernelBrowser($kernel);
+        $client->disableReboot();
+        $client->getKernel()->boot();
+
+        /** @var Router $router */
+        $router = $client->getContainer()->get('router');
+        $router->getRouteCollection()->add('route1', new Route($path));
+
+        $client->request('GET', $path);
+
+        $crawler = $client->request('GET', '/_profiler/latest?panel=router&type=request');
+
+        $matchedRouteCell = $crawler
+            ->filter('#router-logs .status-success td')
+            ->reduce(function (Crawler $td) use ($path): bool {
+                return $td->text() === $path;
+            });
+
+        $this->assertSame(1, $matchedRouteCell->count());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | see below
| License       | MIT

According to [docs](https://www.php.net/manual/en/function.parse-url.php) the `parse_url` function may not produce the expected result for **relative** URLs. In particular, the function produces incorrect results for a relative URL with a port-like string in any part, such as: 
```php
parse_url('/foo/bar:123/baz'); // false
```

But such a URL is valid. So if there is a controller with this route for it, Symfony will correctly match it:

```php
<?php

namespace App\Controller;

use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\Routing\Attribute\Route;

class HelloController extends AbstractController
{
    #[Route('/foo/bar:123/baz')]
    public function world()
    {
        return new Response();
    }
}
```

<img width="1208" alt="match" src="https://github.com/user-attachments/assets/e45fbf13-891e-4373-9e28-5068480e6877">

----
### Bug

But in the profiler, opening the Routing panel will not work; instead of the panel, we see an exception:

<img width="1208" alt="fail" src="https://github.com/user-attachments/assets/c101db2c-dc86-4c39-8598-ac9533bd3725">

This is because `Symfony\Bundle\WebProfilerBundle\Controller::getTraces` method creates a new `Request` from relative path info. And `Request::create` since 6.3 #49376 throws an exception if `parse_url` returns `false`, which is the case here:

https://github.com/symfony/symfony/blob/6d6dd4a93abb2c4d724e0bdb3ab89a22dd3062ac/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php#L83

Prior to version 6.3, the routing panel is displayed, but there are no router matches on it. This is why version 5.4 is also affected.

----
### Solution

So instead of a relative path, I suggest using an absolute URI, which is handled by `parse_url` correctly:

<img width="1208" alt="success" src="https://github.com/user-attachments/assets/99842b7f-da64-42d8-907f-7856ca7d1c3a">

