### PR TITLE
[Validator] reset the validation context after validating nested constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AtLeastOneOfValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AtLeastOneOfValidator.php
@@ -42,9 +42,11 @@ class AtLeastOneOfValidator extends ConstraintValidator
                 continue;
             }
 
+            $context = $this->context;
             $executionContext = clone $this->context;
             $executionContext->setNode($value, $this->context->getObject(), $this->context->getMetadata(), $this->context->getPropertyPath());
             $violations = $validator->inContext($executionContext)->validate($value, $item, $this->context->getGroup())->getViolations();
+            $this->context = $context;
 
             if (\count($this->context->getViolations()) === \count($violations)) {
                 return;

--- a/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraints\AtLeastOneOf;
 use Symfony\Component\Validator\Constraints\AtLeastOneOfValidator;
 use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\Country;
 use Symfony\Component\Validator\Constraints\DivisibleBy;
@@ -27,9 +28,11 @@ use Symfony\Component\Validator\Constraints\Language;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\LessThan;
 use Symfony\Component\Validator\Constraints\Negative;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\Unique;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -295,6 +298,35 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
 
         $this->assertCount(1, $violations);
         $this->assertSame('Dummy translation: [1] Dummy violation.', $violations->get(0)->getMessage());
+    }
+
+    public function testValidateNestedAtLeaseOneOfConstraints()
+    {
+        $data = [
+            'foo' => [
+                'bar' => 'foo.bar',
+                'baz' => 'foo.baz',
+            ],
+        ];
+
+        $constraints = new Collection([
+            'foo' => new AtLeastOneOf([
+                new Collection([
+                    'bar' => new AtLeastOneOf([
+                        new Type('int'),
+                        new Choice(['test1', 'test2'])
+                    ]),
+                ]),
+                new Collection([
+                    'baz' => new Type('int'),
+                ]),
+            ]),
+        ]);
+
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraints);
+
+        self::assertCount(1, $violations);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54577
| License       | MIT
