### PR TITLE
[FrameworkBundle] Re-remove redundant name attribute from `default_context`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1118,7 +1118,6 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('default_context')
                             ->normalizeKeys(false)
-                            ->useAttributeAsKey('name')
                             ->validate()
                                 ->ifTrue(fn () => $this->debug && class_exists(JsonParser::class))
                                 ->then(fn (array $v) => $v + [JsonDecode::DETAILED_ERROR_MESSAGES => true])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This was originally removed in #53657 but was later reintroduced in v7.1.2, likely by accident, in the following merge commit: https://github.com/symfony/symfony/commit/67ac926c96879614b9e099b0e826f25dea5095f2.