### PR TITLE
[TwigBridge] Render a `block` via the `#[Template]` attribute

### DIFF
--- a/src/Symfony/Bridge/Twig/Attribute/Template.php
+++ b/src/Symfony/Bridge/Twig/Attribute/Template.php
@@ -21,11 +21,13 @@ class Template
      * @param string        $template The name of the template to render
      * @param string[]|null $vars     The controller method arguments to pass to the template
      * @param bool          $stream   Enables streaming the template
+     * @param string|null   $block    The name of the block to use in the template
      */
     public function __construct(
         public string $template,
         public ?array $vars = null,
         public bool $stream = false,
+        public ?string $block = null,
     ) {
     }
 }

--- a/src/Symfony/Bridge/Twig/EventListener/TemplateAttributeListener.php
+++ b/src/Symfony/Bridge/Twig/EventListener/TemplateAttributeListener.php
@@ -55,8 +55,16 @@ class TemplateAttributeListener implements EventSubscriberInterface
         }
 
         $event->setResponse($attribute->stream
-            ? new StreamedResponse(fn () => $this->twig->display($attribute->template, $parameters), $status)
-            : new Response($this->twig->render($attribute->template, $parameters), $status)
+         ? new StreamedResponse(
+             null !== $attribute->block
+             ? fn () => $this->twig->load($attribute->template)->displayBlock($attribute->block, $parameters)
+             : fn () => $this->twig->display($attribute->template, $parameters),
+             $status)
+         : new Response(
+             null !== $attribute->block
+                ? $this->twig->load($attribute->template)->renderBlock($attribute->block, $parameters)
+                : $this->twig->render($attribute->template, $parameters),
+             $status)
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/EventListener/TemplateAttributeListenerTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/EventListener/TemplateAttributeListenerTest.php
@@ -17,10 +17,12 @@ use Symfony\Bridge\Twig\EventListener\TemplateAttributeListener;
 use Symfony\Bridge\Twig\Tests\Fixtures\TemplateAttributeController;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class TemplateAttributeListenerTest extends TestCase
 {
@@ -63,6 +65,33 @@ class TemplateAttributeListenerTest extends TestCase
         $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, []);
         $listener->onKernelView($event);
         $this->assertSame('Bar', $event->getResponse()->getContent());
+    }
+
+    public function testAttributeWithBlock()
+    {
+        $twig = new Environment(new ArrayLoader([
+            'foo.html.twig' => 'ERROR {% block bar %}FOOBAR{% endblock %}',
+        ]));
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new TemplateAttributeController(), 'foo'], ['Bar'], $request, null);
+        $listener = new TemplateAttributeListener($twig);
+
+        $request->attributes->set('_template', new Template('foo.html.twig', [], false, 'bar'));
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, ['foo' => 'bar'], $controllerArgumentsEvent);
+        $listener->onKernelView($event);
+        $this->assertSame('FOOBAR', $event->getResponse()->getContent());
+
+        $request->attributes->set('_template', new Template('foo.html.twig', [], true, 'bar'));
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, ['foo' => 'bar'], $controllerArgumentsEvent);
+        $listener->onKernelView($event);
+        $this->assertInstanceOf(StreamedResponse::class, $event->getResponse());
+
+        $request->attributes->set('_template', new Template('foo.html.twig', [], false, 'not_a_block'));
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, ['foo' => 'bar'], $controllerArgumentsEvent);
+        $this->expectExceptionMessage('Block "not_a_block" on template "foo.html.twig" does not exist in "foo.html.twig".');
+        $listener->onKernelView($event);
     }
 
     public function testForm()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

The same way `renderBlock` was added in the [AbstractController](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php#L259), and for the same reasons, this PR adds a `block` parameter on the Template attribute, used by the TemplateAttributeListener.

---

Example taken from the [documentation](https://symfony.com/doc/current/templates.html#rendering-templates)

```php
class ProductController extends AbstractController
{
    #[Template('product/index.html.twig')]
    public function index(): array
    {
        // ...

        // when using the #[Template] attribute, you only need to return
        // an array with the parameters to pass to the template (the attribute
        // is the one which will create and return the Response object).
        return [
            'category' => '...',
            'promotions' => ['...', '...'],
        ];
    }
}
```

With this PR

```php
class ProductController extends AbstractController
{
    #[Template('product/index.html.twig', block: 'main')]
    public function index(): array
    {
        return [
            'category' => '...',
            'promotions' => ['...', '...'],
        ];
    }
}
```

---

🛟 Only problem here, i don't get how to _test_ this properly.. 

`Twig\Template` is abstract, `Twig\TemplateWrapper` is final, and `Environment::load()` must return a `TemplateWrapper`..

I looked at the AbstractController tests but i don't find one covering the load->displayBlock / load->renderBlock.



