### PR TITLE
[Security][SecurityBundle] Allow passing attributes to passport via `Security::login()`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow configuring the secret used to sign login links
+ * Allow passing optional passport attributes to `Security::login()`
 
 7.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -74,14 +74,15 @@ class Security implements AuthorizationCheckerInterface
     }
 
     /**
-     * @param UserInterface    $user              The user to authenticate
-     * @param string|null      $authenticatorName The authenticator name (e.g. "form_login") or service id (e.g. SomeApiKeyAuthenticator::class) - required only if multiple authenticators are configured
-     * @param string|null      $firewallName      The firewall name - required only if multiple firewalls are configured
-     * @param BadgeInterface[] $badges            Badges to add to the user's passport
+     * @param UserInterface        $user              The user to authenticate
+     * @param string|null          $authenticatorName The authenticator name (e.g. "form_login") or service id (e.g. SomeApiKeyAuthenticator::class) - required only if multiple authenticators are configured
+     * @param string|null          $firewallName      The firewall name - required only if multiple firewalls are configured
+     * @param BadgeInterface[]     $badges            Badges to add to the user's passport
+     * @param array<string, mixed> $attributes        Attributes to add to the user's passport
      *
      * @return Response|null The authenticator success response if any
      */
-    public function login(UserInterface $user, ?string $authenticatorName = null, ?string $firewallName = null, array $badges = []): ?Response
+    public function login(UserInterface $user, ?string $authenticatorName = null, ?string $firewallName = null, array $badges = [], array $attributes = []): ?Response
     {
         $request = $this->container->get('request_stack')->getCurrentRequest();
         if (null === $request) {
@@ -99,7 +100,7 @@ class Security implements AuthorizationCheckerInterface
         $userCheckerLocator = $this->container->get('security.user_checker_locator');
         $userCheckerLocator->get($firewallName)->checkPreAuth($user);
 
-        return $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request, $badges);
+        return $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request, $badges, $attributes);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Security/UserAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/UserAuthenticator.php
@@ -38,8 +38,8 @@ class UserAuthenticator implements UserAuthenticatorInterface
         $this->requestStack = $requestStack;
     }
 
-    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = []): ?Response
+    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = [], array $attributes = []): ?Response
     {
-        return $this->getForFirewall()->authenticateUser($user, $authenticator, $request, $badges);
+        return $this->getForFirewall()->authenticateUser($user, $authenticator, $request, $badges, $attributes);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
@@ -135,6 +136,7 @@ class SecurityTest extends TestCase
         $userAuthenticator = $this->createMock(UserAuthenticatorInterface::class);
         $user = $this->createMock(UserInterface::class);
         $userChecker = $this->createMock(UserCheckerInterface::class);
+        $badge = new UserBadge('foo');
 
         $container = new Container();
         $container->set('request_stack', $requestStack);
@@ -143,7 +145,7 @@ class SecurityTest extends TestCase
         $container->set('security.user_checker_locator', $this->createContainer('main', $userChecker));
 
         $firewallMap->expects($this->once())->method('getFirewallConfig')->willReturn($firewall);
-        $userAuthenticator->expects($this->once())->method('authenticateUser')->with($user, $authenticator, $request);
+        $userAuthenticator->expects($this->once())->method('authenticateUser')->with($user, $authenticator, $request, [$badge], ['foo' => 'bar']);
         $userChecker->expects($this->once())->method('checkPreAuth')->with($user);
 
         $firewallAuthenticatorLocator = $this->createMock(ServiceProviderInterface::class);
@@ -161,7 +163,7 @@ class SecurityTest extends TestCase
 
         $security = new Security($container, ['main' => $firewallAuthenticatorLocator]);
 
-        $security->login($user);
+        $security->login($user, badges: [$badge], attributes: ['foo' => 'bar']);
     }
 
     public function testLoginReturnsAuthenticatorResponse()

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -62,12 +62,19 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
     }
 
     /**
-     * @param BadgeInterface[] $badges Optionally, pass some Passport badges to use for the manual login
+     * @param BadgeInterface[]     $badges     Optionally, pass some Passport badges to use for the manual login
+     * @param array<string, mixed> $attributes Optionally, pass some Passport attributes to use for the manual login
      */
-    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = []): ?Response
+    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = [] /* , array $attributes = [] */): ?Response
     {
+        $attributes = 4 < \func_num_args() ? func_get_arg(4) : [];
+
         // create an authentication token for the User
         $passport = new SelfValidatingPassport(new UserBadge($user->getUserIdentifier(), fn () => $user), $badges);
+        foreach ($attributes as $k => $v) {
+            $passport->setAttribute($k, $v);
+        }
+
         $token = $authenticator->createToken($passport, $this->firewallName);
 
         // announce the authentication token

--- a/src/Symfony/Component/Security/Http/Authentication/UserAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/UserAuthenticatorInterface.php
@@ -26,7 +26,8 @@ interface UserAuthenticatorInterface
      * Convenience method to programmatically login a user and return a
      * Response *if any* for success.
      *
-     * @param BadgeInterface[] $badges Optionally, pass some Passport badges to use for the manual login
+     * @param BadgeInterface[]     $badges     Optionally, pass some Passport badges to use for the manual login
+     * @param array<string, mixed> $attributes Optionally, pass some Passport attributes to use for the manual login
      */
-    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = []): ?Response;
+    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = [] /* , array $attributes = [] */): ?Response;
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Pass the current token to the `checkPostAuth()` method of user checkers
  * Deprecate argument `$secret` of `RememberMeAuthenticator`
  * Deprecate passing an empty string as `$userIdentifier` argument to `UserBadge` constructor
+ * Allow passing passport attributes to the `UserAuthenticatorInterface::authenticateUser()` method
 
 7.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Supersedes #57495 after the last comment.