### PR TITLE
[Uid] Add support for binary, base-32 and base-58 representations in `Uuid::isValid()`

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/UuidToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/UuidToStringTransformerTest.php
@@ -56,15 +56,6 @@ class UuidToStringTransformerTest extends TestCase
         $this->assertNull($reverseTransformer->reverseTransform(''));
     }
 
-    public function testReverseTransformExpectsString()
-    {
-        $reverseTransformer = new UuidToStringTransformer();
-
-        $this->expectException(TransformationFailedException::class);
-
-        $reverseTransformer->reverseTransform(Uuid::fromString('123e4567-e89b-12d3-a456-426655440000')->toBase32());
-    }
-
     public function testReverseTransformExpectsValidUuidString()
     {
         $reverseTransformer = new UuidToStringTransformer();

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Make `AbstractUid` implement `Ds\Hashable` if available
+ * Add support for binary, base-32 and base-58 representations in `Uuid::isValid()`
 
 7.1
 ---

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -204,6 +204,16 @@ class UuidTest extends TestCase
         $this->assertTrue(UuidV4::isValid(self::A_UUID_V4));
     }
 
+    public function testIsValidWithVariousFormat()
+    {
+        $uuid = Uuid::v4();
+
+        $this->assertTrue(UuidV4::isValid($uuid->toBase32()));
+        $this->assertTrue(UuidV4::isValid($uuid->toBase58()));
+        $this->assertTrue(UuidV4::isValid($uuid->toBinary()));
+        $this->assertFalse(Uuid::isValid('30J7CNpDMfXPZrCsn4Cgey'), 'Fake base-58 string with the "O" forbidden char is not valid');
+    }
+
     public function testIsValidWithNilUuid()
     {
         $this->assertTrue(Uuid::isValid('00000000-0000-0000-0000-000000000000'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57398
| License       | MIT