### PR TITLE
[Notifier] Deprecate sms77 Notifier bridge

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -118,6 +118,11 @@ SecurityBundle
 
  * Deprecate the `security.hide_user_not_found` config option in favor of `security.expose_security_errors`
 
+ Notifier
+ --------
+
+ * Deprecate the `Sms77` transport, use `SevenIo` instead
+
 Serializer
 ----------
 

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Deprecate the bridge
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/README.md
@@ -1,7 +1,7 @@
 sms77 Notifier
 =================
 
-Provides [sms77](https://www.sms77.io/) integration for Symfony Notifier.
+The sms77 bridge is deprecated, use the Seven.io bridge instead.
 
 DSN example
 -----------

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
@@ -23,6 +23,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author André Matthies <matthiez@gmail.com>
+ *
+ * @deprecated since Symfony 7.3, use the Seven.io bridge instead.
  */
 final class Sms77Transport extends AbstractTransport
 {

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77TransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77TransportFactory.php
@@ -17,11 +17,15 @@ use Symfony\Component\Notifier\Transport\Dsn;
 
 /**
  * @author André Matthies <matthiez@gmail.com>
+ *
+ * @deprecated since Symfony 7.3, use the Seven.io bridge instead.
  */
 final class Sms77TransportFactory extends AbstractTransportFactory
 {
     public function create(Dsn $dsn): Sms77Transport
     {
+        trigger_deprecation('symfony/sms77-notifier', '7.3', 'The "symfony/sms77-notifier" package is deprecated, use "symfony/sevenio-notifier" instead.');
+
         $scheme = $dsn->getScheme();
 
         if ('sms77' !== $scheme) {

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportFactoryTest.php
@@ -15,6 +15,9 @@ use Symfony\Component\Notifier\Bridge\Sms77\Sms77TransportFactory;
 use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
 use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
 
+/**
+ * @group legacy
+ */
 final class Sms77TransportFactoryTest extends AbstractTransportFactoryTestCase
 {
     use IncompleteDsnTestTrait;

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
@@ -19,6 +19,9 @@ use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * @group legacy
+ */
 final class Sms77TransportTest extends TransportTestCase
 {
     public static function createTransport(?HttpClientInterface $client = null, ?string $from = null): Sms77Transport

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client": "^6.4|^7.0",
         "symfony/notifier": "^7.2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Following #52936 
| License       | MIT

#52936 introduced a new Seven.io bridge for Notifier component to replace sms77 but this one has not been deprecated
