### PR TITLE
[HttpClient] reject malformed URLs with a meaningful exception

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -445,6 +445,8 @@ trait HttpClientTrait
      */
     private static function resolveUrl(array $url, ?array $base, array $queryDefaults = []): array
     {
+        $givenUrl = $url;
+
         if (null !== $base && '' === ($base['scheme'] ?? '').($base['authority'] ?? '')) {
             throw new InvalidArgumentException(sprintf('Invalid "base_uri" option: host or scheme is missing in "%s".', implode('', $base)));
         }
@@ -496,6 +498,10 @@ trait HttpClientTrait
 
         if ('?' === ($url['query'] ?? '')) {
             $url['query'] = null;
+        }
+
+        if (null !== $url['scheme'] && null === $url['authority']) {
+            throw new InvalidArgumentException(\sprintf('Invalid URL: host is missing in "%s".', implode('', $givenUrl)));
         }
 
         return $url;

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient\Tests;
 
 use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\ClientState;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
@@ -454,5 +455,15 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         ]);
 
         $this->expectNotToPerformAssertions();
+    }
+
+    public function testMisspelledScheme()
+    {
+        $httpClient = $this->getHttpClient(__FUNCTION__);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid URL: host is missing in "http:/localhost:8057/".');
+
+        $httpClient->request('GET', 'http:/localhost:8057/');
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -63,7 +63,6 @@ class HttpClientTraitTest extends TestCase
     public static function provideResolveUrl(): array
     {
         return [
-            [self::RFC3986_BASE, 'http:h',        'http:h'],
             [self::RFC3986_BASE, 'g',             'http://a/b/c/g'],
             [self::RFC3986_BASE, './g',           'http://a/b/c/g'],
             [self::RFC3986_BASE, 'g/',            'http://a/b/c/g/'],
@@ -117,7 +116,6 @@ class HttpClientTraitTest extends TestCase
             ['http://u:p@a/b/c/d;p?q', '.',       'http://u:p@a/b/c/'],
             // path ending with slash or no slash at all
             ['http://a/b/c/d/',  'e',             'http://a/b/c/d/e'],
-            ['http:no-slash',     'e',            'http:e'],
             // falsey relative parts
             [self::RFC3986_BASE, '//0',           'http://0/'],
             [self::RFC3986_BASE, '0',             'http://a/b/c/0'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57976
| License       | MIT