### PR TITLE
[Serializer][Uid][Validator] Mention RFC 9562

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -24,7 +24,7 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
     public const NORMALIZATION_FORMAT_CANONICAL = 'canonical';
     public const NORMALIZATION_FORMAT_BASE58 = 'base58';
     public const NORMALIZATION_FORMAT_BASE32 = 'base32';
-    public const NORMALIZATION_FORMAT_RFC4122 = 'rfc4122';
+    public const NORMALIZATION_FORMAT_RFC4122 = 'rfc4122'; // RFC 9562 obsoleted RFC 4122 but the format is the same
 
     private $defaultContext = [
         self::NORMALIZATION_FORMAT_KEY => self::NORMALIZATION_FORMAT_CANONICAL,

--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -78,6 +78,8 @@ abstract class AbstractUid implements \JsonSerializable
     }
 
     /**
+     * @param string $uid A valid RFC 9562/4122 uid
+     *
      * @return static
      *
      * @throws \InvalidArgumentException When the passed value is not valid
@@ -124,7 +126,7 @@ abstract class AbstractUid implements \JsonSerializable
     }
 
     /**
-     * Returns the identifier as a RFC4122 case insensitive string.
+     * Returns the identifier as a RFC 9562/4122 case insensitive string.
      */
     public function toRfc4122(): string
     {

--- a/src/Symfony/Component/Uid/BinaryUtil.php
+++ b/src/Symfony/Component/Uid/BinaryUtil.php
@@ -36,7 +36,7 @@ class BinaryUtil
         'u' => 52, 'v' => 53, 'w' => 54, 'x' => 55, 'y' => 56, 'z' => 57,
     ];
 
-    // https://tools.ietf.org/html/rfc4122#section-4.1.4
+    // https://datatracker.ietf.org/doc/html/rfc9562#section-5.1
     // 0x01b21dd213814000 is the number of 100-ns intervals between the
     // UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
     private const TIME_OFFSET_INT = 0x01B21DD213814000;

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Uid;
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *
- * @see https://tools.ietf.org/html/rfc4122#appendix-C for details about namespaces
+ * @see https://datatracker.ietf.org/doc/html/rfc9562/#section-6.6 for details about namespaces
  */
 class Uuid extends AbstractUid
 {

--- a/src/Symfony/Component/Validator/Constraints/Uuid.php
+++ b/src/Symfony/Component/Validator/Constraints/Uuid.php
@@ -39,7 +39,7 @@ class Uuid extends Constraint
         self::INVALID_VARIANT_ERROR => 'INVALID_VARIANT_ERROR',
     ];
 
-    // Possible versions defined by RFC 4122
+    // Possible versions defined by RFC 9562/4122
     public const V1_MAC = 1;
     public const V2_DCE = 2;
     public const V3_MD5 = 3;
@@ -64,7 +64,7 @@ class Uuid extends Constraint
     public $message = 'This is not a valid UUID.';
 
     /**
-     * Strict mode only allows UUIDs that meet the formal definition and formatting per RFC 4122.
+     * Strict mode only allows UUIDs that meet the formal definition and formatting per RFC 9562/4122.
      *
      * Set this to `false` to allow legacy formats with different dash positioning or wrapping characters
      *

--- a/src/Symfony/Component/Validator/Constraints/UuidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UuidValidator.php
@@ -19,13 +19,13 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 /**
  * Validates whether the value is a valid UUID (also known as GUID).
  *
- * Strict validation will allow a UUID as specified per RFC 4122.
+ * Strict validation will allow a UUID as specified per RFC 9562/4122.
  * Loose validation will allow any type of UUID.
  *
  * @author Colin O'Dell <colinodell@gmail.com>
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @see http://tools.ietf.org/html/rfc4122
+ * @see https://datatracker.ietf.org/doc/html/rfc9562
  * @see https://en.wikipedia.org/wiki/Universally_unique_identifier
  */
 class UuidValidator extends ConstraintValidator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

RFC 4122 has been obsoleted by RFC 9562 since May 2024.

The format remains the same so we don't need to do anything. Renaming everything with BC would certainly be a waste of time. However, we can add some comments and update the links to be up-to-date.