### PR TITLE
[DoctrineBridge] In Profiler, Show all fields and values for validation constraints

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UniqueFieldFormValidationEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UniqueFieldFormValidationEntity.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+
+#[Entity]
+class UniqueFieldFormValidationEntity
+{
+    public function __construct(
+        #[Id, Column(type: 'integer')]
+        protected ?int $id = null,
+
+        #[Column(type: 'string', nullable: true)]
+        public ?string $name = null,
+
+        #[Column(type: 'string', nullable: true)]
+        public ?string $lastname = null,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Validation/UniqueFieldEntityFormValidationTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Validation/UniqueFieldEntityFormValidationTest.php
@@ -1,27 +1,31 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\Doctrine\Tests\Form\Validation;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
 use Symfony\Bridge\Doctrine\Tests\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueFieldFormValidationEntity;
-use Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueGroupFieldsEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapper;
-use Symfony\Component\Form\Forms;
-use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
 use Symfony\Component\Form\Tests\Extension\Core\Type\TextTypeTest;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validation;
-use Symfony\Component\Form\Test\TypeTestCase;
 
 class UniqueFieldEntityFormValidationTest extends TypeTestCase
 {
@@ -46,10 +50,11 @@ class UniqueFieldEntityFormValidationTest extends TypeTestCase
 
         return $registry;
     }
+
     protected function getExtensions(): array
     {
         $factory = new ConstraintValidatorFactory([
-            'doctrine.orm.validator.unique' => new UniqueEntityValidator($this->emRegistry)
+            'doctrine.orm.validator.unique' => new UniqueEntityValidator($this->emRegistry),
         ]);
 
         $validator = Validation::createValidatorBuilder()

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Validation/UniqueFieldEntityFormValidationTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Validation/UniqueFieldEntityFormValidationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\Form\Validation;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
+use Symfony\Bridge\Doctrine\Tests\DoctrineTestHelper;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueFieldFormValidationEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueGroupFieldsEntity;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapper;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTestCase;
+use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
+use Symfony\Component\Form\Tests\Extension\Core\Type\TextTypeTest;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class UniqueFieldEntityFormValidationTest extends TypeTestCase
+{
+    private EntityManager $em;
+    private MockObject&ManagerRegistry $emRegistry;
+
+    protected function setUp(): void
+    {
+        $this->em = DoctrineTestHelper::createTestEntityManager();
+        $this->emRegistry = $this->createRegistryMock('default', $this->em);
+
+        parent::setUp();
+    }
+
+    protected function createRegistryMock($name, $em): MockObject&ManagerRegistry
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects($this->any())
+            ->method('getManager')
+            ->with($this->equalTo($name))
+            ->willReturn($em);
+
+        return $registry;
+    }
+    protected function getExtensions(): array
+    {
+        $factory = new ConstraintValidatorFactory([
+            'doctrine.orm.validator.unique' => new UniqueEntityValidator($this->emRegistry)
+        ]);
+
+        $validator = Validation::createValidatorBuilder()
+            ->setConstraintValidatorFactory($factory)
+            ->enableAttributeMapping()
+            ->getValidator();
+
+        return [
+            new ValidatorExtension($validator),
+        ];
+    }
+
+    public function testFormValidationForEntityWithUniqueFieldNotValid()
+    {
+        $entity1 = new UniqueFieldFormValidationEntity(1, 'Foo');
+
+        $form = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, ['data_class' => UniqueFieldFormValidationEntity::class])
+            ->add('name', TextTypeTest::TESTED_TYPE)
+            ->add('token', TextTypeTest::TESTED_TYPE)
+            ->getForm();
+
+        $constraintViolation = new ConstraintViolation(
+            'This value should not be used.',
+            'This value should not be used.',
+            [
+                '{{ value }}' => 'myNameValue',
+                '{{ name value }}' => '"myNameValue"',
+            ],
+            $form,
+            'data.name',
+            'myNameValue',
+            null,
+            'code',
+            new UniqueEntity(
+                ['name']
+            ),
+            $entity1
+        );
+
+        $violationMapper = new ViolationMapper();
+        $violationMapper->mapViolation($constraintViolation, $form, true);
+
+        $this->assertCount(0, $form->getErrors());
+        $this->assertCount(1, $form->get('name')->getErrors());
+        $this->assertSame('This value should not be used.', $form->get('name')->getErrors()[0]->getMessage());
+    }
+
+    public function testFormValidationForEntityWithUniqueGroupFieldsNotValid()
+    {
+        $entity1 = new UniqueFieldFormValidationEntity(1, 'Foo');
+
+        $form = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, ['data_class' => UniqueFieldFormValidationEntity::class])
+            ->add('name', TextTypeTest::TESTED_TYPE)
+            ->add('token', TextTypeTest::TESTED_TYPE)
+            ->getForm();
+
+        $constraintViolation = new ConstraintViolation(
+            'This value should not be used.',
+            'This value should not be used.',
+            [
+                '{{ value }}' => 'myTokenValue, myNameValue',
+                '{{ token value }}' => '"myTokenValue"',
+                '{{ name value }}' => '"myNameValue"',
+            ],
+            $form,
+            'data.name, token',
+            'myTokenValue, myNameValue',
+            null,
+            'code',
+            new UniqueEntity(
+                ['name', 'token']
+            ),
+            $entity1
+        );
+
+        $violationMapper = new ViolationMapper();
+        $violationMapper->mapViolation($constraintViolation, $form, true);
+
+        $this->assertCount(1, $form->getErrors());
+        $this->assertCount(0, $form->get('name')->getErrors());
+        $this->assertSame('This value should not be used.', $form->getErrors()[0]->getMessage());
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -299,9 +299,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($entity2, $constraint);
 
         $this->buildViolation('myMessage')
-            ->atPath('property.path.name')
-            ->setParameter('{{ value }}', '"Foo"')
-            ->setInvalidValue('Foo')
+            ->atPath('property.path.name, name2')
+            ->setParameter('{{ value }}', '"Foo, "')
+            ->setParameter('{{ name value }}', '"Foo"')
+            ->setParameter('{{ name2 value }}', 'null')
+            ->setInvalidValue('Foo, ')
             ->setCause([$entity1])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();
@@ -407,6 +409,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.name2')
             ->setParameter('{{ value }}', '"Bar"')
+            ->setParameter('{{ name value }}', '"Foo"')
+            ->setParameter('{{ name2 value }}', '"Bar"')
             ->setInvalidValue('Bar')
             ->setCause([$entity1])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -828,12 +832,15 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($newEntity, $constraint);
 
-        $expectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 1)';
+        $objectOneExpectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 1)';
+        $objectTwoExpectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 2)';
 
         $this->buildViolation('myMessage')
-            ->atPath('property.path.objectOne')
-            ->setParameter('{{ value }}', $expectedValue)
-            ->setInvalidValue($objectOne)
+            ->atPath('property.path.objectOne, objectTwo')
+            ->setParameter('{{ value }}', '""object", "object""')
+            ->setParameter('{{ objectOne value }}', $objectOneExpectedValue)
+            ->setParameter('{{ objectTwo value }}', $objectTwoExpectedValue)
+            ->setInvalidValue('"object", "object"')
             ->setCause([$entity])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();
@@ -1098,9 +1105,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($dto, $constraint);
 
         $this->buildViolation('myMessage')
-            ->atPath('property.path.name')
-            ->setParameter('{{ value }}', '"Foo"')
-            ->setInvalidValue('Foo')
+            ->atPath('property.path.name, name2')
+            ->setParameter('{{ value }}', '"Foo, Bar"')
+            ->setParameter('{{ name value }}', '"Foo"')
+            ->setParameter('{{ name2 value }}', '"Bar"')
+            ->setInvalidValue('Foo, Bar')
             ->setCause([$entity])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();
@@ -1124,9 +1133,11 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($dto, $constraint);
 
         $this->buildViolation('myMessage')
-            ->atPath('property.path.name')
-            ->setParameter('{{ value }}', '"Foo"')
-            ->setInvalidValue('Foo')
+            ->atPath('property.path.name, name2')
+            ->setParameter('{{ value }}', '"Foo, Bar"')
+            ->setParameter('{{ name value }}', '"Foo"')
+            ->setParameter('{{ name2 value }}', '"Bar"')
+            ->setInvalidValue('Foo, Bar')
             ->setCause([$entity])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -217,7 +217,7 @@ class UniqueEntityValidator extends ConstraintValidator
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->setCause($result);
 
-        if(is_array($criteria) && count($criteria) > 1) {
+        if(\is_array($criteria) && \count($criteria) > 1) {
             foreach($criteria as $field => $value) {
                 $violation->setParameter('{{ '.$field.' value }}', $this->formatWithIdentifiers($em, $class, $value));
             }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -208,7 +208,7 @@ class UniqueEntityValidator extends ConstraintValidator
         }
 
         $errorPath = $constraint->errorPath ?? implode(', ', array_keys($criteria));
-        $invalidValue = $criteria[$errorPath] ?? implode(', ', $criteria);
+        $invalidValue = $criteria[$errorPath] ?? implode(', ', array_map(fn ($o) => is_object($o) ? '"object"' : $o, $criteria));
 
         $violation = $this->context->buildViolation($constraint->message)
             ->atPath($errorPath)
@@ -217,7 +217,7 @@ class UniqueEntityValidator extends ConstraintValidator
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->setCause($result);
 
-        if(is_array($criteria))
+        if(is_array($criteria) && count($criteria) > 1)
         {
             foreach($criteria as $field => $value)
             {

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -217,11 +217,9 @@ class UniqueEntityValidator extends ConstraintValidator
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->setCause($result);
 
-        if(is_array($criteria) && count($criteria) > 1)
-        {
-            foreach($criteria as $field => $value)
-            {
-                $violation->setParameter('{{ ' . $field . ' value }}', $this->formatWithIdentifiers($em, $class, $value));
+        if(is_array($criteria) && count($criteria) > 1) {
+            foreach($criteria as $field => $value) {
+                $violation->setParameter('{{ '.$field.' value }}', $this->formatWithIdentifiers($em, $class, $value));
             }
         }
 

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -208,7 +208,7 @@ class UniqueEntityValidator extends ConstraintValidator
         }
 
         $errorPath = $constraint->errorPath ?? implode(', ', array_keys($criteria));
-        $invalidValue = $criteria[$errorPath] ?? implode(', ', array_map(fn ($o) => is_object($o) ? '"object"' : $o, $criteria));
+        $invalidValue = $criteria[$errorPath] ?? implode(', ', array_map(fn ($o) => \is_object($o) ? '"object"' : $o, $criteria));
 
         $violation = $this->context->buildViolation($constraint->message)
             ->atPath($errorPath)
@@ -217,8 +217,8 @@ class UniqueEntityValidator extends ConstraintValidator
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->setCause($result);
 
-        if(\is_array($criteria) && \count($criteria) > 1) {
-            foreach($criteria as $field => $value) {
+        if (\is_array($criteria) && \count($criteria) > 1) {
+            foreach ($criteria as $field => $value) {
                 $violation->setParameter('{{ '.$field.' value }}', $this->formatWithIdentifiers($em, $class, $value));
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

When using UniqueEntity with multiple fields, show all fields and all values in profiler for debug quickly.
Before only one value was shown : 

![image](https://github.com/user-attachments/assets/b75c5ff4-d425-47d9-b924-bbc4b2fbc4dd)
in form errors : 
![image](https://github.com/user-attachments/assets/6ed43615-8e05-4559-86e0-4152037759cb)


After we have all fields : 
![image](https://github.com/user-attachments/assets/8543f413-0317-4afb-b660-c0ea892558d2)
and in the form, error is not attached to a field but to the top form : 
![image](https://github.com/user-attachments/assets/d4a613f2-8676-4784-92ff-bd8738058054)
