### PR TITLE
[FrameworkBundle] Fix service reset between tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -160,6 +160,11 @@ abstract class KernelTestCase extends TestCase
             static::$kernel->shutdown();
             static::$booted = false;
 
+            if ($container->has('services_resetter')) {
+                // Instantiate the service because Container::reset() only resets services that have been used
+                $container->get('services_resetter');
+            }
+
             if ($container instanceof ResetInterface) {
                 $container->reset();
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/ResettableService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/ResettableService.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer;
+
+class ResettableService
+{
+    private $count = 0;
+
+    public function myCustomName(): void
+    {
+        ++$this->count;
+    }
+
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/KernelTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/KernelTestCaseTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\NonPublicService;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PublicService;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\ResettableService;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\UnusedPrivateService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -40,5 +41,15 @@ class KernelTestCaseTest extends AbstractWebTestCase
         $this->assertTrue($container->has(PrivateService::class));
         $this->assertTrue($container->has('private_service'));
         $this->assertFalse($container->has(UnusedPrivateService::class));
+    }
+
+    public function testServicesAreResetOnEnsureKernelShutdown()
+    {
+        static::bootKernel(['test_case' => 'TestServiceContainer']);
+
+        $resettableService = static::getContainer()->get(ResettableService::class);
+
+        self::ensureKernelShutdown();
+        self::assertSame(1, $resettableService->getCount());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/services.yml
@@ -13,3 +13,8 @@ services:
         arguments:
             - '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\NonPublicService'
             - '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService'
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\ResettableService:
+        public: true
+        tags:
+            - kernel.reset: { method: 'myCustomName' }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "symfony/cache": "^5.2|^6.0",
         "symfony/config": "^5.3|^6.0",
-        "symfony/dependency-injection": "^5.4.5|^6.0.5",
+        "symfony/dependency-injection": "^5.4.44|^6.0.5",
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/event-dispatcher": "^5.1|^6.0",
         "symfony/error-handler": "^4.4.1|^5.0.1|^6.0",

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -299,7 +299,6 @@ class Container implements ContainerInterface, ResetInterface
     public function reset()
     {
         $services = $this->services + $this->privates;
-        $this->services = $this->factories = $this->privates = [];
 
         foreach ($services as $service) {
             try {
@@ -310,6 +309,8 @@ class Container implements ContainerInterface, ResetInterface
                 continue;
             }
         }
+
+        $this->services = $this->factories = $this->privates = [];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, not all services are reset between tests. If a service uses the kernel.reset tag but does not implement the ResetInterface, it never gets reset.