### PR TITLE
[Cache] Fix RedisSentinel param types

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
@@ -33,7 +33,7 @@ class RedisAdapterSentinelTest extends AbstractRedisAdapterTestCase
             throw new SkippedTestSuiteError('REDIS_SENTINEL_SERVICE env var is not defined.');
         }
 
-        self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => $service, 'prefix' => 'prefix_']);
+        self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']&timeout=0&retry_interval=0&read_timeout=0', ['redis_sentinel' => $service, 'prefix' => 'prefix_']);
     }
 
     public function testInvalidDSNHasBothClusterAndSentinel()

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -223,10 +223,10 @@ trait RedisTrait
                         $options = [
                             'host' => $host,
                             'port' => $port,
-                            'connectTimeout' => $params['timeout'],
+                            'connectTimeout' => (float) $params['timeout'],
                             'persistent' => $params['persistent_id'],
-                            'retryInterval' => $params['retry_interval'],
-                            'readTimeout' => $params['read_timeout'],
+                            'retryInterval' => (int) $params['retry_interval'],
+                            'readTimeout' => (float) $params['read_timeout'],
                         ];
 
                         if ($passAuth) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Parameters passed as strings from parse_url to \RedisSentinel constructor cause an exception.
> RedisException : Invalid retry interval in /app/symfony/src/Symfony/Component/Cache/Traits/RedisTrait.php:236

Applies to redis-ext above 6.0.0