### PR TITLE
[Serializer] Add SnakeCaseToCamelCaseNameConverter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * [BC BREAK] The `secrets:decrypt-to-local` command terminates with a non-zero exit code when a secret could not be read
  * Deprecate making `cache.app` adapter taggable, use the `cache.app.taggable` adapter instead
  * Enable `json_decode_detailed_errors` in the default serializer context in debug mode by default when `seld/jsonlint` is installed
+ * Register `Symfony\Component\Serializer\NameConverter\SnakeCaseToCamelCaseNameConverter` as a service named `serializer.name_converter.snake_case_to_camel_case` if available
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -158,6 +158,7 @@ use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
+use Symfony\Component\Serializer\NameConverter\SnakeCaseToCamelCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
@@ -1847,6 +1848,11 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(Headers::class)) {
             $container->removeDefinition('serializer.normalizer.mime_message');
+        }
+
+        // BC layer Serializer < 7.2
+        if (!class_exists(SnakeCaseToCamelCaseNameConverter::class)) {
+            $container->removeDefinition('serializer.name_converter.snake_case_to_camel_case');
         }
 
         if ($container->getParameter('kernel.debug')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -31,6 +31,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
+use Symfony\Component\Serializer\NameConverter\SnakeCaseToCamelCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
@@ -186,8 +187,9 @@ return static function (ContainerConfigurator $container) {
         ->set('serializer.encoder.csv', CsvEncoder::class)
             ->tag('serializer.encoder')
 
-        // Name converter
+        // Name converters
         ->set('serializer.name_converter.camel_case_to_snake_case', CamelCaseToSnakeCaseNameConverter::class)
+        ->set('serializer.name_converter.snake_case_to_camel_case', SnakeCaseToCamelCaseNameConverter::class)
 
         ->set('serializer.name_converter.metadata_aware', MetadataAwareNameConverter::class)
             ->args([service('serializer.mapping.class_metadata_factory')])

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate the `csv_escape_char` context option of `CsvEncoder` and the `CsvEncoder::ESCAPE_CHAR_KEY` constant
  * Deprecate `CsvEncoderContextBuilder::withEscapeChar()` method
+ * Add `SnakeCaseToCamelCaseNameConverter`
 
 7.1
 ---

--- a/src/Symfony/Component/Serializer/NameConverter/SnakeCaseToCamelCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/SnakeCaseToCamelCaseNameConverter.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\NameConverter;
+
+use Symfony\Component\Serializer\Exception\UnexpectedPropertyException;
+
+/**
+ * Underscore to camelCase name converter.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+final readonly class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
+{
+    /**
+     * Require all properties to be written in camelCase.
+     */
+    public const REQUIRE_CAMEL_CASE_PROPERTIES = 'require_camel_case_properties';
+
+    /**
+     * @param string[]|null $attributes     The list of attributes to rename or null for all attributes
+     * @param bool          $lowerCamelCase Use lowerCamelCase style
+     */
+    public function __construct(
+        private ?array $attributes = null,
+        private bool $lowerCamelCase = true,
+    ) {
+    }
+
+    /**
+     * @param class-string|null    $class
+     * @param array<string, mixed> $context
+     */
+    public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+    {
+        if (null !== $this->attributes && !\in_array($propertyName, $this->attributes, true)) {
+            return $propertyName;
+        }
+
+        $camelCasedName = preg_replace_callback(
+            '/(^|_|\.)+(.)/',
+            fn ($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]),
+            $propertyName
+        );
+
+        if ($this->lowerCamelCase) {
+            $camelCasedName = lcfirst($camelCasedName);
+        }
+
+        return $camelCasedName;
+    }
+
+    /**
+     * @param class-string|null    $class
+     * @param array<string, mixed> $context
+     */
+    public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+    {
+        if (($context[self::REQUIRE_CAMEL_CASE_PROPERTIES] ?? false) && $propertyName !== $this->normalize($propertyName, $class, $format, $context)) {
+            throw new UnexpectedPropertyException($propertyName);
+        }
+
+        $snakeCased = strtolower(preg_replace('/[A-Z]/', '_\\0', lcfirst($propertyName)));
+        if (null === $this->attributes || \in_array($snakeCased, $this->attributes, true)) {
+            return $snakeCased;
+        }
+
+        return $propertyName;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/SnakeCaseToCamelCaseNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/SnakeCaseToCamelCaseNameConverterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\NameConverter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\UnexpectedPropertyException;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\NameConverter\SnakeCaseToCamelCaseNameConverter;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Aurélien Pillevesse <aurelienpillevesse@hotmail.fr>
+ */
+class SnakeCaseToCamelCaseNameConverterTest extends TestCase
+{
+    public function testInterface()
+    {
+        $attributeMetadata = new SnakeCaseToCamelCaseNameConverter();
+        $this->assertInstanceOf(NameConverterInterface::class, $attributeMetadata);
+    }
+
+    /**
+     * @dataProvider Symfony\Component\Serializer\Tests\NameConverter\CamelCaseToSnakeCaseNameConverterTest::attributeProvider
+     */
+    public function testNormalize($underscored, $camelCased, $useLowerCamelCase)
+    {
+        $nameConverter = new SnakeCaseToCamelCaseNameConverter(null, $useLowerCamelCase);
+        $this->assertEquals($camelCased, $nameConverter->normalize($underscored));
+    }
+
+    /**
+     * @dataProvider Symfony\Component\Serializer\Tests\NameConverter\CamelCaseToSnakeCaseNameConverterTest::attributeProvider
+     */
+    public function testDenormalize($underscored, $camelCased, $useLowerCamelCase)
+    {
+        $nameConverter = new SnakeCaseToCamelCaseNameConverter(null, $useLowerCamelCase);
+        $this->assertEquals($underscored, $nameConverter->denormalize($camelCased));
+    }
+
+    public function testDenormalizeWithContext()
+    {
+        $nameConverter = new SnakeCaseToCamelCaseNameConverter(null, true);
+        $denormalizedValue = $nameConverter->denormalize('lastName', null, null, [SnakeCaseToCamelCaseNameConverter::REQUIRE_CAMEL_CASE_PROPERTIES => true]);
+
+        $this->assertSame('last_name', $denormalizedValue);
+    }
+
+    public function testErrorDenormalizeWithContext()
+    {
+        $nameConverter = new SnakeCaseToCamelCaseNameConverter(null, true);
+
+        $this->expectException(UnexpectedPropertyException::class);
+        $nameConverter->denormalize('last_name', null, null, [SnakeCaseToCamelCaseNameConverter::REQUIRE_CAMEL_CASE_PROPERTIES => true]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

Using snake_cased properties in PHP classes is a popular convention. For instance, it is used by Eloquent (the Laravel ORM). This new name converter makes it easier to use the Symfony Serializer with class following this convention.

This name converter mirrors the existing `CamelCaseToSnakeCaseNameConverter` behavior and uses the same dataset in tests.