### PR TITLE
[Messenger] skip transient Redis integration tests on AppVeyor

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -344,6 +344,9 @@ class RedisExtIntegrationTest extends TestCase
         }
     }
 
+    /**
+     * @group transient-on-windows
+     */
     public function testGetNonBlocking()
     {
         $redis = $this->createRedisClient();
@@ -379,6 +382,9 @@ class RedisExtIntegrationTest extends TestCase
         }
     }
 
+    /**
+     * @group transient-on-windows
+     */
     public function testItProperlyHandlesEmptyMessages()
     {
         $redisReceiver = new RedisReceiver($this->connection, new Serializer());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
