### PR TITLE
[Security] Revert stateless check for ContextListener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -95,7 +95,7 @@ class ContextListener extends AbstractListener
         }
 
         $request = $event->getRequest();
-        $session = !$request->attributes->getBoolean('_stateless') && $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
+        $session = $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
 
         $request->attributes->set('_security_firewall_run', $this->sessionKey);
 


### PR DESCRIPTION
This reverts commit 40341a1f6dd2e0387b6f3da32b1492a339123525.

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #https://github.com/symfony/symfony/issues/57851
| License       | MIT

Closes https://github.com/symfony/symfony/pull/57854

Cf https://github.com/symfony/symfony/pull/57854#issuecomment-2286687702