### PR TITLE
Remove no-op `ReflectionProperty::setAccessible()` calls

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -34,7 +34,6 @@ class ErrorHandlerTest extends TestCase
     protected function tearDown(): void
     {
         $r = new \ReflectionProperty(ErrorHandler::class, 'exitCode');
-        $r->setAccessible(true);
         $r->setValue(null, 0);
     }
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
@@ -94,8 +94,8 @@ class SendmailTransportTest extends TestCase
         $sendmailTransport->send($mail, $envelope);
 
         $streamProperty = new \ReflectionProperty(SendmailTransport::class, 'stream');
-        $streamProperty->setAccessible(true);
         $stream = $streamProperty->getValue($sendmailTransport);
+
         $this->assertNull($stream->stream);
     }
 
@@ -112,10 +112,9 @@ class SendmailTransportTest extends TestCase
         }
 
         $streamProperty = new \ReflectionProperty(SendmailTransport::class, 'stream');
-        $streamProperty->setAccessible(true);
         $stream = $streamProperty->getValue($sendmailTransport);
         $innerStreamProperty = new \ReflectionProperty(ProcessStream::class, 'stream');
-        $innerStreamProperty->setAccessible(true);
+
         $this->assertNull($innerStreamProperty->getValue($stream));
     }
 
@@ -127,7 +126,6 @@ class SendmailTransportTest extends TestCase
 
         $sendmailTransport = new SendmailTransport(self::FAKE_INTERACTIVE_SENDMAIL);
         $transportProperty = new \ReflectionProperty(SendmailTransport::class, 'transport');
-        $transportProperty->setAccessible(true);
 
         // Replace the transport with an anonymous consumer that trigger the stream methods
         $transportProperty->setValue($sendmailTransport, new class($transportProperty->getValue($sendmailTransport)->getStream()) extends SmtpTransport {

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
@@ -323,7 +323,6 @@ final class BlueskyTransportTest extends TransportTestCase
     {
         $class = new \ReflectionClass(BlueskyTransport::class);
         $method = $class->getMethod('parseFacets');
-        $method->setAccessible(true);
 
         $object = $class->newInstance('user', 'pass', new NullLogger(), $httpClient ?? new MockHttpClient([]));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ReflectionProperty::setAccessible()` is no-op since PHP 8.1.