### PR TITLE
[Mailer] Use the AsyncAWS bundle service if present when wiring the mailer transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
@@ -46,7 +46,6 @@ return static function (ContainerConfigurator $container) {
             ->tag('monolog.logger', ['channel' => 'mailer']);
 
     $factories = [
-        'amazon' => SesTransportFactory::class,
         'azure' => AzureTransportFactory::class,
         'brevo' => BrevoTransportFactory::class,
         'gmail' => GmailTransportFactory::class,
@@ -75,4 +74,10 @@ return static function (ContainerConfigurator $container) {
                 ->parent('mailer.transport_factory.abstract')
                 ->tag('mailer.transport_factory');
     }
+
+    $container->services()
+        ->set('mailer.transport_factory.amazon', SesTransportFactory::class)
+            ->parent('mailer.transport_factory.abstract')
+            ->arg('$sesClient', service('async_aws.client.ses')->ignoreOnInvalid())
+            ->tag('mailer.transport_factory');
 };

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
@@ -13,10 +13,13 @@ namespace Symfony\Component\Mailer\Bridge\Amazon\Transport;
 
 use AsyncAws\Core\Configuration;
 use AsyncAws\Ses\SesClient;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Konstantin Myakshin <molodchick@gmail.com>
@@ -24,6 +27,15 @@ use Symfony\Component\Mailer\Transport\TransportInterface;
  */
 final class SesTransportFactory extends AbstractTransportFactory
 {
+    public function __construct(
+        ?EventDispatcherInterface $dispatcher = null,
+        ?HttpClientInterface $client = null,
+        ?LoggerInterface $logger = null,
+        private ?SesClient $sesClient = null,
+    ) {
+        parent::__construct($dispatcher, $client, $logger);
+    }
+
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
@@ -56,7 +68,7 @@ final class SesTransportFactory extends AbstractTransportFactory
                     null === $dsn->getOption('session_token') ? [] : ['sessionToken' => $dsn->getOption('session_token')]
                 );
 
-                return new $class(new SesClient(Configuration::create($options), null, $this->client, $this->logger), $this->dispatcher, $this->logger);
+                return new $class($this->sesClient ?? new SesClient(Configuration::create($options), null, $this->client, $this->logger), $this->dispatcher, $this->logger);
         }
 
         throw new UnsupportedSchemeException($dsn, 'ses', $this->getSupportedSchemes());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no (yes?)
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

When using async aws's bundle, an SesClient service will be defined, which has proper credential configuration with cache etc.. But this is not used by the mailer when relying on `ses` transports, as it creates its own SesClient instance.

This PR makes it reuse the service if present. I think it could be seen as bugfix and be rebased on 6.4 but I did the patch on 7.2 so posting as is first and if you think it's worth a rebase I'll happily do it.

cc @jderusse who helped me figure this out