### PR TITLE
[Messenger] Add support for the `approximate_max_entries` option in the Redis transport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -323,6 +323,18 @@ class ConnectionTest extends TestCase
         $connection->add('1', []);
     }
 
+    public function testDontApproximateMaxEntries()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('xadd')
+            ->with('queue', '*', ['message' => '{"body":"1","headers":[]}'], 20000, false)
+            ->willReturn('1');
+
+        $connection = Connection::fromDsn('redis://localhost/queue?stream_max_entries=20000&approximate_max_entries=false', [], $redis);
+        $connection->add('1', []);
+    }
+
     public function testDeleteAfterAck()
     {
         $redis = $this->createMock(\Redis::class);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -39,7 +39,8 @@ class Connection
         'auto_setup' => true,
         'delete_after_ack' => true,
         'delete_after_reject' => true,
-        'stream_max_entries' => 0, // any value higher than 0 defines an approximate maximum number of stream entries
+        'stream_max_entries' => 0,
+        'approximate_max_entries' => true, // whether to approximate the max entries or not, which is more efficient if enabled
         'dbindex' => 0,
         'redeliver_timeout' => 3600, // Timeout before redeliver messages still in pending state (seconds)
         'claim_interval' => 60000, // Interval by which pending/abandoned messages should be checked
@@ -62,6 +63,7 @@ class Connection
     private string $consumer;
     private bool $autoSetup;
     private int $maxEntries;
+    private bool $approximateMaxEntries;
     private int $redeliverTimeout;
     private float $nextClaim = 0.0;
     private float $claimInterval;
@@ -177,6 +179,7 @@ class Connection
         $this->queue = $this->stream.'__queue';
         $this->autoSetup = $options['auto_setup'];
         $this->maxEntries = $options['stream_max_entries'];
+        $this->approximateMaxEntries = $options['approximate_max_entries'];
         $this->deleteAfterAck = $options['delete_after_ack'];
         $this->deleteAfterReject = $options['delete_after_reject'];
         $this->redeliverTimeout = $options['redeliver_timeout'] * 1000;
@@ -556,7 +559,7 @@ class Connection
                 }
 
                 if ($this->maxEntries) {
-                    $added = $redis->xadd($this->stream, '*', ['message' => $message], $this->maxEntries, true);
+                    $added = $redis->xadd($this->stream, '*', ['message' => $message], $this->maxEntries, $this->approximateMaxEntries);
                 } else {
                     $added = $redis->xadd($this->stream, '*', ['message' => $message]);
                 }

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `#[AsMessage]` attribute with `$transport` parameter for message routing
  * Add `--format` option to the `messenger:stats` command
  * Add `getRetryDelay()` method to `RecoverableExceptionInterface`
+ * Add support for the `approximate_max_entries` option in the Redis transport
 
 7.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Even if approximation is more efficient (see [Capped Streams](https://redis.io/docs/latest/commands/xadd/#capped-streams)), it might not be wanted in all cases. Approximation will still be enabled by default.