### PR TITLE
[FrameworkBundle] Remove obsolete requires annotation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Psr4RoutingTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Psr4RoutingTest.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-/**
- * @requires function Symfony\Component\Routing\Loader\Psr4DirectoryLoader::__construct
- */
 final class Psr4RoutingTest extends AbstractAttributeRoutingTestCase
 {
     protected function getTestCaseApp(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

FrameworkBundle requires Routing >= 6.4 and Routing 6.4 already ships the class in question. We don't need to check for it anymore.