### PR TITLE
[Messenger] Fix conditional type on WrappedExceptionsInterface

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/WrappedExceptionsInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/WrappedExceptionsInterface.php
@@ -19,13 +19,13 @@ namespace Symfony\Component\Messenger\Exception;
 interface WrappedExceptionsInterface extends \Throwable
 {
     /**
-     * @template TClass of class-string<\Throwable>
+     * @template TException of \Throwable
      *
-     * @param TClass|null $class
+     * @param class-string<TException>|null $class
      *
      * @return \Throwable[]
      *
-     * @psalm-return (TClass is null ? \Throwable[] : TClass[])
+     * @psalm-return ($class is null ? \Throwable[] : TException[])
      */
     public function getWrappedExceptions(?string $class = null, bool $recursive = false): array;
 }

--- a/src/Symfony/Component/Messenger/Exception/WrappedExceptionsTrait.php
+++ b/src/Symfony/Component/Messenger/Exception/WrappedExceptionsTrait.php
@@ -21,13 +21,13 @@ trait WrappedExceptionsTrait
     private array $exceptions;
 
     /**
-     * @template TClass of class-string<\Throwable>
+     * @template TException of \Throwable
      *
-     * @param TClass|null $class
+     * @param class-string<TException>|null $class
      *
      * @return \Throwable[]
      *
-     * @psalm-return (TClass is null ? \Throwable[] : TClass[])
+     * @psalm-return ($class is null ? \Throwable[] : TException[])
      */
     public function getWrappedExceptions(?string $class = null, bool $recursive = false): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/58066#discussion_r1727532561
| License       | MIT

This PR replaces #58068 with a simpler version that still fixes the issue that #58066 caused.

Conditional return types that refer to arguments (here: `$class`) instead of template types are supported by both major static analysis tools:

* https://phpstan.org/r/2bb3f152-3325-4618-a9b2-5470806edc9c
* https://psalm.dev/r/d62bb4307d