### PR TITLE
[Form] Fix handling empty data in ValueToDuplicatesTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -62,7 +62,7 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
         $emptyKeys = [];
 
         foreach ($this->keys as $key) {
-            if (isset($array[$key]) && '' !== $array[$key] && false !== $array[$key] && [] !== $array[$key]) {
+            if (isset($array[$key]) && false !== $array[$key] && [] !== $array[$key]) {
                 if ($array[$key] !== $result) {
                     throw new TransformationFailedException('All values in the array should be the same.');
                 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -70,7 +70,7 @@ class ValueToDuplicatesTransformerTest extends TestCase
             'c' => '',
         ];
 
-        $this->assertNull($this->transformer->reverseTransform($input));
+        $this->assertSame('', $this->transformer->reverseTransform($input));
     }
 
     public function testReverseTransformCompletelyNull()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Tests\Fixtures\NotMappedType;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
@@ -189,6 +190,36 @@ class RepeatedTypeTest extends BaseTypeTestCase
         $this->assertSame('Second label', $form['second']->getConfig()->getOption('label'));
         $this->assertTrue($form['first']->isRequired());
         $this->assertTrue($form['second']->isRequired());
+    }
+
+    /**
+     * @dataProvider emptyDataProvider
+     */
+    public function testSubmitNullForTextTypeWithEmptyDataOptionSetToEmptyString($emptyData, $submittedData, $expected)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'type' => TextType::class,
+            'options' => [
+                'empty_data' => $emptyData,
+            ]
+        ]);
+        $form->submit($submittedData);
+
+        $this->assertSame($expected, $form->getData());
+    }
+
+    public static function emptyDataProvider()
+    {
+        yield ['', null, ''];
+        yield ['', ['first' => null, 'second' => null], ''];
+        yield ['', ['first' => '', 'second' => null], ''];
+        yield ['', ['first' => null, 'second' => ''], ''];
+        yield ['', ['first' => '', 'second' => ''], ''];
+        yield [null, null, null];
+        yield [null, ['first' => null, 'second' => null], null];
+        yield [null, ['first' => '', 'second' => null], null];
+        yield [null, ['first' => null, 'second' => ''], null];
+        yield [null, ['first' => '', 'second' => ''], null];
     }
 
     public function testSubmitUnequal()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #47013
| License       | MIT

The transformer receives the data of child forms that have already been through the transformation schema. If no custom view transformer was used on that child form the empty would already have been changed to null. Thus, receiving an empty string here means that the child form explicitly asked for it and the value must not be exchanged with null.