### PR TITLE
[WebProfilerBundle] Render the toolbar stylesheet

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -163,6 +163,27 @@ class ProfilerController
     }
 
     /**
+     * Renders the Web Debug Toolbar stylesheet.
+     *
+     * @throws NotFoundHttpException
+     */
+    public function toolbarStylesheetAction(): Response
+    {
+        $this->denyAccessIfProfilerDisabled();
+
+        $this->cspHandler?->disableCsp();
+
+        return new Response(
+            $this->twig->render('@WebProfiler/Profiler/toolbar.css.twig'),
+            200,
+            [
+                'Content-Type' => 'text/css',
+                'Cache-Control' => 'max-age=600, private',
+            ],
+        );
+    }
+
+    /**
      * Renders the profiler search bar.
      *
      * @throws NotFoundHttpException
@@ -383,6 +404,9 @@ class ProfilerController
         return $this->templateManager ??= new TemplateManager($this->profiler, $this->twig, $this->templates);
     }
 
+    /**
+     * @throws NotFoundHttpException
+     */
     private function denyAccessIfProfilerDisabled(): void
     {
         if (null === $this->profiler) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.xml
@@ -4,6 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
+    <route id="_wdt_stylesheet" path="/styles.css">
+        <default key="_controller">web_profiler.controller.profiler::toolbarStylesheetAction</default>
+    </route>
+
     <route id="_wdt" path="/{token}">
         <default key="_controller">web_profiler.controller.profiler::toolbarAction</default>
     </route>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -9,9 +9,7 @@
     }) }}
 </div>
 
-<style{% if csp_style_nonce %} nonce="{{ csp_style_nonce }}"{% endif %}>
-    {{ include('@WebProfiler/Profiler/toolbar.css.twig') }}
-</style>
+<link rel="stylesheet"{% if csp_style_nonce %} nonce="{{ csp_style_nonce }}"{% endif %} href="{{ url('_wdt_stylesheet') }}" />
 
 {# CAUTION: the contents of this file are processed by Twig before loading
             them as JavaScript source code. Always use '/*' comments instead

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -137,6 +137,33 @@ class ProfilerControllerTest extends WebTestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testToolbarStylesheetActionWithProfilerDisabled()
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $twig = $this->createMock(Environment::class);
+
+        $controller = new ProfilerController($urlGenerator, null, $twig, []);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The profiler must be enabled.');
+
+        $controller->toolbarStylesheetAction();
+    }
+
+    public function testToolbarStylesheetAction()
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $twig = $this->createMock(Environment::class);
+        $profiler = $this->createMock(Profiler::class);
+
+        $controller = new ProfilerController($urlGenerator, $profiler, $twig, []);
+
+        $response = $controller->toolbarStylesheetAction();
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/css', $response->headers->get('Content-Type'));
+        $this->assertSame('max-age=600, private', $response->headers->get('Cache-Control'));
+    }
+
     public static function getEmptyTokenCases()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

Render the (static) toolbar stylesheet separately from the (dynamic) toolbar content. 

(avoid the 20ko inlined CSS injection on every page)
