### PR TITLE
[Process] Fix the removal of host-specific configuration when managing the ini settings in `PhpSubprocess`

### DIFF
--- a/src/Symfony/Component/Process/PhpSubprocess.php
+++ b/src/Symfony/Component/Process/PhpSubprocess.php
@@ -106,7 +106,7 @@ class PhpSubprocess extends Process
                 throw new RuntimeException('Unable to read ini: '.$file);
             }
             // Check and remove directives after HOST and PATH sections
-            if (preg_match('/^\s*\[(?:PATH|HOST)\s*=/mi', $data, $matches)) {
+            if (preg_match('/^\s*\[(?:PATH|HOST)\s*=/mi', $data, $matches, \PREG_OFFSET_CAPTURE)) {
                 $data = substr($data, 0, $matches[0][1]);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | 
| License       | MIT

`preg_match` can return the offset needed for `substr` in the next line, but without the flag it doesn't put the offset of the capturing group into `$matches[0][1]`

With the example php.ini the code breaks on execution

```ini
opcache.validate_timestamps = 0
[HOST=my.test.host]
opcache.validate_timestamps = 1
``` 
