### PR TITLE
[Translation] Added segment-attributes metadata for Xliff2 files to preserve the `state´ attribute of translations

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Make `ProviderFactoryTestCase` and `ProviderTestCase` compatible with PHPUnit 10+
  * Add `lint:translations` command
  * Deprecate passing an escape character to `CsvFileLoader::setCsvControl()`
+ * Make Xliff 2.0 attributes in segment element available as `segment-attributes`
+   metadata returned by `XliffFileLoader` and make `XliffFileDumper` write them to the file
 
 7.1
 ---

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -193,6 +193,12 @@ class XliffFileDumper extends FileDumper
 
             $segment = $translation->appendChild($dom->createElement('segment'));
 
+            if ($this->hasMetadataArrayInfo('segment-attributes', $metadata)) {
+                foreach ($metadata['segment-attributes'] as $name => $value) {
+                    $segment->setAttribute($name, $value);
+                }
+            }
+
             $s = $segment->appendChild($dom->createElement('source'));
             $s->appendChild($dom->createTextNode($source));
 

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -172,6 +172,13 @@ class XliffFileLoader implements LoaderInterface
                 $catalogue->set((string) $source, $target, $domain);
 
                 $metadata = [];
+                if ($segment->attributes()) {
+                    $metadata['segment-attributes'] = [];
+                    foreach ($segment->attributes() as $key => $value) {
+                        $metadata['segment-attributes'][$key] = (string) $value;
+                    }
+                }
+
                 if (isset($segment->target) && $segment->target->attributes()) {
                     $metadata['target-attributes'] = [];
                     foreach ($segment->target->attributes() as $key => $value) {

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -147,4 +147,22 @@ class XliffFileDumperTest extends TestCase
             $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'fr_FR'])
         );
     }
+
+    public function testFormatCatalogueXliff2WithSegmentAttributes()
+    {
+        $catalogue = new MessageCatalogue('en_US');
+        $catalogue->add([
+            'foo' => 'bar',
+            'key' => '',
+        ]);
+        $catalogue->setMetadata('foo', ['segment-attributes' => ['state' => 'translated']]);
+        $catalogue->setMetadata('key', ['segment-attributes' => ['state' => 'translated', 'subState' => 'My Value']]);
+
+        $dumper = new XliffFileDumper();
+
+        $this->assertStringEqualsFile(
+            __DIR__.'/../Fixtures/resources-2.0-segment-attributes.xlf',
+            $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'fr_FR', 'xliff_version' => '2.0'])
+        );
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0-segment-attributes.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0-segment-attributes.xlf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
+  <file id="messages.en_US">
+    <unit id="ea75LoN" name="foo">
+      <segment state="translated">
+        <source>foo</source>
+        <target>bar</target>
+      </segment>
+    </unit>
+    <unit id="pL305WR" name="key">
+      <segment state="translated" subState="My Value">
+        <source>key</source>
+        <target></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -362,4 +362,29 @@ XLIFF;
 
         $this->assertEquals(['foo' => 'bar', 'bar' => 'baz', 'baz' => 'foo', 'qux' => 'qux source'], $catalogue->all('domain1'));
     }
+
+    public function testLoadVersion2WithSegmentAttributes()
+    {
+        $loader = new XliffFileLoader();
+        $resource = __DIR__.'/../Fixtures/resources-2.0-segment-attributes.xlf';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        // test for "foo" metadata
+        $this->assertTrue($catalogue->defines('foo', 'domain1'));
+        $metadata = $catalogue->getMetadata('foo', 'domain1');
+        $this->assertNotEmpty($metadata);
+        $this->assertCount(1, $metadata['segment-attributes']);
+        $this->assertArrayHasKey('state', $metadata['segment-attributes']);
+        $this->assertSame('translated', $metadata['segment-attributes']['state']);
+
+        // test for "key" metadata
+        $this->assertTrue($catalogue->defines('key', 'domain1'));
+        $metadata = $catalogue->getMetadata('key', 'domain1');
+        $this->assertNotEmpty($metadata);
+        $this->assertCount(2, $metadata['segment-attributes']);
+        $this->assertArrayHasKey('state', $metadata['segment-attributes']);
+        $this->assertSame('translated', $metadata['segment-attributes']['state']);
+        $this->assertArrayHasKey('subState', $metadata['segment-attributes']);
+        $this->assertSame('My Value', $metadata['segment-attributes']['subState']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | None
| License       | MIT

The XliffFileLoader and XliffFileDumper create/parse a "target-attributes" metadata array, for additional attributes on the target XML element. This allowed to read/write the translation state of xliff1.2 files.
In xliff2.0 however, the state attribute is not stored at the target element, but on the "segment" element instead (see [xliff 2.0 specification](https://docs.oasis-open.org/xliff/xliff-core/v2.0/xliff-core-v2.0.html#segment)). Therefore, currently, the state information (and other information stored there) is lost when loading a xliff2.0 file and writing the catalog back.

This pull requests add a new "segment-attributes" metadata, which contains the attributes of the "segment" element, and allows preserving this information and also allows accessing it inside an application via the metadata.