### PR TITLE
[Scheduler] Fix test when an optional package is missing

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SchedulerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SchedulerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Cron\CronExpression;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummySchedule;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyTask;
@@ -59,6 +60,10 @@ class SchedulerTest extends AbstractWebTestCase
 
     public function testAutoconfiguredScheduler()
     {
+        if (!class_exists(CronExpression::class)) {
+            $this->markTestSkipped('The "dragonmantank/cron-expression" package is required to run this test.');
+        }
+
         $container = self::getContainer();
         $container->set('clock', $clock = new MockClock('2023-10-26T08:59:59Z'));
 

--- a/src/Symfony/Component/Scheduler/Tests/RecurringMessageTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/RecurringMessageTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Scheduler\Tests;
 
+use Cron\CronExpression;
 use PHPUnit\Framework\TestCase;
 use Random\Randomizer;
 use Symfony\Component\Scheduler\Exception\InvalidArgumentException;
@@ -20,6 +21,10 @@ class RecurringMessageTest extends TestCase
 {
     public function testCanCreateHashedCronMessage()
     {
+        if (!class_exists(CronExpression::class)) {
+            $this->markTestSkipped('The "dragonmantank/cron-expression" package is required to run this test.');
+        }
+
         $object = new DummyStringableMessage();
 
         if (class_exists(Randomizer::class)) {
@@ -40,6 +45,10 @@ class RecurringMessageTest extends TestCase
 
     public function testUniqueId()
     {
+        if (!class_exists(CronExpression::class)) {
+            $this->markTestSkipped('The "dragonmantank/cron-expression" package is required to run this test.');
+        }
+
         $message1 = RecurringMessage::cron('* * * * *', new \stdClass());
         $message2 = RecurringMessage::cron('* 5 * * *', new \stdClass());
 

--- a/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Scheduler\Tests;
 
+use Cron\CronExpression;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\RecurringMessage;
@@ -20,6 +21,10 @@ class ScheduleTest extends TestCase
 {
     public function testCannotAddDuplicateMessage()
     {
+        if (!class_exists(CronExpression::class)) {
+            $this->markTestSkipped('The "dragonmantank/cron-expression" package is required to run this test.');
+        }
+
         $schedule = new Schedule();
         $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
 

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/CronExpressionTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/CronExpressionTriggerTest.php
@@ -11,12 +11,20 @@
 
 namespace Symfony\Component\Scheduler\Tests\Trigger;
 
+use Cron\CronExpression;
 use PHPUnit\Framework\TestCase;
 use Random\Randomizer;
 use Symfony\Component\Scheduler\Trigger\CronExpressionTrigger;
 
 class CronExpressionTriggerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (!class_exists(CronExpression::class)) {
+            $this->markTestSkipped('The "dragonmantank/cron-expression" package is required to run this test.');
+        }
+    }
+
     /**
      * @dataProvider hashedExpressionProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes the following error in tests when a package is missing:

```
./phpunit src/Symfony/Bundle/FrameworkBundle/ --filter=testAutoconfiguredScheduler
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.

Testing /home/alex/PhpstormProjects/symfony/src/Symfony/Bundle/FrameworkBundle
E                                                                   1 / 1 (100%)

Time: 00:00.902, Memory: 28.00 MB

There was 1 error:

1) Symfony\Bundle\FrameworkBundle\Tests\Functional\SchedulerTest::testAutoconfiguredScheduler
Symfony\Component\Scheduler\Exception\LogicException: You cannot use "Symfony\Component\Scheduler\Trigger\CronExpressionTrigger" as the "cron expression" package is not installed. Try running "composer require dragonmantank/cron-expression".
```