### PR TITLE
Future compatibility with function autoloading

### DIFF
--- a/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
@@ -66,7 +66,7 @@ class ClassExistenceResource implements SelfCheckingResourceInterface
                 throw new \ReflectionException($exists[1]);
             }
         } elseif ([false, null] === $exists = [$loaded, null]) {
-            $thrower = fn(string $name) => (__CLASS__.'::throwOnRequiredClass')($name);
+            $thrower = fn(string $name) => self::throwOnRequiredClass($name);
             if (!self::$autoloadLevel++) {
                 spl_autoload_register($thrower);
             }

--- a/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
@@ -66,8 +66,9 @@ class ClassExistenceResource implements SelfCheckingResourceInterface
                 throw new \ReflectionException($exists[1]);
             }
         } elseif ([false, null] === $exists = [$loaded, null]) {
+            $thrower = fn(string $name) => (__CLASS__.'::throwOnRequiredClass')($name);
             if (!self::$autoloadLevel++) {
-                spl_autoload_register(__CLASS__.'::throwOnRequiredClass');
+                spl_autoload_register($thrower);
             }
             $autoloadedClass = self::$autoloadedClass;
             self::$autoloadedClass = ltrim($this->resource, '\\');
@@ -91,7 +92,7 @@ class ClassExistenceResource implements SelfCheckingResourceInterface
             } finally {
                 self::$autoloadedClass = $autoloadedClass;
                 if (!--self::$autoloadLevel) {
-                    spl_autoload_unregister(__CLASS__.'::throwOnRequiredClass');
+                    spl_autoload_unregister($thrower);
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes?
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/php/php-src/pull/15471
| License       | MIT

While working on an RFC (https://wiki.php.net/rfc/function_autoloading4) for function autoloading, I discovered that Symfony registers an autoloader that accepts two arguments. But an autoloader should never accept a second argument for the current implementation, and the implementation may change.