### PR TITLE
[Finder] do not duplicate directory separators

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -72,7 +72,7 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
         $subPathname .= $this->getFilename();
         $basePath = $this->rootPath;
 
-        if ('/' !== $basePath && !str_ends_with($basePath, $this->directorySeparator)) {
+        if ('/' !== $basePath && !str_ends_with($basePath, $this->directorySeparator) && !str_ends_with($basePath, '/')) {
             $basePath .= $this->directorySeparator;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54352
| License       | MIT

Looking at the [test failures on AppVeyor](https://ci.appveyor.com/project/fabpot/symfony/builds/50345724#L975) it seems that #57895 didn't (at least not fully) fix #54352.