### PR TITLE
[Form] Remove stalled PHP bug mentions

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -120,16 +120,10 @@ class DateType extends AbstractType
                 \Locale::getDefault(),
                 $dateFormat,
                 $timeFormat,
-                // see https://bugs.php.net/66323
-                class_exists(\IntlTimeZone::class, false) ? \IntlTimeZone::createDefault() : null,
+                null,
                 $calendar,
                 $pattern
             );
-
-            // new \IntlDateFormatter may return null instead of false in case of failure, see https://bugs.php.net/66323
-            if (!$formatter) {
-                throw new InvalidOptionsException(intl_get_error_message(), intl_get_error_code());
-            }
 
             $formatter->setLenient(false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
@@ -444,6 +445,14 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
             (new DateTimeToLocalizedStringTransformer(calendar: \IntlDateFormatter::GREGORIAN, pattern: "y-MM-dd y'w'w"))->transform($now),
             (new DateTimeToLocalizedStringTransformer(pattern: "y-MM-dd y'w'w"))->transform($now),
         );
+    }
+
+    public function testInvalidCalendar()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "calendar" option should be either an \IntlDateFormatter constant or an \IntlCalendar instance.');
+
+        new DateTimeToLocalizedStringTransformer(calendar: 123456);
     }
 
     protected function createDateTimeTransformer(?string $inputTimezone = null, ?string $outputTimezone = null): BaseDateTimeTransformer


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The [bug linked](https://bugs.php.net/bug.php?id=66323) in these occurrences is stalled: https://3v4l.org/hC1MO. It now throws an exception on invalid timezone.

In `DateTimeToLocalizedStringTransformer`,  the exception cannot be thrown because timezone are check in the parent constructor call.

In `DateType`, passing `null` to `timezone` results on using the default locale.