### PR TITLE
[Filesystem] Add a warning about `chown()` and `chgrp()` on Windows

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -233,6 +233,9 @@ class Filesystem
     /**
      * Change the owner of an array of files or directories.
      *
+     * This method always throws on Windows, as the underlying PHP function is not supported.
+     * @see https://www.php.net/chown
+     *
      * @param string|iterable $files     A filename, an array of files, or a \Traversable instance to change owner
      * @param string|int      $user      A user name or number
      * @param bool            $recursive Whether change the owner recursively or not
@@ -259,6 +262,9 @@ class Filesystem
 
     /**
      * Change the group of an array of files or directories.
+     *
+     * This method always throws on Windows, as the underlying PHP function is not supported.
+     * @see https://www.php.net/chgrp
      *
      * @param string|iterable $files     A filename, an array of files, or a \Traversable instance to change group
      * @param string|int      $group     A group name or number


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`chmod()` and `chgrp()` are not supported on Windows (see [this](https://github.com/php/php-src/blob/0d616d1b82ca7609a7ece762cb8688d9bed74370/ext/standard/tests/file/chgrp.phpt#L6) and [this](https://github.com/php/php-src/blob/0d616d1b82ca7609a7ece762cb8688d9bed74370/ext/standard/tests/file/chown.phpt#L6)). I propose to skip the logic of these methods when running on Windows.