### PR TITLE
[Process] Add Laravel Herd php detection path

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -86,6 +86,10 @@ class PhpExecutableFinder
             $dirs[] = 'C:\xampp\php\\';
         }
 
+        if ($herdPath = getenv('HERD_HOME')) {
+            $dirs[] = $herdPath.\DIRECTORY_SEPARATOR.'bin';
+        }
+
         return $this->executableFinder->find('php', false, $dirs);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  |yes
| Deprecations? |no 
| Issues        | –
| License       | MIT

As of right now, using the `PhpExecutableFinder` in combination with Laravel Herd, results in an empty string, which is what this PR fixes.

As the PhpExecutableFinder is already aware of XAMPP, it might be a good idea to also add support for Laravel Herd, which is widely used - not only in the Laravel ecosystem.

Laravel Herd uses statically compiled PHP binaries, which is why the `PHP_BINDIR` folder always points to `/bin` instead of a user-specific folder.

As Laravel Herd adds a `HERD_HOME` environment variable, we can check for the existence of this variable and then add the bin subdirectory to the list of directories to search.

I couldn't find any tests for XAMPP, which is why I haven't included any for this addition.