### PR TITLE
[Config] Generate a meta file in JSON format for resource tracking

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add `#[WhenNot]` attribute to prevent service from being registered in a specific environment
+ * Generate a meta file in JSON format for resource tracking
+ * Add `SkippingResourceChecker`
 
 7.1
 ---

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Config;
 
+use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
+use Symfony\Component\Config\Resource\SkippingResourceChecker;
 
 /**
  * ConfigCache caches arbitrary content in files on disk.
@@ -26,18 +28,23 @@ use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
 class ConfigCache extends ResourceCheckerConfigCache
 {
     /**
-     * @param string      $file     The absolute cache path
-     * @param bool        $debug    Whether debugging is enabled or not
-     * @param string|null $metaFile The absolute path to the meta file
+     * @param string                                 $file                 The absolute cache path
+     * @param bool                                   $debug                Whether debugging is enabled or not
+     * @param string|null                            $metaFile             The absolute path to the meta file
+     * @param class-string<ResourceInterface>[]|null $skippedResourceTypes
      */
     public function __construct(
         string $file,
         private bool $debug,
         ?string $metaFile = null,
+        array|null $skippedResourceTypes = null,
     ) {
         $checkers = [];
-        if (true === $this->debug) {
-            $checkers = [new SelfCheckingResourceChecker()];
+        if ($this->debug) {
+            if (null !== $skippedResourceTypes) {
+                $checkers[] = new SkippingResourceChecker($skippedResourceTypes);
+            }
+            $checkers[] = new SelfCheckingResourceChecker();
         }
 
         parent::__construct($file, $checkers, $metaFile);

--- a/src/Symfony/Component/Config/Resource/SkippingResourceChecker.php
+++ b/src/Symfony/Component/Config/Resource/SkippingResourceChecker.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Resource;
+
+use Symfony\Component\Config\ResourceCheckerInterface;
+
+class SkippingResourceChecker implements ResourceCheckerInterface
+{
+    private array $skippedResourceTypes;
+
+    /**
+     * @param class-string<ResourceInterface>[] $skippedResourceTypes
+     */
+    public function __construct(array $skippedResourceTypes = [])
+    {
+        $this->skippedResourceTypes = array_flip($skippedResourceTypes);
+    }
+
+    public function supports(ResourceInterface $metadata): bool
+    {
+        return !$this->skippedResourceTypes || isset($this->skippedResourceTypes[$metadata::class]);
+    }
+
+    public function isFresh(ResourceInterface $resource, int $timestamp): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -30,7 +30,7 @@ class ResourceCheckerConfigCacheTest extends TestCase
 
     protected function tearDown(): void
     {
-        $files = [$this->cacheFile, "{$this->cacheFile}.meta", $this->metaFile];
+        $files = [$this->cacheFile, $this->cacheFile.'.meta', $this->cacheFile.'.meta.json', $this->metaFile, $this->metaFile.'.json'];
 
         foreach ($files as $file) {
             if (file_exists($file)) {
@@ -160,5 +160,14 @@ class ResourceCheckerConfigCacheTest extends TestCase
         $cache->write('foo', [new FileResource(__FILE__)]);
 
         $this->assertStringNotEqualsFile($this->metaFile, '');
+
+        $this->assertStringEqualsFile($this->metaFile.'.json', json_encode([
+            'resources' => [
+                [
+                    '@type' => FileResource::class,
+                    'resource' => __FILE__,
+                ],
+            ],
+        ]));
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Remove `@internal` flag and add `@final` to `ServicesResetter`
+ * Add support for `SYMFONY_DISABLE_RESOURCE_TRACKING` env var
 
 7.1
 ---

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -392,7 +392,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     {
         $class = $this->getContainerClass();
         $buildDir = $this->warmupDir ?: $this->getBuildDir();
-        $cache = new ConfigCache($buildDir.'/'.$class.'.php', $this->debug);
+        $skip = $_SERVER['SYMFONY_DISABLE_RESOURCE_TRACKING'] ?? '';
+        $skip = filter_var($skip, \FILTER_VALIDATE_BOOLEAN,  \FILTER_NULL_ON_FAILURE) ?? explode(',', $skip);
+        $cache = new ConfigCache($buildDir.'/'.$class.'.php', $this->debug, null, \is_array($skip) && ['*'] !== $skip ? $skip : ($skip ? [] : null));
+
         $cachePath = $cache->getPath();
 
         // Silence E_WARNING to ignore "include" failures - don't use "@" to prevent silencing fatal errors


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

At the moment, resource tracking relies on a meta file that contains php-serialized resources.
This PR generates a JSON version of that file next to the php-serialized one.
I'm wondering if this could enable moving resource checking to an outside process (symfony-cli likely).
For experimenting.

The JSON contains entries like e.g.
```json
[
  {
    "@type": "Symfony\\Component\\Config\\Resource\\FileExistenceResource",
    "exists": false,
    "resource": "/home/nicolas/Code/symfony/src/Symfony/Bundle/SecurityBundle/public"
  },
  {
    "@type": "Symfony\\Component\\Config\\Resource\\FileResource",
    "resource": "/home/nicolas/Code/test-res-tracking/composer.json"
  }
]
```

This PR also adds support for a new `SYMFONY_DISABLE_RESOURCE_TRACKING` env var, that allows listing resource classes that should be skipped when checking for freshness. The purpose is to enable mixed checking: the common resource types could be checked by an external process, and the custom ones would still be checked by PHP.

`SYMFONY_DISABLE_RESOURCE_TRACKING` can also be set to `*` or any boolean value supported by filter_var (1, on, true, etc.) to fully disable resource tracking.