### PR TITLE
[Yaml] Add support for dumping `null` as an empty value by using the `Yaml::DUMP_NULL_AS_EMPTY` flag

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate parsing duplicate mapping keys whose value is `null`
+ * Add support for dumping `null` as an empty value by using the `Yaml::DUMP_NULL_AS_EMPTY` flag
 
 7.1
 ---

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -100,7 +100,7 @@ class Inline
      *
      * @throws DumpException When trying to dump PHP resource
      */
-    public static function dump(mixed $value, int $flags = 0): string
+    public static function dump(mixed $value, int $flags = 0, bool $rootLevel = false): string
     {
         switch (true) {
             case \is_resource($value):
@@ -138,7 +138,7 @@ class Inline
             case \is_array($value):
                 return self::dumpArray($value, $flags);
             case null === $value:
-                return self::dumpNull($flags);
+                return self::dumpNull($flags, $rootLevel);
             case true === $value:
                 return 'true';
             case false === $value:
@@ -253,10 +253,14 @@ class Inline
         return \sprintf('{ %s }', implode(', ', $output));
     }
 
-    private static function dumpNull(int $flags): string
+    private static function dumpNull(int $flags, bool $rootLevel = false): string
     {
         if (Yaml::DUMP_NULL_AS_TILDE & $flags) {
             return '~';
+        }
+
+        if (Yaml::DUMP_NULL_AS_EMPTY & $flags && !$rootLevel) {
+            return '';
         }
 
         return 'null';

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -216,6 +216,63 @@ EOF;
         $this->dumper->dump(['foo' => new A(), 'bar' => 1], 0, 0, Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE);
     }
 
+    public function testDumpWithMultipleNullFlagsFormatsThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Yaml::DUMP_NULL_AS_EMPTY and Yaml::DUMP_NULL_AS_TILDE flags cannot be used together.');
+
+        $this->dumper->dump(['foo' => 'bar'], 0, 0, Yaml::DUMP_NULL_AS_EMPTY | Yaml::DUMP_NULL_AS_TILDE);
+    }
+
+    public function testDumpNullAsEmptyInExpandedMapping()
+    {
+        $expected = "qux:\n    foo: bar\n    baz: \n";
+
+        $this->assertSame($expected, $this->dumper->dump(['qux' => ['foo' => 'bar', 'baz' => null]], 2, flags: Yaml::DUMP_NULL_AS_EMPTY));
+    }
+
+    public function testDumpNullAsEmptyWithObject()
+    {
+        $class = new \stdClass();
+        $class->foo = 'bar';
+        $class->baz = null;
+
+        $this->assertSame("foo: bar\nbaz: \n", $this->dumper->dump($class, 2, flags: Yaml::DUMP_NULL_AS_EMPTY | Yaml::DUMP_OBJECT_AS_MAP));
+    }
+
+    public function testDumpNullAsEmptyDumpsWhenInInlineMapping()
+    {
+        $expected = "foo: \nqux: { foo: bar, baz:  }\n";
+
+        $this->assertSame($expected, $this->dumper->dump(['foo' => null, 'qux' => ['foo' => 'bar', 'baz' => null]], 1, flags: Yaml::DUMP_NULL_AS_EMPTY));
+    }
+
+    public function testDumpNullAsEmptyDumpsNestedMaps()
+    {
+        $expected = "foo: \nqux:\n    foo: bar\n    baz: \n";
+
+        $this->assertSame($expected, $this->dumper->dump(['foo' => null, 'qux' => ['foo' => 'bar', 'baz' => null]], 10, flags: Yaml::DUMP_NULL_AS_EMPTY));
+    }
+
+    public function testDumpNullAsEmptyInExpandedSequence()
+    {
+        $expected = "qux:\n    - foo\n    - \n    - bar\n";
+
+        $this->assertSame($expected, $this->dumper->dump(['qux' => ['foo', null, 'bar']], 2, flags: Yaml::DUMP_NULL_AS_EMPTY));
+    }
+
+    public function testDumpNullAsEmptyWhenInInlineSequence()
+    {
+        $expected = "foo: \nqux: [foo, , bar]\n";
+
+        $this->assertSame($expected, $this->dumper->dump(['foo' => null, 'qux' => ['foo', null, 'bar']], 1, flags: Yaml::DUMP_NULL_AS_EMPTY));
+    }
+
+    public function testDumpNullAsEmptyAtRoot()
+    {
+        $this->assertSame('null', $this->dumper->dump(null, 2, flags: Yaml::DUMP_NULL_AS_EMPTY));
+    }
+
     /**
      * @dataProvider getEscapeSequences
      */

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -52,6 +52,33 @@ class ParserTest extends TestCase
         $this->assertSameData($expected, $data);
     }
 
+    public function testEmptyValueInExpandedMappingIsSupported()
+    {
+        $yml = <<<'YAML'
+foo:
+    bar:
+    baz: qux
+YAML;
+
+        $data = $this->parser->parse($yml);
+        $expected = ['foo' => ['bar' => null, 'baz' => 'qux']];
+        $this->assertSameData($expected, $data);
+    }
+
+    public function testEmptyValueInExpandedSequenceIsSupported()
+    {
+        $yml = <<<'YAML'
+foo:
+    - bar
+    -
+    - baz
+YAML;
+
+        $data = $this->parser->parse($yml);
+        $expected = ['foo' => ['bar', null, 'baz']];
+        $this->assertSameData($expected, $data);
+    }
+
     public function testTaggedValueTopLevelNumber()
     {
         $yml = '!number 5';

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -35,6 +35,7 @@ class Yaml
     public const DUMP_EMPTY_ARRAY_AS_SEQUENCE = 1024;
     public const DUMP_NULL_AS_TILDE = 2048;
     public const DUMP_NUMERIC_KEY_AS_STRING = 4096;
+    public const DUMP_NULL_AS_EMPTY = 8192;
 
     /**
      * Parses a YAML file into a PHP value.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58155
| License       | MIT

Another try after #58232. I went for the second solution from @stof (https://github.com/symfony/symfony/pull/58232#issuecomment-2344319568), namely dumping empty value as null just in expanded sequences and mappings. When the inline limit of the dumper is reached, it fallbacks on using `null` (examples in tests).

I'm not 100% happy about the name of the constant, `DUMP_NULL_AS_EMPTY_IN_EXPANDED_NOTATION`. It's verbose. I'm open to suggestions!