### PR TITLE
[HttpClient] Allow setting max persistent connections in `CurlHttpClient`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,11 +122,17 @@ jobs:
         image: dunglas/frankenphp:1.1.0
         ports:
           - 80:80
+          - 8081:81
+          - 8082:82
         volumes:
           - ${{ github.workspace }}:/symfony
         env:
-          SERVER_NAME: 'http://localhost'
+          SERVER_NAME: 'http://localhost http://localhost:81 http://localhost:82'
           CADDY_SERVER_EXTRA_DIRECTIVES: |
+            route /http-client* {
+              root * /symfony/src/Symfony/Component/HttpClient/Tests/Fixtures/response-functional/
+              php_server
+            }
             root * /symfony/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/
 
     steps:

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for amphp/http-client v5 on PHP 8.4+
+ * Allow setting max persistent connections in `CurlHttpClient`
 
 7.1
 ---

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -45,6 +45,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
                              //   password as the second one; or string like username:password - enabling NTLM auth
         'extra' => [
             'curl' => [],    // A list of extra curl options indexed by their corresponding CURLOPT_*
+            'max_connections' => null, // The maximum amount of simultaneously open connections, corresponds to CURLMOPT_MAXCONNECTS
         ],
     ];
     private static array $emptyDefaults = self::OPTIONS_DEFAULTS + ['auth_ntlm' => null];
@@ -450,7 +451,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
     private function ensureState(): CurlClientState
     {
         if (!isset($this->multi)) {
-            $this->multi = new CurlClientState($this->maxHostConnections, $this->maxPendingPushes);
+            $this->multi = new CurlClientState($this->maxHostConnections, $this->maxPendingPushes, $this->defaultOptions['extra']['max_connections'] ?? null);
             $this->multi->logger = $this->logger;
         }
 

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -37,7 +37,7 @@ final class CurlClientState extends ClientState
 
     public static array $curlVersion;
 
-    public function __construct(int $maxHostConnections, int $maxPendingPushes)
+    public function __construct(int $maxHostConnections, int $maxPendingPushes, ?int $maxConnections = null)
     {
         self::$curlVersion ??= curl_version();
 
@@ -52,8 +52,8 @@ final class CurlClientState extends ClientState
         if (\defined('CURLMOPT_MAX_HOST_CONNECTIONS')) {
             $maxHostConnections = curl_multi_setopt($this->handle, \CURLMOPT_MAX_HOST_CONNECTIONS, 0 < $maxHostConnections ? $maxHostConnections : \PHP_INT_MAX) ? 0 : $maxHostConnections;
         }
-        if (\defined('CURLMOPT_MAXCONNECTS') && 0 < $maxHostConnections) {
-            curl_multi_setopt($this->handle, \CURLMOPT_MAXCONNECTS, $maxHostConnections);
+        if (\defined('CURLMOPT_MAXCONNECTS') && null !== $maxConnections ??= 0 < $maxHostConnections ? $maxHostConnections : null) {
+            curl_multi_setopt($this->handle, \CURLMOPT_MAXCONNECTS, $maxConnections);
         }
 
         // Skip configuring HTTP/2 push when it's unsupported or buggy, see https://bugs.php.net/77535

--- a/src/Symfony/Component/HttpClient/Tests/Fixtures/response-functional/index.php
+++ b/src/Symfony/Component/HttpClient/Tests/Fixtures/response-functional/index.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+echo 'Success';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, it's not possible to set the maximum number of simultaneously open connections in the `CurlHttpClient`. The `maxHostConnections` option potentially sets `CURLMOPT_MAXCONNECTS`, but only if `CURLMOPT_MAX_HOST_CONNECTIONS` isn't defined:
https://github.com/symfony/symfony/blob/d575fa5d456f5e0f740887d4abc60efd71f98d28/src/Symfony/Component/HttpClient/Internal/CurlClientState.php#L52-L57
This, of course, isn't helpful if you want `CURLMOPT_MAXCONNECTS` to always be set.

In my use case, I have workers that processes queued URLs and sends purge requests to our multiple Varnish servers. The workers are long-running processes that processes the queue one item at a time, as each request must be handled in real time, making it impossible to delay or batch the URLs. This means that the number of simultaneously open cURL handlers per worker is usually just one. Given that the default configuration for `CURLMOPT_MAXCONNECTS` is 4 times the number of added handlers, this configuration is insufficient, as we have more than 4 Varnish servers. As a result, connections are constantly being opened and closed by each worker. Keeping these connections persistently open significantly reduces the time required to make each request.

I've tested the performance using the following hack:

```php
$reflectionMethod = new \ReflectionMethod(CurlHttpClient::class, 'ensureState');
$curlClientState = $reflectionMethod->invoke($this->client);

curl_multi_setopt($curlClientState->handle, \CURLMOPT_MAXCONNECTS, 500);
```

Here are some graphs that show the results (the dotted vertical line represents the time of deployment):

- The first graph shows the number of new connections being established by the workers. As you can see, it dropped to almost zero.

  ![image](https://github.com/user-attachments/assets/4055065f-0ff7-4554-8cb8-ba7ff9b9f028)
  
- The second graph shows the time it takes to perform the requests. After the initial persistent connections are established, the time significantly decreases.

  ![image](https://github.com/user-attachments/assets/da28d878-48b1-4fc3-b51c-27721bbcf21e)

Even though this hack works, being able to configure this through an option would be much better.
