### PR TITLE
[Serializer] Remove redundant @internal tags from traceable classes

### DIFF
--- a/src/Symfony/Component/Serializer/DataCollector/SerializerDataCollector.php
+++ b/src/Symfony/Component/Serializer/DataCollector/SerializerDataCollector.php
@@ -21,7 +21,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
- * @internal
+ * @final
  */
 class SerializerDataCollector extends DataCollector implements LateDataCollectorInterface
 {

--- a/src/Symfony/Component/Serializer/Debug/TraceableEncoder.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableEncoder.php
@@ -23,7 +23,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
- * @internal
+ * @final
  */
 class TraceableEncoder implements EncoderInterface, DecoderInterface, SerializerAwareInterface
 {

--- a/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
- * @internal
+ * @final
  */
 class TraceableNormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface, NormalizerAwareInterface, DenormalizerAwareInterface, CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
@@ -24,7 +24,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
- * @internal
+ * @final
  */
 class TraceableSerializer implements SerializerInterface, NormalizerInterface, DenormalizerInterface, EncoderInterface, DecoderInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As requested by https://github.com/symfony/symfony/pull/56823#discussion_r1717559482