### PR TITLE
[SecurityBundle] Deprecate XML-configured custom authenticators and providers under security namespace

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -82,6 +82,37 @@ Security
  * Deprecate passing an empty string as `$userIdentifier` argument to `UserBadge` constructor
  * Deprecate returning an empty string in `UserInterface::getUserIdentifier()`
 
+SecurityBundle
+--------------
+
+ * Deprecate XML-configured custom authenticators and providers under security namespace; they must now have their own:
+
+   ```diff
+   <srv:container xmlns="http://symfony.com/schema/dic/security"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+   +           xmlns:custom="http://example.com/schema"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+   -    https://symfony.com/schema/dic/security/security-1.0.xsd">
+   +    https://symfony.com/schema/dic/security/security-1.0.xsd
+   +    http://example.com/schema
+   +    http://example.com/schema.xsd">
+
+        <config>
+           <provider name="custom_provider">
+   -           <provider-name>
+   -               <config key="value"/>
+   -           </provider-name>
+   +           <custom:provider-name>
+   +               <custom:config key="value"/>
+   +           </custom:provider-name>
+           </provider>
+        </config>
+   </srv:container>
+   ```
+
 Serializer
 ----------
 

--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -97,8 +97,8 @@ SecurityBundle
         http://symfony.com/schema/dic/security
    -    https://symfony.com/schema/dic/security/security-1.0.xsd">
    +    https://symfony.com/schema/dic/security/security-1.0.xsd
-   +    http://example.com/schema
-   +    http://example.com/schema.xsd">
+   +    http://example.com/schema http://example.com/schema.xsd">
+   +    <!-- the line above can be omitted if the schema does not have a definition -->
 
         <config>
            <provider name="custom_provider">

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,6 +6,33 @@ CHANGELOG
 
  * Allow configuring the secret used to sign login links
  * Allow passing optional passport attributes to `Security::login()`
+ * Deprecate XML-configured custom authenticators and providers under security namespace; they must now have their own:
+
+   ```diff
+   <srv:container xmlns="http://symfony.com/schema/dic/security"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+   +           xmlns:custom="http://example.com/schema"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+   -    https://symfony.com/schema/dic/security/security-1.0.xsd">
+   +    https://symfony.com/schema/dic/security/security-1.0.xsd
+   +    http://example.com/schema
+   +    http://example.com/schema.xsd">
+
+        <config>
+           <provider name="custom_provider">
+   -           <provider-name>
+   -               <config key="value"/>
+   -           </provider-name>
+   +           <custom:provider-name>
+   +               <custom:config key="value"/>
+   +           </custom:provider-name>
+           </provider>
+        </config>
+   </srv:container>
+   ```
 
 7.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -18,8 +18,8 @@ CHANGELOG
         http://symfony.com/schema/dic/security
    -    https://symfony.com/schema/dic/security/security-1.0.xsd">
    +    https://symfony.com/schema/dic/security/security-1.0.xsd
-   +    http://example.com/schema
-   +    http://example.com/schema.xsd">
+   +    http://example.com/schema http://example.com/schema.xsd">
+   +    <!-- the line above can be omitted if the schema does not have a definition -->
 
         <config>
            <provider name="custom_provider">

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -21,7 +21,7 @@
         "ext-xml": "*",
         "symfony/clock": "^6.4|^7.0",
         "symfony/config": "^6.4|^7.0",
-        "symfony/dependency-injection": "^6.4.11|^7.1.4",
+        "symfony/dependency-injection": "^7.2",
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -458,6 +458,8 @@ class XmlFileLoader extends FileLoader
         try {
             $dom = XmlUtils::loadFile($file, $this->validateSchema(...));
         } catch (\InvalidArgumentException $e) {
+            // When starting the 8.0 branch, this whole catch block should be replaced by the line below:
+            // throw new InvalidArgumentException(\sprintf('Unable to parse file "%s": ', $file).$e->getMessage(), $e->getCode(), $e);
             $invalidSecurityElements = [];
             $errors = explode("\n", $e->getMessage());
             foreach ($errors as $i => $error) {

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -477,6 +477,8 @@ class XmlFileLoader extends FileLoader
                             continue;
                         }
                         if ('provider' === $parent->localName || 'firewall' === $parent->localName) {
+                            trigger_deprecation('symfony/security-bundle', '7.2', 'Custom %s must now be namespaced; please update your security configuration "%s" tag.', 'provider' === $parent->localName ? 'providers' : 'authenticators', $tagName);
+
                             unset($errors[$errorIndex]);
                         }
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

https://github.com/symfony/symfony/pull/57493 allowed XML-configured custom authenticators and providers to stay under the security namespace to avoid a BC break. Now that it got merged into 7.2 this can be deprecated.

Not sure about wordings; feel free to suggest.