### PR TITLE
[HttpKernel] allow narrow type of not nullable getResponse when hasResponse has been called

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/RequestEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/RequestEvent.php
@@ -46,6 +46,8 @@ class RequestEvent extends KernelEvent
 
     /**
      * Returns whether a response was set.
+     *
+     * @psalm-assert-if-true !null $this->getResponse()
      */
     public function hasResponse(): bool
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

```php
if ($event->hasResponse()) {
    return $event->getResponse();
}
```

PHPStan understands now inside the if that Response is not nullable anymore

