### PR TITLE
no longer use the internal `TestFailure` class

### DIFF
--- a/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserCookieValueSameTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserCookieValueSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\BrowserKit\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar;
@@ -31,15 +30,10 @@ class BrowserCookieValueSameTest extends TestCase
         $constraint = new BrowserCookieValueSame('foo', 'babar', false, '/path');
         $this->assertFalse($constraint->evaluate($browser, '', true));
 
-        try {
-            $constraint->evaluate($browser);
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Browser has cookie \"foo\" with path \"/path\" with value \"babar\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Browser has cookie "foo" with path "/path" with value "babar".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate($browser);
     }
 
     private function getBrowser(): AbstractBrowser

--- a/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserHasCookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserHasCookieTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\BrowserKit\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar;
@@ -31,45 +30,32 @@ class BrowserHasCookieTest extends TestCase
         $constraint = new BrowserHasCookie('bar');
         $this->assertFalse($constraint->evaluate($browser, '', true));
 
-        try {
-            $constraint->evaluate($browser);
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Browser has cookie \"bar\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Browser has cookie "bar".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate($browser);
     }
 
     public function testConstraintWithWrongPath()
     {
         $browser = $this->getBrowser();
         $constraint = new BrowserHasCookie('foo', '/other');
-        try {
-            $constraint->evaluate($browser);
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Browser has cookie \"foo\" with path \"/other\".\n", TestFailure::exceptionToString($e));
 
-            return;
-        }
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Browser has cookie "foo" with path "/other".');
 
-        $this->fail();
+        $constraint->evaluate($browser);
     }
 
     public function testConstraintWithWrongDomain()
     {
         $browser = $this->getBrowser();
         $constraint = new BrowserHasCookie('foo', '/path', 'example.org');
-        try {
-            $constraint->evaluate($browser);
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Browser has cookie \"foo\" with path \"/path\" for domain \"example.org\".\n", TestFailure::exceptionToString($e));
 
-            return;
-        }
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Browser has cookie "foo" with path "/path" for domain "example.org".');
 
-        $this->fail();
+        $constraint->evaluate($browser);
     }
 
     private function getBrowser(): AbstractBrowser

--- a/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsSuccessfulTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsSuccessfulTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Console\Tests\Tester\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
 
@@ -35,16 +34,9 @@ final class CommandIsSuccessfulTest extends TestCase
     {
         $constraint = new CommandIsSuccessful();
 
-        try {
-            $constraint->evaluate($exitCode);
-        } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('Failed asserting that the command is successful.', TestFailure::exceptionToString($e));
-            $this->assertStringContainsString($expectedException, TestFailure::exceptionToString($e));
-
-            return;
-        }
-
-        $this->fail();
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Failed asserting that the command is successful\..*'.$expectedException.'/s');
+        $constraint->evaluate($exitCode);
     }
 
     public static function providesUnsuccessful(): iterable

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerAnySelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerAnySelectorTextContainsTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerAnySelectorTextContains;
 
@@ -27,23 +26,25 @@ class CrawlerAnySelectorTextContainsTest extends TestCase
         self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo'), '', true));
         self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo Bar Baz'), '', true));
         self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'), '', true));
+    }
 
-        try {
-            $constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'));
+    public function testDoesNotMatchIfNodeDoesContainExpectedText()
+    {
+        $constraint = new CrawlerAnySelectorTextContains('ul li', 'Foo');
 
-            self::fail();
-        } catch (ExpectationFailedException $e) {
-            self::assertEquals("Failed asserting that the text of any node matching selector \"ul li\" contains \"Foo\".\n", TestFailure::exceptionToString($e));
-        }
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the text of any node matching selector "ul li" contains "Foo".');
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>Foobar'));
+        $constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'));
+    }
 
-            self::fail();
-        } catch (ExpectationFailedException $e) {
-            self::assertEquals("Failed asserting that the Crawler has a node matching selector \"ul li\".\n", TestFailure::exceptionToString($e));
+    public function testDoesNotMatchIfNodeDoesNotExist()
+    {
+        $constraint = new CrawlerAnySelectorTextContains('ul li', 'Foo');
 
-            return;
-        }
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Crawler has a node matching selector "ul li".');
+
+        $constraint->evaluate(new Crawler('<html><head><title>Foobar'));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerAnySelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerAnySelectorTextSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerAnySelectorTextSame;
 
@@ -28,12 +27,9 @@ final class CrawlerAnySelectorTextSameTest extends TestCase
         self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo Bar Baz'), '', true));
         self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'), '', true));
 
-        try {
-            $constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Crawler has at least a node matching selector "ul li" with content "Foo".');
 
-            self::fail();
-        } catch (ExpectationFailedException $e) {
-            self::assertEquals("Failed asserting that the Crawler has at least a node matching selector \"ul li\" with content \"Foo\".\n", TestFailure::exceptionToString($e));
-        }
+        $constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorAttributeValueSame;
 
@@ -26,14 +25,9 @@ class CrawlerSelectorAttributeValueSameTest extends TestCase
         $this->assertFalse($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username">'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>Bar'));
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"input[name=\"username\"]\" with attribute \"value\" of value \"Fabien\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Crawler has a node matching selector "input[name="username"]" with attribute "value" of value "Fabien".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Crawler('<html><head><title>Bar'));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorExistsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorExistsTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorExists;
 
@@ -26,14 +25,9 @@ class CrawlerSelectorExistsTest extends TestCase
         $constraint = new CrawlerSelectorExists('h1');
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>'), '', true));
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>'));
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler matches selector \"h1\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Crawler matches selector "h1".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Crawler('<html><head><title>'));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorTextContains;
 
@@ -25,21 +24,25 @@ class CrawlerSelectorTextContainsTest extends TestCase
         $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foobar'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head></head><body>Bar'), '', true));
+    }
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>Bar'));
+    public function testDoesNotMatchIfNodeTextIsNotExpectedValue()
+    {
+        $constraint = new CrawlerSelectorTextContains('title', 'Foo');
 
-            $this->fail();
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the text \"Bar\" of the node matching selector \"title\" contains \"Foo\".\n", TestFailure::exceptionToString($e));
-        }
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the text "Bar" of the node matching selector "title" contains "Foo".');
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head></head><body>Bar'));
+        $constraint->evaluate(new Crawler('<html><head><title>Bar'));
+    }
 
-            $this->fail();
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"title\".\n", TestFailure::exceptionToString($e));
-        }
+    public function testDoesNotMatchIfNodeDoesNotExist()
+    {
+        $constraint = new CrawlerSelectorTextContains('title', 'Foo');
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Crawler has a node matching selector "title".');
+
+        $constraint->evaluate(new Crawler('<html><head></head><body>Bar'));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorTextSame;
 
@@ -25,14 +24,9 @@ class CrawlerSelectorTextSameTest extends TestCase
         $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foo'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>Bar'));
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"title\" with content \"Foo\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Crawler has a node matching selector "title" with content "Foo".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Crawler('<html><head><title>Bar'));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/RequestAttributeValueSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/RequestAttributeValueSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Test\Constraint\RequestAttributeValueSame;
 
@@ -28,14 +27,9 @@ class RequestAttributeValueSameTest extends TestCase
         $constraint = new RequestAttributeValueSame('bar', 'foo');
         $this->assertFalse($constraint->evaluate($request, '', true));
 
-        try {
-            $constraint->evaluate($request);
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Request has attribute \"bar\" with value \"foo\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Request has attribute "bar" with value "foo".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate($request);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseCookieValueSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseCookieValueSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseCookieValueSame;
@@ -31,15 +30,10 @@ class ResponseCookieValueSameTest extends TestCase
         $constraint = new ResponseCookieValueSame('foo', 'babar', '/path');
         $this->assertFalse($constraint->evaluate($response, '', true));
 
-        try {
-            $constraint->evaluate($response);
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Response has cookie \"foo\" with path \"/path\" with value \"babar\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Response has cookie "foo" with path "/path" with value "babar".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate($response);
     }
 
     public function testCookieWithNullValueIsComparedAsEmptyString()

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseFormatSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseFormatSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseFormatSame;
@@ -32,15 +31,10 @@ class ResponseFormatSameTest extends TestCase
         $this->assertTrue($constraint->evaluate(new Response('', 200, ['Content-Type' => 'application/vnd.myformat']), '', true));
         $this->assertFalse($constraint->evaluate(new Response(), '', true));
 
-        try {
-            $constraint->evaluate(new Response('', 200, ['Content-Type' => 'application/ld+json']));
-        } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("Failed asserting that the Response format is custom.\nHTTP/1.0 200 OK", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Failed asserting that the Response format is custom.\nHTTP/1.0 200 OK");
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Response('', 200, ['Content-Type' => 'application/ld+json']));
     }
 
     public function testNullFormat()
@@ -48,14 +42,9 @@ class ResponseFormatSameTest extends TestCase
         $constraint = new ResponseFormatSame(new Request(), null);
         $this->assertTrue($constraint->evaluate(new Response(), '', true));
 
-        try {
-            $constraint->evaluate(new Response('', 200, ['Content-Type' => 'application/ld+json']));
-        } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("Failed asserting that the Response format is null.\nHTTP/1.0 200 OK", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Failed asserting that the Response format is null.\nHTTP/1.0 200 OK");
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Response('', 200, ['Content-Type' => 'application/ld+json']));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHasCookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHasCookieTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseHasCookie;
@@ -29,14 +28,9 @@ class ResponseHasCookieTest extends TestCase
         $constraint = new ResponseHasCookie('bar');
         $this->assertFalse($constraint->evaluate($response, '', true));
 
-        try {
-            $constraint->evaluate($response);
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Response has cookie \"bar\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Response has cookie "bar".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate($response);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHasHeaderTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHasHeaderTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseHasHeader;
 
@@ -26,14 +25,9 @@ class ResponseHasHeaderTest extends TestCase
         $constraint = new ResponseHasHeader('X-Date');
         $this->assertFalse($constraint->evaluate(new Response(), '', true));
 
-        try {
-            $constraint->evaluate(new Response());
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Response has header \"X-Date\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Response has header "X-Date".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Response());
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseHeaderSame;
 
@@ -26,14 +25,9 @@ class ResponseHeaderSameTest extends TestCase
         $constraint = new ResponseHeaderSame('Cache-Control', 'public');
         $this->assertFalse($constraint->evaluate(new Response(), '', true));
 
-        try {
-            $constraint->evaluate(new Response());
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Response has header \"Cache-Control\" with value \"public\".\n", TestFailure::exceptionToString($e));
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public".');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Response());
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsRedirectedTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsRedirectedTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseIsRedirected;
 
@@ -26,17 +25,10 @@ class ResponseIsRedirectedTest extends TestCase
         $this->assertTrue($constraint->evaluate(new Response('', 301), '', true));
         $this->assertFalse($constraint->evaluate(new Response(), '', true));
 
-        try {
-            $constraint->evaluate(new Response('Body content'));
-        } catch (ExpectationFailedException $e) {
-            $exceptionMessage = TestFailure::exceptionToString($e);
-            $this->assertStringContainsString("Failed asserting that the Response is redirected.\nHTTP/1.0 200 OK", $exceptionMessage);
-            $this->assertStringContainsString('Body content', $exceptionMessage);
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Failed asserting that the Response is redirected.\nHTTP\/1.0 200 OK.+Body content/s');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Response('Body content'));
     }
 
     public function testReducedVerbosity()
@@ -45,9 +37,8 @@ class ResponseIsRedirectedTest extends TestCase
         try {
             $constraint->evaluate(new Response('Body content'));
         } catch (ExpectationFailedException $e) {
-            $exceptionMessage = TestFailure::exceptionToString($e);
-            $this->assertStringContainsString("Failed asserting that the Response is redirected.\nHTTP/1.0 200 OK", $exceptionMessage);
-            $this->assertStringNotContainsString('Body content', $exceptionMessage);
+            $this->assertStringContainsString("Failed asserting that the Response is redirected.\nHTTP/1.0 200 OK", $e->getMessage());
+            $this->assertStringNotContainsString('Body content', $e->getMessage());
 
             return;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsSuccessfulTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsSuccessfulTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseIsSuccessful;
 
@@ -26,17 +25,10 @@ class ResponseIsSuccessfulTest extends TestCase
         $this->assertTrue($constraint->evaluate(new Response(), '', true));
         $this->assertFalse($constraint->evaluate(new Response('', 404), '', true));
 
-        try {
-            $constraint->evaluate(new Response('Response body', 404));
-        } catch (ExpectationFailedException $e) {
-            $exceptionMessage = TestFailure::exceptionToString($e);
-            $this->assertStringContainsString("Failed asserting that the Response is successful.\nHTTP/1.0 404 Not Found", $exceptionMessage);
-            $this->assertStringContainsString('Response body', $exceptionMessage);
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Failed asserting that the Response is successful.\nHTTP\/1.0 404 Not Found.+Response body/s');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Response('Response body', 404));
     }
 
     public function testReducedVerbosity()
@@ -46,9 +38,8 @@ class ResponseIsSuccessfulTest extends TestCase
         try {
             $constraint->evaluate(new Response('Response body', 404));
         } catch (ExpectationFailedException $e) {
-            $exceptionMessage = TestFailure::exceptionToString($e);
-            $this->assertStringContainsString("Failed asserting that the Response is successful.\nHTTP/1.0 404 Not Found", $exceptionMessage);
-            $this->assertStringNotContainsString('Response body', $exceptionMessage);
+            $this->assertStringContainsString("Failed asserting that the Response is successful.\nHTTP/1.0 404 Not Found", $e->getMessage());
+            $this->assertStringNotContainsString('Response body', $e->getMessage());
 
             return;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsUnprocessableTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsUnprocessableTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseIsUnprocessable;
 
@@ -26,17 +25,10 @@ class ResponseIsUnprocessableTest extends TestCase
         $this->assertTrue($constraint->evaluate(new Response('', 422), '', true));
         $this->assertFalse($constraint->evaluate(new Response(), '', true));
 
-        try {
-            $constraint->evaluate(new Response('Response body'));
-        } catch (ExpectationFailedException $e) {
-            $exceptionMessage = TestFailure::exceptionToString($e);
-            $this->assertStringContainsString("Failed asserting that the Response is unprocessable.\nHTTP/1.0 200 OK", $exceptionMessage);
-            $this->assertStringContainsString('Response body', $exceptionMessage);
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Failed asserting that the Response is unprocessable.\nHTTP\/1.0 200 OK.+Response body/s');
 
-            return;
-        }
-
-        $this->fail();
+        $constraint->evaluate(new Response('Response body'));
     }
 
     public function testReducedVerbosity()
@@ -46,9 +38,8 @@ class ResponseIsUnprocessableTest extends TestCase
         try {
             $constraint->evaluate(new Response('Response body'));
         } catch (ExpectationFailedException $e) {
-            $exceptionMessage = TestFailure::exceptionToString($e);
-            $this->assertStringContainsString("Failed asserting that the Response is unprocessable.\nHTTP/1.0 200 OK", $exceptionMessage);
-            $this->assertStringNotContainsString('Response body', $exceptionMessage);
+            $this->assertStringContainsString("Failed asserting that the Response is unprocessable.\nHTTP/1.0 200 OK", $e->getMessage());
+            $this->assertStringNotContainsString('Response body', $e->getMessage());
 
             return;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseStatusCodeSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseStatusCodeSameTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseStatusCodeSame;
 
@@ -28,17 +27,11 @@ class ResponseStatusCodeSameTest extends TestCase
         $this->assertTrue($constraint->evaluate(new Response('', 404), '', true));
 
         $constraint = new ResponseStatusCodeSame(200);
-        try {
-            $constraint->evaluate(new Response('Response body', 404));
-        } catch (ExpectationFailedException $e) {
-            $exceptionMessage = TestFailure::exceptionToString($e);
-            $this->assertStringContainsString("Failed asserting that the Response status code is 200.\nHTTP/1.0 404 Not Found", TestFailure::exceptionToString($e));
-            $this->assertStringContainsString('Response body', $exceptionMessage);
 
-            return;
-        }
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Failed asserting that the Response status code is 200.\nHTTP\/1.0 404 Not Found.+Response body/s');
 
-        $this->fail();
+        $constraint->evaluate(new Response('Response body', 404));
     }
 
     public function testReducedVerbosity()
@@ -48,9 +41,8 @@ class ResponseStatusCodeSameTest extends TestCase
         try {
             $constraint->evaluate(new Response('Response body', 404));
         } catch (ExpectationFailedException $e) {
-            $exceptionMessage = TestFailure::exceptionToString($e);
-            $this->assertStringContainsString("Failed asserting that the Response status code is 200.\nHTTP/1.0 404 Not Found", TestFailure::exceptionToString($e));
-            $this->assertStringNotContainsString('Response body', $exceptionMessage);
+            $this->assertStringContainsString("Failed asserting that the Response status code is 200.\nHTTP/1.0 404 Not Found", $e->getMessage());
+            $this->assertStringNotContainsString('Response body', $e->getMessage());
 
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The class was removed in PHPUnit 10.