### PR TITLE
[Validator] Add `$groups` and `$payload` to `Compound` constructor

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Compound.php
+++ b/src/Symfony/Component/Validator/Constraints/Compound.php
@@ -24,7 +24,7 @@ abstract class Compound extends Composite
     /** @var Constraint[] */
     public array $constraints = [];
 
-    public function __construct(mixed $options = null)
+    public function __construct(mixed $options = null, ?array $groups = null, mixed $payload = null)
     {
         if (isset($options[$this->getCompositeOption()])) {
             throw new ConstraintDefinitionException(\sprintf('You can\'t redefine the "%s" option. Use the "%s::getConstraints()" method instead.', $this->getCompositeOption(), __CLASS__));
@@ -32,7 +32,7 @@ abstract class Compound extends Composite
 
         $this->constraints = $this->getConstraints($this->normalizeOptions($options));
 
-        parent::__construct($options);
+        parent::__construct($options, $groups, $payload);
     }
 
     final protected function getCompositeOption(): string

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompoundTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompoundTest.php
@@ -26,6 +26,24 @@ class CompoundTest extends TestCase
         new EmptyCompound(['constraints' => [new NotBlank()]]);
     }
 
+    public function testGroupsAndPayload()
+    {
+        $payload = new \stdClass();
+        $compound = new EmptyCompound(groups: ['my-group', 'my-other-group'], payload: $payload);
+
+        $this->assertSame(['my-group', 'my-other-group'], $compound->groups);
+        $this->assertSame($payload, $compound->payload);
+    }
+
+    public function testGroupsAndPayloadInOptionsArray()
+    {
+        $payload = new \stdClass();
+        $compound = new EmptyCompound(['groups' => ['my-group', 'my-other-group'], 'payload' => $payload]);
+
+        $this->assertSame(['my-group', 'my-other-group'], $compound->groups);
+        $this->assertSame($payload, $compound->payload);
+    }
+
     public function testCanDependOnNormalizedOptions()
     {
         $constraint = new ForwardingOptionCompound($min = 3);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

While reviewing #49547 I noticed that the `$groups` and `$payload` parameters introduced in #41994 cannot be leveraged in compound constraints. I'd like to change that.