### PR TITLE
[Ldap] Clean `ldap_connect()` call in `LdapTestCase`

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
@@ -17,12 +17,7 @@ class LdapTestCase extends TestCase
 {
     protected function getLdapConfig()
     {
-        if (\PHP_VERSION_ID < 80300) {
-            $h = @ldap_connect(getenv('LDAP_HOST'), getenv('LDAP_PORT'));
-        } else {
-            $h = @ldap_connect('ldap://'.getenv('LDAP_HOST').':'.getenv('LDAP_PORT'));
-        }
-
+        $h = @ldap_connect('ldap://'.getenv('LDAP_HOST').':'.getenv('LDAP_PORT'));
         @ldap_set_option($h, \LDAP_OPT_PROTOCOL_VERSION, 3);
 
         if (!$h || !@ldap_bind($h)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

After https://github.com/symfony/symfony/pull/58143#issuecomment-2337390548, follow-up for #58143