### PR TITLE
[FrameworkBundle] fix XSD to allow to configure locks without resources

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -492,7 +492,7 @@
 
     <xsd:complexType name="lock">
         <xsd:sequence>
-            <xsd:element name="resource" type="lock_resource" minOccurs="1" maxOccurs="unbounded" />
+            <xsd:element name="resource" type="lock_resource" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock.php
@@ -1,0 +1,5 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'lock' => null,
+]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see https://ci.appveyor.com/project/fabpot/symfony/builds/50611181#L1780