### PR TITLE
[VarDumper] Select HtmlDumper only if `Accept` header contains "html"

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for adding more default casters to `AbstractCloner::addDefaultCasters()`
+ * Select HtmlDumper only if `Accept` header contains "html"
 
 7.3
 ---

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_html.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_html.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test dump() with "Accept: text/html" uses HTML dumper
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+$_SERVER['HTTP_ACCEPT'] = 'text/html';
+dump('Test with HTML');
+--EXPECTF--
+%a>Test with HTML</%a

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -76,11 +76,11 @@ class VarDumper
             case 'server' === $format:
             case $format && 'tcp' === parse_url($format, \PHP_URL_SCHEME):
                 $host = 'server' === $format ? $_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912' : $format;
-                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? new CliDumper() : new HtmlDumper();
+                $dumper = str_contains($_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html'), 'html') ? new HtmlDumper() : new CliDumper();
                 $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders());
                 break;
             default:
-                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? new CliDumper() : new HtmlDumper();
+                $dumper = str_contains($_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html'), 'html') ? new HtmlDumper() : new CliDumper();
         }
 
         if (!$dumper instanceof ServerDumper) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`dump()` and `dd()` are very practical but sometimes a little too verbose, typically when debugging an JSON API for example. This change will only enable HtmlDumper when the `Accept` header exists and contains either `text/html` or `*/*` in non-cli SAPI env.