### PR TITLE
[Security] Do not try to clear CSRF on stateless request

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -21,4 +21,3 @@ security:
                 secret: secret
             logout:
                 invalidate_session: false
-            stateless: true

--- a/src/Symfony/Component/Security/Http/EventListener/CsrfTokenClearingLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CsrfTokenClearingLogoutListener.php
@@ -32,7 +32,12 @@ class CsrfTokenClearingLogoutListener implements EventSubscriberInterface
 
     public function onLogout(LogoutEvent $event): void
     {
-        if ($this->csrfTokenStorage instanceof SessionTokenStorage && !$event->getRequest()->hasPreviousSession()) {
+        $request = $event->getRequest();
+
+        if (
+            $this->csrfTokenStorage instanceof SessionTokenStorage
+            && ($request->attributes->getBoolean('_stateless') || !$request->hasPreviousSession())
+        ) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CsrfTokenClearingLogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CsrfTokenClearingLogoutListenerTest.php
@@ -15,13 +15,14 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\EventListener\CsrfTokenClearingLogoutListener;
 
 class CsrfTokenClearingLogoutListenerTest extends TestCase
 {
-    public function testSkipsClearingSessionTokenStorageOnStatelessRequest()
+    public function testSkipsClearingSessionTokenStorageOnRequestWithoutSession()
     {
         try {
             (new CsrfTokenClearingLogoutListener(
@@ -29,6 +30,27 @@ class CsrfTokenClearingLogoutListenerTest extends TestCase
             ))->onLogout(new LogoutEvent(new Request(), null));
         } catch (SessionNotFoundException) {
             $this->fail('clear() must not be called if the request is not associated with a session instance');
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testSkipsClearingSessionTokenStorageOnStatelessRequest()
+    {
+        $session = new Session();
+
+        // Create a stateless request with a previous session
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set($session->getName(), 'previous_session');
+        $request->attributes->set('_stateless', true);
+
+        try {
+            (new CsrfTokenClearingLogoutListener(
+                new SessionTokenStorage(new RequestStack())
+            ))->onLogout(new LogoutEvent($request, null));
+        } catch (SessionNotFoundException) {
+            $this->fail('clear() must not be called if the request is stateless');
         }
 
         $this->addToAssertionCount(1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This was my original proposal to https://github.com/symfony/symfony/pull/54742

I still think checking the `_stateless` attribute is a good compromise for this use case.

And I can find similar check in few other places:

![image](https://github.com/user-attachments/assets/4b4f9a0a-68f8-482c-ab1e-0e31a25a84a6)
