### PR TITLE
[DependencyInjection] Fix invalid phpdoc in ContainerBuilder

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -117,7 +117,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     private array $vendors;
 
     /**
-     * @var string[] the list of paths in vendor directories
+     * @var array<string, bool> the cache for paths being in vendor directories
      */
     private array $pathsInVendor = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

Having the right type in phpdoc helps Psalm in our CI setup (all errors reported in https://github.com/symfony/symfony/actions/runs/10304849213/job/28524293972?pr=57948 are caused by this invalid type) and also makes it easier for contributors to understand that code. 