### PR TITLE
[Security] Deprecate empty user identifier

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -39,6 +39,8 @@ Security
 
  * Add `$token` argument to `UserCheckerInterface::checkPostAuth()`
  * Deprecate argument `$secret` of `RememberMeToken` and `RememberMeAuthenticator`
+ * Deprecate passing an empty string as `$userIdentifier` argument to `UserBadge` constructor
+ * Deprecate returning an empty string in `UserInterface::getUserIdentifier()`
 
 String
 ------

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `$token` argument to `UserCheckerInterface::checkPostAuth()`
  * Deprecate argument `$secret` of `RememberMeToken`
+ * Deprecate returning an empty string in `UserInterface::getUserIdentifier()`
 
 7.0
 ---

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -56,6 +56,8 @@ interface UserInterface
 
     /**
      * Returns the identifier for this user (e.g. username or email address).
+     *
+     * @return non-empty-string
      */
     public function getUserIdentifier(): string;
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/UserBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/UserBadge.php
@@ -52,6 +52,11 @@ class UserBadge implements BadgeInterface
         ?callable $userLoader = null,
         private ?array $attributes = null,
     ) {
+        if ('' === $userIdentifier) {
+            trigger_deprecation('symfony/security-http', '7.2', 'Using an empty string as user identifier is deprecated and will throw an exception in Symfony 8.0.');
+            // throw new BadCredentialsException('Empty user identifier.');
+        }
+
         if (\strlen($userIdentifier) > self::MAX_USERNAME_LENGTH) {
             throw new BadCredentialsException('Username too long.');
         }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Pass the current token to the `checkPostAuth()` method of user checkers
  * Deprecate argument `$secret` of `RememberMeAuthenticator`
+ * Deprecate passing an empty string as `$userIdentifier` argument to `UserBadge` constructor
 
 7.1
 ---

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Passport/Badge/UserBadgeTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Passport/Badge/UserBadgeTest.php
@@ -12,15 +12,29 @@
 namespace Symfony\Component\Security\Http\Tests\Authenticator\Passport\Badge;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class UserBadgeTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     public function testUserNotFound()
     {
         $badge = new UserBadge('dummy', fn () => null);
         $this->expectException(UserNotFoundException::class);
         $badge->getUser();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testEmptyUserIdentifier()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/security-http 7.2: Using an empty string as user identifier is deprecated and will throw an exception in Symfony 8.0.');
+        // $this->expectException(BadCredentialsException::class)
+        new UserBadge('', fn () => null);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #57982
| License       | MIT

