### PR TITLE
[PsrHttpMessageBridge] Fix conversion of partitioned cookies in the PSR-7 bridge

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Factory/HttpFoundationFactory.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Factory/HttpFoundationFactory.php
@@ -132,87 +132,10 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
         $response->setProtocolVersion($psrResponse->getProtocolVersion());
 
         foreach ($cookies as $cookie) {
-            $response->headers->setCookie($this->createCookie($cookie));
+            $response->headers->setCookie(Cookie::fromString($cookie));
         }
 
         return $response;
-    }
-
-    /**
-     * Creates a Cookie instance from a cookie string.
-     *
-     * Some snippets have been taken from the Guzzle project: https://github.com/guzzle/guzzle/blob/5.3/src/Cookie/SetCookie.php#L34
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function createCookie(string $cookie): Cookie
-    {
-        foreach (explode(';', $cookie) as $part) {
-            $part = trim($part);
-
-            $data = explode('=', $part, 2);
-            $name = $data[0];
-            $value = isset($data[1]) ? trim($data[1], " \n\r\t\0\x0B\"") : null;
-
-            if (!isset($cookieName)) {
-                $cookieName = $name;
-                $cookieValue = $value;
-
-                continue;
-            }
-
-            if ('expires' === strtolower($name) && null !== $value) {
-                $cookieExpire = new \DateTime($value);
-
-                continue;
-            }
-
-            if ('path' === strtolower($name) && null !== $value) {
-                $cookiePath = $value;
-
-                continue;
-            }
-
-            if ('domain' === strtolower($name) && null !== $value) {
-                $cookieDomain = $value;
-
-                continue;
-            }
-
-            if ('secure' === strtolower($name)) {
-                $cookieSecure = true;
-
-                continue;
-            }
-
-            if ('httponly' === strtolower($name)) {
-                $cookieHttpOnly = true;
-
-                continue;
-            }
-
-            if ('samesite' === strtolower($name) && null !== $value) {
-                $samesite = $value;
-
-                continue;
-            }
-        }
-
-        if (!isset($cookieName)) {
-            throw new \InvalidArgumentException('The value of the Set-Cookie header is malformed.');
-        }
-
-        return new Cookie(
-            $cookieName,
-            $cookieValue,
-            $cookieExpire ?? 0,
-            $cookiePath ?? '/',
-            $cookieDomain ?? null,
-            isset($cookieSecure),
-            isset($cookieHttpOnly),
-            true,
-            $samesite ?? null
-        );
     }
 
     private function createStreamedResponseCallback(StreamInterface $body): callable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

`symfony/http-foundation` supports partitioned cookies in 6.4+. However, the PSR-7 was failing to convert such partitioned cookies when creating an HttpFoundation Response because it used its own parsing logic for the `Set-Cookie` header instead of reusing the logic exposed by HttpFoundation (since Symfony 3.3), and that logic was outdated. I fixed that by using `Cookie::fromString` for the parsing of the cookie.

Note that the logic in the bridge was also only testing a few cases, while HttpFoundation has a more extensive test coverage for its parsing algorithm. And there is no reason to maintain such parsing twice (with totally different implementations)
