### PR TITLE
[AssetMapper] Add logical failure implementation

### DIFF
--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * Add logical failure implementation.
  * Shorten the public digest of mapped assets to 7 characters
 
 7.1

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
@@ -42,18 +42,26 @@ final class ImportMapInstallCommand extends Command
         $finishedCount = 0;
         $progressBar = new ProgressBar($output);
         $progressBar->setFormat('<info>%current%/%max%</info> %bar% %url%');
-        $downloadedPackages = $this->packageDownloader->downloadPackages(function (string $package, string $event, ResponseInterface $response, int $totalPackages) use (&$finishedCount, $progressBar) {
-            $progressBar->setMessage($response->getInfo('url'), 'url');
-            if (0 === $progressBar->getMaxSteps()) {
-                $progressBar->setMaxSteps($totalPackages);
-                $progressBar->start();
-            }
 
-            if ('finished' === $event) {
-                ++$finishedCount;
-                $progressBar->advance();
-            }
-        });
+        try {
+            $downloadedPackages = $this->packageDownloader->downloadPackages(function (string $package, string $event, ResponseInterface $response, int $totalPackages) use (&$finishedCount, $progressBar) {
+                $progressBar->setMessage($response->getInfo('url'), 'url');
+                if (0 === $progressBar->getMaxSteps()) {
+                    $progressBar->setMaxSteps($totalPackages);
+                    $progressBar->start();
+                }
+
+                if ('finished' === $event) {
+                    ++$finishedCount;
+                    $progressBar->advance();
+                }
+            });
+        } catch (\Throwable $throwable) {
+            $io->error($throwable->getMessage());
+
+            return Command::FAILURE;
+        }
+
         $progressBar->finish();
         $progressBar->clear();
 

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\AssetMapper\Command;
 
+use Symfony\Component\AssetMapper\Exception\LogicException;
 use Symfony\Component\AssetMapper\ImportMap\RemotePackageDownloader;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -56,7 +57,7 @@ final class ImportMapInstallCommand extends Command
                     $progressBar->advance();
                 }
             });
-        } catch (\LogicException $throwable) {
+        } catch (LogicException $throwable) {
             $io->error($throwable->getMessage());
 
             return Command::FAILURE;

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
@@ -59,7 +59,7 @@ final class ImportMapInstallCommand extends Command
                     $progressBar->advance();
                 }
             });
-        } catch (LogicException|TimeoutException|TransportException $throwable) {
+        } catch (LogicException $throwable) {
             $io->error($throwable->getMessage());
 
             return Command::FAILURE;

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
@@ -56,7 +56,7 @@ final class ImportMapInstallCommand extends Command
                     $progressBar->advance();
                 }
             });
-        } catch (\Throwable $throwable) {
+        } catch (\LogicException $throwable) {
             $io->error($throwable->getMessage());
 
             return Command::FAILURE;

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpClient\Exception\TimeoutException;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -57,7 +59,7 @@ final class ImportMapInstallCommand extends Command
                     $progressBar->advance();
                 }
             });
-        } catch (LogicException $throwable) {
+        } catch (LogicException|TimeoutException|TransportException $throwable) {
             $io->error($throwable->getMessage());
 
             return Command::FAILURE;

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapInstallCommand.php
@@ -19,8 +19,6 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\HttpClient\Exception\TimeoutException;
-use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**

--- a/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageDownloader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageDownloader.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\AssetMapper\ImportMap;
 
+use Symfony\Component\AssetMapper\Exception\LogicException;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -73,7 +74,7 @@ class RemotePackageDownloader
         $downloadedPackages = [];
         foreach ($remoteEntriesToDownload as $package => $entry) {
             if (!isset($contents[$package])) {
-                throw new \LogicException(\sprintf('The package "%s" was not downloaded.', $package));
+                throw new LogicException(\sprintf('The package "%s" was not downloaded.', $package));
             }
 
             $this->remotePackageStorage->save($entry, $contents[$package]['content']);
@@ -92,7 +93,7 @@ class RemotePackageDownloader
         }
 
         if ($contents) {
-            throw new \LogicException(\sprintf('The following packages were unexpectedly downloaded: "%s".', implode('", "', array_keys($contents))));
+            throw new LogicException(\sprintf('The following packages were unexpectedly downloaded: "%s".', implode('", "', array_keys($contents))));
         }
 
         $this->saveInstalled($newInstalled);
@@ -136,7 +137,7 @@ class RemotePackageDownloader
             }
 
             if (!isset($data['dependencies'])) {
-                throw new \LogicException(\sprintf('The package "%s" is missing its dependencies.', $package));
+                throw new LogicException(\sprintf('The package "%s" is missing its dependencies.', $package));
             }
 
             if (!isset($data['extraFiles'])) {

--- a/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageDownloader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/RemotePackageDownloader.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\AssetMapper\ImportMap;
 use Symfony\Component\AssetMapper\Exception\LogicException;
 use Symfony\Component\AssetMapper\ImportMap\Resolver\PackageResolverInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpClient\Exception\TimeoutException;
+use Symfony\Component\HttpClient\Exception\TransportException;
 
 /**
  * @final
@@ -70,7 +72,11 @@ class RemotePackageDownloader
             return [];
         }
 
-        $contents = $this->packageResolver->downloadPackages($remoteEntriesToDownload, $progressCallback);
+        try {
+            $contents = $this->packageResolver->downloadPackages($remoteEntriesToDownload, $progressCallback);
+        } catch (TimeoutException|TransportException $exception) {
+            throw new LogicException($exception->getMessage());
+        }
         $downloadedPackages = [];
         foreach ($remoteEntriesToDownload as $package => $entry) {
             if (!isset($contents[$package])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

The following feature/change is to make sure we can rely on the correct status codes in the CI/CD pipelines.
Whenever the download part fail now we get the correct failure status code.

Incase things are missing please let me know, Not sure if any additional information is needed since this seems like a small change which appears to be pretty clear.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
