### PR TITLE
[AssetMaper] Fix entropy of hash in public path

### DIFF
--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -116,9 +116,10 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
         if ($isPredigested) {
             return $this->assetsPathResolver->resolvePublicPath($asset->logicalPath);
         }
-
-        $digest = substr(base64_encode($digest), 0, self::PUBLIC_DIGEST_LENGTH);
-        $digestedPath = preg_replace_callback('/\.(\w+)$/', fn ($matches) => "-{$digest}{$matches[0]}", $asset->logicalPath);
+        $digest = base64_encode(hex2bin($digest));
+        $digest = substr($digest, 0, self::PUBLIC_DIGEST_LENGTH);
+        $digest = strtr($digest, '+/', '-_');
+        $digestedPath = preg_replace('/\.(\w+)$/', "-{$digest}\\0", $asset->logicalPath);
 
         return $this->assetsPathResolver->resolvePublicPath($digestedPath);
     }

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
@@ -21,7 +21,7 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', '/assets/file1-YjM0NDV.css');
+        $client->request('GET', '/assets/file1-s0Rct6h.css');
         $response = $client->getResponse();
         $this->assertSame(200, $response->getStatusCode());
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
@@ -39,7 +39,7 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', '/assets/voilà-NjM0NDQ.css');
+        $client->request('GET', '/assets/voilà-Y0RCLaa.css');
         $response = $client->getResponse();
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(<<<EOF

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
@@ -59,12 +59,12 @@ class AssetMapperCompileCommandTest extends TestCase
         // match Compiling \d+ assets
         $this->assertMatchesRegularExpression('/Compiled \d+ assets/', $tester->getDisplay());
 
-        $this->assertFileExists($targetBuildDir.'/subdir/file5-ZjRmZGM.js');
+        $this->assertFileExists($targetBuildDir.'/subdir/file5-9P3Dc3X.js');
         $this->assertSame(<<<EOF
         import '../file4.js';
         console.log('file5.js');
 
-        EOF, $this->filesystem->readFile($targetBuildDir.'/subdir/file5-ZjRmZGM.js'));
+        EOF, $this->filesystem->readFile($targetBuildDir.'/subdir/file5-9P3Dc3X.js'));
 
         $finder = new Finder();
         $finder->in($targetBuildDir)->files();

--- a/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageIntegrationTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageIntegrationTest.php
@@ -37,7 +37,7 @@ class MapperAwareAssetPackageIntegrationTest extends TestCase
     {
         $packages = $this->kernel->getContainer()->get('public.assets.packages');
         \assert($packages instanceof Packages);
-        $this->assertSame('/assets/file1-YjM0NDV.css', $packages->getUrl('file1.css'));
+        $this->assertSame('/assets/file1-s0Rct6h.css', $packages->getUrl('file1.css'));
         $this->assertSame('/non-existent.css', $packages->getUrl('non-existent.css'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #
| License       | MIT

$digest is already in hexa. Turning it in base64 requires first making it binary. Also, we have to use the url-safe variant of base64.
