### PR TITLE
[Security][SecurityBundle] Show user account status errors

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -39,6 +39,12 @@ FrameworkBundle
    because its default value will change in version 8.0
  * Deprecate the `--show-arguments` option of the `container:debug` command, as arguments are now always shown
 
+
+SecurityBundle
+--------------
+
+ * Deprecate the `security.hide_user_not_found` config option in favor of `security.expose_security_errors`
+
 Serializer
 ----------
 

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add `Security::isGrantedForUser()` to test user authorization without relying on the session. For example, users not currently logged in, or while processing a message from a message queue
  * Add encryption support to `OidcTokenHandler` (JWE)
+ * Add `expose_security_errors` config option to display `AccountStatusException`
+ * Deprecate the `security.hide_user_not_found` config option in favor of `security.expose_security_errors`
 
 7.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -58,6 +58,7 @@ use Symfony\Component\Security\Core\User\ChainUserChecker;
 use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
@@ -154,7 +155,8 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 ));
         }
 
-        $container->setParameter('security.authentication.hide_user_not_found', $config['hide_user_not_found']);
+        $container->setParameter('security.authentication.hide_user_not_found', ExposeSecurityLevel::All !== $config['expose_security_errors']);
+        $container->setParameter('.security.authentication.expose_security_errors', $config['expose_security_errors']);
 
         if (class_exists(Application::class)) {
             $loader->load('debug_console.php');

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -55,6 +55,7 @@
         <xsd:attribute name="strategy" type="access_decision_manager_strategy" />
         <xsd:attribute name="service" type="xsd:string" />
         <xsd:attribute name="strategy-service" type="xsd:string" />
+        <xsd:attribute name="expose-security-errors" type="access_decision_manager_expose_security_level" />
         <xsd:attribute name="allow-if-all-abstain" type="xsd:boolean" />
         <xsd:attribute name="allow-if-equal-granted-denied" type="xsd:boolean" />
     </xsd:complexType>
@@ -65,6 +66,14 @@
             <xsd:enumeration value="consensus" />
             <xsd:enumeration value="unanimous" />
             <xsd:enumeration value="priority" />
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="access_decision_manager_expose_security_level">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="none" />
+            <xsd:enumeration value="account_status" />
+            <xsd:enumeration value="all" />
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -42,7 +42,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('provider key'),
                 service('logger')->nullOnInvalid(),
                 param('security.authentication.manager.erase_credentials'),
-                param('security.authentication.hide_user_not_found'),
+                param('.security.authentication.expose_security_errors'),
                 abstract_arg('required badges'),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])

--- a/src/Symfony/Component/Security/Http/Authentication/ExposeSecurityLevel.php
+++ b/src/Symfony/Component/Security/Http/Authentication/ExposeSecurityLevel.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authentication;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+enum ExposeSecurityLevel: string
+{
+    case None = 'none';
+    case AccountStatus = 'account_status';
+    case All = 'all';
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add encryption support to `OidcTokenHandler` (JWE)
+ * Replace `$hideAccountStatusExceptions` argument with `$exposeSecurityErrors` in `AuthenticatorManager` constructor
 
 7.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature? | yes 
| Deprecations? | no
| Issues        | Fix #50028
| License       | MIT

According to the `hideUserNotFoundExceptions` flag, only `UserNotFoundException` should be hidden, but the implementation was also silencing account specific errors.

To fix the issue in a BC way, a new `hide_account_status_exceptions` config key was introduced to show account exceptions. 

This key should be changed to **false** with an upcoming version (7.3 or 7.4?), so that the existing `hide_user_not_found` config key works as intended with the upcoming symfony 8 release.