### PR TITLE
[Validator] Add the `DataUri` constraint for validating Data URI content

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add the `WordCount` constraint
  * Add the `Week` constraint
  * Add `CompoundConstraintTestCase` to ease testing Compound Constraints
+ * Add the `DataUri` constraint for validating Data URI content
 
 7.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/DataUri.php
+++ b/src/Symfony/Component/Validator/Constraints/DataUri.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validates that a value is a valid data URI string.
+ *
+ * @author Kev <https://github.com/symfonyaml>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class DataUri extends Constraint
+{
+    public const INVALID_DATA_URI_ERROR = 'b9e175d1-8d7a-4e28-bf65-ad2448a3b3cf';
+
+    protected const ERROR_NAMES = [
+        self::INVALID_DATA_URI_ERROR => 'INVALID_DATA_URI_ERROR',
+    ];
+
+    public string $message = 'This value is not a valid data URI.';
+
+    /**
+     * @param array<string,mixed>|null $options
+     * @param string[]|null            $groups
+     */
+    public function __construct(
+        ?array $options = null,
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct($options ?? [], $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/DataUriValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DataUriValidator.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 /**
  * @author Kev <https://github.com/symfonyaml>
+ *
  * @see https://datatracker.ietf.org/doc/html/rfc2397
  */
 class DataUriValidator extends ConstraintValidator
@@ -54,8 +55,8 @@ class DataUriValidator extends ConstraintValidator
         }
 
         if (!preg_match(static::PATTERN, $value)) {
-            if (strlen($value) > self::MAX_MESSAGE_VALUE_LENGTH) {
-                $value = sprintf('%s (truncated)', $this->formatValue(substr($value, 0, self::MAX_MESSAGE_VALUE_LENGTH) . '...'));
+            if (\strlen($value) > self::MAX_MESSAGE_VALUE_LENGTH) {
+                $value = \sprintf('%s (truncated)', $this->formatValue(substr($value, 0, self::MAX_MESSAGE_VALUE_LENGTH).'...'));
             } else {
                 $value = $this->formatValue($value);
             }

--- a/src/Symfony/Component/Validator/Constraints/DataUriValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DataUriValidator.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+/**
+ * @author Kev <https://github.com/symfonyaml>
+ * @see https://datatracker.ietf.org/doc/html/rfc2397
+ */
+class DataUriValidator extends ConstraintValidator
+{
+    /** maximum number of characters allowed in a error message */
+    private const MAX_MESSAGE_VALUE_LENGTH = 30;
+    /** data-uri regexp */
+    public const PATTERN = '~^
+            data:
+            (?:\w+\/(?:(?!;).)+)?  # MIME-type
+            (?:;[\w\W]*?[^;])*     # parameters
+            (;base64)?             # encoding
+            ,
+            [^$]+                  # data
+        $~ixuD';
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof DataUri) {
+            throw new UnexpectedTypeException($constraint, DataUri::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!\is_scalar($value) && !$value instanceof \Stringable) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        $value = (string) $value;
+        if ('' === $value) {
+            return;
+        }
+
+        if (!preg_match(static::PATTERN, $value)) {
+            if (strlen($value) > self::MAX_MESSAGE_VALUE_LENGTH) {
+                $value = sprintf('%s (truncated)', $this->formatValue(substr($value, 0, self::MAX_MESSAGE_VALUE_LENGTH) . '...'));
+            } else {
+                $value = $this->formatValue($value);
+            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $value)
+                ->setCode(DataUri::INVALID_DATA_URI_ERROR)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/DataUriValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DataUriValidatorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\DataUri;
+use Symfony\Component\Validator\Constraints\DataUriValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @author Kev <https://github.com/symfonyaml>
+ */
+class DataUriValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): DataUriValidator
+    {
+        return new DataUriValidator();
+    }
+
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new DataUri());
+
+        $this->assertNoViolation();
+    }
+
+    public function testBlankIsValid()
+    {
+        $this->validator->validate('', new DataUri());
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getValidValues
+     */
+    public function testValidValues(string $value)
+    {
+        $this->validator->validate($value, new DataUri());
+
+        $this->assertNoViolation();
+    }
+
+    public static function getValidValues()
+    {
+        return [
+            'mime type is omitted' => ['data:,FooBar'],
+            'just charset' => ['data:;charset=UTF-8,FooBar'],
+            'plain text' => ['data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=='],
+            'text html' => ['data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E'],
+            'plain text with charset' => ['data:text/plain;charset=UTF-8,the%20data:1234,5678'],
+            'with meta key=value' => ['data:image/jpeg;key=value;base64,UEsDBBQAAAAI'],
+            'without base64 key name' => ['data:image/jpeg;key=value,UEsDBBQAAAAI'],
+            'jpeg image' => ['data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD'],
+            'png image' => ['data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='],
+            'gif image' => ['data:image/gif;base64,R0lGODlhyAAiALM...DfD0QAADs='],
+            'svg' => ['data:image/svg+xml,%3Csvg%20version%3D%221.1%22%3E%3C%2Fsvg%3E'],
+            'networking applications' => ['data:application/vnd-xxx-query,select_vcount,fcol_from_fieldtable/local,123456789'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidValues
+     */
+    public function testInvalidValues($value, $valueAsString)
+    {
+        $constraint = new DataUri([
+            'message' => 'myMessage',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $valueAsString)
+            ->setCode(DataUri::INVALID_DATA_URI_ERROR)
+            ->assertRaised();
+    }
+
+    public static function getInvalidValues()
+    {
+        return [
+            'random string' => ['foobar', '"foobar"'],
+            'zero' => [0, '"0"'],
+            'integer' => [1234, '"1234"'],
+            'truncated invalid value' => [
+                '1234567890123456789012345678901', // 31 chars
+                '"123456789012345678901234567890..." (truncated)',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT


## Purpose
Inspired by the [Yaml constraint](https://github.com/symfony/symfony/pull/53749), I've added a new feature to the Validator component for validating DataUri *([RFC-2397](https://datatracker.ietf.org/doc/html/rfc2397))* content with a dedicated constraint.

**Real world use case**: Having an image content encoded in base64 within a database. With this new feature, you can validate the integrity of these data, ensuring the data Uri is valid.

## Exemple
```php
namespace App\Entity;

use Symfony\Component\Validator\Constraints as Assert;

class Book
{
    #[Assert\DataUri]
    private string $cover;
}
```
