### PR TITLE
[Serializer] Fix for method named `get()`

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -100,14 +100,19 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             $name = $reflMethod->name;
             $attributeName = null;
 
-            if (str_starts_with($name, 'get') || str_starts_with($name, 'has') || str_starts_with($name, 'can')) {
+            if (3 < \strlen($name) && match ($name[0]) {
+                'g' => str_starts_with($name, 'get'),
+                'h' => str_starts_with($name, 'has'),
+                'c' => str_starts_with($name, 'can'),
+                default => false,
+            }) {
                 // getters, hassers and canners
                 $attributeName = substr($name, 3);
 
                 if (!$reflClass->hasProperty($attributeName)) {
                     $attributeName = lcfirst($attributeName);
                 }
-            } elseif (str_starts_with($name, 'is')) {
+            } elseif ('is' !== $name && str_starts_with($name, 'is')) {
                 // issers
                 $attributeName = substr($name, 2);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58012 
| License       | MIT

During normalization, if a class has a method called `get` that method will get confused for an accessor and it will go through logic relating to property-access for the property named `substr('get', 3)`.

Eventually a new PropertyPath instance will be created with an empty path which will trigger an exception.
```php
$serializer->serialize(new class { 
    public function get() {} 
}, 'json');
```