### PR TITLE
[Yaml] Add support for dumping `null` as an empty string by using the `Yaml::DUMP_NULL_AS_EMPTY` flag

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate parsing duplicate mapping keys whose value is `null`
+ * Add support for dumping `null` as an empty string by using the `Yaml::DUMP_NULL_AS_EMPTY` flag
 
 7.1
 ---

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -46,6 +46,10 @@ class Dumper
      */
     public function dump(mixed $input, int $inline = 0, int $indent = 0, int $flags = 0): string
     {
+        if ($flags & Yaml::DUMP_NULL_AS_TILDE && $flags & Yaml::DUMP_NULL_AS_EMPTY) {
+            throw new \InvalidArgumentException('The Yaml::DUMP_NULL_AS_TILDE and Yaml::DUMP_NULL_AS_EMPTY flags cannot be used together.');
+        }
+
         $output = '';
         $prefix = $indent ? str_repeat(' ', $indent) : '';
         $dumpObjectAsInlineMap = true;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -259,6 +259,10 @@ class Inline
             return '~';
         }
 
+        if (Yaml::DUMP_NULL_AS_EMPTY & $flags) {
+            return '';
+        }
+
         return 'null';
     }
 

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -853,6 +853,11 @@ YAML;
         $this->assertSame('{ foo: ~ }', $this->dumper->dump(['foo' => null], 0, 0, Yaml::DUMP_NULL_AS_TILDE));
     }
 
+    public function testDumpNullAsEmpty()
+    {
+        $this->assertSame('{ foo:  }', $this->dumper->dump(['foo' => null], 0, 0, Yaml::DUMP_NULL_AS_EMPTY));
+    }
+
     /**
      * @dataProvider getNumericKeyData
      */
@@ -1011,6 +1016,14 @@ YAML;
             var_export($expected, true),
             var_export($actual, true)
         );
+    }
+
+    public function testUseDumpAsTildeAndDumpAsEmptyFlagsTogether()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Yaml::DUMP_NULL_AS_TILDE and Yaml::DUMP_NULL_AS_EMPTY flags cannot be used together.');
+
+        $this->dumper->dump(['foo' => null], 0, 0, Yaml::DUMP_NULL_AS_TILDE | Yaml::DUMP_NULL_AS_EMPTY);
     }
 }
 

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -35,6 +35,7 @@ class Yaml
     public const DUMP_EMPTY_ARRAY_AS_SEQUENCE = 1024;
     public const DUMP_NULL_AS_TILDE = 2048;
     public const DUMP_NUMERIC_KEY_AS_STRING = 4096;
+    public const DUMP_NULL_AS_EMPTY = 8192;
 
     /**
      * Parses a YAML file into a PHP value.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58155
| License       | MIT

Empty value in Yaml is a valid representation of `null`, it makes sense to me to support dumping an empty value, just like dumping null as tilde is already supported.