### PR TITLE
[HttpFoundation] let test fail if an expected exception is not thrown

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseStatusCodeSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseStatusCodeSameTest.php
@@ -54,5 +54,7 @@ class ResponseStatusCodeSameTest extends TestCase
 
             return;
         }
+
+        $this->fail();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | see https://github.com/symfony/symfony/pull/58177#discussion_r1744967867
| License       | MIT
