### PR TITLE
[ExpressionLanguage] Fix typo in exception message

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
@@ -45,7 +45,7 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
 
             new ExpressionFunction('env', fn ($arg) => sprintf('$container->getEnv(%s)', $arg), function (array $variables, $value) {
                 if (!$this->getEnv) {
-                    throw new LogicException('You need to pass a getEnv closure to the expression langage provider to use the "env" function.');
+                    throw new LogicException('You need to pass a getEnv closure to the expression language provider to use the "env" function.');
                 }
 
                 return ($this->getEnv)($value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | ---
| License       | MIT

I just noticed this typo. I am an unsure how "public API" an exception message is in regards of the backwards compatibility. Therefore I am unsure whether it is "breaking" and should be part of a feature-ish release or needs 3 PRs for the major versions. I do not see a case for typos in https://symfony.com/bc which is not bad just difficult to follow for this minor changes.
