### PR TITLE
[DependencyInjection] Fix bug on windows, memory exhausted on cache clear, impossible to install new project

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1752,9 +1752,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         foreach ($this->vendors as $vendor) {
             if (\in_array($path[\strlen($vendor)] ?? '', ['/', \DIRECTORY_SEPARATOR], true) && str_starts_with($path, $vendor)) {
-                $this->pathsInVendor[$vendor.'/composer'] = false;
-                $this->addResource(new FileResource($vendor.'/composer/installed.json'));
-                $this->pathsInVendor[$vendor.'/composer'] = true;
+                $this->pathsInVendor[$vendor.\DIRECTORY_SEPARATOR.'composer'] = false;
+                $this->addResource(new FileResource($vendor.\DIRECTORY_SEPARATOR.'composer'.\DIRECTORY_SEPARATOR.'installed.json'));
+                $this->pathsInVendor[$vendor.\DIRECTORY_SEPARATOR.'composer'] = true;
 
                 return $this->pathsInVendor[$path] = true;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix 
| License       | MIT

Since https://github.com/symfony/symfony/pull/57948 on windows, I can't make a cache clear with a fatal error form memory exhausted or install a new symfony app.
Xdebug saw an infinite loop.


Correction with DIRECTORY_SEPARATOR constant instead /