### PR TITLE
[Validator] Clean code on Unique

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -54,7 +54,7 @@ class Unique extends Constraint
         $this->message = $message ?? $this->message;
         $this->normalizer = $normalizer ?? $this->normalizer;
         $this->fields = $fields ?? $this->fields;
-        $this->errorPath = $errorPath ?? $this->errorPath;
+        $this->errorPath = $errorPath;
 
         if (null !== $this->normalizer && !\is_callable($this->normalizer)) {
             throw new InvalidArgumentException(\sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Just cleaning some code, errorPath is nullable, so in construct, if we dont pass the parameter, useless to say $this->errorPath = $this->errorPath