### PR TITLE
[Notifier][TurboSMS] Process partial accepted response from transport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
@@ -89,8 +89,14 @@ final class TurboSmsTransport extends AbstractTransport
         if (200 === $response->getStatusCode()) {
             $success = $response->toArray(false);
 
+            if (null === $messageId = $success['response_result'][0]['message_id']) {
+                $responseResult = $success['response_result'][0];
+
+                throw new TransportException(sprintf('Unable to send SMS with TurboSMS: Error code %d with message "%s".', (int) $responseResult['response_code'], $responseResult['response_status']), $response);
+            }
+
             $sentMessage = new SentMessage($message, (string) $this);
-            $sentMessage->setMessageId($success['response_result'][0]['message_id']);
+            $sentMessage->setMessageId($messageId);
 
             return $sentMessage;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | None 
| License       | MIT


TurboSMS can return `null` as message id, if sms not sent to recipient. Example:

```json
{
   "response_code": 802,
   "response_status": "SUCCESS_MESSAGE_PARTIAL_ACCEPTED",
   "response_result": [
      {
         "phone": "recipient_1",
         "response_code": 406,
         "message_id": null,
         "response_status": "NOT_ALLOWED_RECIPIENT_COUNTRY"
      },
      {
         "phone": "recipient_2",
         "response_code": 0,
         "message_id": "f83f8868-5e46-c6cf-e4fb-615e5a293754",
         "response_status": "OK"
      }
   ]
}
```

And we receive error:

```
Symfony\Component\Notifier\Message\SentMessage::setMessageId(): Argument #1 ($id) must be of type string, null given, called in /code/vendor/symfony/turbo-sms-notifier/TurboSmsTransport.php on line 93
```

Symfony use only one phone number for sent, as result we check only first `response_result`.
