### PR TITLE
[Ldap] Add support for `sasl_bind` and `whoami` LDAP operations

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -29,6 +29,11 @@ FrameworkBundle
 
  * [BC BREAK] The `secrets:decrypt-to-local` command terminates with a non-zero exit code when a secret could not be read
 
+Ldap
+----
+
+ * Add methods for `saslBind()` and `whoami()` to `ConnectionInterface` and `LdapInterface`
+
 Messenger
 ---------
 

--- a/src/Symfony/Component/Ldap/Adapter/ConnectionInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/ConnectionInterface.php
@@ -14,9 +14,13 @@ namespace Symfony\Component\Ldap\Adapter;
 use Symfony\Component\Ldap\Exception\AlreadyExistsException;
 use Symfony\Component\Ldap\Exception\ConnectionTimeoutException;
 use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
+use Symfony\Component\Ldap\Exception\LdapException;
 
 /**
  * @author Charles Sarrazin <charles@sarraz.in>
+ *
+ * @method void   saslBind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authcId = null, ?string $authzId = null, ?string $props =  null)
+ * @method string whoami()
  */
 interface ConnectionInterface
 {
@@ -33,4 +37,19 @@ interface ConnectionInterface
      * @throws InvalidCredentialsException When the connection can't be created because of an LDAP_INVALID_CREDENTIALS error
      */
     public function bind(?string $dn = null, #[\SensitiveParameter] ?string $password = null): void;
+
+    /*
+     * Binds the connection against a user's DN and password using SASL.
+     *
+     * @throws LdapException               When SASL support is not available
+     * @throws AlreadyExistsException      When the connection can't be created because of an LDAP_ALREADY_EXISTS error
+     * @throws ConnectionTimeoutException  When the connection can't be created because of an LDAP_TIMEOUT error
+     * @throws InvalidCredentialsException When the connection can't be created because of an LDAP_INVALID_CREDENTIALS error
+     */
+     // public function saslBind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authcId = null, ?string $authzId = null, ?string $props = null): void;
+
+    /*
+     * Return authenticated and authorized (for SASL) DN.
+     */
+     // public function whoami(): string;
 }

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add methods for `saslBind()` and `whoami()` to `ConnectionInterface` and `LdapInterface`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Ldap/Ldap.php
+++ b/src/Symfony/Component/Ldap/Ldap.php
@@ -32,6 +32,16 @@ final class Ldap implements LdapInterface
         $this->adapter->getConnection()->bind($dn, $password);
     }
 
+    public function saslBind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authcId = null, ?string $authzId = null, ?string $props = null): void
+    {
+        $this->adapter->getConnection()->saslBind($dn, $password, $mech, $realm, $authcId, $authzId, $props);
+    }
+
+    public function whoami(): string
+    {
+        return $this->adapter->getConnection()->whoami();
+    }
+
     public function query(string $dn, string $query, array $options = []): QueryInterface
     {
         return $this->adapter->createQuery($dn, $query, $options);

--- a/src/Symfony/Component/Ldap/LdapInterface.php
+++ b/src/Symfony/Component/Ldap/LdapInterface.php
@@ -16,9 +16,10 @@ use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Exception\ConnectionException;
 
 /**
- * Ldap interface.
- *
  * @author Charles Sarrazin <charles@sarraz.in>
+ *
+ * @method void   saslBind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authcId = null, ?string $authzId = null, ?string $props =  null)
+ * @method string whoami()
  */
 interface LdapInterface
 {
@@ -26,11 +27,23 @@ interface LdapInterface
     public const ESCAPE_DN = 0x02;
 
     /**
-     * Return a connection bound to the ldap.
+     * Returns a connection bound to the ldap.
      *
      * @throws ConnectionException if dn / password could not be bound
      */
     public function bind(?string $dn = null, #[\SensitiveParameter] ?string $password = null): void;
+
+    /**
+     * Returns a connection bound to the ldap using SASL.
+     *
+     * @throws ConnectionException if dn / password could not be bound
+     */
+     // public function saslBind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authcId = null, ?string $authzId = null, ?string $props = null): void;
+
+    /**
+     * Returns authenticated and authorized (for SASL) DN.
+     */
+     // public function whoami(): string;
 
     /**
      * Queries a ldap server for entries matching the given criteria.

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -37,6 +37,17 @@ class AdapterTest extends LdapTestCase
     /**
      * @group functional
      */
+    public function testSaslBind()
+    {
+        $ldap = new Adapter($this->getLdapConfig());
+
+        $ldap->getConnection()->saslBind('cn=admin,dc=symfony,dc=com', 'symfony');
+        $this->assertEquals('cn=admin,dc=symfony,dc=com', $ldap->getConnection()->whoami());
+    }
+
+    /**
+     * @group functional
+     */
     public function testLdapQuery()
     {
         $ldap = new Adapter($this->getLdapConfig());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

    SASL bind let the caller supply various options, including proxy
    authentication, where one user uses its own credentials to login
    as another one (subjected to LDAP directory access contro usingl
    authzFrom/authzTo attributes). In this case, ldapwhoami is used
    to retreive the resulting authenticated and authorized DN after
    bind success.
    
    Tested with SimpleSAMLphp 2.2.2 with minor patches.

