### PR TITLE
[Scheduler] Add capability to skip missed periodic tasks, only the last schedule will be called

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add capability to skip missed periodic tasks, only the last schedule will be called
+
 6.4
 ---
 

--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -74,7 +74,15 @@ final class MessageGenerator implements MessageGeneratorInterface
                 $yield = false;
             }
 
-            if ($nextTime = $trigger->getNextRunDate($time)) {
+            $nextTime = $trigger->getNextRunDate($time);
+
+            if ($this->schedule->shouldProcessOnlyLastMissedRun()) {
+                while ($nextTime < $this->clock->now()) {
+                    $nextTime = $trigger->getNextRunDate($nextTime);
+                }
+            }
+
+            if ($nextTime) {
                 $heap->insert([$nextTime, $index, $recurringMessage]);
             }
 

--- a/src/Symfony/Component/Scheduler/Schedule.php
+++ b/src/Symfony/Component/Scheduler/Schedule.php
@@ -31,6 +31,7 @@ final class Schedule implements ScheduleProviderInterface
     private ?LockInterface $lock = null;
     private ?CacheInterface $state = null;
     private bool $shouldRestart = false;
+    private bool $onlyLastMissed = false;
 
     public function with(RecurringMessage $message, RecurringMessage ...$messages): static
     {
@@ -121,6 +122,21 @@ final class Schedule implements ScheduleProviderInterface
     public function getState(): ?CacheInterface
     {
         return $this->state;
+    }
+
+    /**
+     * @return $this
+     */
+    public function processOnlyLastMissedRun(bool $onlyLastMissed): static
+    {
+        $this->onlyLastMissed = $onlyLastMissed;
+
+        return $this;
+    }
+
+    public function shouldProcessOnlyLastMissedRun(): bool
+    {
+        return $this->onlyLastMissed;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57858
| License       | MIT

Allow a Schedule to run only once reccuring messages when a worker break (with stateful enalbed)
