### PR TITLE
[Cache] Fix missing class import

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -90,18 +90,18 @@ class RedisTraitTest extends TestCase
     public function testPconnectSelectsCorrectDatabase()
     {
         if (!class_exists(\Redis::class)) {
-            throw new SkippedTestSuiteError('The "Redis" class is required.');
+            self::markTestSkipped('The "Redis" class is required.');
         }
         if (!getenv('REDIS_HOST')) {
-            throw new SkippedTestSuiteError('REDIS_HOST env var is not defined.');
+            self::markTestSkipped('REDIS_HOST env var is not defined.');
         }
         if (!\ini_get('redis.pconnect.pooling_enabled')) {
-            throw new SkippedTestSuiteError('The bug only occurs when pooling is enabled.');
+            self::markTestSkipped('The bug only occurs when pooling is enabled.');
         }
 
         // Limit the connection pool size to 1:
         if (false === $prevPoolSize = ini_set('redis.pconnect.connection_limit', 1)) {
-            throw new SkippedTestSuiteError('Unable to set pool size');
+            self::markTestSkipped('Unable to set pool size');
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This test is supposed to throw PHPUnit's `SkippedTestSuiteError`, but that doesn't work because the class is not imported. Given that this class is marked as internal and that calling `markTestSkipped()` should achieve the same goal, I switched to that method. This is also consistent with other methods in this trait.