### PR TITLE
[Process] do not search in $PATH entries not allowed by open_basedir

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -48,9 +48,14 @@ class ExecutableFinder
      */
     public function find(string $name, ?string $default = null, array $extraDirs = [])
     {
+        $dirs = array_merge(
+            explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
+            $extraDirs
+        );
+
         if (\ini_get('open_basedir')) {
             $searchPath = array_merge(explode(\PATH_SEPARATOR, \ini_get('open_basedir')), $extraDirs);
-            $dirs = [];
+
             foreach ($searchPath as $path) {
                 // Silencing against https://bugs.php.net/69240
                 if (@is_dir($path)) {
@@ -61,11 +66,6 @@ class ExecutableFinder
                     }
                 }
             }
-        } else {
-            $dirs = array_merge(
-                explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
-                $extraDirs
-            );
         }
 
         $suffixes = [''];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

replaces #57954

The current version of the `ExecutableFinder` only checks the paths in the `open_basedir` when set. However, this will cause the `ExecutableFinder` not find the executable in question if it is in a subfolder of one of the `open_basedir` paths.

For example the environment might be configured as follows:

* `PATH=/usr/bin`
* `open_basedir=/usr`

In this case the `ExecutableFinder` only checks the `/usr` folder and won't find the binaries in `/usr/bin`, even though the PHP process would be allowed to access `/usr/bin`, as the `open_basedir` restriction allows access to subfolders.

This PR fixes that by always adding the paths from `PATH` to the directories to be checked.

_Note:_ this is not an issue in Symfony 6.4+. The `open_basedir` logic does not exist there and thus that problem does not exist there.
