### PR TITLE
[Config][DependencyInjection] Optimize dumped resources for tracking

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -81,7 +81,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
             $file = $class->getFileName();
             if (false !== $file && is_file($file)) {
                 foreach ($this->excludedVendors as $vendor) {
-                    if (str_starts_with($file, $vendor) && false !== strpbrk(substr($file, \strlen($vendor), 1), '/'.\DIRECTORY_SEPARATOR)) {
+                    if (\in_array($file[\strlen($vendor)] ?? '', ['/', \DIRECTORY_SEPARATOR], true) && str_starts_with($file, $vendor)) {
                         $file = false;
                         break;
                     }
@@ -154,6 +154,13 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
         }
 
         foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED) as $m) {
+            foreach ($this->excludedVendors as $vendor) {
+                $file = $m->getFileName();
+                if (\in_array($file[\strlen($vendor)] ?? '', ['/', \DIRECTORY_SEPARATOR], true) && str_starts_with($file, $vendor)) {
+                    continue 2;
+                }
+            }
+
             foreach ($m->getAttributes() as $a) {
                 $attributes[] = [$a->getName(), (string) $a];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Looking at the resource tracking cache, I figured out we could remove tracking some more resources.

On a webapp skeleton, this goes from 85 to 39 resources to track.

On my Ubuntu, I couldn't measure a difference, but on slow filesystems (Windows, shared mounts), I hope this might improve the DX a bit during dev. Anyone able to confirm?