### PR TITLE
[Serializer] Support serialized names and paths configuration per group

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -37,3 +37,8 @@ parameters:
         -
             message: '#^Method Symfony\\Component\\ErrorHandler\\ErrorRenderer\\HtmlErrorRenderer\:\:\w+\(\) is unused\.$#'
             path: src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+        # the $groups argument is declared on the final AttributeMetadata, and left commented
+        # out on the interface so implementers are not forced to add it
+        -
+            message: '#^Method Symfony\\Component\\Serializer\\Mapping\\AttributeMetadataInterface\:\:(get|set)Serialized(Name|Path)\(\) invoked with [12] parameters?, [01] required\.$#'
+            path: src/Symfony/Component/Serializer/*.php

--- a/src/Symfony/Component/Serializer/Attribute/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Attribute/SerializedName.php
@@ -16,17 +16,33 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 /**
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class SerializedName
 {
+    public readonly array $groups;
+
     /**
-     * @param string $serializedName The name of the property as it will be serialized
+     * @param string       $serializedName The name of the property as it will be serialized
+     * @param string|array $groups         The groups to use when serializing or deserializing
      */
     public function __construct(
         public readonly string $serializedName,
+        string|array $groups = ['*'],
     ) {
         if ('' === $serializedName) {
             throw new InvalidArgumentException(\sprintf('Parameter given to "%s" must be a non-empty string.', self::class));
+        }
+
+        $this->groups = (array) $groups;
+
+        if (!$this->groups) {
+            throw new InvalidArgumentException(\sprintf('Parameter "groups" given to "%s" must not be empty, omit it to apply to every group.', static::class));
+        }
+
+        foreach ($this->groups as $group) {
+            if (!\is_string($group) || '' === $group) {
+                throw new InvalidArgumentException(\sprintf('Parameter "groups" given to "%s" must be a string or an array of non-empty strings, "%s" given.', static::class, get_debug_type($group)));
+            }
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Attribute/SerializedPath.php
+++ b/src/Symfony/Component/Serializer/Attribute/SerializedPath.php
@@ -18,20 +18,35 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 /**
  * @author Tobias Bönner <tobi@boenner.family>
  */
-#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class SerializedPath
 {
     public readonly PropertyPath $serializedPath;
 
+    public readonly array $groups;
+
     /**
-     * @param string $serializedPath A path using a valid PropertyAccess syntax where the value is stored in a normalized representation
+     * @param string       $serializedPath A path using a valid PropertyAccess syntax where the value is stored in a normalized representation
+     * @param string|array $groups         The groups to use when serializing or deserializing
      */
-    public function __construct(string $serializedPath)
+    public function __construct(string $serializedPath, string|array $groups = ['*'])
     {
         try {
             $this->serializedPath = new PropertyPath($serializedPath);
         } catch (InvalidPropertyPathException) {
             throw new InvalidArgumentException(\sprintf('Parameter given to "%s" must be a valid property path.', self::class));
+        }
+
+        $this->groups = (array) $groups;
+
+        if (!$this->groups) {
+            throw new InvalidArgumentException(\sprintf('Parameter "groups" given to "%s" must not be empty, omit it to apply to every group.', static::class));
+        }
+
+        foreach ($this->groups as $group) {
+            if (!\is_string($group) || '' === $group) {
+                throw new InvalidArgumentException(\sprintf('Parameter "groups" given to "%s" must be a string or an array of non-empty strings, "%s" given.', static::class, get_debug_type($group)));
+            }
         }
     }
 }

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property
  * Add the `XmlEncoder::BOOLEAN_REPR` context option to choose the strings representing booleans when encoding, e.g. `['true', 'false']`
  * Add support for denormalizing arrays of union types, e.g. `array<Foo|Bar>`
+ * Add support for configuring serialized names and paths per group, with repeatable `#[SerializedName]` and `#[SerializedPath]` attributes, a `serialized` key in YAML and a `<serialized>` element in XML
 
 8.1
 ---

--- a/src/Symfony/Component/Serializer/Command/DebugCommand.php
+++ b/src/Symfony/Component/Serializer/Command/DebugCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 
@@ -103,8 +104,8 @@ class DebugCommand extends Command
             $data[$attributeMetadata->getName()] = [
                 'groups' => $attributeMetadata->getGroups(),
                 'maxDepth' => $attributeMetadata->getMaxDepth(),
-                'serializedName' => $attributeMetadata->getSerializedName(),
-                'serializedPath' => $attributeMetadata->getSerializedPath() ? (string) $attributeMetadata->getSerializedPath() : null,
+                'serializedNames' => AttributeMetadata::getSerializedNamesFromAttributeMetadata($attributeMetadata),
+                'serializedPaths' => array_map('strval', AttributeMetadata::getSerializedPathsFromAttributeMetadata($attributeMetadata)),
                 'ignore' => $attributeMetadata->isIgnored(),
                 'normalizationContexts' => $attributeMetadata->getNormalizationContexts(),
                 'denormalizationContexts' => $attributeMetadata->getDenormalizationContexts(),

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -23,8 +23,8 @@ class AttributeMetadata implements AttributeMetadataInterface
     private string $name;
     private array $groups = [];
     private ?int $maxDepth = null;
-    private ?string $serializedName = null;
-    private ?PropertyPath $serializedPath = null;
+    private array $serializedNames = [];
+    private array $serializedPaths = [];
     private bool $ignore = false;
 
     /**
@@ -69,24 +69,76 @@ class AttributeMetadata implements AttributeMetadataInterface
         return $this->maxDepth;
     }
 
-    public function setSerializedName(?string $serializedName): void
+    /**
+     * @param list<string> $groups
+     */
+    public function setSerializedName(?string $serializedName, array $groups = ['*']): void
     {
-        $this->serializedName = $serializedName;
+        if (isset($serializedName)) {
+            foreach ($groups as $group) {
+                $this->serializedNames[$group] = $serializedName;
+            }
+        } else {
+            foreach ($groups as $group) {
+                unset($this->serializedNames[$group]);
+            }
+        }
     }
 
-    public function getSerializedName(): ?string
+    /**
+     * @param list<string> $groups
+     */
+    public function getSerializedName(array $groups = ['*']): ?string
     {
-        return $this->serializedName;
+        // first match in declaration order, so that the order of the groups in the context has no effect
+        foreach ($this->serializedNames as $group => $serializedName) {
+            if ('*' !== $group && \in_array($group, $groups, true)) {
+                return $serializedName;
+            }
+        }
+
+        return $this->serializedNames['*'] ?? null;
     }
 
-    public function setSerializedPath(?PropertyPath $serializedPath = null): void
+    public function getSerializedNames(): array
     {
-        $this->serializedPath = $serializedPath;
+        return $this->serializedNames;
     }
 
-    public function getSerializedPath(): ?PropertyPath
+    /**
+     * @param list<string> $groups
+     */
+    public function setSerializedPath(?PropertyPath $serializedPath = null, array $groups = ['*']): void
     {
-        return $this->serializedPath;
+        if (isset($serializedPath)) {
+            foreach ($groups as $group) {
+                $this->serializedPaths[$group] = $serializedPath;
+            }
+        } else {
+            foreach ($groups as $group) {
+                unset($this->serializedPaths[$group]);
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $groups
+     */
+    public function getSerializedPath(array $groups = ['*']): ?PropertyPath
+    {
+        // first match in declaration order, so that the order of the groups in the context has no effect
+        foreach ($this->serializedPaths as $group => $serializedPath) {
+            if ('*' !== $group && \in_array($group, $groups, true)) {
+                return $serializedPath;
+            }
+        }
+
+        return $this->serializedPaths['*'] ?? null;
+    }
+
+    public function getSerializedPaths(): array
+    {
+        return $this->serializedPaths;
     }
 
     public function setIgnore(bool $ignore): void
@@ -159,8 +211,16 @@ class AttributeMetadata implements AttributeMetadataInterface
 
         // Overwrite only if not defined
         $this->maxDepth ??= $attributeMetadata->getMaxDepth();
-        $this->serializedName ??= $attributeMetadata->getSerializedName();
-        $this->serializedPath ??= $attributeMetadata->getSerializedPath();
+
+        // Overwrite only if serialized names are empty
+        if (!$this->serializedNames) {
+            $this->serializedNames = self::getSerializedNamesFromAttributeMetadata($attributeMetadata);
+        }
+
+        // Overwrite only if serialized paths are empty
+        if (!$this->serializedPaths) {
+            $this->serializedPaths = self::getSerializedPathsFromAttributeMetadata($attributeMetadata);
+        }
 
         // Overwrite only if both contexts are empty
         if (!$this->normalizationContexts && !$this->denormalizationContexts) {
@@ -173,17 +233,73 @@ class AttributeMetadata implements AttributeMetadataInterface
         }
     }
 
+    /**
+     * BC layer for extraction of serialized names from attribute metadata.
+     * Can be removed as soon as AttributeMetadataInterface::getSerializedNames() become part of the interface.
+     *
+     * @internal
+     *
+     * @return array<string, string>
+     */
+    public static function getSerializedNamesFromAttributeMetadata(AttributeMetadataInterface $attributeMetadata): array
+    {
+        if (method_exists($attributeMetadata, 'getSerializedNames')) {
+            return $attributeMetadata->getSerializedNames();
+        }
+
+        if (null !== $serializedName = $attributeMetadata->getSerializedName()) {
+            return ['*' => $serializedName];
+        }
+
+        return [];
+    }
+
+    /**
+     * BC layer for extraction of serialized paths from attribute metadata.
+     * Can be removed as soon as AttributeMetadataInterface::getSerializedPaths() become part of the interface.
+     *
+     * @internal
+     *
+     * @return array<string, PropertyPath>
+     */
+    public static function getSerializedPathsFromAttributeMetadata(AttributeMetadataInterface $attributeMetadata): array
+    {
+        if (method_exists($attributeMetadata, 'getSerializedPaths')) {
+            return $attributeMetadata->getSerializedPaths();
+        }
+
+        if (null !== $serializedPath = $attributeMetadata->getSerializedPath()) {
+            return ['*' => $serializedPath];
+        }
+
+        return [];
+    }
+
     public function __serialize(): array
     {
         return [
             'name' => $this->name,
             'groups' => $this->groups,
             'maxDepth' => $this->maxDepth,
-            'serializedName' => $this->serializedName,
-            'serializedPath' => $this->serializedPath,
+            'serializedNames' => $this->serializedNames,
+            'serializedPaths' => $this->serializedPaths,
             'ignore' => $this->ignore,
             'normalizationContexts' => $this->normalizationContexts,
             'denormalizationContexts' => $this->denormalizationContexts,
         ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        // a cache warmed before the names and paths became per-group holds the single-value keys
+        if (\array_key_exists('serializedName', $data)) {
+            $data['serializedNames'] = null !== $data['serializedName'] ? ['*' => $data['serializedName']] : [];
+            $data['serializedPaths'] = null !== ($data['serializedPath'] ?? null) ? ['*' => $data['serializedPath']] : [];
+            unset($data['serializedName'], $data['serializedPath']);
+        }
+
+        foreach ($data as $property => $value) {
+            $this->$property = $value;
+        }
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -21,6 +21,9 @@ use Symfony\Component\PropertyAccess\PropertyPath;
  * @psalm-inheritors AttributeMetadata
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @method string[]       getSerializedNames() Gets all the serialized names per group.
+ * @method PropertyPath[] getSerializedPaths() Gets all the serialized paths per group.
  */
 interface AttributeMetadataInterface
 {
@@ -53,17 +56,31 @@ interface AttributeMetadataInterface
 
     /**
      * Sets the serialization name for this attribute.
+     *
+     * @param list<string> $groups
      */
-    public function setSerializedName(?string $serializedName): void;
+    public function setSerializedName(?string $serializedName /* , array $groups = ['*'] */): void;
 
     /**
      * Gets the serialization name for this attribute.
+     *
+     * @param list<string> $groups
      */
-    public function getSerializedName(): ?string;
+    public function getSerializedName(/* array $groups = ['*'] */): ?string;
 
-    public function setSerializedPath(?PropertyPath $serializedPath): void;
+    /**
+     * Sets the serialization path for this attribute.
+     *
+     * @param list<string> $groups
+     */
+    public function setSerializedPath(?PropertyPath $serializedPath /* , array $groups = ['*'] */): void;
 
-    public function getSerializedPath(): ?PropertyPath;
+    /**
+     * Gets the serialization path for this attribute.
+     *
+     * @param list<string> $groups
+     */
+    public function getSerializedPath(/* array $groups = ['*'] */): ?PropertyPath;
 
     /**
      * Sets if this attribute must be ignored or not.

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -133,8 +133,8 @@ class AttributeLoader implements LoaderInterface
 
                     match (true) {
                         $attribute instanceof MaxDepth => $attributeMetadata->setMaxDepth($attribute->maxDepth),
-                        $attribute instanceof SerializedName => $attributeMetadata->setSerializedName($attribute->serializedName),
-                        $attribute instanceof SerializedPath => $attributeMetadata->setSerializedPath($attribute->serializedPath),
+                        $attribute instanceof SerializedName => $attributeMetadata->setSerializedName($attribute->serializedName, $attribute->groups),
+                        $attribute instanceof SerializedPath => $attributeMetadata->setSerializedPath($attribute->serializedPath, $attribute->groups),
                         $attribute instanceof Ignore => $attributeMetadata->setIgnore(true),
                         $attribute instanceof Context => $this->setAttributeContextsForGroups($attribute, $attributeMetadata),
                         default => null,
@@ -191,13 +191,13 @@ class AttributeLoader implements LoaderInterface
                         throw new MappingException(\sprintf('SerializedName on "%s::%s()" cannot be added. SerializedName can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
-                    $attributeMetadata->setSerializedName($attribute->serializedName);
+                    $attributeMetadata->setSerializedName($attribute->serializedName, $attribute->groups);
                 } elseif ($attribute instanceof SerializedPath) {
                     if (!$attributeMetadata) {
                         throw new MappingException(\sprintf('SerializedPath on "%s::%s()" cannot be added. SerializedPath can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
-                    $attributeMetadata->setSerializedPath($attribute->serializedPath);
+                    $attributeMetadata->setSerializedPath($attribute->serializedPath, $attribute->groups);
                 } elseif ($attribute instanceof Ignore) {
                     if ($attributeMetadata && !$this->hasPublicPropertyForAccessor($reflectionClass, $attributeName)) {
                         $attributeMetadata->setIgnore(true);

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -78,6 +78,22 @@ class XmlFileLoader extends FileLoader
                     $attributeMetadata->setIgnore(XmlUtils::phpize($attribute['ignore']));
                 }
 
+                foreach ($attribute->serialized as $mapping) {
+                    $groups = array_map(strval(...), (array) $mapping->group) ?: ['*'];
+
+                    if (isset($mapping['name'])) {
+                        $attributeMetadata->setSerializedName((string) $mapping['name'], $groups);
+                    }
+
+                    if (isset($mapping['path'])) {
+                        try {
+                            $attributeMetadata->setSerializedPath(new PropertyPath((string) $mapping['path']), $groups);
+                        } catch (InvalidPropertyPathException) {
+                            throw new MappingException(\sprintf('The "path" value must be a valid property path for the attribute "%s" of the class "%s".', $attributeName, $classMetadata->getName()));
+                        }
+                    }
+                }
+
                 foreach ($attribute->context as $node) {
                     $groups = (array) $node->group;
                     $context = $this->parseContext($node->entry);

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -103,6 +103,42 @@ class YamlFileLoader extends FileLoader
                     $attributeMetadata->setIgnore($data['ignore']);
                 }
 
+                if (isset($data['serialized']) && !\is_array($data['serialized'])) {
+                    throw new MappingException(\sprintf('The "serialized" value must be a list in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                }
+
+                foreach ($data['serialized'] ?? [] as $line) {
+                    $groups = $line['groups'] ?? ['*'];
+
+                    if (!\is_array($groups)) {
+                        throw new MappingException(\sprintf('The "groups" value must be a list in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                    }
+
+                    foreach ($groups as $group) {
+                        if (!\is_string($group) || '' === $group) {
+                            throw new MappingException(\sprintf('Group names must be non-empty strings in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                        }
+                    }
+
+                    if (isset($line['name'])) {
+                        $serializedName = $line['name'];
+
+                        if (!\is_string($serializedName) || '' === $serializedName) {
+                            throw new MappingException(\sprintf('The "name" value must be a non-empty string in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                        }
+
+                        $attributeMetadata->setSerializedName($serializedName, $groups);
+                    }
+
+                    if (isset($line['path'])) {
+                        try {
+                            $attributeMetadata->setSerializedPath(new PropertyPath((string) $line['path']), $groups);
+                        } catch (InvalidPropertyPathException) {
+                            throw new MappingException(\sprintf('The "path" value must be a valid property path in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                        }
+                    }
+                }
+
                 foreach ($data['contexts'] ?? [] as $line) {
                     $groups = $line['groups'] ?? [];
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
@@ -63,6 +63,7 @@
         </xsd:annotation>
         <xsd:choice minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="group" type="xsd:string" maxOccurs="unbounded" />
+            <xsd:element name="serialized" type="serialized" maxOccurs="unbounded" />
             <xsd:element name="context" type="context" maxOccurs="unbounded" />
             <xsd:element name="normalization_context" type="context" maxOccurs="unbounded" />
             <xsd:element name="denormalization_context" type="context" maxOccurs="unbounded" />
@@ -75,21 +76,17 @@
                 </xsd:restriction>
             </xsd:simpleType>
         </xsd:attribute>
-        <xsd:attribute name="serialized-name">
-            <xsd:simpleType>
-                <xsd:restriction base="xsd:string">
-                    <xsd:minLength value="1" />
-                </xsd:restriction>
-            </xsd:simpleType>
-        </xsd:attribute>
-        <xsd:attribute name="serialized-path">
-            <xsd:simpleType>
-                <xsd:restriction base="xsd:string">
-                    <xsd:minLength value="1" />
-                </xsd:restriction>
-            </xsd:simpleType>
-        </xsd:attribute>
+        <xsd:attribute name="serialized-name" type="serialized-name-or-path" />
+        <xsd:attribute name="serialized-path" type="serialized-name-or-path" />
         <xsd:attribute name="ignore" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="serialized">
+        <xsd:sequence minOccurs="0">
+            <xsd:element name="group" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="name" type="serialized-name-or-path" />
+        <xsd:attribute name="path" type="serialized-name-or-path" />
     </xsd:complexType>
 
     <xsd:complexType name="context">
@@ -112,5 +109,11 @@
         </xsd:sequence>
         <xsd:attribute type="xsd:string" name="name" />
     </xsd:complexType>
+
+    <xsd:simpleType name="serialized-name-or-path">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
 </xsd:schema>

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json
@@ -45,6 +45,41 @@
                     "type": "boolean",
                     "description": "Whether to ignore this attribute during serialization"
                   },
+                  "serialized": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "description": "Serialized name or path with optional groups",
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Custom name for serialization"
+                        },
+                        "path": {
+                          "type": "string",
+                          "description": "Property path for serialization (e.g., '[one][two]')"
+                        },
+                        "groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Groups this entry applies to"
+                        }
+                      },
+                      "anyOf": [
+                        {
+                          "required": ["name"]
+                        },
+                        {
+                          "required": ["path"]
+                        }
+                      ]
+                    },
+                    "description": "Mapping configurations for this attribute"
+                  },
                   "contexts": {
                     "type": "array",
                     "items": {

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -47,11 +47,12 @@ final class MetadataAwareNameConverter implements NameConverterInterface
             return $this->normalizeFallback($propertyName, $class, $format, $context);
         }
 
-        if (!\array_key_exists($class, self::$normalizeCache) || !\array_key_exists($propertyName, self::$normalizeCache[$class])) {
-            self::$normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class);
+        $cacheKey = $this->getCacheKey($class, $context);
+        if (!\array_key_exists($cacheKey, self::$normalizeCache) || !\array_key_exists($propertyName, self::$normalizeCache[$cacheKey])) {
+            self::$normalizeCache[$cacheKey][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class, $context);
         }
 
-        return self::$normalizeCache[$class][$propertyName] ?? $this->normalizeFallback($propertyName, $class, $format, $context);
+        return self::$normalizeCache[$cacheKey][$propertyName] ?? $this->normalizeFallback($propertyName, $class, $format, $context);
     }
 
     public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
@@ -68,7 +69,7 @@ final class MetadataAwareNameConverter implements NameConverterInterface
         return self::$denormalizeCache[$cacheKey][$propertyName] ?? $this->denormalizeFallback($propertyName, $class, $format, $context);
     }
 
-    private function getCacheValueForNormalization(string $propertyName, string $class): ?string
+    private function getCacheValueForNormalization(string $propertyName, string $class, array $context): ?string
     {
         if (!$this->metadataFactory->hasMetadataFor($class)) {
             return null;
@@ -79,11 +80,13 @@ final class MetadataAwareNameConverter implements NameConverterInterface
             return null;
         }
 
-        if (null !== $attributesMetadata[$propertyName]->getSerializedName() && null !== $attributesMetadata[$propertyName]->getSerializedPath()) {
+        $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
+
+        if (null !== $attributesMetadata[$propertyName]->getSerializedName($contextGroups) && null !== $attributesMetadata[$propertyName]->getSerializedPath($contextGroups)) {
             throw new LogicException(\sprintf('Found SerializedName and SerializedPath attributes on property "%s" of class "%s".', $propertyName, $class));
         }
 
-        return $attributesMetadata[$propertyName]->getSerializedName() ?? null;
+        return $attributesMetadata[$propertyName]->getSerializedName($contextGroups) ?? null;
     }
 
     private function normalizeFallback(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
@@ -117,18 +120,19 @@ final class MetadataAwareNameConverter implements NameConverterInterface
 
         $classMetadata = $this->metadataFactory->getMetadataFor($class);
 
+        $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
+
         $cache = [];
         foreach ($classMetadata->getAttributesMetadata() as $name => $metadata) {
-            if (null === $metadata->getSerializedName()) {
+            if (null === $serializedName = $metadata->getSerializedName($contextGroups)) {
                 continue;
             }
 
-            if (null !== $metadata->getSerializedName() && null !== $metadata->getSerializedPath()) {
+            if (null !== $metadata->getSerializedPath($contextGroups)) {
                 throw new LogicException(\sprintf('Found SerializedName and SerializedPath attributes on property "%s" of class "%s".', $name, $class));
             }
 
             $metadataGroups = $metadata->getGroups();
-            $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
 
             if ($contextGroups && !$metadataGroups) {
                 continue;
@@ -138,7 +142,7 @@ final class MetadataAwareNameConverter implements NameConverterInterface
                 continue;
             }
 
-            $cache[$metadata->getSerializedName()] = $name;
+            $cache[$serializedName] = $name;
         }
 
         return $cache;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -225,7 +225,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             if (!$this->serializer instanceof NormalizerInterface) {
                 if (null === $attributeValue || \is_scalar($attributeValue)) {
-                    $normalizedData = $this->updateData($normalizedData, $attribute, $attributeValue, $class, $format, $attributeContext, $attributesMetadata, $classMetadata);
+                    $normalizedData = $this->updateData($normalizedData, $attribute, $attributeValue, $class, $format, $context, $attributeContext, $attributesMetadata, $classMetadata);
                     continue;
                 }
                 throw new LogicException(\sprintf('Cannot normalize attribute "%s" because the injected serializer is not a normalizer.', $attribute));
@@ -233,7 +233,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             $childContext = $this->createChildContext($attributeContext, $attribute, $format);
 
-            $normalizedData = $this->updateData($normalizedData, $attribute, $this->serializer->normalize($attributeValue, $format, $childContext), $class, $format, $attributeContext, $attributesMetadata, $classMetadata);
+            $normalizedData = $this->updateData($normalizedData, $attribute, $this->serializer->normalize($attributeValue, $format, $childContext), $class, $format, $context, $attributeContext, $attributesMetadata, $classMetadata);
         }
 
         $preserveEmptyObjects = $context[self::PRESERVE_EMPTY_OBJECTS] ?? $this->defaultContext[self::PRESERVE_EMPTY_OBJECTS] ?? false;
@@ -339,7 +339,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         $mappedClass = $this->getMappedClass($normalizedData, $type, $context);
 
-        $nestedAttributes = $this->getNestedAttributes($mappedClass);
+        $nestedAttributes = $this->getNestedAttributes($mappedClass, $context);
         $nestedData = $originalNestedData = [];
         $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()->enableExceptionOnInvalidIndex()->getPropertyAccessor();
         foreach ($nestedAttributes as $property => $serializedPath) {
@@ -890,13 +890,17 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * Sets an attribute and apply the name converter if necessary.
      */
-    private function updateData(array $data, string $attribute, mixed $attributeValue, string $class, ?string $format, array $context, ?array $attributesMetadata, ?ClassMetadataInterface $classMetadata): array
+    private function updateData(array $data, string $attribute, mixed $attributeValue, string $class, ?string $format, array $context, array $attributeContext, ?array $attributesMetadata, ?ClassMetadataInterface $classMetadata): array
     {
-        if (null === $attributeValue && ($context[self::SKIP_NULL_VALUES] ?? $this->defaultContext[self::SKIP_NULL_VALUES] ?? false)) {
+        if (null === $attributeValue && ($attributeContext[self::SKIP_NULL_VALUES] ?? $this->defaultContext[self::SKIP_NULL_VALUES] ?? false)) {
             return $data;
         }
 
-        if (null !== $classMetadata && null !== $serializedPath = ($attributesMetadata[$attribute] ?? null)?->getSerializedPath()) {
+        // resolve the serialized names and paths with the groups of the top-level context, not the
+        // ones a per-attribute #[Context] may override: when denormalizing, the name has to be
+        // resolved before the attribute is known, so only the top-level groups can apply there,
+        // and the name would not round trip otherwise
+        if (null !== $classMetadata && null !== $serializedPath = ($attributesMetadata[$attribute] ?? null)?->getSerializedPath($this->getGroups($context))) {
             $propertyAccessor = PropertyAccess::createPropertyAccessor();
             if ($propertyAccessor->isReadable($data, $serializedPath) && null !== $propertyAccessor->getValue($data, $serializedPath)) {
                 throw new LogicException(\sprintf('The element you are trying to set is already populated: "%s".', (string) $serializedPath));
@@ -907,7 +911,13 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         if ($this->nameConverter) {
-            $attribute = $this->nameConverter->normalize($attribute, $class, $format, $context);
+            $nameContext = $attributeContext;
+            if (\array_key_exists(self::GROUPS, $context)) {
+                $nameContext[self::GROUPS] = $context[self::GROUPS];
+            } else {
+                unset($nameContext[self::GROUPS]);
+            }
+            $attribute = $this->nameConverter->normalize($attribute, $class, $format, $nameContext);
         }
 
         $data[$attribute] = $attributeValue;
@@ -1016,7 +1026,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * Returns all attributes with a SerializedPath attribute and the respective path.
      */
-    private function getNestedAttributes(string $class): array
+    private function getNestedAttributes(string $class, array $context): array
     {
         if (!$this->classMetadataFactory?->hasMetadataFor($class)) {
             return [];
@@ -1026,7 +1036,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $serializedPaths = [];
         $classMetadata = $this->classMetadataFactory->getMetadataFor($class);
         foreach ($classMetadata->getAttributesMetadata() as $name => $metadata) {
-            if (!$serializedPath = $metadata->getSerializedPath()) {
+            if (!$serializedPath = $metadata->getSerializedPath($this->getGroups($context))) {
                 continue;
             }
             $pathIdentifier = implode(',', $serializedPath->getElements());

--- a/src/Symfony/Component/Serializer/Tests/Attribute/SerializedNameTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/SerializedNameTest.php
@@ -28,6 +28,14 @@ class SerializedNameTest extends TestCase
         new SerializedName('');
     }
 
+    public function testInvalidGroupOption()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('Parameter "groups" given to "%s" must be a string or an array of non-empty strings, "stdClass" given', SerializedName::class));
+
+        new SerializedName('foo', ['fine', new \stdClass()]);
+    }
+
     public function testSerializedNameParameters()
     {
         $foo = new SerializedName('foo');

--- a/src/Symfony/Component/Serializer/Tests/Attribute/SerializedPathTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/SerializedPathTest.php
@@ -29,6 +29,14 @@ class SerializedPathTest extends TestCase
         new SerializedPath('');
     }
 
+    public function testInvalidGroupOption()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('Parameter "groups" given to "%s" must be a string or an array of non-empty strings, "stdClass" given', SerializedPath::class));
+
+        new SerializedPath('foo', ['fine', new \stdClass()]);
+    }
+
     public function testSerializedPath()
     {
         $path = '[one][two]';

--- a/src/Symfony/Component/Serializer/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Command/DebugCommandTest.php
@@ -36,43 +36,47 @@ class DebugCommandTest extends TestCase
             Symfony\Component\Serializer\Tests\Dummy\DummyClassOne
             ------------------------------------------------------
 
-            +----------+---------------------------------------+
-            | Property | Options                               |
-            +----------+---------------------------------------+
-            | code     | [                                     |
-            |          |   "groups" => [                       |
-            |          |     "book:read",                      |
-            |          |     "book:write"                      |
-            |          |   ],                                  |
-            |          |   "maxDepth" => 1,                    |
-            |          |   "serializedName" => "identifier",   |
-            |          |   "serializedPath" => null,           |
-            |          |   "ignore" => true,                   |
-            |          |   "normalizationContexts" => [        |
-            |          |     "*" => [                          |
-            |          |       "groups" => [                   |
-            |          |         "book:read"                   |
-            |          |       ]                               |
-            |          |     ]                                 |
-            |          |   ],                                  |
-            |          |   "denormalizationContexts" => [      |
-            |          |     "*" => [                          |
-            |          |       "groups" => [                   |
-            |          |         "book:write"                  |
-            |          |       ]                               |
-            |          |     ]                                 |
-            |          |   ]                                   |
-            |          | ]                                     |
-            | name     | [                                     |
-            |          |   "groups" => [],                     |
-            |          |   "maxDepth" => null,                 |
-            |          |   "serializedName" => null,           |
-            |          |   "serializedPath" => "[data][name]", |
-            |          |   "ignore" => false,                  |
-            |          |   "normalizationContexts" => [],      |
-            |          |   "denormalizationContexts" => []     |
-            |          | ]                                     |
-            +----------+---------------------------------------+
+            +----------+-----------------------------------+
+            | Property | Options                           |
+            +----------+-----------------------------------+
+            | code     | [                                 |
+            |          |   "groups" => [                   |
+            |          |     "book:read",                  |
+            |          |     "book:write"                  |
+            |          |   ],                              |
+            |          |   "maxDepth" => 1,                |
+            |          |   "serializedNames" => [          |
+            |          |     "*" => "identifier"           |
+            |          |   ],                              |
+            |          |   "serializedPaths" => [],        |
+            |          |   "ignore" => true,               |
+            |          |   "normalizationContexts" => [    |
+            |          |     "*" => [                      |
+            |          |       "groups" => [               |
+            |          |         "book:read"               |
+            |          |       ]                           |
+            |          |     ]                             |
+            |          |   ],                              |
+            |          |   "denormalizationContexts" => [  |
+            |          |     "*" => [                      |
+            |          |       "groups" => [               |
+            |          |         "book:write"              |
+            |          |       ]                           |
+            |          |     ]                             |
+            |          |   ]                               |
+            |          | ]                                 |
+            | name     | [                                 |
+            |          |   "groups" => [],                 |
+            |          |   "maxDepth" => null,             |
+            |          |   "serializedNames" => [],        |
+            |          |   "serializedPaths" => [          |
+            |          |     "*" => "[data][name]"         |
+            |          |   ],                              |
+            |          |   "ignore" => false,              |
+            |          |   "normalizationContexts" => [],  |
+            |          |   "denormalizationContexts" => [] |
+            |          | ]                                 |
+            +----------+-----------------------------------+
 
             TXT,
             $tester->getDisplay(true),
@@ -97,8 +101,8 @@ class DebugCommandTest extends TestCase
             | type     | [                                                                      |
             |          |   "groups" => [],                                                      |
             |          |   "maxDepth" => null,                                                  |
-            |          |   "serializedName" => null,                                            |
-            |          |   "serializedPath" => null,                                            |
+            |          |   "serializedNames" => [],                                             |
+            |          |   "serializedPaths" => [],                                             |
             |          |   "ignore" => false,                                                   |
             |          |   "normalizationContexts" => [],                                       |
             |          |   "denormalizationContexts" => [],                                     |

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedNameDummy.php
@@ -25,6 +25,9 @@ class SerializedNameDummy
 
     public $quux;
 
+    #[SerializedName('duxi'), SerializedName('duxa', 'a')]
+    public $duux;
+
     /**
      * @var self
      */

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPathDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPathDummy.php
@@ -23,6 +23,9 @@ class SerializedPathDummy
 
     public $seven;
 
+    #[SerializedPath('[five][six]'), SerializedPath('[six][five]', 'a')]
+    public $eleven;
+
     #[SerializedPath('[three][four]')]
     public function getSeven()
     {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPathPerGroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPathPerGroupDummy.php
@@ -11,14 +11,13 @@
 
 namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
 
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\SerializedPath;
 
-class SerializedPathInConstructorDummy
+class SerializedPathPerGroupDummy
 {
-    public function __construct(
-        #[SerializedPath('[one][two]')] public $three,
-        #[SerializedPath('[five][six]'), SerializedPath('[six][five]', 'a')]
-        public $eleven,
-    ) {
-    }
+    #[Groups(['a', 'b'])]
+    #[SerializedPath('[six][five]', 'a')]
+    #[SerializedPath('[five][six]', 'b')]
+    public $eleven;
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPerGroupWithContextDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPerGroupWithContextDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Serializer\Attribute\SerializedName;
+use Symfony\Component\Serializer\Attribute\SerializedPath;
+
+class SerializedPerGroupWithContextDummy
+{
+    #[Groups(['a', 'b'])]
+    #[Context(normalizationContext: ['groups' => ['b']], denormalizationContext: ['groups' => ['b']])]
+    #[SerializedName('inA', 'a')]
+    #[SerializedName('inB', 'b')]
+    public $name;
+
+    #[Groups(['a', 'b'])]
+    #[Context(normalizationContext: ['groups' => ['b']], denormalizationContext: ['groups' => ['b']])]
+    #[SerializedPath('[in][a]', 'a')]
+    #[SerializedPath('[in][b]', 'b')]
+    public $path;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
@@ -22,6 +22,12 @@ class OtherSerializedNameDummy
     #[Groups(['a'])]
     private $buz;
 
+    #[Groups(['a']), SerializedName('duxi'), SerializedName('duxa', 'a')]
+    public $duux;
+
+    #[Groups(['i', 'a']), SerializedName('puxi', 'i'), SerializedName('puxa', 'a')]
+    public $puux;
+
     public function setBuz($buz)
     {
         $this->buz = $buz;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/invalid-serialized-group-name.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/invalid-serialized-group-name.yml
@@ -1,0 +1,6 @@
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy':
+  attributes:
+    foo:
+      serialized:
+        - name: bar
+          groups: ['']

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/invalid-serialized-groups.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/invalid-serialized-groups.yml
@@ -1,0 +1,6 @@
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy':
+  attributes:
+    foo:
+      serialized:
+        - name: bar
+          groups: baz

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/invalid-serialized-shape.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/invalid-serialized-shape.yml
@@ -1,0 +1,4 @@
+'Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy':
+  attributes:
+    foo:
+      serialized: bar

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -23,15 +23,32 @@
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy">
         <attribute name="foo" serialized-name="baz" />
         <attribute name="bar" serialized-name="qux" />
+        <attribute name="duux">
+            <serialized name="duxi" />
+            <serialized name="duxa">
+                <group>a</group>
+            </serialized>
+        </attribute>
     </class>
 
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy">
         <attribute name="three" serialized-path="[one][two]" />
         <attribute name="seven" serialized-path="[three][four]" />
+        <attribute name="eleven">
+            <serialized path="[five][six]" />
+            <serialized path="[six][five]">
+                <group>a</group>
+            </serialized>
+        </attribute>
     </class>
 
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathInConstructorDummy">
         <attribute name="three" serialized-path="[one][two]" />
+        <attribute name="eleven" serialized-path="[five][six]">
+            <serialized path="[six][five]">
+                <group>a</group>
+            </serialized>
+        </attribute>
     </class>
 
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy">

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -15,17 +15,35 @@
     foo:
       serialized_name: 'baz'
     bar:
-      serialized_name: 'qux'
+      serialized:
+        - name: 'qux'
+    duux:
+      serialized:
+        - name: 'duxi'
+        - name: 'duxa'
+          groups: [a]
+
 'Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy':
   attributes:
     three:
       serialized_path: '[one][two]'
     seven:
-      serialized_path: '[three][four]'
+      serialized:
+        - path: '[three][four]'
+    eleven:
+      serialized:
+        - path: '[five][six]'
+        - path: '[six][five]'
+          groups: [a]
 'Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathInConstructorDummy':
   attributes:
     three:
       serialized_path: '[one][two]'
+    eleven:
+      serialized_path: '[five][six]'
+      serialized:
+        - path: '[six][five]'
+          groups: [a]
 'Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy':
   discriminator_map:
     type_property: type

--- a/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
@@ -68,6 +68,30 @@ class AttributeMetadataTest extends TestCase
         $this->assertEquals($serializedPath, $attributeMetadata->getSerializedPath());
     }
 
+    public function testSerializedNameResolutionIgnoresTheOrderOfTheContextGroups()
+    {
+        $attributeMetadata = new AttributeMetadata('name');
+        $attributeMetadata->setSerializedName('inB', ['b']);
+        $attributeMetadata->setSerializedName('inA', ['a']);
+
+        $this->assertSame('inB', $attributeMetadata->getSerializedName(['a', 'b']));
+        $this->assertSame('inB', $attributeMetadata->getSerializedName(['b', 'a']));
+        $this->assertSame('inA', $attributeMetadata->getSerializedName(['a']));
+    }
+
+    public function testSerializedPathResolutionIgnoresTheOrderOfTheContextGroups()
+    {
+        $attributeMetadata = new AttributeMetadata('path');
+        $inB = new PropertyPath('[in][b]');
+        $inA = new PropertyPath('[in][a]');
+        $attributeMetadata->setSerializedPath($inB, ['b']);
+        $attributeMetadata->setSerializedPath($inA, ['a']);
+
+        $this->assertSame($inB, $attributeMetadata->getSerializedPath(['a', 'b']));
+        $this->assertSame($inB, $attributeMetadata->getSerializedPath(['b', 'a']));
+        $this->assertSame($inA, $attributeMetadata->getSerializedPath(['a']));
+    }
+
     public function testIgnore()
     {
         $attributeMetadata = new AttributeMetadata('ignored');

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -111,6 +111,8 @@ class AttributeLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+        $this->assertEquals('duxi', $attributesMetadata['duux']->getSerializedName());
+        $this->assertEquals('duxa', $attributesMetadata['duux']->getSerializedName(['a']));
     }
 
     public function testLoadSerializedPath()
@@ -121,6 +123,8 @@ class AttributeLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals(new PropertyPath('[one][two]'), $attributesMetadata['three']->getSerializedPath());
         $this->assertEquals(new PropertyPath('[three][four]'), $attributesMetadata['seven']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[five][six]'), $attributesMetadata['eleven']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[six][five]'), $attributesMetadata['eleven']->getSerializedPath(['a']));
     }
 
     public function testLoadSerializedPathInConstructor()
@@ -130,6 +134,8 @@ class AttributeLoaderTest extends TestCase
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals(new PropertyPath('[one][two]'), $attributesMetadata['three']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[five][six]'), $attributesMetadata['eleven']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[six][five]'), $attributesMetadata['eleven']->getSerializedPath(['a']));
     }
 
     public function testLoadClassMetadataAndMerge()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -80,6 +80,8 @@ class XmlFileLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+        $this->assertEquals('duxi', $attributesMetadata['duux']->getSerializedName());
+        $this->assertEquals('duxa', $attributesMetadata['duux']->getSerializedName(['a']));
     }
 
     public function testSerializedPath()
@@ -90,6 +92,8 @@ class XmlFileLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('[one][two]', $attributesMetadata['three']->getSerializedPath());
         $this->assertEquals('[three][four]', $attributesMetadata['seven']->getSerializedPath());
+        $this->assertEquals('[five][six]', $attributesMetadata['eleven']->getSerializedPath());
+        $this->assertEquals('[six][five]', $attributesMetadata['eleven']->getSerializedPath(['a']));
     }
 
     public function testSerializedPathInConstructor()
@@ -99,6 +103,8 @@ class XmlFileLoaderTest extends TestCase
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('[one][two]', $attributesMetadata['three']->getSerializedPath());
+        $this->assertEquals('[five][six]', $attributesMetadata['eleven']->getSerializedPath());
+        $this->assertEquals('[six][five]', $attributesMetadata['eleven']->getSerializedPath(['a']));
     }
 
     public function testLoadDiscriminatorMap()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -97,6 +97,8 @@ class YamlFileLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+        $this->assertEquals('duxi', $attributesMetadata['duux']->getSerializedName());
+        $this->assertEquals('duxa', $attributesMetadata['duux']->getSerializedName(['a']));
     }
 
     public function testSerializedPath()
@@ -107,6 +109,8 @@ class YamlFileLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals(new PropertyPath('[one][two]'), $attributesMetadata['three']->getSerializedPath());
         $this->assertEquals(new PropertyPath('[three][four]'), $attributesMetadata['seven']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[five][six]'), $attributesMetadata['eleven']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[six][five]'), $attributesMetadata['eleven']->getSerializedPath(['a']));
     }
 
     public function testSerializedPathInConstructor()
@@ -116,6 +120,8 @@ class YamlFileLoaderTest extends TestCase
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals(new PropertyPath('[one][two]'), $attributesMetadata['three']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[five][six]'), $attributesMetadata['eleven']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[six][five]'), $attributesMetadata['eleven']->getSerializedPath(['a']));
     }
 
     public function testLoadDiscriminatorMap()
@@ -149,6 +155,30 @@ class YamlFileLoaderTest extends TestCase
         $this->expectExceptionMessage('The "ignore" value must be a boolean');
 
         (new YamlFileLoader(__DIR__.'/../../Fixtures/invalid-ignore.yml'))->loadClassMetadata(new ClassMetadata(IgnoreDummy::class));
+    }
+
+    public function testLoadInvalidSerializedShape()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The "serialized" value must be a list');
+
+        (new YamlFileLoader(__DIR__.'/../../Fixtures/invalid-serialized-shape.yml'))->loadClassMetadata(new ClassMetadata(SerializedNameDummy::class));
+    }
+
+    public function testLoadInvalidSerializedGroups()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The "groups" value must be a list');
+
+        (new YamlFileLoader(__DIR__.'/../../Fixtures/invalid-serialized-groups.yml'))->loadClassMetadata(new ClassMetadata(SerializedNameDummy::class));
+    }
+
+    public function testLoadInvalidSerializedGroupName()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Group names must be non-empty strings');
+
+        (new YamlFileLoader(__DIR__.'/../../Fixtures/invalid-serialized-group-name.yml'))->loadClassMetadata(new ClassMetadata(SerializedNameDummy::class));
     }
 
     protected function getLoaderForContextMapping(): LoaderInterface

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\NameConverter;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\SerializedName;
 use Symfony\Component\Serializer\Attribute\SerializedPath;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -92,6 +93,7 @@ final class MetadataAwareNameConverterTest extends TestCase
             ['foo', 'baz'],
             ['bar', 'qux'],
             ['quux', 'quux'],
+            ['duux', 'duxi'],
             [0, 0],
         ];
     }
@@ -102,6 +104,7 @@ final class MetadataAwareNameConverterTest extends TestCase
             ['foo', 'baz'],
             ['bar', 'qux'],
             ['quux', 'QUUX'],
+            ['duux', 'duxi'],
             [0, 0],
         ];
     }
@@ -116,6 +119,22 @@ final class MetadataAwareNameConverterTest extends TestCase
         $this->assertEquals($expected, $nameConverter->normalize($propertyName, OtherSerializedNameDummy::class, null, $context));
     }
 
+    #[DataProvider('fallbackAttributeAndContextProvider')]
+    public function testNormalizeWithGroupsAndFallback(string $propertyName, string $expected, array $context = [])
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+
+        $fallback = $this->createStub(NameConverterInterface::class);
+        $fallback
+            ->method('normalize')
+            ->willReturnCallback(static fn ($propertyName) => strtoupper($propertyName))
+        ;
+
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory, $fallback);
+
+        $this->assertSame($expected, $nameConverter->normalize($propertyName, OtherSerializedNameDummy::class, null, $context));
+    }
+
     #[DataProvider('attributeAndContextProvider')]
     public function testDenormalizeWithGroups(string $expected, string $propertyName, array $context = [])
     {
@@ -124,6 +143,22 @@ final class MetadataAwareNameConverterTest extends TestCase
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
 
         $this->assertEquals($expected, $nameConverter->denormalize($propertyName, OtherSerializedNameDummy::class, null, $context));
+    }
+
+    #[DataProvider('fallbackAttributeAndContextProvider')]
+    public function testDenormalizeWithGroupsAndFallback(string $expected, string $propertyName, array $context = [])
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+
+        $fallback = $this->createStub(NameConverterInterface::class);
+        $fallback
+            ->method('denormalize')
+            ->willReturnCallback(static fn ($propertyName) => strtolower($propertyName))
+        ;
+
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory, $fallback);
+
+        $this->assertSame($expected, $nameConverter->denormalize($propertyName, OtherSerializedNameDummy::class, null, $context));
     }
 
     public static function attributeAndContextProvider(): array
@@ -136,6 +171,33 @@ final class MetadataAwareNameConverterTest extends TestCase
             ['buz', 'buz', ['groups' => ['c']]],
             ['buz', 'buz', []],
             ['buzForExport', 'buz', ['groups' => ['*']]],
+            ['duux', 'duxi', ['groups' => ['*']]],
+            ['duux', 'duxa', ['groups' => ['a']]],
+            ['puux', 'puux', []],
+            ['puux', 'puux', ['groups' => ['*']]],
+            ['puux', 'puxi', ['groups' => ['i']]],
+            ['puux', 'puxa', ['groups' => ['a']]],
+            ['puux', 'puux', ['groups' => ['z']]],
+        ];
+    }
+
+    public static function fallbackAttributeAndContextProvider(): array
+    {
+        return [
+            ['buz', 'BUZ', ['groups' => ['a']]],
+            ['buzForExport', 'buz', ['groups' => ['b']]],
+            ['buz', 'BUZ', ['groups' => 'a']],
+            ['buzForExport', 'buz', ['groups' => 'b']],
+            ['buz', 'BUZ', ['groups' => ['c']]],
+            ['buz', 'BUZ', []],
+            ['buzForExport', 'buz', ['groups' => ['*']]],
+            ['duux', 'duxi', ['groups' => ['*']]],
+            ['duux', 'duxa', ['groups' => ['a']]],
+            ['puux', 'PUUX', []],
+            ['puux', 'PUUX', ['groups' => ['*']]],
+            ['puux', 'puxi', ['groups' => ['i']]],
+            ['puux', 'puxa', ['groups' => ['a']]],
+            ['puux', 'PUUX', ['groups' => ['z']]],
         ];
     }
 
@@ -156,7 +218,23 @@ final class MetadataAwareNameConverterTest extends TestCase
         $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Found SerializedName and SerializedPath attributes on property "foo" of class "Symfony\Component\Serializer\Tests\NameConverter\NestedPathAndName".');
-        $nameConverter->denormalize('foo', NestedPathAndName::class);
+        $nameConverter->denormalize('five', NestedPathAndName::class);
+    }
+
+    public function testDenormalizeWithNestedPathAndNameSameGroup()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Found SerializedName and SerializedPath attributes on property "bar" of class "Symfony\Component\Serializer\Tests\NameConverter\NestedPathAndNameSameGroup".');
+        $nameConverter->denormalize('eight', NestedPathAndNameSameGroup::class, null, ['groups' => 'a']);
+    }
+
+    public function testDenormalizeWithNestedPathAndNameDifferentGroups()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $this->assertSame('baz', $nameConverter->denormalize('eleven', NestedPathAndNameDifferentGroups::class, null, ['groups' => 'a']));
     }
 
     public function testNormalizeWithNestedPathAndName()
@@ -167,10 +245,38 @@ final class MetadataAwareNameConverterTest extends TestCase
         $this->expectExceptionMessage('Found SerializedName and SerializedPath attributes on property "foo" of class "Symfony\Component\Serializer\Tests\NameConverter\NestedPathAndName".');
         $nameConverter->normalize('foo', NestedPathAndName::class);
     }
+
+    public function testNormalizeWithNestedPathAndNameSameGroup()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Found SerializedName and SerializedPath attributes on property "bar" of class "Symfony\Component\Serializer\Tests\NameConverter\NestedPathAndNameSameGroup".');
+        $nameConverter->normalize('bar', NestedPathAndNameSameGroup::class, null, ['groups' => 'a']);
+    }
+
+    public function testNormalizeWithNestedPathAndNameDifferentGroups()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $this->assertSame('eleven', $nameConverter->normalize('baz', NestedPathAndNameDifferentGroups::class, null, ['groups' => 'a']));
+    }
 }
 
 class NestedPathAndName
 {
     #[SerializedName('five'), SerializedPath('[one][two][three]')]
     public $foo;
+}
+
+class NestedPathAndNameSameGroup
+{
+    #[Groups(['a']), SerializedName('eight', 'a'), SerializedPath('[four][five][six]', 'a')]
+    public $bar;
+}
+
+class NestedPathAndNameDifferentGroups
+{
+    #[Groups(['a', 'b']), SerializedName('eleven', 'a'), SerializedPath('[seven][eight][nine]', 'b')]
+    public $baz;
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -58,6 +58,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathPerGroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPerGroupWithContextDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberFour;
@@ -1779,6 +1781,65 @@ class AbstractObjectNormalizerTest extends TestCase
 
             throw $e;
         }
+    }
+
+    public function testSerializedPathPerGroupIsUsedWhenNormalizing()
+    {
+        $normalizer = $this->getSerializedPathPerGroupNormalizer();
+        $object = new SerializedPathPerGroupDummy();
+        $object->eleven = 'ELEVEN';
+
+        $this->assertSame(['six' => ['five' => 'ELEVEN']], $normalizer->normalize($object, null, ['groups' => ['a']]));
+        $this->assertSame(['five' => ['six' => 'ELEVEN']], $normalizer->normalize($object, null, ['groups' => ['b']]));
+    }
+
+    public function testSerializedPathPerGroupIsUsedWhenDenormalizing()
+    {
+        $normalizer = $this->getSerializedPathPerGroupNormalizer();
+
+        $inA = $normalizer->denormalize(['six' => ['five' => 'ELEVEN']], SerializedPathPerGroupDummy::class, null, ['groups' => ['a']]);
+        $this->assertSame('ELEVEN', $inA->eleven);
+
+        $inB = $normalizer->denormalize(['five' => ['six' => 'ELEVEN']], SerializedPathPerGroupDummy::class, null, ['groups' => ['b']]);
+        $this->assertSame('ELEVEN', $inB->eleven);
+    }
+
+    public function testSerializedPathPerGroupRoundTrips()
+    {
+        $normalizer = $this->getSerializedPathPerGroupNormalizer();
+        $object = new SerializedPathPerGroupDummy();
+        $object->eleven = 'ELEVEN';
+
+        foreach ([['a'], ['b']] as $groups) {
+            $data = $normalizer->normalize($object, null, ['groups' => $groups]);
+            $this->assertSame('ELEVEN', $normalizer->denormalize($data, SerializedPathPerGroupDummy::class, null, ['groups' => $groups])->eleven);
+        }
+    }
+
+    public function testSerializedPerGroupIgnoresTheGroupsOfPerAttributeContexts()
+    {
+        $normalizer = $this->getSerializedPathPerGroupNormalizer();
+        $object = new SerializedPerGroupWithContextDummy();
+        $object->name = 'NAME';
+        $object->path = 'PATH';
+
+        $data = $normalizer->normalize($object, null, ['groups' => ['a']]);
+
+        $this->assertSame(['inA' => 'NAME', 'in' => ['a' => 'PATH']], $data);
+
+        $denormalized = $normalizer->denormalize($data, SerializedPerGroupWithContextDummy::class, null, ['groups' => ['a']]);
+
+        $this->assertSame('NAME', $denormalized->name);
+        $this->assertSame('PATH', $denormalized->path);
+    }
+
+    private function getSerializedPathPerGroupNormalizer(): ObjectNormalizer
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        new Serializer([$normalizer]);
+
+        return $normalizer;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #30483, Fix #53858
| License       | MIT

`#[SerializedName]` and `#[SerializedPath]` become repeatable and take a `groups` argument, so one property can be exposed under different names or paths depending on the serialization groups:

```php
class Person
{
    #[Groups(['registration', 'update'])]
    #[SerializedName('address1', 'registration')]
    #[SerializedName('address2', 'update')]
    public string $address;
}
```

```php
$serializer->serialize($person, 'json', ['groups' => ['registration']]); // {"address1": "..."}
$serializer->serialize($person, 'json', ['groups' => ['update']]);       // {"address2": "..."}
```

Denormalization honors the same mapping: with the `registration` group, the value is read from the `address1` key. This is what #30483 asked for in 2019 and #53858 in 2024, in the shape #53858 proposed.

The YAML and XML mapping formats gain the equivalent, under a `serialized` key and a `<serialized>` element:

```yaml
attributes:
    address:
        serialized:
            - name: 'address1'
              groups: [registration]
            - name: 'address2'
              groups: [update]
```

```xml
<attribute name="address">
    <serialized name="address1">
        <group>registration</group>
    </serialized>
    <serialized name="address2">
        <group>update</group>
    </serialized>
</attribute>
```

Entries use `name` or `path`, never both on the same entry. The existing flat `serialized_name`/`serialized_path` keys and attributes keep working and mean "every group".

## Resolution rules

* A name or path declared without groups (or with `'*'`) applies to every group and is the fallback when no declared group is in the context, the same `'*'` convention the component uses for per-group contexts.
* When several declared entries match the context, the first declared one wins. The order of the groups in the context has no effect.
* An empty `groups` array on the attribute throws; omitting the argument is the way to target every group.
* The groups that pick names and paths are the ones of the top-level context. A per-attribute `#[Context]` that overrides `groups` applies to the value, not to the name or path, so what is written under a group always reads back under the same group.

## Compatibility

* Mappings that do not use the new argument serialize byte-for-byte as before.
* A metadata cache warmed by an older Symfony version is upgraded transparently on unserialize.
* `debug:serializer` reports `serializedNames`/`serializedPaths` maps in place of the former scalars.

## For the documentation

* The repeatable `#[SerializedName]`/`#[SerializedPath]` attributes and their `groups` argument, with the YAML `serialized` key and the XML `<serialized>` element.
* `'*'` and absent groups meaning every group, and serving as the fallback.
* Declaration-order resolution when several groups match.
* Per-attribute `#[Context]` groups applying to values but not to names and paths.
