### PR TITLE
[TwigBridge] Avoid calling deprecated mergeGlobals()

### DIFF
--- a/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
+++ b/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
@@ -44,7 +44,7 @@ class TwigRendererEngine extends AbstractRendererEngine
     {
         $cacheKey = $view->vars[self::CACHE_KEY_VAR];
 
-        $context = $this->environment->mergeGlobals($variables);
+        $context = $variables + $this->environment->getGlobals();
 
         ob_start();
 
@@ -164,7 +164,7 @@ class TwigRendererEngine extends AbstractRendererEngine
         // theme is a reference and we don't want to change it.
         $currentTheme = $theme;
 
-        $context = $this->environment->mergeGlobals([]);
+        $context = $this->environment->getGlobals();
 
         // The do loop takes care of template inheritance.
         // Add blocks from all templates in the inheritance tree, but avoid


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follows twigphp/Twig#4283
| License       | MIT

`getGlobals()` is documented as the official replacement for `mergeGlobals()` despite being flagged `@internal`. I've left a comment on the upstream PR.