### PR TITLE
[Mime] Close file handle

### DIFF
--- a/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php
+++ b/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php
@@ -50,6 +50,7 @@ class FileinfoMimeTypeGuesser implements MimeTypeGuesserInterface
             return null;
         }
         $mimeType = $finfo->file($path);
+        finfo_close($finfo);
 
         if ($mimeType && 0 === (\strlen($mimeType) % 2)) {
             $mimeStart = substr($mimeType, 0, \strlen($mimeType) >> 1);

--- a/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php
+++ b/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php
@@ -50,7 +50,7 @@ class FileinfoMimeTypeGuesser implements MimeTypeGuesserInterface
             return null;
         }
         $mimeType = $finfo->file($path);
-        finfo_close($finfo);
+        unset($finfo);
 
         if ($mimeType && 0 === (\strlen($mimeType) % 2)) {
             $mimeStart = substr($mimeType, 0, \strlen($mimeType) >> 1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? |no 
| License       | MIT

Currently the `finfo` file handle does not get closed which can result in the error 
`Too many open files in [...]/vendor/symfony/symfony/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php`
if `guessMimeType()` gets called for more than `ulimit -n` files.

According to https://stackoverflow.com/a/32102146 the file handle can be closed with `unset()` - as it is done in [PHP's unit tests](https://github.com/php/php-src/blob/8a2015451ac18b656e3fcd608bce9eb2f86db452/ext/fileinfo/tests/finfo_close_basic.phpt#L19)