### PR TITLE
[Mailer] [Brevo] Support the `unique_proxy_open` event

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/RemoteEvent/BrevoPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/RemoteEvent/BrevoPayloadConverter.php
@@ -41,6 +41,7 @@ final class BrevoPayloadConverter implements PayloadConverterInterface
                 'unique_opened' => MailerEngagementEvent::OPEN,
                 'opened' => MailerEngagementEvent::OPEN,
                 'proxy_open' => MailerEngagementEvent::OPEN,
+                'unique_proxy_open' => MailerEngagementEvent::OPEN,
                 'complaint' => MailerEngagementEvent::SPAM,
                 default => throw new ParseException(sprintf('Unsupported event "%s".', $payload['event'])),
             };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Brevo's webhooks are using an event named `unique_proxy_open`, functionally similiar to the `proxy_open` event.

It is not explicitly mentioned in the Documentation but I log many errors concerning this issue.

 

<img width="936" alt="Screenshot 2024-08-17 at 01 53 45" src="https://github.com/user-attachments/assets/765d97f7-13bd-4915-960d-0692d823c9b5">

<img width="819" alt="Screenshot 2024-08-17 at 01 56 58" src="https://github.com/user-attachments/assets/daa703ba-b9e3-426c-8c68-60f12fb42acb">
