### PR TITLE
[Form] skip tests requiring the intl extension if it's not installed

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -638,6 +638,8 @@ class NumberToLocalizedStringTransformerTest extends TestCase
      */
     public function testReverseTransformENotation($output, $input)
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('en');
 
         $transformer = new NumberToLocalizedStringTransformer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT