### PR TITLE
[HttpClient] Fix setting `CURLMOPT_MAXCONNECTS`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -118,6 +118,23 @@ jobs:
           KAFKA_CFG_LISTENERS: 'PLAINTEXT://:9092'
           KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper:2181'
         options: --name=kafka
+      frankenphp:
+        image: dunglas/frankenphp:1.1.0
+        ports:
+          - 80:80
+          - 8681:81
+          - 8682:82
+          - 8683:83
+          - 8684:84
+        volumes:
+          - ${{ github.workspace }}:/symfony
+        env:
+          SERVER_NAME: 'http://localhost http://localhost:81 http://localhost:82 http://localhost:83 http://localhost:84'
+          CADDY_SERVER_EXTRA_DIRECTIVES: |
+            route /http-client* {
+              root * /symfony/src/Symfony/Component/HttpClient/Tests/Fixtures/response-functional/
+              php_server
+            }
 
     steps:
       - name: Checkout

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -52,8 +52,8 @@ final class CurlClientState extends ClientState
         if (\defined('CURLPIPE_MULTIPLEX')) {
             curl_multi_setopt($this->handle, \CURLMOPT_PIPELINING, \CURLPIPE_MULTIPLEX);
         }
-        if (\defined('CURLMOPT_MAX_HOST_CONNECTIONS')) {
-            $maxHostConnections = curl_multi_setopt($this->handle, \CURLMOPT_MAX_HOST_CONNECTIONS, 0 < $maxHostConnections ? $maxHostConnections : \PHP_INT_MAX) ? 0 : $maxHostConnections;
+        if (\defined('CURLMOPT_MAX_HOST_CONNECTIONS') && 0 < $maxHostConnections) {
+            $maxHostConnections = curl_multi_setopt($this->handle, \CURLMOPT_MAX_HOST_CONNECTIONS, $maxHostConnections) ? 4294967295 : $maxHostConnections;
         }
         if (\defined('CURLMOPT_MAXCONNECTS') && 0 < $maxHostConnections) {
             curl_multi_setopt($this->handle, \CURLMOPT_MAXCONNECTS, $maxHostConnections);

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -144,4 +144,34 @@ class CurlHttpClientTest extends HttpClientTestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('/302', $response->toArray()['REQUEST_URI'] ?? null);
     }
+
+    /**
+     * @group integration
+     */
+    public function testMaxConnections()
+    {
+        foreach ($ports = [80, 8681, 8682, 8683, 8684] as $port) {
+            if (!($fp = @fsockopen('localhost', $port, $errorCode, $errorMessage, 2))) {
+                self::markTestSkipped('FrankenPHP is not running');
+            }
+            fclose($fp);
+        }
+
+        $httpClient = $this->getHttpClient(__FUNCTION__);
+
+        $expectedResults = [
+            [false, false, false, false, false],
+            [true, true, true, true, true],
+            [true, true, true, true, true],
+        ];
+
+        foreach ($expectedResults as $expectedResult) {
+            foreach ($ports as $i => $port) {
+                $response = $httpClient->request('GET', \sprintf('http://localhost:%s/http-client', $port));
+                $response->getContent();
+
+                self::assertSame($expectedResult[$i], str_contains($response->getInfo('debug'), 'Re-using existing connection'));
+            }
+        }
+    }
 }

--- a/src/Symfony/Component/HttpClient/Tests/Fixtures/response-functional/index.php
+++ b/src/Symfony/Component/HttpClient/Tests/Fixtures/response-functional/index.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+echo 'Success';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

An alternative approach for #58270, see https://github.com/symfony/symfony/pull/58270#discussion_r1760730586.