### PR TITLE
[Webhook] Allow request parsers to return multiple `RemoteEvent`'s

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -84,6 +84,15 @@ TwigBridge
 
  * Deprecate passing a tag to the constructor of `FormThemeNode`
 
+Webhook
+-------
+
+ * [BC BREAK] `RequestParserInterface::parse()` return type changed from
+   `?RemoteEvent` to `RemoteEvent|array<RemoteEvent>|null`. Classes already
+   implementing this interface are unaffected but consumers of this method
+   will need to be updated to handle the new return type. Projects relying on
+   the `WebhookController` of the component are not affected by the BC break
+
 Yaml
 ----
 

--- a/src/Symfony/Component/Webhook/CHANGELOG.md
+++ b/src/Symfony/Component/Webhook/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Make `AbstractRequestParserTestCase` compatible with PHPUnit 10+
  * Add `PayloadSerializerInterface` with implementations to decouple the remote event handling from the Serializer component
  * Add optional `$request` argument to `RequestParserInterface::createSuccessfulResponse()` and `RequestParserInterface::createRejectedResponse()`
+ * [BC BREAK] Change return type of `RequestParserInterface::parse()` to `RemoteEvent|array<RemoteEvent>|null` (from `?RemoteEvent`)
 
 6.4
 ---

--- a/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
+++ b/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
@@ -22,7 +22,7 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
  */
 abstract class AbstractRequestParser implements RequestParserInterface
 {
-    public function parse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent
+    public function parse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|array|null
     {
         $this->validate($request);
 
@@ -47,7 +47,7 @@ abstract class AbstractRequestParser implements RequestParserInterface
 
     abstract protected function getRequestMatcher(): RequestMatcherInterface;
 
-    abstract protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent;
+    abstract protected function doParse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|array|null;
 
     protected function validate(Request $request): void
     {

--- a/src/Symfony/Component/Webhook/Client/RequestParserInterface.php
+++ b/src/Symfony/Component/Webhook/Client/RequestParserInterface.php
@@ -24,11 +24,11 @@ interface RequestParserInterface
     /**
      * Parses an HTTP Request and converts it into a RemoteEvent.
      *
-     * @return ?RemoteEvent Returns null if the webhook must be ignored
+     * @return RemoteEvent|RemoteEvent[]|null Returns null if the webhook must be ignored
      *
      * @throws RejectWebhookException When the payload is rejected (signature issue, parse issue, ...)
      */
-    public function parse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent;
+    public function parse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|array|null;
 
     /**
      * @param Request|null $request The original request that was received by the webhook controller

--- a/src/Symfony/Component/Webhook/Test/AbstractRequestParserTestCase.php
+++ b/src/Symfony/Component/Webhook/Test/AbstractRequestParserTestCase.php
@@ -26,7 +26,7 @@ abstract class AbstractRequestParserTestCase extends TestCase
      * @dataProvider getPayloads
      */
     #[DataProvider('getPayloads')]
-    public function testParse(string $payload, RemoteEvent $expected)
+    public function testParse(string $payload, RemoteEvent|array $expected)
     {
         $request = $this->createRequest($payload);
         $parser = $this->createRequestParser();
@@ -35,7 +35,7 @@ abstract class AbstractRequestParserTestCase extends TestCase
     }
 
     /**
-     * @return iterable<array{string, RemoteEvent}>
+     * @return iterable<array{string, RemoteEvent|RemoteEvent[]}>
      */
     public static function getPayloads(): iterable
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Unblocks https://github.com/symfony/symfony/pull/50324
| License       | MIT

I've run into services that send their webhook events in bulk - a single request containing multiple events.

This is one idea to allow this. I'd like to get some input before going further.

TODO:
- [x] Update changelog
- [x] Update/add tests
