### PR TITLE
[Validator] Add `@template` on `CompoundConstraintTestCase`

### DIFF
--- a/src/Symfony/Component/Validator/Test/CompoundConstraintTestCase.php
+++ b/src/Symfony/Component/Validator/Test/CompoundConstraintTestCase.php
@@ -27,6 +27,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * A test case to ease testing Compound Constraints.
  *
  * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @template T of Compound
  */
 abstract class CompoundConstraintTestCase extends TestCase
 {
@@ -119,5 +121,8 @@ abstract class CompoundConstraintTestCase extends TestCase
         $this->assertSame(0, $violationsCount, \sprintf('No violation expected. Got %d.', $violationsCount));
     }
 
+    /**
+     * @return T
+     */
     abstract protected function createCompound(): Compound;
 }

--- a/src/Symfony/Component/Validator/Tests/Test/CompoundConstraintTestCaseTest.php
+++ b/src/Symfony/Component/Validator/Tests/Test/CompoundConstraintTestCaseTest.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Test\CompoundConstraintTestCase;
 use Symfony\Component\Validator\Tests\Fixtures\DummyCompoundConstraint;
 
+/**
+ * @extends CompoundConstraintTestCase<DummyCompoundConstraint>
+ */
 class CompoundConstraintTestCaseTest extends CompoundConstraintTestCase
 {
     protected function createCompound(): Compound


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

While writing [the docs](https://github.com/symfony/symfony-docs/pull/20150), I realized `@template` could be added. Moreover, it is already present on `ConstraintValidatorTestCase`.