### PR TITLE
[DependencyInjection] Fix error message typo in `YamlFileLoader`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -547,7 +547,7 @@ class YamlFileLoader extends FileLoader
                 }
 
                 if (\is_string($k)) {
-                    throw new InvalidArgumentException(sprintf('Invalid method call for service "%s", did you forgot a leading dash before "%s: ..." in "%s"?', $id, $k, $file));
+                    throw new InvalidArgumentException(sprintf('Invalid method call for service "%s", did you forget a leading dash before "%s: ..." in "%s"?', $id, $k, $file));
                 }
 
                 if (isset($call['method']) && \is_string($call['method'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This fixes a small typo in an error message inside `YamlFileLoader`.