### PR TITLE
[AssetMapper] Load es-module-shims only if importmap is not supported

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -95,7 +95,7 @@ class ImportMapRenderer
             $this->addWebLinkPreloads($request, $cssLinks);
         }
 
-        $scriptAttributes = $this->createAttributesString($attributes);
+        $scriptAttributes = $attributes || $this->scriptAttributes ? ' '.$this->createAttributesString($attributes) : '';
         $importMapJson = json_encode(['imports' => $importMap], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG);
         $output .= <<<HTML
 
@@ -114,21 +114,26 @@ class ImportMapRenderer
         }
 
         if ($polyfillPath) {
-            $url = $this->escapeAttributeValue($polyfillPath);
-            $polyfillAttributes = $scriptAttributes;
+            $polyfillAttributes = $attributes + $this->scriptAttributes;
 
             // Add security attributes for the default polyfill hosted on jspm.io
             if (self::DEFAULT_ES_MODULE_SHIMS_POLYFILL_URL === $polyfillPath) {
-                $polyfillAttributes = $this->createAttributesString([
+                $polyfillAttributes = [
                     'crossorigin' => 'anonymous',
                     'integrity' => self::DEFAULT_ES_MODULE_SHIMS_POLYFILL_INTEGRITY,
-                ] + $attributes);
+                ] + $polyfillAttributes;
             }
 
             $output .= <<<HTML
-
-                <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support -->
-                <script async src="$url"$polyfillAttributes></script>
+                <script async$scriptAttributes>
+                if (!HTMLScriptElement.supports || !HTMLScriptElement.supports('importmap')) (function () {
+                    const script = document.createElement('script');
+                    script.src = '{$this->escapeAttributeValue($polyfillPath, \ENT_NOQUOTES)}';
+                    script.setAttribute('async', 'async');
+                    {$this->createAttributesString($polyfillAttributes, "script.setAttribute('%s', '%s');", "\n    ", \ENT_NOQUOTES)}
+                    document.head.appendChild(script);
+                })();
+                </script>
                 HTML;
         }
 
@@ -151,12 +156,14 @@ class ImportMapRenderer
         return $output;
     }
 
-    private function escapeAttributeValue(string $value): string
+    private function escapeAttributeValue(string $value, int $flags = \ENT_COMPAT | \ENT_SUBSTITUTE): string
     {
-        return htmlspecialchars($value, \ENT_COMPAT | \ENT_SUBSTITUTE, $this->charset);
+        $value = htmlspecialchars($value, $flags, $this->charset);
+
+        return \ENT_NOQUOTES & $flags ? addslashes($value) : $value;
     }
 
-    private function createAttributesString(array $attributes): string
+    private function createAttributesString(array $attributes, string $pattern = '%s="%s"', string $glue = ' ', int $flags = \ENT_COMPAT | \ENT_SUBSTITUTE): string
     {
         $attributeString = '';
 
@@ -166,14 +173,16 @@ class ImportMapRenderer
         }
 
         foreach ($attributes as $name => $value) {
-            $attributeString .= ' ';
-            if (true === $value) {
-                $attributeString .= $name;
-
-                continue;
+            if ('' !== $attributeString) {
+                $attributeString .= $glue;
             }
-            $attributeString .= \sprintf('%s="%s"', $name, $this->escapeAttributeValue($value));
+            if (true === $value) {
+                $value = $name;
+            }
+            $attributeString .= \sprintf($pattern, $this->escapeAttributeValue($name, $flags), $this->escapeAttributeValue($value, $flags));
         }
+
+        $attributeString = preg_replace('/\b([^ =]++)="\1"/', '\1', $attributeString);
 
         return $attributeString;
     }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -77,7 +77,7 @@ class ImportMapRendererTest extends TestCase
 
         $this->assertStringContainsString('<script type="importmap">', $html);
         // polyfill is rendered as a normal script tag
-        $this->assertStringContainsString('<script async src="https://ga.jspm.io/npm:es-module-shims"></script>', $html);
+        $this->assertStringContainsString("script.src = 'https://ga.jspm.io/npm:es-module-shims';", $html);
         // and is hidden from the import map
         $this->assertStringNotContainsString('"es-module-shim"', $html);
         $this->assertStringContainsString('import \'app\';', $html);
@@ -120,8 +120,8 @@ class ImportMapRendererTest extends TestCase
             polyfillImportName: 'es-module-shims',
         );
         $html = $renderer->render(['app']);
-        $this->assertStringContainsString('<script async src="https://ga.jspm.io/npm:es-module-shims@', $html);
-        $this->assertStringContainsString('es-module-shims.js" crossorigin="anonymous" integrity="sha384-', $html);
+        $this->assertStringContainsString("script.src = 'https://ga.jspm.io/npm:es-module-shims@", $html);
+        $this->assertStringContainsString("script.setAttribute('crossorigin', 'anonymous');\n    script.setAttribute('integrity', 'sha384-", $html);
     }
 
     public function testCustomScriptAttributes()
@@ -132,7 +132,13 @@ class ImportMapRendererTest extends TestCase
         ]);
         $html = $renderer->render([]);
         $this->assertStringContainsString('<script type="importmap" something data-turbo-track="reload">', $html);
-        $this->assertStringContainsString('<script async src="https://polyfillUrl.example" something data-turbo-track="reload"></script>', $html);
+        $this->assertStringContainsString('<script async something data-turbo-track="reload">', $html);
+        $this->assertStringContainsString(<<<EOTXT
+            script.src = 'https://polyfillUrl.example';
+            script.setAttribute('async', 'async');
+            script.setAttribute('something', 'something');
+            script.setAttribute('data-turbo-track', 'reload');
+        EOTXT, $html);
     }
 
     public function testWithEntrypoint()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Let's not load the polyfill if the browser already supports importmaps