### PR TITLE
[FrameworkBundle] Remove default value for `gc_probability` config option

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -673,7 +673,7 @@ class Configuration implements ConfigurationInterface
                         ->enumNode('cookie_samesite')->values([null, Cookie::SAMESITE_LAX, Cookie::SAMESITE_STRICT, Cookie::SAMESITE_NONE])->defaultValue('lax')->end()
                         ->booleanNode('use_cookies')->end()
                         ->scalarNode('gc_divisor')->end()
-                        ->scalarNode('gc_probability')->defaultValue(1)->end()
+                        ->scalarNode('gc_probability')->end()
                         ->scalarNode('gc_maxlifetime')->end()
                         ->scalarNode('save_path')
                             ->info('Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -814,7 +814,6 @@ class ConfigurationTest extends TestCase
                 'cookie_httponly' => true,
                 'cookie_samesite' => 'lax',
                 'cookie_secure' => 'auto',
-                'gc_probability' => 1,
                 'metadata_update_threshold' => 0,
             ],
             'request' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

While playing on a test app, I experienced an error related to the session GC:

> Notice: SessionHandler::gc(): ps_files_cleanup_dir: opendir(/var/lib/php/sessions) failed: Permission denied (13)

This is triggered by StrictSessionHandler calling the gc() method of the native session handler.

I figured out the GC was running with 1/1440 probability so I tried increasing the probability to reproduce. I did so patching my ini settings and this did nothing, until I figured out that the corresponding option shadows the ini settings.

This was done 10 years ago in #10366 (/cc @fabpot) to fix #10349. Re-reading that issue, I think it doesn't apply anymore: by default, we now encourage storing sessions in the folder configured in the ini settings also.

Let's revert that PR.

Then, what about the error itself? It happens because the folder configured on my Ubuntu doesn't have the `x` permission, so that the session GC cannot list its content. This is consistent with `session.gc_probability` being set to `0`. My host relies on cron instead of this GC. Which means there's nothing else to fix actually.