### PR TITLE
[Clock] Add support for closures in the `MockClock` constructor

### DIFF
--- a/src/Symfony/Component/Clock/CHANGELOG.md
+++ b/src/Symfony/Component/Clock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add support for closures in the `MockClock` constructor
+
 7.1
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53903
| License       | MIT

Adds support for closures in MockClock constructor:

```php
$clock = new MockClock(static fn () => DatePoint::createFromFormat('U', $_SERVER['REQUEST_TIME_FLOAT']));
```

This allows to put some logic to generate the time return by this clock. Note that the closure is executed _only_ when the time is needed, not when the instance is created.

After the first call, the closure is not executed anymore and the same time is returned every time. If you want to indicate to the clock that the closure should be called again next time, you can use the new `MockClock::reset()` method.

edit: see https://github.com/symfony/symfony/issues/53903#issuecomment-2273137602 for how this could be leveraged using DI