### PR TITLE
[Security] consistent singular/plural translation in Dutch

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nl.xlf
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Te veel mislukte inlogpogingen, probeer het over %minutes% minuten opnieuw.</target>
+                <target>Te veel onjuiste inlogpogingen, probeer het opnieuw over %minutes% minuten.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The plural form of "Too many failed login attempts, ..." was added later and was most likely a machine translation. As this translation is inconsistent with the preexisting singular translation (and others) update it to be consistent.
