### PR TITLE
 Allow usage of expressions for defining validation groups in `#[MapRequestPayload]`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -263,6 +263,10 @@ class FrameworkExtension extends Extension
             $container->removeAlias(PsrClockInterface::class);
         }
 
+        if (!ContainerBuilder::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/framework-bundle'])) {
+            $container->removeDefinition('controller.expression_language');
+        }
+
         $container->registerAliasForArgument('parameter_bag', PsrContainerInterface::class);
 
         $loader->load('process.php');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -92,6 +92,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('cache.validator_expression_language')
             ->parent('cache.system')
+            ->private()
             ->tag('cache.pool')
 
         ->set('validator.expression_language_provider', ExpressionLanguageProvider::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver;
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolver;
@@ -74,6 +75,7 @@ return static function (ContainerConfigurator $container) {
                 service('validator')->nullOnInvalid(),
                 service('translator')->nullOnInvalid(),
                 param('validator.translation_domain'),
+                service('controller.expression_language')->nullOnInvalid(),
             ])
             ->tag('controller.targeted_value_resolver', ['name' => RequestPayloadValueResolver::class])
             ->tag('kernel.event_subscriber')
@@ -160,5 +162,12 @@ return static function (ContainerConfigurator $container) {
 
         ->alias(ControllerHelper::class, 'controller.helper')
 
+        ->set('controller.expression_language', ExpressionLanguage::class)
+            ->args([service('cache.controller_expression_language')->nullOnInvalid()])
+
+        ->set('cache.controller_expression_language')
+            ->parent('cache.system')
+            ->private()
+            ->tag('cache.pool')
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -315,6 +315,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('cache.security_is_granted_attribute_expression_language')
             ->parent('cache.system')
+            ->private()
             ->tag('cache.pool')
 
         ->set('security.is_csrf_token_valid_attribute_expression_language', BaseExpressionLanguage::class)
@@ -322,6 +323,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('cache.security_is_csrf_token_valid_attribute_expression_language')
             ->parent('cache.system')
+            ->private()
             ->tag('cache.pool')
     ;
 };

--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Attribute;
 
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
@@ -18,6 +19,8 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
 
 /**
  * Controller parameter tag to map the query string of the request to typed object and validate it.
+ *
+ * @psalm-import-type GroupResolver from RequestPayloadValueResolver
  *
  * @author Konstantin Myakshin <molodchick@gmail.com>
  */
@@ -27,14 +30,14 @@ class MapQueryString extends ValueResolver
     public ArgumentMetadata $metadata;
 
     /**
-     * @param array<string, mixed>                    $serializationContext       The serialization context to use when deserializing the query string
-     * @param string|GroupSequence|array<string>|null $validationGroups           The validation groups to use when validating the query string mapping
-     * @param class-string                            $resolver                   The class name of the resolver to use
-     * @param int                                     $validationFailedStatusCode The HTTP code to return if the validation fails
+     * @param array<string, mixed>                                             $serializationContext       The serialization context to use when deserializing the query string
+     * @param string|Expression|GroupSequence|GroupResolver|array<string>|null $validationGroups           The validation groups to use when validating the query string mapping
+     * @param class-string                                                     $resolver                   The class name of the resolver to use
+     * @param int                                                              $validationFailedStatusCode The HTTP code to return if the validation fails
      */
     public function __construct(
         public readonly array $serializationContext = [],
-        public readonly string|GroupSequence|array|null $validationGroups = null,
+        public readonly string|Expression|GroupSequence|\Closure|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
         public readonly int $validationFailedStatusCode = Response::HTTP_NOT_FOUND,
         public readonly ?string $key = null,

--- a/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapRequestPayload.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Attribute;
 
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
@@ -18,6 +19,8 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
 
 /**
  * Controller parameter tag to map the request content to typed object and validate it.
+ *
+ * @psalm-import-type GroupResolver from RequestPayloadValueResolver
  *
  * @author Konstantin Myakshin <molodchick@gmail.com>
  */
@@ -27,17 +30,17 @@ class MapRequestPayload extends ValueResolver
     public ArgumentMetadata $metadata;
 
     /**
-     * @param array<string>|string|null               $acceptFormat               The payload formats to accept (i.e. "json", "xml")
-     * @param array<string, mixed>                    $serializationContext       The serialization context to use when deserializing the payload
-     * @param string|GroupSequence|array<string>|null $validationGroups           The validation groups to use when validating the query string mapping
-     * @param class-string                            $resolver                   The class name of the resolver to use
-     * @param int                                     $validationFailedStatusCode The HTTP code to return if the validation fails
-     * @param class-string|string|null                $type                       The element type for array deserialization
+     * @param array<string>|string|null                                        $acceptFormat               The payload formats to accept (i.e. "json", "xml")
+     * @param array<string, mixed>                                             $serializationContext       The serialization context to use when deserializing the payload
+     * @param string|Expression|GroupSequence|GroupResolver|array<string>|null $validationGroups           The validation groups to use when validating the query string mapping
+     * @param class-string                                                     $resolver                   The class name of the resolver to use
+     * @param int                                                              $validationFailedStatusCode The HTTP code to return if the validation fails
+     * @param class-string|string|null                                         $type                       The element type for array deserialization
      */
     public function __construct(
         public readonly array|string|null $acceptFormat = null,
         public readonly array $serializationContext = [],
-        public readonly string|GroupSequence|array|null $validationGroups = null,
+        public readonly string|Expression|GroupSequence|\Closure|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
         public readonly int $validationFailedStatusCode = Response::HTTP_UNPROCESSABLE_ENTITY,
         public readonly ?string $type = null,

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Allow setting a condition when the `Cache` attribute should be applied
  * Deprecate passing a non-flat list of attributes to `Controller::setController()`
  * Deprecate the `Symfony\Component\HttpKernel\DependencyInjection\Extension` class, use the parent `Symfony\Component\DependencyInjection\Extension\Extension` class instead
+ * Allow using Expression or \Closure for `validationGroups` in `#[MapRequestPayload]` and `#[MapQueryString]`
 
 8.0
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\MapQueryString;
@@ -32,6 +34,7 @@ use Symfony\Component\Serializer\Exception\UnsupportedFormatException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
@@ -40,6 +43,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Konstantin Myakshin <molodchick@gmail.com>
+ *
+ * @psalm-type GroupResolver = \Closure(array<string, mixed>, Request, ?object):string|GroupSequence|array<string>
  *
  * @final
  */
@@ -64,6 +69,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
         private readonly ?ValidatorInterface $validator = null,
         private readonly ?TranslatorInterface $translator = null,
         private string $translationDomain = 'validators',
+        private ?ExpressionLanguage $expressionLanguage = null,
     ) {
     }
 
@@ -147,7 +153,8 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                     if (\is_array($payload) && !empty($constraints) && !$constraints instanceof Assert\All) {
                         $constraints = new Assert\All($constraints);
                     }
-                    $violations->addAll($this->validator->validate($payload, $constraints, $argument->validationGroups ?? null));
+                    $groups = $this->resolveValidationGroups($argument->validationGroups ?? null, $event);
+                    $violations->addAll($this->validator->validate($payload, $constraints, $groups));
                 }
 
                 if (\count($violations)) {
@@ -261,5 +268,64 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
         }
 
         return $params;
+    }
+
+    private function resolveValidationGroups(Expression|string|GroupSequence|\Closure|array|null $validationGroups, ControllerArgumentsEvent $event): string|GroupSequence|array|null
+    {
+        $controller = $event->getController();
+        $controller = match (true) {
+            \is_object($controller) => $controller,
+            \is_array($controller) && \is_object($controller[0]) => $controller[0],
+            default => null,
+        };
+
+        if ($validationGroups instanceof Expression) {
+            $validationGroups = $this->getExpressionLanguage()->evaluate($validationGroups, [
+                'request' => $event->getRequest(),
+                'args' => $event->getNamedArguments(),
+                'this' => $controller,
+            ]);
+        }
+
+        if ($validationGroups instanceof \Closure) {
+            $validationGroups = $validationGroups($event->getNamedArguments(), $event->getRequest(), $controller);
+        }
+
+        if (null === $validationGroups || \is_string($validationGroups) || $validationGroups instanceof GroupSequence) {
+            return $validationGroups;
+        }
+
+        if (!\is_array($validationGroups)) {
+            throw new \LogicException('The validation groups expression or closure must return a string, an array of strings, or a GroupSequence.');
+        }
+
+        foreach ($validationGroups as $group) {
+            if ($group instanceof Expression) {
+                throw new \LogicException('Nested expressions in validation groups are not supported. Use a single Expression or a list of strings (or a GroupSequence) instead.');
+            }
+
+            if ($group instanceof \Closure) {
+                throw new \LogicException('Nested closures in validation groups are not supported. Use a single Closure or a list of strings (or a GroupSequence) instead.');
+            }
+
+            if ($group instanceof GroupSequence) {
+                throw new \LogicException('GroupSequence cannot be used inside an array of validation groups. Pass the GroupSequence as the top-level validationGroups value instead.');
+            }
+
+            if (!\is_string($group)) {
+                throw new \LogicException('Validation groups must be strings.');
+            }
+        }
+
+        return $validationGroups;
+    }
+
+    private function getExpressionLanguage(): ExpressionLanguage
+    {
+        if (!class_exists(ExpressionLanguage::class)) {
+            throw new \LogicException('You cannot use expressions in controller attributes as the ExpressionLanguage component is not available. Try running "composer require symfony/expression-language".');
+        }
+
+        return $this->expressionLanguage ??= new ExpressionLanguage();
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\MapQueryString;
@@ -22,9 +24,11 @@ use Symfony\Component\HttpKernel\Attribute\ValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\BasicTypesController;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
@@ -1003,6 +1007,161 @@ class RequestPayloadValueResolverTest extends TestCase
         $resolver->onKernelControllerArguments($event);
 
         $this->assertEquals([$payload], $event->getArguments());
+    }
+
+    public function testExpressionAsValidationGroup()
+    {
+        $content = '{"price": 24}';
+
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())
+            ->method('validate')
+            ->with(new RequestPayload(24.0), null, 'foo');
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator, expressionLanguage: new ExpressionLanguage());
+
+        $argument = new ArgumentMetadata('payload', RequestPayload::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(validationGroups: new Expression('args["foo"]')),
+        ]);
+
+        $request = Request::create('/{foo}/{bar}/{baz}', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
+
+        $arguments = (array) $resolver->resolve($request, $argument);
+        array_unshift($arguments, 'foo', 15, 1.23);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        $controllerEvent = new ControllerEvent($kernel, [new BasicTypesController(), 'action'], $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $event = new ControllerArgumentsEvent($kernel, $controllerEvent, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+    }
+
+    public function testExpressionAsValidationGroupCanUseController()
+    {
+        $content = '{"price": 24}';
+
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())
+            ->method('validate')
+            ->with(new RequestPayload(24.0), null, 'foo');
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator, expressionLanguage: new ExpressionLanguage());
+
+        $argument = new ArgumentMetadata('payload', RequestPayload::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(validationGroups: new Expression('this ? args["foo"] : "bar"')),
+        ]);
+
+        $request = Request::create('/{foo}/{bar}/{baz}', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
+
+        $arguments = (array) $resolver->resolve($request, $argument);
+        array_unshift($arguments, 'foo', 15, 1.23);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        $controllerEvent = new ControllerEvent($kernel, [new BasicTypesController(), 'action'], $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $event = new ControllerArgumentsEvent($kernel, $controllerEvent, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+    }
+
+    public function testClosureAsValidationGroup()
+    {
+        $content = '{"price": 24}';
+
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())
+            ->method('validate')
+            ->with(new RequestPayload(24.0), null, 'foo');
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator, expressionLanguage: new ExpressionLanguage());
+
+        $asserted = false;
+        $self = $this;
+
+        $argument = new ArgumentMetadata('payload', RequestPayload::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(validationGroups: static function (array $args, Request $request, ?object $controller) use (&$asserted, $self): string {
+                $self->assertInstanceOf(BasicTypesController::class, $controller);
+                $asserted = true;
+
+                return $args['foo'];
+            }),
+        ]);
+
+        $request = Request::create('/{foo}/{bar}/{baz}', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
+
+        $arguments = (array) $resolver->resolve($request, $argument);
+        array_unshift($arguments, 'foo', 15, 1.23);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        $controllerEvent = new ControllerEvent($kernel, [new BasicTypesController(), 'action'], $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $event = new ControllerArgumentsEvent($kernel, $controllerEvent, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $this->assertTrue($asserted);
+    }
+
+    public function testExpressionAsValidationGroupForQueryString()
+    {
+        $serializer = new Serializer([new ObjectNormalizer()]);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())
+            ->method('validate')
+            ->with(new QueryPayload(1.0), null, 'foo')
+            ->willReturn(new ConstraintViolationList());
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator, expressionLanguage: new ExpressionLanguage());
+
+        $argument = new ArgumentMetadata('payload', QueryPayload::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(validationGroups: new Expression('args["foo"]')),
+        ]);
+
+        $request = Request::create('/', 'GET', ['page' => 1.0]);
+
+        $arguments = (array) $resolver->resolve($request, $argument);
+        array_unshift($arguments, 'foo', 15, 1.23);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $controllerEvent = new ControllerEvent($kernel, [new BasicTypesController(), 'action'], $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new ControllerArgumentsEvent($kernel, $controllerEvent, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+    }
+
+    public function testNestedExpressionsInValidationGroupsAreNotSupported()
+    {
+        $content = '{"price": 24}';
+
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->never())
+            ->method('validate');
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator, expressionLanguage: new ExpressionLanguage());
+
+        $argument = new ArgumentMetadata('payload', RequestPayload::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(validationGroups: ['foo', new Expression('args["foo"]')]),
+        ]);
+
+        $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
+        $arguments = (array) $resolver->resolve($request, $argument);
+        array_unshift($arguments, 'foo', 15, 1.23);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $controllerEvent = new ControllerEvent($kernel, [new BasicTypesController(), 'action'], $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new ControllerArgumentsEvent($kernel, $controllerEvent, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->expectException(\LogicException::class);
+
+        $resolver->onKernelControllerArguments($event);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR adds option to use Expression for defining validation groups when using `#[MapRequestPayload]` and 
`#[MapQueryString]`


Inspired by expression options when using `#[IsGranted]`, request and args are available.



Example:
We have route which is used to update user info. Entity `User` has property `type` which can be `admin` or `regular`.
If user is admin, his password must be very strong and they must have image while regular user can have weaker password and image is not required.
Payload used in request:
```php
final readonly class UpdateUserDTO
{
    public function __construct(
        #[Assert\NotNull(message: 'Admin user must have image', groups: ['admin'])]
        public ?string $image,
        #[Assert\PasswordStrength(minScore: Assert\PasswordStrength::STRENGTH_MEDIUM, groups: ['regular'])]
        #[Assert\PasswordStrength(minScore: Assert\PasswordStrength::STRENGTH_VERY_STRONG, groups: ['admin'])]
        public string  $password,
    ) {
    }
}
```

We need to dynamically determine which validation group to use based on context (User that is being updated).
Current way of doing this is to manually call `validate` method:
```php
$violations = $this->validator->validate($dto, groups: [$user->getType()]);
// handle violations...
```

This PR allows usage of Expression with access to arguments so above code can be replaced with `#[MapRequestPayload]`
```php
#[Route('/user/{id}', methods: ['PUT'])]
public function updateUserAction(
    User $user,
    #[MapRequestPayload(
        validationGroups: [new Expression('args["user"].getType()')],
    )] UpdateUserDTO $dto
)
```


