### PR TITLE
[FrameworkBundle] Finish incomplete tests for lock & semaphore config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock.php
@@ -1,0 +1,9 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'lock' => null,
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock_named.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock_named.php
@@ -1,0 +1,16 @@
+<?php
+
+$container->setParameter('env(REDIS_DSN)', 'redis://paas.com');
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'lock' => [
+        'foo' => 'semaphore',
+        'bar' => 'flock',
+        'baz' => ['semaphore', 'flock'],
+        'qux' => '%env(REDIS_DSN)%',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/semaphore.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/semaphore.php
@@ -1,0 +1,9 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'semaphore' => 'redis://localhost',
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/semaphore_named.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/semaphore_named.php
@@ -1,0 +1,14 @@
+<?php
+
+$container->setParameter('env(REDIS_DSN)', 'redis://paas.com');
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'semaphore' => [
+        'foo' => 'redis://paas.com',
+        'qux' => '%env(REDIS_DSN)%',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock.xml
@@ -8,6 +8,8 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:lock/>
+        <framework:lock>
+            <framework:resource>semaphore</framework:resource>
+        </framework:lock>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/semaphore.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/semaphore.xml
@@ -8,6 +8,8 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:semaphore/>
+        <framework:semaphore>
+            <framework:resource>redis://localhost</framework:resource>
+        </framework:semaphore>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/semaphore_named.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/semaphore_named.xml
@@ -5,19 +5,12 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <parameters>
-        <parameter key="env(REDIS_URL)">redis://paas.com</parameter>
-    </parameters>
-
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:lock>
-            <framework:resource name="foo">semaphore</framework:resource>
-            <framework:resource name="bar">flock</framework:resource>
-            <framework:resource name="baz">semaphore</framework:resource>
-            <framework:resource name="baz">flock</framework:resource>
+        <framework:semaphore>
+            <framework:resource name="foo">redis://paas.com</framework:resource>
             <framework:resource name="qux">%env(REDIS_DSN)%</framework:resource>
-        </framework:lock>
+        </framework:semaphore>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2396,6 +2396,62 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertFalse($container->has('assets._default_package'));
     }
 
+    public function testDefaultLock()
+    {
+        $container = $this->createContainerFromFile('lock');
+
+        self::assertTrue($container->hasDefinition('lock.default.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.default.factory')->getArgument(0));
+        self::assertEquals(new Reference('semaphore'), $storeDef->getArgument(0));
+    }
+
+    public function testNamedLocks()
+    {
+        $container = $this->createContainerFromFile('lock_named');
+
+        self::assertTrue($container->hasDefinition('lock.foo.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.foo.factory')->getArgument(0));
+        self::assertEquals(new Reference('semaphore'), $storeDef->getArgument(0));
+
+        self::assertTrue($container->hasDefinition('lock.bar.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.bar.factory')->getArgument(0));
+        self::assertEquals(new Reference('flock'), $storeDef->getArgument(0));
+
+        self::assertTrue($container->hasDefinition('lock.baz.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.baz.factory')->getArgument(0));
+        self::assertIsArray($storeDefArg = $storeDef->getArgument(0));
+        $storeDef1 = $container->getDefinition($storeDefArg[0]);
+        $storeDef2 = $container->getDefinition($storeDefArg[1]);
+        self::assertEquals(new Reference('semaphore'), $storeDef1->getArgument(0));
+        self::assertEquals(new Reference('flock'), $storeDef2->getArgument(0));
+
+        self::assertTrue($container->hasDefinition('lock.qux.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.qux.factory')->getArgument(0));
+        self::assertStringContainsString('REDIS_DSN', $storeDef->getArgument(0));
+    }
+
+    public function testDefaultSemaphore()
+    {
+        $container = $this->createContainerFromFile('semaphore');
+
+        self::assertTrue($container->hasDefinition('semaphore.default.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('semaphore.default.factory')->getArgument(0));
+        self::assertSame('redis://localhost', $storeDef->getArgument(0));
+    }
+
+    public function testNamedSemaphores()
+    {
+        $container = $this->createContainerFromFile('semaphore_named');
+
+        self::assertTrue($container->hasDefinition('semaphore.foo.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('semaphore.foo.factory')->getArgument(0));
+        self::assertSame('redis://paas.com', $storeDef->getArgument(0));
+
+        self::assertTrue($container->hasDefinition('semaphore.qux.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('semaphore.qux.factory')->getArgument(0));
+        self::assertStringContainsString('REDIS_DSN', $storeDef->getArgument(0));
+    }
+
     protected function createContainer(array $data = [])
     {
         return new ContainerBuilder(new EnvPlaceholderParameterBag(array_merge([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I noticed this while working on #58249. Basically, the test files were partially added but never used, so the tests were incomplete. ~Also, there's a bug in the schema, as the configuration in those files didn't work.~