### PR TITLE
[DoctrineBridge] Loosened CollectionToArrayTransformer::transform() to accept ReadableCollection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
         "async-aws/sqs": "^1.0|^2.0",
         "async-aws/sns": "^1.0",
         "cache/integration-tests": "dev-master",
-        "doctrine/collections": "^1.0|^2.0",
+        "doctrine/collections": "^1.8|^2.0",
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^3.6|^4",
         "doctrine/orm": "^2.15|^3",
@@ -163,6 +163,7 @@
     "conflict": {
         "ext-psr": "<1.1|>=2",
         "async-aws/core": "<1.5",
+        "doctrine/collections": "<1.8",
         "doctrine/dbal": "<3.6",
         "doctrine/orm": "<2.15",
         "egulias/email-validator": "~3.0.0",

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Accept `ReadableCollection` in `CollectionToArrayTransformer`
+
 7.1
 ---
 

--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Form\DataTransformer;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ReadableCollection;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
@@ -40,8 +41,8 @@ class CollectionToArrayTransformer implements DataTransformerInterface
             return $collection;
         }
 
-        if (!$collection instanceof Collection) {
-            throw new TransformationFailedException('Expected a Doctrine\Common\Collections\Collection object.');
+        if (!$collection instanceof ReadableCollection) {
+            throw new TransformationFailedException(\sprintf('Expected a "%s" object.', ReadableCollection::class));
         }
 
         return $collection->toArray();

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Tests\Form\DataTransformer;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\ReadableCollection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\DataTransformer\CollectionToArrayTransformer;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -64,6 +65,118 @@ class CollectionToArrayTransformerTest extends TestCase
     {
         $this->expectException(TransformationFailedException::class);
         $this->transformer->transform('Foo');
+    }
+
+    public function testTransformReadableCollection()
+    {
+        $array = [
+            2 => 'foo',
+            3 => 'bar',
+        ];
+
+        $collection = new class($array) implements ReadableCollection
+        {
+            public function __construct(private readonly array $array)
+            {
+            }
+
+            public function contains($element): bool
+            {
+            }
+
+            public function isEmpty(): bool
+            {
+            }
+
+            public function containsKey($key): bool
+            {
+            }
+
+            public function get($key): mixed
+            {
+            }
+
+            public function getKeys(): array
+            {
+            }
+
+            public function getValues(): array
+            {
+            }
+
+            public function toArray(): array
+            {
+                return $this->array;
+            }
+
+            public function first(): mixed
+            {
+            }
+
+            public function last(): mixed
+            {
+            }
+
+            public function key(): string|int|null
+            {
+            }
+
+            public function current(): mixed
+            {
+            }
+
+            public function next(): mixed
+            {
+            }
+
+            public function slice($offset, $length = null): array
+            {
+            }
+
+            public function exists(\Closure $p): bool
+            {
+            }
+
+            public function filter(\Closure $p): ReadableCollection
+            {
+            }
+
+            public function map(\Closure $func): ReadableCollection
+            {
+            }
+
+            public function partition(\Closure $p): array
+            {
+            }
+
+            public function forAll(\Closure $p): bool
+            {
+            }
+
+            public function indexOf($element): int|string|bool
+            {
+            }
+
+            public function findFirst(\Closure $p): mixed
+            {
+            }
+
+            public function reduce(\Closure $func, mixed $initial = null): mixed
+            {
+            }
+
+            public function getIterator(): \Traversable
+            {
+                return new \ArrayIterator($this->array);
+            }
+
+            public function count(): int
+            {
+                return count($this->array);
+            }
+        };
+
+        $this->assertSame($array, $this->transformer->transform($collection));
     }
 
     public function testReverseTransform()

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -43,13 +43,14 @@
         "symfony/uid": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",
-        "doctrine/collections": "^1.0|^2.0",
+        "doctrine/collections": "^1.8|^2.0",
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^3.6|^4",
         "doctrine/orm": "^2.15|^3",
         "psr/log": "^1|^2|^3"
     },
     "conflict": {
+        "doctrine/collections": "<1.8",
         "doctrine/dbal": "<3.6",
         "doctrine/lexer": "<1.1",
         "doctrine/orm": "<2.15",


### PR DESCRIPTION
Since 1.8.0 doctrine/collections ships ReadableCollection, which the Collection interface extends. This commit relaxes the behavior of CollectionToArrayTransformer::transform(), allowing it to tranform instances of ReadableCollection.

| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Issues        | 
| License       | MIT

Since 1.8.0 doctrine/collections ships ReadableCollection, which the Collection interface extends. This commit relaxes the behavior of CollectionToArrayTransformer::transform(), allowing it to transform instances of ReadableCollection.

This change does not break BC, but does make `doctrine/collections` a non-dev dependency in order to require at least `1.8.0` of that library (previously, the lower-bound version was implicitly `^1.5` via `doctrine/o[rd]m`. This is one of several reasons why I'm considering this an addition and not a bugfix. Symfony maintainers are, of course, welcome to backport this patch to earlier versions of the framework at their discretion.

I've omitted a test here, since the signal:noise ratio would be poor due the the necessary inclusion of a boilerplate ReadableCollection implementation. I'm happy to add one if desired, however.