### PR TITLE
[HttpKernel] pass CSV escape characters explicitly

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -60,7 +60,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
 
         $result = [];
         while (\count($result) < $limit && $line = $this->readLineFromFile($file)) {
-            $values = str_getcsv($line);
+            $values = str_getcsv($line, ',', '"', '\\');
 
             if (7 !== \count($values)) {
                 // skip invalid lines
@@ -187,7 +187,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 $profile->getTime(),
                 $profile->getParentToken(),
                 $profile->getStatusCode(),
-            ]);
+            ], ',', '"', '\\');
             fclose($file);
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -336,12 +336,12 @@ class FileProfilerStorageTest extends TestCase
 
         $handle = fopen($this->tmpDir.'/index.csv', 'r');
         for ($i = 0; $i < $iteration; ++$i) {
-            $row = fgetcsv($handle);
+            $row = fgetcsv($handle, null, ',', '"', '\\');
             $this->assertEquals('token'.$i, $row[0]);
             $this->assertEquals('127.0.0.'.$i, $row[1]);
             $this->assertEquals('http://foo.bar/'.$i, $row[3]);
         }
-        $this->assertFalse(fgetcsv($handle));
+        $this->assertFalse(fgetcsv($handle, null, ',', '"', '\\'));
     }
 
     public function testReadLineFromFile()

--- a/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
@@ -31,7 +31,7 @@ class CsvFileDumper extends FileDumper
         $handle = fopen('php://memory', 'r+');
 
         foreach ($messages->all($domain) as $source => $target) {
-            fputcsv($handle, [$source, $target], $this->delimiter, $this->enclosure);
+            fputcsv($handle, [$source, $target], $this->delimiter, $this->enclosure, '\\');
         }
 
         rewind($handle);

--- a/src/Symfony/Component/Validator/Resources/bin/sync-iban-formats.php
+++ b/src/Symfony/Component/Validator/Resources/bin/sync-iban-formats.php
@@ -129,7 +129,7 @@ final class SwiftRegistryIbanProvider
         array_shift($lines);
 
         foreach ($lines as $line) {
-            $columns = str_getcsv($line, "\t");
+            $columns = str_getcsv($line, "\t", '"', '\\');
             $propertyLabel = array_shift($columns);
 
             if (!isset($properties[$propertyLabel])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Not passing the `$escape` parameter is deprecated since PHP 8.4 as the default value will change in the future.