### PR TITLE
[Messenger] Prevent waiting time to overflow when using long delays

### DIFF
--- a/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
@@ -83,7 +83,7 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
         $delay = $this->delayMilliseconds * $this->multiplier ** $retries;
 
         if ($this->jitter > 0) {
-            $randomness = (int) ($delay * $this->jitter);
+            $randomness = (int) min(\PHP_INT_MAX, $delay * $this->jitter);
             $delay += random_int(-$randomness, +$randomness);
         }
 
@@ -91,6 +91,6 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
             return $this->maxDelayMilliseconds;
         }
 
-        return (int) ceil($delay);
+        return (int) min(\PHP_INT_MAX, ceil($delay));
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
@@ -60,6 +60,14 @@ class MultiplierRetryStrategyTest extends TestCase
         $this->assertSame($expectedDelay, $strategy->getWaitingTime($envelope));
     }
 
+    public function testGetWaitTimeWithOverflowingDelay()
+    {
+        $strategy = new MultiplierRetryStrategy(512, \PHP_INT_MAX, 2, 0, 1);
+        $envelope = new Envelope(new \stdClass(), [new RedeliveryStamp(10)]);
+
+        $this->assertSame(\PHP_INT_MAX, $strategy->getWaitingTime($envelope));
+    }
+
     public static function getWaitTimeTests(): iterable
     {
         // delay, multiplier, maxDelay, retries, expectedDelay


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57779
| License       | MIT

There are two places where integers can overflow, thus the limiting to `PHP_INT_MAX`.