### PR TITLE
[FrameworkBundle] Add `--resolve-env-vars` option to `lint:container` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for setting `headers` with `Symfony\Bundle\FrameworkBundle\Controller\TemplateController`
+ * Add `--resolve-env-vars` option to `lint:container` command
  * Derivate `kernel.secret` from the decryption secret when its env var is not defined
  * Make the `config/` directory optional in `MicroKernelTrait`, add support for service arguments in the
    invokable Kernel class, and register `FrameworkBundle` by default when the `bundles.php` file is missing

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Compiler\CheckAliasValidityPass;
@@ -39,6 +40,7 @@ final class ContainerLintCommand extends Command
     {
         $this
             ->setHelp('This command parses service definitions and ensures that injected values match the type declarations of each services\' class.')
+            ->addOption('resolve-env-vars', null, InputOption::VALUE_NONE, 'Resolve environment variables and fail if one is missing.')
         ;
     }
 
@@ -58,7 +60,7 @@ final class ContainerLintCommand extends Command
         $container->setParameter('container.build_time', time());
 
         try {
-            $container->compile();
+            $container->compile((bool) $input->getOption('resolve-env-vars'));
         } catch (InvalidArgumentException $e) {
             $errorIo->error($e->getMessage());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no
| Issues        | Fix #58105
| License       | MIT

