### PR TITLE
[DependencyInjection] Fix importing PHP configs in the prepend extension method

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -92,6 +92,7 @@ abstract class FileLoader extends BaseFileLoader
             }
         } finally {
             --$this->importing;
+            $this->loadExtensionConfigs();
         }
 
         return null;

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -143,7 +143,12 @@ class PhpFileLoader extends FileLoader
         // Force load ContainerConfigurator to make env(), param() etc available.
         class_exists(ContainerConfigurator::class);
 
-        $callback(...$arguments);
+        ++$this->importing;
+        try {
+            $callback(...$arguments);
+        } finally {
+            --$this->importing;
+        }
 
         foreach ($configBuilders as $configBuilder) {
             $this->loadExtensionConfig($configBuilder->getExtensionAlias(), ContainerConfigurator::processValue($configBuilder->toArray()));

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -47,13 +47,29 @@ class PhpFileLoaderTest extends TestCase
         $this->assertEquals('foo', $container->getParameter('foo'), '->load() loads a PHP file resource');
     }
 
-    public function testPrependExtensionConfig()
+    public function testPrependExtensionConfigWithLoadMethod()
     {
         $container = new ContainerBuilder();
         $container->registerExtension(new \AcmeExtension());
         $container->prependExtensionConfig('acme', ['foo' => 'bar']);
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Fixtures'), 'prod', new ConfigBuilderGenerator(sys_get_temp_dir()), true);
         $loader->load('config/config_builder.php');
+
+        $expected = [
+            ['color' => 'red'],
+            ['color' => 'blue'],
+            ['foo' => 'bar'],
+        ];
+        $this->assertSame($expected, $container->getExtensionConfig('acme'));
+    }
+
+    public function testPrependExtensionConfigWithImportMethod()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new \AcmeExtension());
+        $container->prependExtensionConfig('acme', ['foo' => 'bar']);
+        $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Fixtures'), 'prod', new ConfigBuilderGenerator(sys_get_temp_dir()), true);
+        $loader->import('config/config_builder.php');
 
         $expected = [
             ['color' => 'red'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57936
| License       | MIT

I missed this nesting case during https://github.com/symfony/symfony/pull/52843.