### PR TITLE
[HttpKernel] Extract `ConfigCache` creation from `initializeContainer`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Remove `@internal` flag and add `@final` to `ServicesResetter`
+ * Add method `buildConfigCache` to `Kernel` that allow custom implementation in final project
 
 7.1
 ---

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -383,6 +383,14 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     }
 
     /**
+     * Build the ConfigCache instance used to test id the service container is fresh or not.
+     */
+    protected function buildConfigCache(string $file): ConfigCache
+    {
+        return new ConfigCache($file, $this->debug);
+    }
+
+    /**
      * Initializes the service container.
      *
      * The built version of the service container is used when fresh, otherwise the
@@ -392,7 +400,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     {
         $class = $this->getContainerClass();
         $buildDir = $this->warmupDir ?: $this->getBuildDir();
-        $cache = new ConfigCache($buildDir.'/'.$class.'.php', $this->debug);
+        $cache = $this->buildConfigCache($buildDir.'/'.$class.'.php');
         $cachePath = $cache->getPath();
 
         // Silence E_WARNING to ignore "include" failures - don't use "@" to prevent silencing fatal errors


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | None
| License       | MIT


**Context**

I'm working on a large Symfony application (with approximately 3,500 services and 3,800 routes) that heavily uses annotations and PHP attributes, and autowiring. While we don't encounter any performance issues in production, we frequently experience crashes in the development environment. These crashes occur because the kernel attempts to rebuild the container at runtime, but fails to do so during an HTTP request due to memory limits being reached.

This behavior is caused by the following code: https://github.com/symfony/config/blob/7.1/ConfigCache.php#L39-L41

I patched our kernel to prevent container builds at runtime in the development environment, but it would be great if Symfony provided an easy way to do this

Our application: Symfony 5.4  (upgrade in progress) / PHP 8.2

**Change**

The purpose of this pull request is to allow the project kernel to override the behavior of Symfony\Component\HttpKernel\Kernel::initializeContainer by substituting the ConfigCache instance.


PS: This is my first PR on this project, so please feel free to let me know if I've made any mistakes.
