### PR TITLE
[HttpKernel] Use TypeInfo for `#[MapRequestPayload]` type resolution

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -29,6 +29,11 @@ FrameworkBundle
 
  * [BC BREAK] The `secrets:decrypt-to-local` command terminates with a non-zero exit code when a secret could not be read
 
+HttpKernel
+----------
+
+ * Deprecate the `$type` parameter of `#[MapRequestPayload]`, use the TypeInfo component for automatic type detection instead
+
 Messenger
 ---------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -46,6 +46,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('monolog.logger', ['channel' => 'request'])
 
         ->set('argument_metadata_factory', ArgumentMetadataFactory::class)
+            ->args([
+                service('type_info.resolver')->nullOnInvalid(),
+            ])
 
         ->set('argument_resolver', ArgumentResolver::class)
             ->args([

--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
@@ -40,8 +40,13 @@ class MapRequestPayload extends ValueResolver
         public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
         public readonly int $validationFailedStatusCode = Response::HTTP_UNPROCESSABLE_ENTITY,
+        /** @deprecated since Symfony 7.2 */
         public readonly ?string $type = null,
     ) {
+        if ($type) {
+            trigger_deprecation('symfony/http-kernel', '7.2', 'The "type" parameter of the #[MapRequestPayload] attribute is deprecated and will be removed in Symfony 8.0. Try running "composer require symfony/type-info phpstan/phpdoc-parser" to get automatic type detection instead.');
+        }
+
         parent::__construct($resolver);
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Remove `@internal` flag and add `@final` to `ServicesResetter`
+ * Deprecate the `$type` parameter of `#[MapRequestPayload]`, use the TypeInfo component for automatic type detection instead
 
 7.1
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -83,6 +83,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             throw new \LogicException(\sprintf('Mapping variadic argument "$%s" is not supported.', $argument->getName()));
         }
 
+        // @deprecated since Symfony 7.2, remove the if statement in 8.0
         if ($attribute instanceof MapRequestPayload) {
             if ('array' === $argument->getType()) {
                 if (!$attribute->type) {
@@ -202,6 +203,8 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             throw new UnsupportedMediaTypeHttpException(\sprintf('Unsupported format, expects "%s", but "%s" given.', implode('", "', (array) $attribute->acceptFormat), $format));
         }
 
+        // @deprecated since Symfony 7.2. In 8.0, replace the whole if/else block by:
+        // $type = $argument->getType();
         if ('array' === $argument->getType() && null !== $attribute->type) {
             $type = $attribute->type.'[]';
         } else {

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\AttributeController;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\BasicTypesController;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\NullableController;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\VariadicController;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 
 class ArgumentMetadataFactoryTest extends TestCase
 {
@@ -151,6 +152,24 @@ class ArgumentMetadataFactoryTest extends TestCase
         ], $arguments);
     }
 
+    public function testListOfObjectsWithTypeInfo()
+    {
+        $arguments = (new ArgumentMetadataFactory(TypeResolver::create()))->createArgumentMetadata([$this, 'listOfObjects']);
+        $this->assertEquals([
+            new ArgumentMetadata('products', DummyProduct::class.'[]', false, false, null, false, [], controllerName: $this::class.'::listOfObjects'),
+            new ArgumentMetadata('bar', null, false, true, null, controllerName: $this::class.'::listOfObjects'),
+        ], $arguments);
+    }
+
+    public function testListOfObjectsWithoutTypeInfo()
+    {
+        $arguments = $this->factory->createArgumentMetadata([$this, 'listOfObjects']);
+        $this->assertEquals([
+            new ArgumentMetadata('products', 'array', false, false, null, false, [], controllerName: $this::class.'::listOfObjects'),
+            new ArgumentMetadata('bar', null, false, true, null, controllerName: $this::class.'::listOfObjects'),
+        ], $arguments);
+    }
+
     public function signature1(self $foo, array $bar, callable $baz)
     {
     }
@@ -170,4 +189,16 @@ class ArgumentMetadataFactoryTest extends TestCase
     public function signature5(?array $foo = null, $bar = null)
     {
     }
+
+    /**
+     * @param DummyProduct[] $products
+     */
+    public function listOfObjects(array $products, $bar = null)
+    {
+    }
+}
+
+class DummyProduct
+{
+    public $price;
 }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -25,6 +25,7 @@
         "psr/log": "^1|^2|^3"
     },
     "require-dev": {
+        "phpstan/phpdoc-parser": "^1.0",
         "symfony/browser-kit": "^6.4|^7.0",
         "symfony/clock": "^6.4|^7.0",
         "symfony/config": "^6.4|^7.0",
@@ -42,6 +43,7 @@
         "symfony/stopwatch": "^6.4|^7.0",
         "symfony/translation": "^6.4|^7.0",
         "symfony/translation-contracts": "^2.5|^3",
+        "symfony/type-info": "^7.2",
         "symfony/uid": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",
@@ -67,6 +69,7 @@
         "symfony/translation": "<6.4",
         "symfony/translation-contracts": "<2.5",
         "symfony/twig-bridge": "<6.4",
+        "symfony/type-info": "<7.2",
         "symfony/validator": "<6.4",
         "symfony/var-dumper": "<6.4",
         "twig/twig": "<3.0.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Simplifying mapping request parameters to object lists.  Before/After:

```diff
    /**
     * @param Product[] $products
     */
    #[Route(path: "/products", methods: "POST")]
    public function __invoke(
-        #[MapRequestPayload(type: Product::class)] array $products,
+        #[MapRequestPayload] array $products,
    ): Response {
    }
```

/cc @yceruto @mtarld 