### PR TITLE
[Serializer] Fix `ObjectNormalizer` gives warnings on normalizing with public static property

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -197,7 +197,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
         if ($context['_read_attributes'] ?? true) {
             if (!isset(self::$isReadableCache[$class.$attribute])) {
-                self::$isReadableCache[$class.$attribute] = (\is_object($classOrObject) && $this->propertyAccessor->isReadable($classOrObject, $attribute)) || $this->propertyInfoExtractor->isReadable($class, $attribute) || $this->hasAttributeAccessorMethod($class, $attribute);
+                self::$isReadableCache[$class.$attribute] = $this->propertyInfoExtractor->isReadable($class, $attribute) || $this->hasAttributeAccessorMethod($class, $attribute) || (\is_object($classOrObject) && $this->propertyAccessor->isReadable($classOrObject, $attribute));
             }
 
             return self::$isReadableCache[$class.$attribute];

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -927,6 +927,16 @@ class ObjectNormalizerTest extends TestCase
 
         $this->assertEquals($expected, $obj);
     }
+
+    public function testObjectNormalizerWithAttributeLoaderAndObjectHasStaticProperty()
+    {
+        $class = new class {
+            public static string $foo;
+        };
+
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+        $this->assertSame([], $normalizer->normalize($class));
+    }
 }
 
 class ProxyObjectDummy extends ObjectDummy


### PR DESCRIPTION
| Q             | A           |
|---------------|-------------|
| Branch?       | 6.4 |
| Bug fix?      | yes         |
| New feature?  | no          |
| Deprecations? | no          |
| Issues        | Fix #58221  |
| License       | MIT         |

The error message has been occurring since version 6.4.11/7.1.2. If the condition is changed to version >=7.1.2, the error message no longer occurs.

The error is thrown with the following ObjectNormalizer configuration:

```php
$class = new class {
    public static string $foo = "hallo";
};

$normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
$normalizer->normalize($class);
```

`(\is_object($classOrObject) && $this->propertyAccessor->isReadable($classOrObject, $attribute))` is true and therefore the entire condition is true.

I moved the condition into a method to improve readability and reduce complexity.

All serializer tests are successful.

### Condition

For better readability here with breaks.

**7.1.1**
https://github.com/symfony/symfony/blob/v7.1.1/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php#L180
```php
if (!isset(self::$isReadableCache[$class.$attribute])) {
    self::$isReadableCache[$class.$attribute] =
    $this->propertyInfoExtractor->isReadable($class, $attribute)
    || $this->hasAttributeAccessorMethod($class, $attribute);
}
```

**>=7.2.2**
https://github.com/symfony/symfony/blob/v7.1.2/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php#L180
```php
if (!isset(self::$isReadableCache[$class.$attribute])) {
    self::$isReadableCache[$class.$attribute] =
    (\is_object($classOrObject) && $this->propertyAccessor->isReadable($classOrObject, $attribute))
    || $this->propertyInfoExtractor->isReadable($class, $attribute)
    || $this->hasAttributeAccessorMethod($class, $attribute);
}
```

**Fixed condition**
```php
if (!isset(self::$isReadableCache[$class.$attribute])) {
    self::$isReadableCache[$class.$attribute] =
    $this->propertyInfoExtractor->isReadable($class, $attribute)
    || $this->hasAttributeAccessorMethod($class, $attribute)
    || (\is_object($classOrObject) && $this->propertyAccessor->isReadable($classOrObject, $attribute));
}
```


