### PR TITLE
[SecurityBundle] Revert adding `_stateless` attribute to the request when firewall is stateless and the attribute is not already set

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -72,14 +72,7 @@ class FirewallMap implements FirewallMapInterface
             if (null === $requestMatcher || $requestMatcher->matches($request)) {
                 $request->attributes->set('_firewall_context', $contextId);
 
-                /** @var FirewallContext $context */
-                $context = $this->container->get($contextId);
-
-                if ($context->getConfig()?->isStateless() && !$request->attributes->has('_stateless')) {
-                    $request->attributes->set('_stateless', true);
-                }
-
-                return $context;
+                return $this->container->get($contextId);
             }
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -63,7 +63,7 @@ class FirewallMapTest extends TestCase
         $firewallContext = $this->createMock(FirewallContext::class);
 
         $firewallConfig = new FirewallConfig('main', 'user_checker', null, true, true);
-        $firewallContext->expects($this->exactly(2))->method('getConfig')->willReturn($firewallConfig);
+        $firewallContext->expects($this->once())->method('getConfig')->willReturn($firewallConfig);
 
         $listener = function () {};
         $firewallContext->expects($this->once())->method('getListeners')->willReturn([$listener]);
@@ -93,7 +93,7 @@ class FirewallMapTest extends TestCase
 
     public static function providesStatefulStatelessRequests(): \Generator
     {
-        yield [new Request(), true];
+        yield [new Request(), false];
         yield [new Request(attributes: ['_stateless' => false]), false];
         yield [new Request(attributes: ['_stateless' => true]), true];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50715
| License       | MIT

#40372 was about routes matching both stateful and stateless firewalls: you couldn’t easily configure them as stateless under a stateless firewall only.

#48044 fixed it by linking these two attributes: a stateless firewall then implied a stateless request. While it can sound logical, this impacted many projects using the session while authenticating users in a stateless fashion.

At last, #49997 allowed to override this behavior by explicitly configuring routes as *not* stateless. This kind of proved that #48044 was a mistake: you cannot tell a request must be stateless only because it matches a stateless firewall.

As such, this PR reverts #48044 (and consequently #49997) so that configuring routes as stateless is the developers responsibility alone. It also reopens #40372, but I think this issue should be fixed in an opt-in way (with a new `firewall.stateless.with_routes` boolean configuration in the SecurityBundle e.g.).