### PR TITLE
[PropertyAccess] Fix handling property names with a `.`

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -674,6 +674,7 @@ class PropertyAccessorTest extends TestCase
             [['firstName' => 'Bernhard'], '[firstName]', 'Bernhard'],
             [['index' => ['firstName' => 'Bernhard']], '[index][firstName]', 'Bernhard'],
             [(object) ['firstName' => 'Bernhard'], 'firstName', 'Bernhard'],
+            [(object) ['first.Name' => 'Bernhard'], 'first.Name', 'Bernhard'],
             [(object) ['property' => ['firstName' => 'Bernhard']], 'property[firstName]', 'Bernhard'],
             [['index' => (object) ['firstName' => 'Bernhard']], '[index].firstName', 'Bernhard'],
             [(object) ['property' => (object) ['firstName' => 'Bernhard']], 'property.firstName', 'Bernhard'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58100
| License       | MIT

If the property path contains a dot, it is considered to be an access to an underlying property. However, some edge cases allow to have dots in property names, especially with `stdClass`.

Minimal reproducer:

```php
$stdclass = (object) ['bankAccount.iban' => 'NL16TEST0436169118', 'bankSummary' => ''];
$accessor = PropertyAccess::createPropertyAccessor();

dump($accessor->getValue($stdclass, 'bankAccount.iban')); // returns "NL16TEST0436169118"

$accessor->setValue($stdclass, 'bankAccount.iban', 'value');
dump($accessor->getValue($stdclass, 'bankAccount.iban')); // returns "value"
```