### PR TITLE
[VarExporter] Allow reinitializing lazy objects with a new initializer

### DIFF
--- a/src/Symfony/Component/VarExporter/CHANGELOG.md
+++ b/src/Symfony/Component/VarExporter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Allow reinitializing lazy objects with a new initializer
+
 6.4
 ---
 

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
@@ -38,8 +38,8 @@ class LazyObjectState
      * @param array<string, true> $skippedProperties
      */
     public function __construct(
-        public readonly \Closure $initializer,
-        public readonly array $skippedProperties = [],
+        public \Closure $initializer,
+        public array $skippedProperties = [],
     ) {
     }
 

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -51,6 +51,17 @@ trait LazyGhostTrait
             $instance ??= Registry::$classReflectors[$class]->newInstanceWithoutConstructor();
         }
 
+        if (isset($instance->lazyObjectState)) {
+            $instance->lazyObjectState->initializer = $initializer;
+            $instance->lazyObjectState->skippedProperties = $skippedProperties ??= [];
+
+            if (LazyObjectState::STATUS_UNINITIALIZED_FULL !== $instance->lazyObjectState->status) {
+                $instance->lazyObjectState->reset($instance);
+            }
+
+            return $instance;
+        }
+
         $instance->lazyObjectState = new LazyObjectState($initializer, $skippedProperties ??= []);
 
         foreach (Registry::$classResetters[$class] as $reset) {

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -47,6 +47,13 @@ trait LazyProxyTrait
             $instance ??= Registry::$classReflectors[$class]->newInstanceWithoutConstructor();
         }
 
+        if (isset($instance->lazyObjectState)) {
+            $instance->lazyObjectState->initializer = $initializer;
+            unset($instance->lazyObjectState->realInstance);
+
+            return $instance;
+        }
+
         $instance->lazyObjectState = new LazyObjectState($initializer);
 
         foreach (Registry::$classResetters[$class] as $reset) {

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/RegularClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/RegularClass.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+class RegularClass
+{
+    public function __construct(
+        public int $foo
+    ) {
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -280,6 +280,17 @@ class LazyGhostTraitTest extends TestCase
         $this->assertSame(['property' => 'property', 'method' => 'method'], $output);
     }
 
+    public function testReinitLazyGhost()
+    {
+        $object = TestClass::createLazyGhost(function ($p) { $p->public = 2; });
+
+        $this->assertSame(2, $object->public);
+
+        TestClass::createLazyGhost(function ($p) { $p->public = 3; }, null, $object);
+
+        $this->assertSame(3, $object->public);
+    }
+
     /**
      * @template T
      *

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Component\VarExporter\ProxyHelper;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\RegularClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\FinalPublicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\ReadOnlyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\StringMagicGetClass;
@@ -293,6 +294,31 @@ class LazyProxyTraitTest extends TestCase
         $output = $serializer->normalize($object);
 
         $this->assertSame(['property' => 'property', 'method' => 'method'], $output);
+    }
+
+    public function testReinitRegularLazyProxy()
+    {
+        $object = $this->createLazyProxy(RegularClass::class, fn () => new RegularClass(123));
+
+        $this->assertSame(123, $object->foo);
+
+        $object::createLazyProxy(fn () => new RegularClass(234), $object);
+
+        $this->assertSame(234, $object->foo);
+    }
+
+    /**
+     * @requires PHP 8.3
+     */
+    public function testReinitReadonlyLazyProxy()
+    {
+        $object = $this->createLazyProxy(ReadOnlyClass::class, fn () => new ReadOnlyClass(123));
+
+        $this->assertSame(123, $object->foo);
+
+        $object::createLazyProxy(fn () => new ReadOnlyClass(234), $object);
+
+        $this->assertSame(234, $object->foo);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Being able to call createLazyGhost/Proxy on an existing lazy object is a capability that PHP 8.4 will provide thanks to https://wiki.php.net/rfc/lazy-objects, and that zenstruck/foundry desires also to implement refreshable fixtures. /cc @kbond @nikophil

