### PR TITLE
[Dotenv] Fix can not load BOM-signed env files

### DIFF
--- a/CHANGELOG-6.4.md
+++ b/CHANGELOG-6.4.md
@@ -1,3 +1,4 @@
+
 CHANGELOG for 6.4.x
 ===================
 
@@ -9,6 +10,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 * 6.4.11 (2024-08-30)
 
+ * bug #58214 [Dotenv] Fix can not load BOM-signed env files (hosni)
  * bug #58110 [PropertyAccess] Fix handling property names with a `.` (alexandre-daubois)
  * bug #58127 [Validator] synchronize IBAN formats (xabbuh)
  * bug #58112 fix Twig 3.12 compatibility (xabbuh)

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -180,6 +180,13 @@ class DotenvTest extends TestCase
             // underscores
             ['_FOO=BAR', ['_FOO' => 'BAR']],
             ['_FOO_BAR=FOOBAR', ['_FOO_BAR' => 'FOOBAR']],
+
+            // BOM charachters
+            ["\xEF\xBB\xBFFOO=BAR", ['FOO' => 'BAR']], // UTF-8
+            ["\xFE\xFFFOO=BAR", ['FOO' => 'BAR']], // UTF-16 (big-endian)
+            ["\xFF\xFEFOO=BAR", ['FOO' => 'BAR']], // UTF-16 (little-endian)
+            ["\x00\x00\xFE\xFFFOO=BAR", ['FOO' => 'BAR']], // UTF-32 (big-endian)
+            ["\xFF\xFE\x00\x00FOO=BAR", ['FOO' => 'BAR']], // UTF-32 (little-endian)
         ];
 
         if ('\\' !== \DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58214 
| License       | MIT

In this PR, I fixed the load env file BOM characters.
You can see the full explanation of the issue: https://github.com/symfony/symfony/issues/58214
More about BOM: [Byte Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark)
