### PR TITLE
[VarDumper] dd() can fallback to a plain text dumper if no suitable Dumper found

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -55,11 +55,23 @@ if (!function_exists('dd')) {
             exit(1);
         }
 
+        $acceptHeader = $_SERVER['HTTP_ACCEPT'] ?? '---';
+
+        if (
+            str_contains($acceptHeader, '*/*') ||
+            str_contains($acceptHeader, 'text/html') ||
+            \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)
+        ) {
+            dump($vars);
+
+            exit(1);
+        }
+
         if (array_key_exists(0, $vars) && 1 === count($vars)) {
-            VarDumper::dump($vars[0]);
+            var_dump($vars[0]);
         } else {
-            foreach ($vars as $k => $v) {
-                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
+            foreach ($vars as $var) {
+                var_dump($var);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49754 #54772
| License       | MIT

Thanks to this change `dd()` fallbacks to a simple plain text dumber if no suitable dumper can be found (discussed also in #58070). So that it could adapt to any situation, even if the consumer did not send any accept headers by default, like Guzzle.

I tested and it works well with:
- PHPUnit
- Chrome dev tools (results with HTML tags)
- APIs consumed with Guzzle without accept headers (results in plain text)
