### PR TITLE
[HttpKernel] Fix method naming collision of dummy logger implementations

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -100,7 +100,7 @@ class ErrorListenerTest extends TestCase
         }
 
         $this->assertEquals(3, $logger->countErrors());
-        $logs = $logger->getLogs('critical');
+        $logs = $logger->getLogsForLevel('critical');
         $this->assertCount(3, $logs);
         $this->assertStringStartsWith('Uncaught PHP Exception Exception: "foo" at ErrorListenerTest.php line', $logs[0]);
         $this->assertStringStartsWith('Uncaught PHP Exception Exception: "foo" at ErrorListenerTest.php line', $logs[1]);
@@ -124,8 +124,8 @@ class ErrorListenerTest extends TestCase
         $this->assertEquals(new Response('foo', 401), $event->getResponse());
 
         $this->assertEquals(0, $logger->countErrors());
-        $this->assertCount(0, $logger->getLogs('critical'));
-        $this->assertCount(1, $logger->getLogs('warning'));
+        $this->assertCount(0, $logger->getLogsForLevel('critical'));
+        $this->assertCount(1, $logger->getLogsForLevel('warning'));
     }
 
     public function testHandleWithLogLevelAttribute()
@@ -139,8 +139,8 @@ class ErrorListenerTest extends TestCase
         $l->onKernelException($event);
 
         $this->assertEquals(0, $logger->countErrors());
-        $this->assertCount(0, $logger->getLogs('critical'));
-        $this->assertCount(1, $logger->getLogs('warning'));
+        $this->assertCount(0, $logger->getLogsForLevel('critical'));
+        $this->assertCount(1, $logger->getLogsForLevel('warning'));
     }
 
     public function testHandleClassImplementingInterfaceWithLogLevelAttribute()
@@ -154,8 +154,8 @@ class ErrorListenerTest extends TestCase
         $l->onKernelException($event);
 
         $this->assertEquals(0, $logger->countErrors());
-        $this->assertCount(0, $logger->getLogs('critical'));
-        $this->assertCount(1, $logger->getLogs('warning'));
+        $this->assertCount(0, $logger->getLogsForLevel('critical'));
+        $this->assertCount(1, $logger->getLogsForLevel('warning'));
     }
 
     public function testHandleWithLogLevelAttributeAndCustomConfiguration()
@@ -173,8 +173,8 @@ class ErrorListenerTest extends TestCase
         $l->onKernelException($event);
 
         $this->assertEquals(0, $logger->countErrors());
-        $this->assertCount(0, $logger->getLogs('warning'));
-        $this->assertCount(1, $logger->getLogs('info'));
+        $this->assertCount(0, $logger->getLogsForLevel('warning'));
+        $this->assertCount(1, $logger->getLogsForLevel('info'));
     }
 
     /**
@@ -326,6 +326,11 @@ class TestLogger extends Logger implements DebugLoggerInterface
     public function countErrors(?Request $request = null): int
     {
         return \count($this->logs['critical']);
+    }
+
+    public function getLogs(?Request $request = null): array
+    {
+        return [];
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Logger.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\HttpKernel\Tests;
 
-use Psr\Log\LoggerInterface;
+use Psr\Log\AbstractLogger;
 
-class Logger implements LoggerInterface
+class Logger extends AbstractLogger
 {
     protected array $logs;
 
@@ -22,9 +22,9 @@ class Logger implements LoggerInterface
         $this->clear();
     }
 
-    public function getLogs($level = false): array
+    public function getLogsForLevel(string $level): array
     {
-        return false === $level ? $this->logs : $this->logs[$level];
+        return $this->logs[$level];
     }
 
     public function clear(): void
@@ -44,45 +44,5 @@ class Logger implements LoggerInterface
     public function log($level, $message, array $context = []): void
     {
         $this->logs[$level][] = $message;
-    }
-
-    public function emergency($message, array $context = []): void
-    {
-        $this->log('emergency', $message, $context);
-    }
-
-    public function alert($message, array $context = []): void
-    {
-        $this->log('alert', $message, $context);
-    }
-
-    public function critical($message, array $context = []): void
-    {
-        $this->log('critical', $message, $context);
-    }
-
-    public function error($message, array $context = []): void
-    {
-        $this->log('error', $message, $context);
-    }
-
-    public function warning($message, array $context = []): void
-    {
-        $this->log('warning', $message, $context);
-    }
-
-    public function notice($message, array $context = []): void
-    {
-        $this->log('notice', $message, $context);
-    }
-
-    public function info($message, array $context = []): void
-    {
-        $this->log('info', $message, $context);
-    }
-
-    public function debug($message, array $context = []): void
-    {
-        $this->log('debug', $message, $context);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

In HttpKernel's test suite, we use a dummy logger implementation which exposes a `getLogs()` method. Our own `DebugLoggerInterface` also defines a `getLogs()` method with a different signature and different semantics. Then there's also a `TestLogger` class which extends our dummy logger _and_ implements that interface which leads to a weird naming collision.

In this PR, I'm renaming the dummy's `getLogs()` method to `getLogsForLevel()` to resolve this situation. While I'm at it, I'm also simplifying the implementation by leveraging the `AbstractLogger` class from the psr/log contracts.

Since I'm only changing test classes, I believe that the method signature changes should not cause any trouble.