### PR TITLE
[Cache] Fix compatibility with Redis 6.1.0 pre-releases

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Redis6ProxyTrait.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6ProxyTrait.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Cache\Traits;
 
-if (version_compare(phpversion('redis'), '6.1.0', '>=')) {
+if (version_compare(phpversion('redis'), '6.1.0-dev', '>=')) {
     /**
      * @internal
      */
@@ -27,7 +27,7 @@ if (version_compare(phpversion('redis'), '6.1.0', '>=')) {
             return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hRandField(...\func_get_args());
         }
 
-        public function hSet($key, $fields_and_vals): \Redis|false|int
+        public function hSet($key, ...$fields_and_vals): \Redis|false|int
         {
             return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSet(...\func_get_args());
         }

--- a/src/Symfony/Component/Cache/Traits/RedisCluster6ProxyTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster6ProxyTrait.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Cache\Traits;
 
-if (version_compare(phpversion('redis'), '6.1.0', '>')) {
+if (version_compare(phpversion('redis'), '6.1.0-dev', '>')) {
     /**
      * @internal
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57884
| License       | MIT

The solution provided in #57885 will fix the compatibility with the PHPRedis 6.1.0 release, but the issue persists on the pre-releases (for instance the [6.1.0RC1](https://pecl.php.net/package/redis/6.1.0RC1) version).
I propose to use the new signatures for any 6.1.0 version, including its pre-releases.

```php
version_compare('6.1.0RC1', '6.1.0', '>='); // false
version_compare('6.1.0RC1', '6.1.0-dev', '>='); // true
```
