### PR TITLE
[Filesystem] make sure temp files can be cleaned up on Windows

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -696,6 +696,10 @@ class Filesystem
             $this->rename($tmpFile, $filename, true);
         } finally {
             if (file_exists($tmpFile)) {
+                if ('\\' === \DIRECTORY_SEPARATOR && !is_writable($tmpFile)) {
+                    self::box('chmod', $tmpFile, self::box('fileperms', $tmpFile) | 0200);
+                }
+
                 self::box('unlink', $tmpFile);
             }
         }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1826,6 +1826,22 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFilePermissions(745, $filename);
     }
 
+    public function testDumpFileCleansUpAfterFailure()
+    {
+        $targetFile = $this->workspace.'/dump-file';
+        $this->filesystem->touch($targetFile);
+        $this->filesystem->chmod($targetFile, 0444);
+
+        try {
+            $this->filesystem->dumpFile($targetFile, 'any content');
+        } catch (IOException $e) {
+        } finally {
+            $this->filesystem->chmod($targetFile, 0666);
+        }
+
+        $this->assertSame([$targetFile], glob($this->workspace.'/*'));
+    }
+
     public function testCopyShouldKeepExecutionPermission()
     {
         $this->markAsSkippedIfChmodIsMissing();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

based on the findings while debugging the AppVeyor failures that we worked around in #58152