### PR TITLE
[DependencyInjection] Add support for `key-type` in `XmlFileLoader`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate `!tagged` tag, use `!tagged_iterator` instead
  * Add a `ContainerBuilder::registerChild()` shortcut method for registering child definitions
+ * Add support for `key-type` in `XmlFileLoader`
 
 7.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -534,6 +534,21 @@ class XmlFileLoader extends FileLoader
                 $key = $arg->getAttribute('key');
             }
 
+            switch ($arg->getAttribute('key-type')) {
+                case 'binary':
+                    if (false === $key = base64_decode($key, true)) {
+                        throw new InvalidArgumentException(\sprintf('Tag "<%s>" with key-type="binary" does not have a valid base64 encoded key in "%s".', $name, $file));
+                    }
+                    break;
+                case 'constant':
+                    try {
+                        $key = \constant(trim($key));
+                    } catch (\Error) {
+                        throw new InvalidArgumentException(\sprintf('The key "%s" is not a valid constant in "%s".', $key, $file));
+                    }
+                    break;
+            }
+
             $trim = $arg->hasAttribute('trim') && XmlUtils::phpize($arg->getAttribute('trim'));
             $onInvalid = $arg->getAttribute('on-invalid');
             $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -270,6 +270,7 @@
       <xsd:element name="property" type="property" maxOccurs="unbounded" />
       <xsd:element name="service" type="service" />
     </xsd:choice>
+    <xsd:attribute name="key-type" type="key_type" />
     <xsd:attribute name="type" type="argument_type" />
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="key" type="xsd:string" />
@@ -315,6 +316,7 @@
       <xsd:element name="service" type="service" />
       <xsd:element name="exclude" type="xsd:string" maxOccurs="unbounded" />
     </xsd:choice>
+    <xsd:attribute name="key-type" type="key_type" />
     <xsd:attribute name="type" type="argument_type" />
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="key" type="xsd:string" />
@@ -362,6 +364,13 @@
       <xsd:enumeration value="tagged" />
       <xsd:enumeration value="tagged_iterator" />
       <xsd:enumeration value="tagged_locator" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="key_type">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="binary" />
+      <xsd:enumeration value="constant" />
     </xsd:restriction>
   </xsd:simpleType>
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/key_type_argument.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/key_type_argument.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar">
+      <argument type="collection">
+        <argument key-type="constant" key="PHP_INT_MAX">Value 1</argument>
+        <argument key="PHP_INT_MAX">Value 2</argument>
+        <argument key-type="binary" key="AQID">Value 3</argument>
+      </argument>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/key_type_incorrect_bin.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/key_type_incorrect_bin.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar">
+      <property key-type="binary" key="My_Key">Value 3</property>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/key_type_property.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/key_type_property.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar">
+      <property type="collection" key="quz">
+        <property key-type="constant" key="PHP_INT_MAX">Value 1</property>
+        <property key="PHP_INT_MAX">Value 2</property>
+        <property key-type="binary" key="AQID">Value 3</property>
+      </property>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/key_type_wrong_constant.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/key_type_wrong_constant.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar">
+      <property type="collection" key="quz">
+        <property key-type="constant" key="PHP_Unknown_CONST">Value 1</property>
+      </property>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -1280,6 +1280,54 @@ class XmlFileLoaderTest extends TestCase
         $loader->load('static_constructor_and_factory.xml');
     }
 
+    public function testArgumentKeyType()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('key_type_argument.xml');
+
+        $definition = $container->getDefinition('foo');
+        $this->assertSame([
+            \PHP_INT_MAX => 'Value 1',
+            'PHP_INT_MAX' => 'Value 2',
+            "\x01\x02\x03" => 'Value 3',
+        ], $definition->getArgument(0));
+    }
+
+    public function testPropertyKeyType()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('key_type_property.xml');
+
+        $definition = $container->getDefinition('foo');
+        $this->assertSame([
+            \PHP_INT_MAX => 'Value 1',
+            'PHP_INT_MAX' => 'Value 2',
+            "\x01\x02\x03" => 'Value 3',
+        ], $definition->getProperties()['quz']);
+    }
+
+    public function testInvalidBinaryKeyType()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('Tag "<property>" with key-type="binary" does not have a valid base64 encoded key in "%s".', self::$fixturesPath.'/xml/key_type_incorrect_bin.xml'));
+        $loader->load('key_type_incorrect_bin.xml');
+    }
+
+    public function testUnknownConstantAsKey()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The key "PHP_Unknown_CONST" is not a valid constant in "%s".', self::$fixturesPath.'/xml/key_type_wrong_constant.xml'));
+        $loader->load('key_type_wrong_constant.xml');
+    }
+
     /**
      * @group legacy
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #45708
| License       | MIT

Quoting the tests to show how this works:

```xml
<?xml version="1.0" encoding="utf-8"?>
<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
  <services>
    <service id="foo" class="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar">
      <argument type="collection">
        <argument key-type="constant" key="PHP_INT_MAX">Value 1</argument>
        <argument key="PHP_INT_MAX">Value 2</argument>
        <argument key-type="binary" key="AQID">Value 3</argument>
      </argument>
    </service>
  </services>
</container>
```

Makes the following pass:

```php
    public function testArgumentKeyType()
    {
        // ...

        $definition = $container->getDefinition('foo');
        $this->assertSame([
            \PHP_INT_MAX => 'Value 1',
            'PHP_INT_MAX' => 'Value 2',
            "\x01\x02\x03" => 'Value 3',
        ], $definition->getArgument(0));
    }
```