### PR TITLE
[ExpressionLanguage] Add support for `<<`, `>>`, and `~` bitwise operators

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add support for null-coalescing unknown variables
  * Add support for comments using `/*` & `*/`
  * Allow passing any iterable as `$providers` list to `ExpressionLanguage` constructor
+ * Add support for `<<`, `>>`, and `~` bitwise operators
 
 7.1
 ---

--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -72,7 +72,7 @@ class Lexer
             } elseif (preg_match('{/\*.*?\*/}A', $expression, $match, 0, $cursor)) {
                 // comments
                 $cursor += \strlen($match[0]);
-            } elseif (preg_match('/(?<=^|[\s(])starts with(?=[\s(])|(?<=^|[\s(])ends with(?=[\s(])|(?<=^|[\s(])contains(?=[\s(])|(?<=^|[\s(])matches(?=[\s(])|(?<=^|[\s(])not in(?=[\s(])|(?<=^|[\s(])not(?=[\s(])|(?<=^|[\s(])and(?=[\s(])|\=\=\=|\!\=\=|(?<=^|[\s(])or(?=[\s(])|\|\||&&|\=\=|\!\=|\>\=|\<\=|(?<=^|[\s(])in(?=[\s(])|\.\.|\*\*|\!|\||\^|&|\<|\>|\+|\-|~|\*|\/|%/A', $expression, $match, 0, $cursor)) {
+            } elseif (preg_match('/(?<=^|[\s(])starts with(?=[\s(])|(?<=^|[\s(])ends with(?=[\s(])|(?<=^|[\s(])contains(?=[\s(])|(?<=^|[\s(])matches(?=[\s(])|(?<=^|[\s(])not in(?=[\s(])|(?<=^|[\s(])not(?=[\s(])|(?<=^|[\s(])and(?=[\s(])|\=\=\=|\!\=\=|(?<=^|[\s(])or(?=[\s(])|\|\||&&|\=\=|\!\=|\>\=|\<\=|(?<=^|[\s(])in(?=[\s(])|\.\.|\*\*|\!|\||\^|&|<<|>>|\<|\>|\+|\-|~|\*|\/|%/A', $expression, $match, 0, $cursor)) {
                 // operators
                 $tokens[] = new Token(Token::OPERATOR_TYPE, $match[0], $cursor + 1);
                 $cursor += \strlen($match[0]);

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -130,6 +130,10 @@ class BinaryNode extends Node
                 return $left ^ $right;
             case '&':
                 return $left & $right;
+            case '<<':
+                return $left << $right;
+            case '>>':
+                return $left >> $right;
             case '==':
                 return $left == $right;
             case '===':

--- a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
@@ -25,6 +25,7 @@ class UnaryNode extends Node
         'not' => '!',
         '+' => '+',
         '-' => '-',
+        '~' => '~',
     ];
 
     public function __construct(string $operator, Node $node)
@@ -53,6 +54,7 @@ class UnaryNode extends Node
             'not',
             '!' => !$value,
             '-' => -$value,
+            '~' => ~$value,
             default => $value,
         };
     }

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -43,6 +43,7 @@ class Parser
             '!' => ['precedence' => 50],
             '-' => ['precedence' => 500],
             '+' => ['precedence' => 500],
+            '~' => ['precedence' => 500],
         ];
         $this->binaryOperators = [
             'or' => ['precedence' => 10, 'associativity' => self::OPERATOR_LEFT],
@@ -67,6 +68,8 @@ class Parser
             'ends with' => ['precedence' => 20, 'associativity' => self::OPERATOR_LEFT],
             'matches' => ['precedence' => 20, 'associativity' => self::OPERATOR_LEFT],
             '..' => ['precedence' => 25, 'associativity' => self::OPERATOR_LEFT],
+            '<<' => ['precedence' => 25, 'associativity' => self::OPERATOR_LEFT],
+            '>>' => ['precedence' => 25, 'associativity' => self::OPERATOR_LEFT],
             '+' => ['precedence' => 30, 'associativity' => self::OPERATOR_LEFT],
             '-' => ['precedence' => 30, 'associativity' => self::OPERATOR_LEFT],
             '~' => ['precedence' => 40, 'associativity' => self::OPERATOR_LEFT],

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -97,8 +97,11 @@ class LexerTest extends TestCase
                     new Token('punctuation', ']', 27),
                     new Token('operator', '-', 29),
                     new Token('number', 1990, 31),
+                    new Token('operator', '+', 39),
+                    new Token('operator', '~', 41),
+                    new Token('name', 'qux', 42),
                 ],
-                '(3 + 5) ~ foo("bar").baz[4] - 1.99E+3',
+                '(3 + 5) ~ foo("bar").baz[4] - 1.99E+3 + ~qux',
             ],
             [
                 [new Token('operator', '..', 1)],

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -35,6 +35,8 @@ class BinaryNodeTest extends AbstractNodeTestCase
             [0, new BinaryNode('&', new ConstantNode(2), new ConstantNode(4))],
             [6, new BinaryNode('|', new ConstantNode(2), new ConstantNode(4))],
             [6, new BinaryNode('^', new ConstantNode(2), new ConstantNode(4))],
+            [32, new BinaryNode('<<', new ConstantNode(2), new ConstantNode(4))],
+            [2, new BinaryNode('>>', new ConstantNode(32), new ConstantNode(4))],
 
             [true, new BinaryNode('<', new ConstantNode(1), new ConstantNode(2))],
             [true, new BinaryNode('<=', new ConstantNode(1), new ConstantNode(2))],
@@ -90,6 +92,8 @@ class BinaryNodeTest extends AbstractNodeTestCase
             ['(2 & 4)', new BinaryNode('&', new ConstantNode(2), new ConstantNode(4))],
             ['(2 | 4)', new BinaryNode('|', new ConstantNode(2), new ConstantNode(4))],
             ['(2 ^ 4)', new BinaryNode('^', new ConstantNode(2), new ConstantNode(4))],
+            ['(2 << 4)', new BinaryNode('<<', new ConstantNode(2), new ConstantNode(4))],
+            ['(32 >> 4)', new BinaryNode('>>', new ConstantNode(32), new ConstantNode(4))],
 
             ['(1 < 2)', new BinaryNode('<', new ConstantNode(1), new ConstantNode(2))],
             ['(1 <= 2)', new BinaryNode('<=', new ConstantNode(1), new ConstantNode(2))],
@@ -142,6 +146,8 @@ class BinaryNodeTest extends AbstractNodeTestCase
             ['(2 & 4)', new BinaryNode('&', new ConstantNode(2), new ConstantNode(4))],
             ['(2 | 4)', new BinaryNode('|', new ConstantNode(2), new ConstantNode(4))],
             ['(2 ^ 4)', new BinaryNode('^', new ConstantNode(2), new ConstantNode(4))],
+            ['(2 << 4)', new BinaryNode('<<', new ConstantNode(2), new ConstantNode(4))],
+            ['(32 >> 4)', new BinaryNode('>>', new ConstantNode(32), new ConstantNode(4))],
 
             ['(1 < 2)', new BinaryNode('<', new ConstantNode(1), new ConstantNode(2))],
             ['(1 <= 2)', new BinaryNode('<=', new ConstantNode(1), new ConstantNode(2))],

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/UnaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/UnaryNodeTest.php
@@ -23,6 +23,7 @@ class UnaryNodeTest extends AbstractNodeTestCase
             [3, new UnaryNode('+', new ConstantNode(3))],
             [false, new UnaryNode('!', new ConstantNode(true))],
             [false, new UnaryNode('not', new ConstantNode(true))],
+            [-6, new UnaryNode('~', new ConstantNode(5))],
         ];
     }
 
@@ -33,6 +34,7 @@ class UnaryNodeTest extends AbstractNodeTestCase
             ['(+3)', new UnaryNode('+', new ConstantNode(3))],
             ['(!true)', new UnaryNode('!', new ConstantNode(true))],
             ['(!true)', new UnaryNode('not', new ConstantNode(true))],
+            ['(~5)', new UnaryNode('~', new ConstantNode(5))],
         ];
     }
 
@@ -43,6 +45,7 @@ class UnaryNodeTest extends AbstractNodeTestCase
             ['(+ 3)', new UnaryNode('+', new ConstantNode(3))],
             ['(! true)', new UnaryNode('!', new ConstantNode(true))],
             ['(not true)', new UnaryNode('not', new ConstantNode(true))],
+            ['(~ 5)', new UnaryNode('~', new ConstantNode(5))],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

In order to fully support [this idea](https://github.com/symfony/symfony/pull/57522#issuecomment-2302462105), I suggest adding to ExpressionLanguage the 3 currently missing bitwise operators, namely left shift, right shift and binary not.

```php
use Symfony\Component\ExpressionLanguage\ExpressionLanguage;

require 'vendor/autoload.php';

$el = new ExpressionLanguage();

$el->evaluate('1 << 4'); // 16
$el->evaluate('32 >> 4'); // 2
$el->evaluate('~5'); // -6
```