### PR TITLE
[SecurityBundle] Disallow using legacy hash algorithms for password hashing when migrating passwords

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow configuring the secret used to sign login links
+ * Disallow using legacy hash algorithms for password hashing when migrating passwords
 
 7.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -900,6 +900,28 @@ class SecurityExtensionTest extends TestCase
         ]);
     }
 
+    public function testMigrateToLegacyHasherThrows()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'password_hashers' => [
+                'legacy' => 'md5',
+                'App\User' => [
+                    'id' => 'App\Security\CustomHasher',
+                    'algorithm' => 'sha256',
+                    'migrate_from' => 'legacy',
+                ],
+            ],
+            'firewalls' => ['main' => ['http_basic' => true]],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The algorithm should not be a legacy hash algorithm when migrating from another hasher.');
+
+        $container->compile();
+    }
+
     protected function getRawContainer()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #58053
| License       | MIT

After https://github.com/symfony/symfony/issues/58053#issuecomment-2307907528 (cc @chalasr). Two concerns about this PR:
- I'm not sure this is a bug fix or a feature. Stof stated that "using a MessageDigestPasswordHasher as the best hasher of a MigratingPasswordHasher won't work as expected." in the issue, so maybe it could be a bugfix after all.
- What do you think of this approach? Should we forbid more algorithms?