### PR TITLE
[Process] Fix finding executables independently of open_basedir

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -48,25 +48,10 @@ class ExecutableFinder
      */
     public function find(string $name, ?string $default = null, array $extraDirs = [])
     {
-        if (\ini_get('open_basedir')) {
-            $searchPath = array_merge(explode(\PATH_SEPARATOR, \ini_get('open_basedir')), $extraDirs);
-            $dirs = [];
-            foreach ($searchPath as $path) {
-                // Silencing against https://bugs.php.net/69240
-                if (@is_dir($path)) {
-                    $dirs[] = $path;
-                } else {
-                    if (basename($path) == $name && @is_executable($path)) {
-                        return $path;
-                    }
-                }
-            }
-        } else {
-            $dirs = array_merge(
-                explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
-                $extraDirs
-            );
-        }
+        $dirs = array_merge(
+            explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
+            $extraDirs
+        );
 
         $suffixes = [''];
         if ('\\' === \DIRECTORY_SEPARATOR) {
@@ -78,7 +63,16 @@ class ExecutableFinder
                 if (@is_file($file = $dir.\DIRECTORY_SEPARATOR.$name.$suffix) && ('\\' === \DIRECTORY_SEPARATOR || @is_executable($file))) {
                     return $file;
                 }
+
+                if (!@is_dir($dir) && basename($dir) === $name.$suffix && @is_executable($dir)) {
+                    return $dir;
+                }
             }
+        }
+
+        $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v --';
+        if (\function_exists('exec') && ($executablePath = strtok(@exec($command.' '.escapeshellarg($name)), \PHP_EOL)) && is_executable($executablePath)) {
+            return $executablePath;
         }
 
         return $default;

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -36,7 +36,7 @@ class PhpExecutableFinder
         if ($php = getenv('PHP_BINARY')) {
             if (!is_executable($php)) {
                 $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v --';
-                if ($php = strtok(exec($command.' '.escapeshellarg($php)), \PHP_EOL)) {
+                if (\function_exists('exec') && $php = strtok(exec($command.' '.escapeshellarg($php)), \PHP_EOL)) {
                     if (!is_executable($php)) {
                         return false;
                     }

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -19,20 +19,9 @@ use Symfony\Component\Process\ExecutableFinder;
  */
 class ExecutableFinderTest extends TestCase
 {
-    private $path;
-
     protected function tearDown(): void
     {
-        if ($this->path) {
-            // Restore path if it was changed.
-            putenv('PATH='.$this->path);
-        }
-    }
-
-    private function setPath($path)
-    {
-        $this->path = getenv('PATH');
-        putenv('PATH='.$path);
+        putenv('PATH='.($_SERVER['PATH'] ?? $_SERVER['Path']));
     }
 
     public function testFind()
@@ -41,7 +30,7 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
-        $this->setPath(\dirname(\PHP_BINARY));
+        putenv('PATH='.\dirname(\PHP_BINARY));
 
         $finder = new ExecutableFinder();
         $result = $finder->find($this->getPhpBinaryName());
@@ -57,7 +46,7 @@ class ExecutableFinderTest extends TestCase
 
         $expected = 'defaultValue';
 
-        $this->setPath('');
+        putenv('PATH=');
 
         $finder = new ExecutableFinder();
         $result = $finder->find('foo', $expected);
@@ -71,7 +60,7 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
-        $this->setPath('');
+        putenv('PATH=');
 
         $finder = new ExecutableFinder();
 
@@ -86,7 +75,7 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
-        $this->setPath('');
+        putenv('PATH=');
 
         $extraDirs = [\dirname(\PHP_BINARY)];
 
@@ -109,37 +98,12 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
+        putenv('PATH='.\dirname(\PHP_BINARY));
         $initialOpenBaseDir = ini_set('open_basedir', \dirname(\PHP_BINARY).\PATH_SEPARATOR.'/');
 
         try {
             $finder = new ExecutableFinder();
             $result = $finder->find($this->getPhpBinaryName());
-
-            $this->assertSamePath(\PHP_BINARY, $result);
-        } finally {
-            ini_set('open_basedir', $initialOpenBaseDir);
-        }
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testFindProcessInOpenBasedir()
-    {
-        if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
-        }
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Cannot run test on windows');
-        }
-
-        $this->setPath('');
-
-        $initialOpenBaseDir = ini_set('open_basedir', \PHP_BINARY.\PATH_SEPARATOR.'/');
-
-        try {
-            $finder = new ExecutableFinder();
-            $result = $finder->find($this->getPhpBinaryName(), false);
 
             $this->assertSamePath(\PHP_BINARY, $result);
         } finally {
@@ -163,7 +127,7 @@ class ExecutableFinderTest extends TestCase
 
         $this->assertFalse(is_executable($target));
 
-        $this->setPath(sys_get_temp_dir());
+        putenv('PATH='.sys_get_temp_dir());
 
         $finder = new ExecutableFinder();
         $result = $finder->find(basename($target), false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This backports #47422 to 5.4, which is a bugfix really.

Instead of #58008 and #57954 /cc @xabbuh @fritzmg