### PR TITLE
[Mime] remove constructor argument type-hint

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -24,7 +24,7 @@ class RawMessage
      * @param iterable<string>|string|resource $message
      */
     public function __construct(
-        private mixed $message,
+        private $message,
     ) {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The child class Message does not call the parent constructor which means that the $message property will never be initialized when using CPP.