### PR TITLE
[VarDumper] Fix generator dump format for PHP 8.4

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -592,11 +592,11 @@ Generator {
   function: "Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::baz"
   this: Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo { …}
   %s: {
-    %sGeneratorDemo.php:14 {
+    %sGeneratorDemo.php:12 {
       Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo->baz()
+      › 
+      › public function baz()
       › {
-      ›     yield from bar();
-      › }
     }
     Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo->baz() {}
 %A}
@@ -617,7 +617,9 @@ array:2 [
     %s: {
       %s%eTests%eFixtures%eGeneratorDemo.php:%d {
         Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo()
-%A      ›     yield 1;
+        › {
+        ›     yield 1;
+        › }
 %A    }
       %s%eTests%eFixtures%eGeneratorDemo.php:20 { …}
       %s%eTests%eFixtures%eGeneratorDemo.php:14 { …}
@@ -629,9 +631,9 @@ array:2 [
     %s: {
       %s%eTests%eFixtures%eGeneratorDemo.php:%d {
         Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo()
+        › {
         ›     yield 1;
         › }
-        › 
       }
 %A  }
     closed: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Generator dump format likely changed because of https://github.com/php/php-src/pull/15328. I propose to update the test dedicated to dumping generators in PHP >= 8.4.

cc @xabbuh 