### PR TITLE
[Security] Update `TraceableAccessDecisionManager` to reset class context

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Core\Authorization;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Decorates the original AccessDecisionManager class to log information
@@ -23,7 +24,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
  *
  * @internal
  */
-class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
+class TraceableAccessDecisionManager implements AccessDecisionManagerInterface, ResetInterface
 {
     private AccessDecisionManagerInterface $manager;
     private ?AccessDecisionStrategyInterface $strategy = null;
@@ -105,5 +106,12 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
     public function getDecisionLog(): array
     {
         return $this->decisionLog;
+    }
+
+    public function reset(): void
+    {
+        $this->voters = [];
+        $this->decisionLog = [];
+        $this->currentLog = [];
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -110,7 +110,6 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface, 
 
     public function reset(): void
     {
-        $this->voters = [];
         $this->decisionLog = [];
         $this->currentLog = [];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

In swoole/roadrunner runtime, \Symfony\Bundle\SecurityBundle\EventListener\VoteListener will add addVoterVote many times. It is better to make TraceableAccessDecisionManager resettable, or it will will increase memory usage in swoole/roadrunner runtime application.