### PR TITLE
[ExpressionLanguage] Fix matches to handle booleans being used as regexp

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -52,6 +52,8 @@ class BinaryNode extends Node
         if ('matches' == $operator) {
             if ($this->nodes['right'] instanceof ConstantNode) {
                 $this->evaluateMatches($this->nodes['right']->evaluate([], []), '');
+            } elseif ($this->nodes['right'] instanceof self && '~' !== $this->nodes['right']->attributes['operator']) {
+                throw new SyntaxError('The regex passed to "matches" must be a string.');
             }
 
             $compiler

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -221,6 +221,27 @@ class BinaryNodeTest extends AbstractNodeTestCase
         eval('$regexp = "this is not a regexp"; '.$compiler->getSource().';');
     }
 
+    public function testCompileMatchesWithBooleanBinaryNode()
+    {
+        $binaryNode = new BinaryNode('||', new ConstantNode(true), new ConstantNode(false));
+        $node = new BinaryNode('matches', new ConstantNode('abc'), $binaryNode);
+
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessage('The regex passed to "matches" must be a string');
+        $compiler = new Compiler([]);
+        $node->compile($compiler);
+    }
+
+    public function testCompileMatchesWithStringBinaryNode()
+    {
+        $binaryNode = new BinaryNode('~', new ConstantNode('a'), new ConstantNode('b'));
+        $node = new BinaryNode('matches', new ConstantNode('abc'), $binaryNode);
+
+        $compiler = new Compiler([]);
+        $node->compile($compiler);
+        $this->expectNotToPerformAssertions();
+    }
+
     public function testDivisionByZero()
     {
         $node = new BinaryNode('/', new ConstantNode(1), new ConstantNode(0));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

I'm marking this as a bug fix but this could be seen as a "new feature" as existing `matches` syntax functionality works just fine. 

I wanted to build on top of the work done at https://github.com/symfony/symfony/pull/45875. This handles invalid regular expressions and also does an extra check inside the `compile` method. It checks the right hand side for a `ConstantNode` and validates that it's a valid regexp. The idea is that we can go **even further** and check for `BinaryNode` because in most cases, this is an invalid regexp since a boolean usually returned. The exception is `~` which is for string concatenation since that could result in a valid regexp.

This extra check could help prevent invalid expressions like `"a" matches ("/a/" || "/b/")` where one could mistake `"/a/" || "/b/"` as being a valid regexp (when the correct approach would've been `"a" matches "/a|b/"`)

