### PR TITLE
[DependencyInjection] Fix issue between decorator and service locator index

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -120,6 +120,10 @@ class DecoratorServicePass extends AbstractRecursivePass
 
             $container->setAlias($inner, $id)->setPublic($public);
         }
+
+        foreach ($decoratingDefinitions as $inner => $definition) {
+            $definition->addTag('container.decorator', ['id' => $inner]);
+        }
     }
 
     protected function processValue($value, bool $isRoot = false)

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -82,7 +82,8 @@ trait PriorityTaggedServiceTrait
                 } elseif (null === $defaultIndex && $defaultPriorityMethod && $class) {
                     $defaultIndex = PriorityTaggedServiceUtil::getDefault($container, $serviceId, $class, $defaultIndexMethod ?? 'getDefaultName', $tagName, $indexAttribute, $checkTaggedItem);
                 }
-                $index = $index ?? $defaultIndex ?? $defaultIndex = $serviceId;
+                $decorated = $definition->getTag('container.decorator')[0]['id'] ?? null;
+                $index = $index ?? $defaultIndex ?? $defaultIndex = $decorated ?? $serviceId;
 
                 $services[] = [$priority, ++$i, $index, $serviceId, $class];
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -198,7 +198,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEmpty($container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessMovesTagsFromDecoratedDefinitionToDecoratingDefinitionMultipleTimes()
@@ -221,7 +221,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEmpty($container->getDefinition('deco1')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz']], $container->getDefinition('deco2')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('deco2')->getTags());
     }
 
     public function testProcessLeavesServiceLocatorTagOnOriginalDefinition()
@@ -240,7 +240,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEquals(['container.service_locator' => [0 => []]], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessLeavesServiceSubscriberTagOnOriginalDefinition()
@@ -259,7 +259,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEquals(['container.service_subscriber' => [], 'container.service_subscriber.locator' => []], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessLeavesProxyTagOnOriginalDefinition()
@@ -278,7 +278,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEquals(['proxy' => 'foo'], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testCannotDecorateSyntheticService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -153,6 +153,9 @@ class PriorityTaggedServiceTraitTest extends TestCase
 
         $container->register('service4', HelloInterface::class)->addTag('my_custom_tag');
 
+        $definition = $container->register('debug.service5', \stdClass::class)->addTag('my_custom_tag');
+        $definition->addTag('container.decorator', ['id' => 'service5']);
+
         $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
 
         $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar');
@@ -161,6 +164,7 @@ class PriorityTaggedServiceTraitTest extends TestCase
             'service1' => new TypedReference('service1', FooTagClass::class),
             '10' => new TypedReference('service3', IntTagClass::class),
             'service4' => new TypedReference('service4', HelloInterface::class),
+            'service5' => new TypedReference('debug.service5', \stdClass::class),
         ];
         $services = $priorityTaggedServiceTraitImplementation->test($tag, $container);
         $this->assertSame(array_keys($expected), array_keys($services));

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
@@ -15,4 +15,6 @@ services:
     decorated:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\StdClassDecorator
         public: true
+        tags:
+            - container.decorator: { id: decorated }
         arguments: [!service { class: stdClass }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
@@ -7,6 +7,8 @@ services:
     foo:
         class: Class2
         public: true
+        tags:
+            - container.decorator: { id: bar }
         file: file.php
         lazy: true
         arguments: [!service { class: Class1 }]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53174
| License       | MIT

This PR is not finished yet. I want to gather feedback before writing tests.

To explain what is wrong, I create a [reproducer](https://github.com/lyrixx/test/tree/symfony/symfony/pull/58000).

Basically, when we decorates a services, we replace the old ID with a new ID in the DIC.

Then, when we build a service locator, we use the new ID. This is really not handy because our code
is dependant on the new name or old name, depending if the decorator is here or not!

This issue discribe very well the issue: https://github.com/symfony/symfony/issues/53174

So in this PR, I save the original ID in the decorator definition. Then I used this initial ID to build the `$index` of the 
service locator.

---

With this PR and the reproducer, I got what would be expected

![image](https://github.com/user-attachments/assets/73f6321d-d711-452b-9d20-577e82e062d8)


* Original ID in the locator
* But we retrieve the decorated
* Works well with decorator of decorator (etc)