### PR TITLE
Improve dump for SPA apps like.

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -66,3 +66,70 @@ if (!function_exists('dd')) {
         exit(1);
     }
 }
+
+if (!function_exists('dumph')) {
+    /**
+     * @author Nicolas Grekas <p@tchwork.com>
+     * @author Alexandre Daubois <alex.daubois@gmail.com>
+     */
+    function dumph(mixed ...$vars): mixed
+    {
+        // CORS for SPA apps like.
+        header("Access-Control-Allow-Origin: " . $_SERVER['HTTP_ORIGIN'] ?? '*');
+        header('Access-Control-Allow-Methods: *');
+        header('Access-Control-Allow-Headers: *');
+        header('Access-Control-Allow-Credentials: true');
+
+        if (!$vars) {
+            VarDumper::dump(new ScalarStub('🐛'));
+
+            return null;
+        }
+
+        if (array_key_exists(0, $vars) && 1 === count($vars)) {
+            VarDumper::dump($vars[0]);
+            $k = 0;
+        } else {
+            foreach ($vars as $k => $v) {
+                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
+            }
+        }
+
+        if (1 < count($vars)) {
+            return $vars;
+        }
+
+        return $vars[$k];
+    }
+}
+
+if (!function_exists('ddh')) {
+    function ddh(mixed ...$vars): never
+    {
+        // CORS for SPA apps like.
+        header("Access-Control-Allow-Origin: " . $_SERVER['HTTP_ORIGIN'] ?? '*');
+        header('Access-Control-Allow-Methods: *');
+        header('Access-Control-Allow-Headers: *');
+        header('Access-Control-Allow-Credentials: true');
+
+        if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) && !headers_sent()) {
+            header('HTTP/1.1 500 Internal Server Error');
+        }
+
+        if (!$vars) {
+            VarDumper::dump(new ScalarStub('🐛'));
+
+            exit(1);
+        }
+
+        if (array_key_exists(0, $vars) && 1 === count($vars)) {
+            VarDumper::dump($vars[0]);
+        } else {
+            foreach ($vars as $k => $v) {
+                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
+            }
+        }
+
+        exit(1);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -106,14 +106,14 @@ if (!function_exists('dumph')) {
 if (!function_exists('ddh')) {
     function ddh(mixed ...$vars): never
     {
-        // CORS for SPA apps like.
-        header("Access-Control-Allow-Origin: " . $_SERVER['HTTP_ORIGIN'] ?? '*');
-        header('Access-Control-Allow-Methods: *');
-        header('Access-Control-Allow-Headers: *');
-        header('Access-Control-Allow-Credentials: true');
-
         if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) && !headers_sent()) {
             header('HTTP/1.1 500 Internal Server Error');
+
+            // CORS for SPA apps like.
+            header("Access-Control-Allow-Origin: " . $_SERVER['HTTP_ORIGIN'] ?? '*');
+            header('Access-Control-Allow-Methods: *');
+            header('Access-Control-Allow-Headers: *');
+            header('Access-Control-Allow-Credentials: true');
         }
 
         if (!$vars) {

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -67,42 +67,6 @@ if (!function_exists('dd')) {
     }
 }
 
-if (!function_exists('dumph')) {
-    /**
-     * @author Nicolas Grekas <p@tchwork.com>
-     * @author Alexandre Daubois <alex.daubois@gmail.com>
-     */
-    function dumph(mixed ...$vars): mixed
-    {
-        // CORS for SPA apps like.
-        header("Access-Control-Allow-Origin: " . $_SERVER['HTTP_ORIGIN'] ?? '*');
-        header('Access-Control-Allow-Methods: *');
-        header('Access-Control-Allow-Headers: *');
-        header('Access-Control-Allow-Credentials: true');
-
-        if (!$vars) {
-            VarDumper::dump(new ScalarStub('🐛'));
-
-            return null;
-        }
-
-        if (array_key_exists(0, $vars) && 1 === count($vars)) {
-            VarDumper::dump($vars[0]);
-            $k = 0;
-        } else {
-            foreach ($vars as $k => $v) {
-                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
-            }
-        }
-
-        if (1 < count($vars)) {
-            return $vars;
-        }
-
-        return $vars[$k];
-    }
-}
-
 if (!function_exists('ddh')) {
     function ddh(mixed ...$vars): never
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | *
| License       | MIT


A lot of people (including me) use SPA/javascript applications and it would be easier if you could sometimes see the result directly in the browser without having to copy the request to Insomnia or to always manually enter the necessary headers.

