### PR TITLE
[Process] Fix backwards compatibility for invalid commands

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -358,6 +358,11 @@ class Process implements \IteratorAggregate
 
         try {
             $process = @proc_open($commandline, $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $this->options);
+
+            // Ensure array vs string commands behave the same
+            if (!$process && \is_array($commandline)) {
+                $process = @proc_open('exec '.$this->buildShellCommandline($commandline), $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $this->options);
+            }
         } finally {
             if ($this->ignoredSignals && \function_exists('pcntl_sigprocmask')) {
                 // we restore the signal mask here to avoid any side effects

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -72,13 +72,8 @@ class ProcessTest extends TestCase
      */
     public function testInvalidCommand(Process $process)
     {
-        try {
-            $this->assertSame('\\' === \DIRECTORY_SEPARATOR ? 1 : 127, $process->run());
-        } catch (ProcessStartFailedException $e) {
-            // An invalid command might already fail during start since PHP 8.3 for platforms
-            // supporting posix_spawn(), see https://github.com/php/php-src/issues/12589
-            $this->assertStringContainsString('No such file or directory', $e->getMessage());
-        }
+        // An invalid command should not fail during start
+        $this->assertSame('\\' === \DIRECTORY_SEPARATOR ? 1 : 127, $process->run());
     }
 
     public function invalidProcessProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | maybe?
| Issues        | Fix #57946
| License       | MIT

As discussed in https://github.com/symfony/symfony/issues/57946#issuecomment-2332184584