### PR TITLE
[HttpKernel] ESI fragment content may be missing in conditional requests

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -237,7 +237,9 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
         $response->prepare($request);
 
-        $response->isNotModified($request);
+        if (HttpKernelInterface::MAIN_REQUEST === $type) {
+            $response->isNotModified($request);
+        }
 
         return $response;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1329,6 +1329,175 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals(100, $this->response->getTtl());
     }
 
+    public function testEsiCacheIncludesEmbeddedResponseContentWhenMainResponseFailsRevalidationAndEmbeddedResponseIsFresh()
+    {
+        $this->setNextResponses([
+            [
+                'status' => 200,
+                'body' => 'main <esi:include src="/foo" />',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=0', // goes stale immediately
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                    'Last-Modified' => 'Mon, 12 Aug 2024 10:00:00 +0000',
+                ],
+            ],
+            [
+                'status' => 200,
+                'body' => 'embedded',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=10', // stays fresh
+                    'Last-Modified' => 'Mon, 12 Aug 2024 10:05:00 +0000',
+                ]
+            ],
+        ]);
+
+        // prime the cache
+        $this->request('GET', '/', [], [], true);
+        $this->assertSame(200, $this->response->getStatusCode());
+        $this->assertSame('main embedded', $this->response->getContent());
+        $this->assertSame('Mon, 12 Aug 2024 10:05:00 +0000', $this->response->getLastModified()->format(\DATE_RFC2822)); // max of both values
+
+        $this->setNextResponses([
+            [
+                // On the next request, the main response has an updated Last-Modified (main page was modified)...
+                'status' => 200,
+                'body' => 'main <esi:include src="/foo" />',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=0',
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                    'Last-Modified' => 'Mon, 12 Aug 2024 10:10:00 +0000',
+                ],
+            ],
+            // no revalidation request happens for the embedded response, since it is still fresh
+        ]);
+
+        // Re-request with Last-Modified time that we received when the cache was primed
+        $this->request('GET', '/', ['HTTP_IF_MODIFIED_SINCE' => 'Mon, 12 Aug 2024 10:05:00 +0000'], [], true);
+
+        $this->assertSame(200, $this->response->getStatusCode());
+
+        // The cache should use the content ("embedded") from the cached entry
+        $this->assertSame('main embedded', $this->response->getContent());
+
+        $traces = $this->cache->getTraces();
+        $this->assertSame(['stale', 'invalid', 'store'], $traces['GET /']);
+
+        // The embedded resource was still fresh
+        $this->assertSame(['fresh'], $traces['GET /foo']);
+    }
+
+    public function testEsiCacheIncludesEmbeddedResponseContentWhenMainResponseFailsRevalidationAndEmbeddedResponseIsValid()
+    {
+        $this->setNextResponses([
+            [
+                'status' => 200,
+                'body' => 'main <esi:include src="/foo" />',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=0', // goes stale immediately
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                    'Last-Modified' => 'Mon, 12 Aug 2024 10:00:00 +0000',
+                ],
+            ],
+            [
+                'status' => 200,
+                'body' => 'embedded',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=0', // goes stale immediately
+                    'Last-Modified' => 'Mon, 12 Aug 2024 10:05:00 +0000',
+                ]
+            ],
+        ]);
+
+        // prime the cache
+        $this->request('GET', '/', [], [], true);
+        $this->assertSame(200, $this->response->getStatusCode());
+        $this->assertSame('main embedded', $this->response->getContent());
+        $this->assertSame('Mon, 12 Aug 2024 10:05:00 +0000', $this->response->getLastModified()->format(\DATE_RFC2822)); // max of both values
+
+        $this->setNextResponses([
+            [
+                // On the next request, the main response has an updated Last-Modified (main page was modified)...
+                'status' => 200,
+                'body' => 'main <esi:include src="/foo" />',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=0',
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                    'Last-Modified' => 'Mon, 12 Aug 2024 10:10:00 +0000',
+                ],
+            ],
+            [
+                // We have a stale cache entry for the embedded response which will be revalidated.
+                // Let's assume the resource did not change, so the controller sends a 304 without content body.
+                'status' => 304,
+                'body' => '',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=0',
+                ],
+            ],
+        ]);
+
+        // Re-request with Last-Modified time that we received when the cache was primed
+        $this->request('GET', '/', ['HTTP_IF_MODIFIED_SINCE' => 'Mon, 12 Aug 2024 10:05:00 +0000'], [], true);
+
+        $this->assertSame(200, $this->response->getStatusCode());
+
+        // The cache should use the content ("embedded") from the cached entry
+        $this->assertSame('main embedded', $this->response->getContent());
+
+        $traces = $this->cache->getTraces();
+        $this->assertSame(['stale', 'invalid', 'store'], $traces['GET /']);
+
+        // Check that the embedded resource was successfully revalidated
+        $this->assertSame(['stale', 'valid', 'store'], $traces['GET /foo']);
+    }
+
+    public function testEsiCacheIncludesEmbeddedResponseContentWhenMainAndEmbeddedResponseAreFresh()
+    {
+        $this->setNextResponses([
+            [
+                'status' => 200,
+                'body' => 'main <esi:include src="/foo" />',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=10',
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                    'Last-Modified' => 'Mon, 12 Aug 2024 10:05:00 +0000',
+                ],
+            ],
+            [
+                'status' => 200,
+                'body' => 'embedded',
+                'headers' => [
+                    'Cache-Control' => 's-maxage=10',
+                    'Last-Modified' => 'Mon, 12 Aug 2024 10:00:00 +0000',
+                ]
+            ],
+        ]);
+
+        // prime the cache
+        $this->request('GET', '/', [], [], true);
+        $this->assertSame(200, $this->response->getStatusCode());
+        $this->assertSame('main embedded', $this->response->getContent());
+        $this->assertSame('Mon, 12 Aug 2024 10:05:00 +0000', $this->response->getLastModified()->format(\DATE_RFC2822));
+
+        // Assume that a client received 'Mon, 12 Aug 2024 10:00:00 +0000' as last-modified information in the past. This may, for example,
+        // be the case when the "main" response at that point had an older Last-Modified time, so the embedded response's Last-Modified time
+        // governed the result for the combined response. In other words, the client received a Last-Modified time that still validates the
+        // embedded response as of now, but no longer matches the Last-Modified time of the "main" resource.
+        // Now this client does a revalidation request.
+        $this->request('GET', '/', ['HTTP_IF_MODIFIED_SINCE' => 'Mon, 12 Aug 2024 10:00:00 +0000'], [], true);
+
+        $this->assertSame(200, $this->response->getStatusCode());
+
+        // The cache should use the content ("embedded") from the cached entry
+        $this->assertSame('main embedded', $this->response->getContent());
+
+        $traces = $this->cache->getTraces();
+        $this->assertSame(['fresh'], $traces['GET /']);
+
+        // Check that the embedded resource was successfully revalidated
+        $this->assertSame(['fresh'], $traces['GET /foo']);
+    }
+
     public function testEsiCacheForceValidation()
     {
         $responses = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The content for ESI-embedded fragments may be missing from the combined (main) response generated by the `HttpCache` under certain conditions:

1. The main request sent to the cache must be a conditional request with either `If-Modified-Since` or `If-None-Match`
2. The embedded response processed by the cache matches the validator (last-modified or etag)
3. The resulting (combined) response generated by the `HttpCache` does not match the validator

Condition 3 is necessary since otherwise the cache returns an empty 304 response. In that case, the issue still exists, but we don't see or care about it and the wrong body is not sent at all.

Regarding condition 2, it does not matter where this embedded response comes from. It may be a fresh (cached) response taken from the cache, it may be a stale cache entry that has been revalidated; probably it can even be a non-cacheable response.

In practice, the conditional request will always use `If-Modified-Since`: We're dealing with ESI subrequests, and the combined response created by the `HttpCache` does not provide `ETag`s, so a client has nothing to validate against.

Only since #42355 (merged in to 6.2) the main response will include a `Last-Modified` header, given that all of the included responses provided one. Probably that is the reason why this bug was not spotted earlier - it required that change and all of the responses processed by the cache must provide `Last-Modified` data.

Conditions 2 + 3 together seem unlikely, but may in fact happen easily when you have an application that generates different chunks of cacheable content for the main and embedded requests and adds last-modified information to them. For example:

* First request:  Main response modified at time 1, embedded fragment modified at time 2 -> last-modified at 2
* Data for main response changes at time 3
* Second request with "If-Modified-Since" time 2
* Embedded fragment still modified at time 2, main response at time 3 -> last-modified at 3
  * the embedded fragment is considered as not modified, content is stripped
  * main response is generated, fragment content is missing





