### PR TITLE
Pass `validator.translation_domain` to `RequestPayloadValueResolver`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -71,6 +71,7 @@ return static function (ContainerConfigurator $container) {
                 service('serializer'),
                 service('validator')->nullOnInvalid(),
                 service('translator')->nullOnInvalid(),
+                param('validator.translation_domain'),
             ])
             ->tag('controller.targeted_value_resolver', ['name' => RequestPayloadValueResolver::class])
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -65,6 +65,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
         private readonly SerializerInterface&DenormalizerInterface $serializer,
         private readonly ?ValidatorInterface $validator = null,
         private readonly ?TranslatorInterface $translator = null,
+        private string $translationDomain = 'validators',
     ) {
     }
 
@@ -137,7 +138,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                         if ($error->canUseMessageForUser()) {
                             $parameters['hint'] = $error->getMessage();
                         }
-                        $message = $trans($template, $parameters, 'validators');
+                        $message = $trans($template, $parameters, $this->translationDomain);
                         $violations->add(new ConstraintViolation($message, $template, $parameters, null, $error->getPath(), null));
                     }
                     $payload = $e->getData();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| Issues        | Fix #58170
| License       | MIT

Replaces hardcoded validation translation domain by container param `validator.translation_domain`.
Used [UploadValidatorExtension](https://github.com/symfony/symfony/blob/7f15676de99eae53b5b818a038b1bf070577b341/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php#L24) as inspiration.
