### PR TITLE
Mitigate PHPUnit deprecations (5.4)

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
@@ -62,7 +62,7 @@ class DoctrineCloseConnectionMiddlewareTest extends MiddlewareTestCase
         $managerRegistry
             ->method('getManager')
             ->with('unknown_manager')
-            ->will($this->throwException(new \InvalidArgumentException()));
+            ->willThrowException(new \InvalidArgumentException());
 
         $middleware = new DoctrineCloseConnectionMiddleware($managerRegistry, 'unknown_manager');
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -101,7 +101,7 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
         $managerRegistry
             ->method('getManager')
             ->with('unknown_manager')
-            ->will($this->throwException(new \InvalidArgumentException()));
+            ->willThrowException(new \InvalidArgumentException());
 
         $middleware = new DoctrinePingConnectionMiddleware($managerRegistry, 'unknown_manager');
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineTransactionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineTransactionMiddlewareTest.php
@@ -73,7 +73,7 @@ class DoctrineTransactionMiddlewareTest extends MiddlewareTestCase
         $managerRegistry
             ->method('getManager')
             ->with('unknown_manager')
-            ->will($this->throwException(new \InvalidArgumentException()));
+            ->willThrowException(new \InvalidArgumentException());
 
         $middleware = new DoctrineTransactionMiddleware($managerRegistry, 'unknown_manager');
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
@@ -57,9 +57,9 @@ class FailoverTransportTest extends TestCase
     public function testSendAllDead()
     {
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->expects($this->once())->method('send')->will($this->throwException(new TransportException()));
+        $t1->expects($this->once())->method('send')->willThrowException(new TransportException());
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->expects($this->once())->method('send')->will($this->throwException(new TransportException()));
+        $t2->expects($this->once())->method('send')->willThrowException(new TransportException());
         $t = new FailoverTransport([$t1, $t2]);
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('All transports failed.');
@@ -70,7 +70,7 @@ class FailoverTransportTest extends TestCase
     public function testSendOneDead()
     {
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->expects($this->once())->method('send')->will($this->throwException(new TransportException()));
+        $t1->expects($this->once())->method('send')->willThrowException(new TransportException());
         $t2 = $this->createMock(TransportInterface::class);
         $t2->expects($this->exactly(3))->method('send');
         $t = new FailoverTransport([$t1, $t2]);

--- a/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
@@ -57,9 +57,9 @@ class RoundRobinTransportTest extends TestCase
     public function testSendAllDead()
     {
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->expects($this->once())->method('send')->will($this->throwException(new TransportException()));
+        $t1->expects($this->once())->method('send')->willThrowException(new TransportException());
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->expects($this->once())->method('send')->will($this->throwException(new TransportException()));
+        $t2->expects($this->once())->method('send')->willThrowException(new TransportException());
         $t = new RoundRobinTransport([$t1, $t2]);
         $p = new \ReflectionProperty($t, 'cursor');
         $p->setAccessible(true);
@@ -81,7 +81,7 @@ class RoundRobinTransportTest extends TestCase
     public function testSendOneDead()
     {
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->expects($this->once())->method('send')->will($this->throwException(new TransportException()));
+        $t1->expects($this->once())->method('send')->willThrowException(new TransportException());
         $t2 = $this->createMock(TransportInterface::class);
         $t2->expects($this->exactly(3))->method('send');
         $t = new RoundRobinTransport([$t1, $t2]);
@@ -101,7 +101,7 @@ class RoundRobinTransportTest extends TestCase
         $t1 = $this->createMock(TransportInterface::class);
         $t1->expects($this->exactly(4))->method('send');
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->expects($this->once())->method('send')->will($this->throwException(new TransportException()));
+        $t2->expects($this->once())->method('send')->willThrowException(new TransportException());
         $t = new RoundRobinTransport([$t1, $t2], 60);
         $p = new \ReflectionProperty($t, 'cursor');
         $p->setAccessible(true);
@@ -152,13 +152,13 @@ class RoundRobinTransportTest extends TestCase
         $t1 = $this->createMock(TransportInterface::class);
         $e1 = new TransportException();
         $e1->appendDebug('Debug message 1');
-        $t1->expects($this->once())->method('send')->will($this->throwException($e1));
+        $t1->expects($this->once())->method('send')->willThrowException($e1);
         $t1->expects($this->once())->method('__toString')->willReturn('t1');
 
         $t2 = $this->createMock(TransportInterface::class);
         $e2 = new TransportException();
         $e2->appendDebug('Debug message 2');
-        $t2->expects($this->once())->method('send')->will($this->throwException($e2));
+        $t2->expects($this->once())->method('send')->willThrowException($e2);
         $t2->expects($this->once())->method('__toString')->willReturn('t2');
 
         $t = new RoundRobinTransport([$t1, $t2]);

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
@@ -68,7 +68,7 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             ->with($this->callback(function (Envelope $envelope) use (&$series) {
                 return $envelope->getMessage() === array_shift($series);
             }))
-            ->will($this->willHandleMessage());
+            ->willReturnCallback($this->handleMessageCallback());
 
         $messageBus->dispatch($message);
     }
@@ -282,7 +282,7 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
         $handlingMiddleware
             ->method('handle')
             ->with($this->expectHandledMessage($event))
-            ->will($this->willHandleMessage());
+            ->willReturnCallback($this->handleMessageCallback());
 
         $eventBus = new MessageBus([
             $middleware,
@@ -301,11 +301,11 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
         });
     }
 
-    private function willHandleMessage(): ReturnCallback
+    private function handleMessageCallback(): \Closure
     {
-        return $this->returnCallback(function ($envelope, StackInterface $stack) {
+        return function ($envelope, StackInterface $stack) {
             return $stack->next()->handle($envelope, $stack);
-        });
+        };
     }
 }
 

--- a/src/Symfony/Component/Notifier/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/FailoverTransportTest.php
@@ -80,11 +80,11 @@ class FailoverTransportTest extends TestCase
 
         $t1 = $this->createMock(TransportInterface::class);
         $t1->method('supports')->with($message)->willReturn(true);
-        $t1->expects($this->once())->method('send')->with($message)->will($this->throwException($this->createMock(TransportExceptionInterface::class)));
+        $t1->expects($this->once())->method('send')->with($message)->willThrowException($this->createMock(TransportExceptionInterface::class));
 
         $t2 = $this->createMock(TransportInterface::class);
         $t2->method('supports')->with($message)->willReturn(true);
-        $t2->expects($this->once())->method('send')->with($message)->will($this->throwException($this->createMock(TransportExceptionInterface::class)));
+        $t2->expects($this->once())->method('send')->with($message)->willThrowException($this->createMock(TransportExceptionInterface::class));
 
         $t = new FailoverTransport([$t1, $t2]);
 
@@ -100,7 +100,7 @@ class FailoverTransportTest extends TestCase
 
         $t1 = $this->createMock(TransportInterface::class);
         $t1->method('supports')->with($message)->willReturn(true);
-        $t1->expects($this->once())->method('send')->will($this->throwException($this->createMock(TransportExceptionInterface::class)));
+        $t1->expects($this->once())->method('send')->willThrowException($this->createMock(TransportExceptionInterface::class));
 
         $t2 = $this->createMock(TransportInterface::class);
         $t2->method('supports')->with($message)->willReturn(true);
@@ -117,7 +117,7 @@ class FailoverTransportTest extends TestCase
 
         $t1 = $this->createMock(TransportInterface::class);
         $t1->method('supports')->with($message)->willReturn(true);
-        $t1->method('send')->will($this->throwException($this->createMock(TransportExceptionInterface::class)));
+        $t1->method('send')->willThrowException($this->createMock(TransportExceptionInterface::class));
         $t1->expects($this->once())->method('send');
         $t2 = $this->createMock(TransportInterface::class);
         $t2->method('supports')->with($message)->willReturn(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Calling `->will(...)` is deprecated in many cases: https://github.com/sebastianbergmann/phpunit/blob/main/DEPRECATIONS.md.