### PR TITLE
[Dotenv] Fix can not load BOM-signed env files

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -229,7 +229,7 @@ final class Dotenv
     public function parse(string $data, string $path = '.env'): array
     {
         $this->path = $path;
-        $this->data = str_replace(["\r\n", "\r"], "\n", $data);
+        $this->data = $this->normalizeString($data);
         $this->lineno = 1;
         $this->cursor = 0;
         $this->end = \strlen($this->data);
@@ -263,6 +263,25 @@ final class Dotenv
             $this->values = [];
             unset($this->path, $this->cursor, $this->lineno, $this->data, $this->end);
         }
+    }
+
+    private function normalizeString(string $data): string
+    {
+        /**
+         * Remove BOM charachters from first of the string
+         * The order of the if statements is important due to the varying lengths of BOM characters (4, 3, or 2 bytes).
+         * @see https://github.com/symfony/symfony/issues/58214
+         * @see https://en.wikipedia.org/wiki/Byte_order_mark
+         */
+        if (\substr($data, 0, 4) == "\x00\x00\xFE\xFF" || \substr($data, 0, 4) == "\xFF\xFE\x00\x00") { // UTF-32 (big-endian|little-endian)
+            $data = \substr($data, 4);
+        } elseif (\substr($data, 0, 3) == "\xEF\xBB\xBF") { // UTF-8
+            $data = \substr($data, 3);
+        } elseif (\substr($data, 0, 2) == "\xFE\xFF" || \substr($data, 0, 2) == "\xFF\xFE") { // UTF-16 (big-endian|little-endian)
+            $data = \substr($data, 2);
+        }
+
+        return str_replace(["\r\n", "\r"], "\n", $data);
     }
 
     private function lexVarname(): string

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -180,6 +180,13 @@ class DotenvTest extends TestCase
             // underscores
             ['_FOO=BAR', ['_FOO' => 'BAR']],
             ['_FOO_BAR=FOOBAR', ['_FOO_BAR' => 'FOOBAR']],
+
+            // BOM charachters
+            ["\xEF\xBB\xBFFOO=BAR", ['FOO' => 'BAR']], // UTF-8
+            ["\xFE\xFFFOO=BAR", ['FOO' => 'BAR']], // UTF-16 (big-endian)
+            ["\xFF\xFEFOO=BAR", ['FOO' => 'BAR']], // UTF-16 (little-endian)
+            ["\x00\x00\xFE\xFFFOO=BAR", ['FOO' => 'BAR']], // UTF-32 (big-endian)
+            ["\xFF\xFE\x00\x00FOO=BAR", ['FOO' => 'BAR']], // UTF-32 (little-endian)
         ];
 
         if ('\\' !== \DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 for features / 5.4, 6.4, and 7.1 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #58214 
| License       | MIT

In this PR, I fixed the load env file BOM characters.
You can see the full explanation of the issue: https://github.com/symfony/symfony/issues/58214
More about BOM: [Byte Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark)
