### PR TITLE
[Serializer] remove custom CSV escape character from tests

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -158,7 +158,7 @@ CSV
         $this->encoder = new CsvEncoder([
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => "'",
-            CsvEncoder::ESCAPE_CHAR_KEY => '|',
+            CsvEncoder::ESCAPE_CHAR_KEY => \PHP_VERSION_ID < 70400 ? '|' : '',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
         ]);
 
@@ -184,7 +184,7 @@ CSV
             , $this->encoder->encode($value, 'csv', [
                 CsvEncoder::DELIMITER_KEY => ';',
                 CsvEncoder::ENCLOSURE_KEY => "'",
-                CsvEncoder::ESCAPE_CHAR_KEY => '|',
+                CsvEncoder::ESCAPE_CHAR_KEY => \PHP_VERSION_ID < 70400 ? '|' : '',
                 CsvEncoder::KEY_SEPARATOR_KEY => '-',
             ]));
     }
@@ -194,7 +194,7 @@ CSV
         $encoder = new CsvEncoder([
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => "'",
-            CsvEncoder::ESCAPE_CHAR_KEY => '|',
+            CsvEncoder::ESCAPE_CHAR_KEY => \PHP_VERSION_ID < 70400 ? '|' : '',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
         ]);
         $value = ['a' => 'he\'llo', 'c' => ['d' => 'foo']];
@@ -583,7 +583,7 @@ CSV
         $this->encoder = new CsvEncoder([
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => "'",
-            CsvEncoder::ESCAPE_CHAR_KEY => '|',
+            CsvEncoder::ESCAPE_CHAR_KEY => \PHP_VERSION_ID < 70400 ? '|' : '',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
         ]);
 
@@ -605,7 +605,7 @@ CSV
             , 'csv', [
                 CsvEncoder::DELIMITER_KEY => ';',
                 CsvEncoder::ENCLOSURE_KEY => "'",
-                CsvEncoder::ESCAPE_CHAR_KEY => '|',
+                CsvEncoder::ESCAPE_CHAR_KEY => \PHP_VERSION_ID < 70400 ? '|' : '',
                 CsvEncoder::KEY_SEPARATOR_KEY => '-',
             ]));
     }
@@ -615,7 +615,7 @@ CSV
         $encoder = new CsvEncoder([
             CsvEncoder::DELIMITER_KEY => ';',
             CsvEncoder::ENCLOSURE_KEY => "'",
-            CsvEncoder::ESCAPE_CHAR_KEY => '|',
+            CsvEncoder::ESCAPE_CHAR_KEY => \PHP_VERSION_ID < 70400 ? '|' : '',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
             CsvEncoder::AS_COLLECTION_KEY => true, // Can be removed in 5.0
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

using custom escape character will be deprecated from PHP 8.4