### PR TITLE
[HttpFoundation] Deprecate more options in `NativeSessionStorage`

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -29,6 +29,11 @@ FrameworkBundle
 
  * [BC BREAK] The `secrets:decrypt-to-local` command terminates with a non-zero exit code when a secret could not be read
 
+HttpFoundation
+--------------
+
+ * Deprecate passing `referer_check`, `use_only_cookies`, `use_trans_sid`, `trans_sid_hosts` and `trans_sid_tags` options to `NativeSessionStorage`
+
 Ldap
 ----
 

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add optional `$requests` parameter to `RequestStack::__construct()`
  * Add optional `$v4Bytes` and `$v6Bytes` parameters to `IpUtils::anonymize()`
  * Add `PRIVATE_SUBNETS` as a shortcut for private IP address ranges to `Request::setTrustedProxies()`
+ * Deprecate passing `referer_check`, `use_only_cookies`, `use_trans_sid`, `trans_sid_hosts` and `trans_sid_tags` options to `NativeSessionStorage`
 
 7.1
 ---

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -62,16 +62,16 @@ class NativeSessionStorage implements SessionStorageInterface
      * gc_probability, "1"
      * lazy_write, "1"
      * name, "PHPSESSID"
-     * referer_check, ""
+     * referer_check, "" (deprecated since Symfony 7.2, to be removed in Symfony 8.0)
      * serialize_handler, "php"
      * use_strict_mode, "1"
      * use_cookies, "1"
-     * use_only_cookies, "1"
-     * use_trans_sid, "0"
+     * use_only_cookies, "1" (deprecated since Symfony 7.2, to be removed in Symfony 8.0)
+     * use_trans_sid, "0" (deprecated since Symfony 7.2, to be removed in Symfony 8.0)
      * sid_length, "32"
      * sid_bits_per_character, "5"
-     * trans_sid_hosts, $_SERVER['HTTP_HOST']
-     * trans_sid_tags, "a=href,area=href,frame=src,form="
+     * trans_sid_hosts, $_SERVER['HTTP_HOST'] (deprecated since Symfony 7.2, to be removed in Symfony 8.0)
+     * trans_sid_tags, "a=href,area=href,frame=src,form=" (deprecated since Symfony 7.2, to be removed in Symfony 8.0)
      */
     public function __construct(array $options = [], AbstractProxy|\SessionHandlerInterface|null $handler = null, ?MetadataBag $metaBag = null)
     {
@@ -328,6 +328,10 @@ class NativeSessionStorage implements SessionStorageInterface
         ]);
 
         foreach ($options as $key => $value) {
+            if (\in_array($key, ['referer_check', 'use_only_cookies', 'use_trans_sid', 'trans_sid_hosts', 'trans_sid_tags'], true)) {
+                trigger_deprecation('symfony/http-foundation', '7.2', 'NativeSessionStorage\'s "%s" option is deprecated and will be ignored in Symfony 8.0.', $key);
+            }
+
             if (isset($validOptions[$key])) {
                 if ('cookie_secure' === $key && 'auto' === $value) {
                     continue;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
@@ -28,7 +28,6 @@ ini_set('session.cookie_domain', '');
 ini_set('session.cookie_secure', '');
 ini_set('session.cookie_httponly', '');
 ini_set('session.use_cookies', 1);
-ini_set('session.use_only_cookies', 1);
 ini_set('session.cache_expire', 180);
 ini_set('session.cookie_path', '/');
 ini_set('session.cookie_domain', '');

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler;
@@ -32,6 +33,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
  */
 class NativeSessionStorageTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private string $savePath;
 
     private $initialSessionSaveHandler;
@@ -215,10 +218,14 @@ class NativeSessionStorageTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * The test must only be removed when the "session.trans_sid_tags" option is removed from PHP or when the "trans_sid_tags" option is no longer supported by the native session storage.
      */
     public function testTransSidTagsOption()
     {
+        $this->expectDeprecation('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_tags" option is deprecated and will be ignored in Symfony 8.0.');
+
         $previousErrorHandler = set_error_handler(function ($errno, $errstr) use (&$previousErrorHandler) {
             if ('ini_set(): Usage of session.trans_sid_tags INI setting is deprecated' !== $errstr) {
                 return $previousErrorHandler ? $previousErrorHandler(...\func_get_args()) : false;
@@ -356,5 +363,25 @@ class NativeSessionStorageTest extends TestCase
         $storage->save();
 
         $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testPassingDeprecatedOptions()
+    {
+        $this->expectDeprecation('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "referer_check" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectDeprecation('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "use_only_cookies" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectDeprecation('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "use_trans_sid" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectDeprecation('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_hosts" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectDeprecation('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_tags" option is deprecated and will be ignored in Symfony 8.0.');
+
+        $this->getStorage([
+            'referer_check' => 'foo',
+            'use_only_cookies' => 'foo',
+            'use_trans_sid' => 'foo',
+            'trans_sid_hosts' => 'foo',
+            'trans_sid_tags' => 'foo',
+        ]);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/polyfill-mbstring": "~1.1",
         "symfony/polyfill-php83": "^1.27"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

Another round of deprecations for sessions. RFC for reference: https://wiki.php.net/rfc/deprecate-get-post-sessions#proposal