### PR TITLE
[HttpFoundation] Add optional `$v4Bytes` and `$v6Bytes` parameters to `IpUtils::anonymize()`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 7.2
 ---
 
- * Add optional `$requests` argument to `RequestStack::__construct()`
+ * Add optional `$requests` parameter to `RequestStack::__construct()`
+ * Add optional `$v4Bytes` and `$v6Bytes` parameters to `IpUtils::anonymize()`
 
 7.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | on
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #50778
| License       | MIT
| Doc PR | https://github.com/symfony/symfony-docs/pull/20138

This PR answers to the need of more anonymization of IP addresses. This adds 2 new parameters to the `IpUtils::anonymize()` that you can use this way:

```php
$ipv4 = '123.234.235.236';
$anonymousIpv4 = IpUtils::anonymize($ipv4, v4Bytes: 3);
// $anonymousIpv4 = '123.0.0.0'

$ipv6 = '2a01:198:603:10:396e:4789:8e99:890f';
$anonymousIpv6 = IpUtils::anonymize($ipv6, v6Bytes: 10);
// $anonymousIpv6 = '2a01:198:603::'
```