### PR TITLE
[Webhook] Pass original request to `RequestParserInterface`

### DIFF
--- a/src/Symfony/Component/Webhook/CHANGELOG.md
+++ b/src/Symfony/Component/Webhook/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `PayloadSerializerInterface` with implementations to decouple the remote event handling from the Serializer component
+ * Add optional `$request` argument to `RequestParserInterface::createSuccessfulResponse()` and `RequestParserInterface::createRejectedResponse()`
 
 6.4
 ---

--- a/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
+++ b/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
@@ -29,12 +29,18 @@ abstract class AbstractRequestParser implements RequestParserInterface
         return $this->doParse($request, $secret);
     }
 
-    public function createSuccessfulResponse(): Response
+    /**
+     * @param Request|null $request The original request that was received by the webhook controller
+     */
+    public function createSuccessfulResponse(/* ?Request $request = null */): Response
     {
         return new Response('', 202);
     }
 
-    public function createRejectedResponse(string $reason): Response
+    /**
+     * @param Request|null $request The original request that was received by the webhook controller
+     */
+    public function createRejectedResponse(string $reason/* , ?Request $request = null */): Response
     {
         return new Response($reason, 406);
     }

--- a/src/Symfony/Component/Webhook/Client/RequestParserInterface.php
+++ b/src/Symfony/Component/Webhook/Client/RequestParserInterface.php
@@ -30,7 +30,13 @@ interface RequestParserInterface
      */
     public function parse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent;
 
-    public function createSuccessfulResponse(): Response;
+    /**
+     * @param Request|null $request The original request that was received by the webhook controller
+     */
+    public function createSuccessfulResponse(/* ?Request $request = null */): Response;
 
-    public function createRejectedResponse(string $reason): Response;
+    /**
+     * @param Request|null $request The original request that was received by the webhook controller
+     */
+    public function createRejectedResponse(string $reason/* , ?Request $request = null */): Response;
 }

--- a/src/Symfony/Component/Webhook/Controller/WebhookController.php
+++ b/src/Symfony/Component/Webhook/Controller/WebhookController.php
@@ -42,11 +42,11 @@ final class WebhookController
         $parser = $this->parsers[$type]['parser'];
 
         if (!$event = $parser->parse($request, $this->parsers[$type]['secret'])) {
-            return $parser->createRejectedResponse('Unable to parse the webhook payload.');
+            return $parser->createRejectedResponse('Unable to parse the webhook payload.', $request);
         }
 
         $this->bus->dispatch(new ConsumeRemoteEventMessage($type, $event));
 
-        return $parser->createSuccessfulResponse();
+        return $parser->createSuccessfulResponse($request);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57195
| License       | MIT

Allows to forge the success/failure response of the webhook depending on the data of the request received by the webhook controller.