### PR TITLE
[Ldap] Fix extension deprecation

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
@@ -17,7 +17,12 @@ class LdapTestCase extends TestCase
 {
     protected function getLdapConfig()
     {
-        $h = @ldap_connect(getenv('LDAP_HOST'), getenv('LDAP_PORT'));
+        if (\PHP_VERSION_ID < 80300) {
+            $h = @ldap_connect(getenv('LDAP_HOST'), getenv('LDAP_PORT'));
+        } else {
+            $h = @ldap_connect('ldap://'.getenv('LDAP_HOST').':'.getenv('LDAP_PORT'));
+        }
+
         @ldap_set_option($h, \LDAP_OPT_PROTOCOL_VERSION, 3);
 
         if (!$h || !@ldap_bind($h)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two arguments constructor is deprecated since PHP 8.3: https://www.php.net/manual/en/function.ldap-connect.php