### PR TITLE
[Translation] [Loco] Ability to configure value of `status` query-variable

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/Bridge/Loco/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add support for the `status` query parameter of Loco translation API
+
 6.1
 ---
 

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -38,11 +38,16 @@ final class LocoProvider implements ProviderInterface
         private string $defaultLocale,
         private string $endpoint,
         private ?TranslatorBagInterface $translatorBag = null,
+        private ?string $restrictToStatus = null,
     ) {
     }
 
     public function __toString(): string
     {
+        if ($this->restrictToStatus) {
+            return \sprintf('loco://%s?status=%s', $this->endpoint, $this->restrictToStatus);
+        }
+
         return \sprintf('loco://%s', $this->endpoint);
     }
 
@@ -96,7 +101,7 @@ final class LocoProvider implements ProviderInterface
                 $response = $this->client->request('GET', \sprintf('export/locale/%s.xlf', rawurlencode($locale)), [
                     'query' => [
                         'filter' => $domain,
-                        'status' => 'translated,blank-translation',
+                        'status' => $this->restrictToStatus ?? 'translated,blank-translation',
                     ],
                     'headers' => [
                         'If-Modified-Since' => $previousCatalogue instanceof CatalogueMetadataAwareInterface ? $previousCatalogue->getCatalogueMetadata('last-modified', $domain) : null,

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProviderFactory.php
@@ -43,6 +43,7 @@ final class LocoProviderFactory extends AbstractProviderFactory
 
         $endpoint = 'default' === $dsn->getHost() ? self::HOST : $dsn->getHost();
         $endpoint .= $dsn->getPort() ? ':'.$dsn->getPort() : '';
+        $restrictToStatus = $dsn->getOption('status');
 
         $client = $this->client->withOptions([
             'base_uri' => 'https://'.$endpoint.'/api/',
@@ -51,7 +52,7 @@ final class LocoProviderFactory extends AbstractProviderFactory
             ],
         ]);
 
-        return new LocoProvider($client, $this->loader, $this->logger, $this->defaultLocale, $endpoint, $this->translatorBag);
+        return new LocoProvider($client, $this->loader, $this->logger, $this->defaultLocale, $endpoint, $this->translatorBag, $restrictToStatus);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Translation/Bridge/Loco/README.md
+++ b/src/Symfony/Component/Translation/Bridge/Loco/README.md
@@ -8,7 +8,7 @@ DSN example
 
 ```
 // .env file
-LOCO_DSN=loco://API_KEY@default
+LOCO_DSN=loco://API_KEY@default?status=translated,blank-translation
 ```
 
 where:

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderFactoryTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderFactoryTest.php
@@ -34,6 +34,11 @@ class LocoProviderFactoryTest extends ProviderFactoryTestCase
             'loco://localise.biz',
             'loco://API_KEY@default',
         ];
+
+        yield [
+            'loco://localise.biz?status=translated,provisional',
+            'loco://API_KEY@default?status=translated,provisional',
+        ];
     }
 
     public static function incompleteDsnProvider(): iterable

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderWithoutTranslatorBagTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderWithoutTranslatorBagTest.php
@@ -25,9 +25,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class LocoProviderWithoutTranslatorBagTest extends LocoProviderTest
 {
-    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, ?TranslatorBagInterface $translatorBag = null): ProviderInterface
+    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, ?TranslatorBagInterface $translatorBag = null, ?string $restrictToStatus = null): ProviderInterface
     {
-        return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint, null);
+        return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint, null, $restrictToStatus);
     }
 
     /**


### PR DESCRIPTION
Added ability to configure value of `status` query-variable when fetching translations from loco API.

| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

With loco it is possible to flag your translations as `provisional`, meaning that they might not be approved by someone in charge of your project's translations. For example these provisional translations might be auto-translated.

To still be able to use these auto-translated translations in your project it must be possible to integrate them (i.e. via CLI command `bin/console translation:pull loco`)
Therefore, when invoking the export-API of loco a different value for the field `status` has to be given. Right now it is statically set to `translated,blank-translation`, meaning provisional translations will *not* get fetched.

With the DSN to the translation provider, we can already provide options to the translation provider implementation with query-parameters like this:
`loco://API_KEY@default?status=translated,provisional`

I have used this functionality for setting the desired value. By default (if omitted) the current value `translated,blank-translation` will be used.