### PR TITLE
Miscellaneous tests improvements

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractDivLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractDivLayoutTestCase.php
@@ -619,6 +619,13 @@ abstract class AbstractDivLayoutTestCase extends AbstractLayoutTestCase
         );
     }
 
+    public static function themeBlockInheritanceProvider(): array
+    {
+        return [
+            [['theme.html.twig']],
+        ];
+    }
+
     /**
      * @dataProvider themeInheritanceProvider
      */
@@ -661,6 +668,13 @@ abstract class AbstractDivLayoutTestCase extends AbstractLayoutTestCase
     ]
 '
         );
+    }
+
+    public static function themeInheritanceProvider(): array
+    {
+        return [
+            [['parent_label.html.twig'], ['child_label.html.twig']],
+        ];
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -349,20 +349,6 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
         $this->renderer->setTheme($view, $themes, $useDefaultThemes);
     }
 
-    public static function themeBlockInheritanceProvider(): array
-    {
-        return [
-            [['theme.html.twig']],
-        ];
-    }
-
-    public static function themeInheritanceProvider(): array
-    {
-        return [
-            [['parent_label.html.twig'], ['child_label.html.twig']],
-        ];
-    }
-
     protected function getTemplatePaths(): array
     {
         return [

--- a/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
+++ b/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
@@ -26,11 +26,11 @@ class CacheDataCollectorTest extends TestCase
     {
         $statistics = $this->getCacheDataCollectorStatisticsFromEvents([]);
 
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['calls'], 0, 'calls');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['reads'], 0, 'reads');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['hits'], 0, 'hits');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['misses'], 0, 'misses');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 0, 'writes');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['calls'], 'calls');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['reads'], 'reads');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['hits'], 'hits');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['misses'], 'misses');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['writes'], 'writes');
     }
 
     public function testOneEventDataCollector()
@@ -43,11 +43,11 @@ class CacheDataCollectorTest extends TestCase
 
         $statistics = $this->getCacheDataCollectorStatisticsFromEvents([$traceableAdapterEvent]);
 
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['calls'], 1, 'calls');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['reads'], 1, 'reads');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['hits'], 0, 'hits');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['misses'], 1, 'misses');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 0, 'writes');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['calls'], 'calls');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['reads'], 'reads');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['hits'], 'hits');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['misses'], 'misses');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['writes'], 'writes');
     }
 
     public function testHitedEventDataCollector()
@@ -62,11 +62,11 @@ class CacheDataCollectorTest extends TestCase
 
         $statistics = $this->getCacheDataCollectorStatisticsFromEvents([$traceableAdapterEvent]);
 
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['calls'], 1, 'calls');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['reads'], 1, 'reads');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['hits'], 0, 'hits');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['misses'], 1, 'misses');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 0, 'writes');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['calls'], 'calls');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['reads'], 'reads');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['hits'], 'hits');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['misses'], 'misses');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['writes'], 'writes');
     }
 
     public function testSavedEventDataCollector()
@@ -78,11 +78,11 @@ class CacheDataCollectorTest extends TestCase
 
         $statistics = $this->getCacheDataCollectorStatisticsFromEvents([$traceableAdapterEvent]);
 
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['calls'], 1, 'calls');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['reads'], 0, 'reads');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['hits'], 0, 'hits');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['misses'], 0, 'misses');
-        $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 1, 'writes');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['calls'], 'calls');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['reads'], 'reads');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['hits'], 'hits');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['misses'], 'misses');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['writes'], 'writes');
     }
 
     public function testCollectBeforeEnd()
@@ -100,8 +100,8 @@ class CacheDataCollectorTest extends TestCase
 
         $stats = $collector->getStatistics();
         $this->assertGreaterThan(0, $stats[self::INSTANCE_NAME]['time']);
-        $this->assertEquals($stats[self::INSTANCE_NAME]['hits'], 0, 'hits');
-        $this->assertEquals($stats[self::INSTANCE_NAME]['misses'], 1, 'misses');
+        $this->assertSame(0, $stats[self::INSTANCE_NAME]['hits'], 'hits');
+        $this->assertSame(1, $stats[self::INSTANCE_NAME]['misses'], 'misses');
     }
 
     private function getCacheDataCollectorStatisticsFromEvents(array $traceableAdapterEvents)

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -79,11 +79,11 @@ class LoggerDataCollectorTest extends TestCase
 
         $this->assertCount(1, $processedLogs);
 
-        $this->assertEquals($processedLogs[0]['type'], 'deprecation');
-        $this->assertEquals($processedLogs[0]['errorCount'], 1);
-        $this->assertEquals($processedLogs[0]['timestamp'], (new \DateTimeImmutable())->setTimestamp(filemtime($path))->format(\DateTimeInterface::RFC3339_EXTENDED));
-        $this->assertEquals($processedLogs[0]['priority'], 100);
-        $this->assertEquals($processedLogs[0]['priorityName'], 'DEBUG');
+        $this->assertSame('deprecation', $processedLogs[0]['type']);
+        $this->assertSame(1, $processedLogs[0]['errorCount']);
+        $this->assertSame($processedLogs[0]['timestamp'], (new \DateTimeImmutable())->setTimestamp(filemtime($path))->format(\DateTimeInterface::RFC3339_EXTENDED));
+        $this->assertSame(100, $processedLogs[0]['priority']);
+        $this->assertSame('DEBUG', $processedLogs[0]['priorityName']);
         $this->assertNull($processedLogs[0]['channel']);
 
         $this->assertInstanceOf(Data::class, $processedLogs[0]['message']);

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ControllerArgumentsEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ControllerArgumentsEventTest.php
@@ -26,7 +26,7 @@ class ControllerArgumentsEventTest extends TestCase
     public function testControllerArgumentsEvent()
     {
         $event = new ControllerArgumentsEvent(new TestHttpKernel(), function () {}, ['test'], new Request(), HttpKernelInterface::MAIN_REQUEST);
-        $this->assertEquals($event->getArguments(), ['test']);
+        $this->assertSame(['test'], $event->getArguments());
     }
 
     public function testSetAttributes()

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -160,43 +160,37 @@ class AdapterTest extends LdapTestCase
         $ldap->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
         $entries = $this->setupTestUsers($ldap);
 
-        $unpaged_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+        $unpagedQuery = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
             'scope' => Query::SCOPE_ONE,
         ]);
-        $fully_paged_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+        $fullyPagedQuery = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
             'scope' => Query::SCOPE_ONE,
             'pageSize' => 25,
         ]);
-        $paged_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+        $pagedQuery = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
             'scope' => Query::SCOPE_ONE,
             'pageSize' => 5,
         ]);
 
         try {
-            $unpaged_results = $unpaged_query->execute();
-            $fully_paged_results = $fully_paged_query->execute();
-            $paged_results = $paged_query->execute();
-
             // All four of the above queries should result in the 25 'users' being returned
-            $this->assertEquals($unpaged_results->count(), 25);
-            $this->assertEquals($fully_paged_results->count(), 25);
-            $this->assertEquals($paged_results->count(), 25);
+            $this->assertCount(25, $unpagedQuery->execute());
+            $this->assertCount(25, $fullyPagedQuery->execute());
+            $this->assertCount(25, $pagedQuery->execute());
 
             // They should also result in 1 or 25 / pageSize results
-            $this->assertEquals(\count($unpaged_query->getResources()), 1);
-            $this->assertEquals(\count($fully_paged_query->getResources()), 1);
-            $this->assertEquals(\count($paged_query->getResources()), 5);
+            $this->assertCount(1, $unpagedQuery->getResources());
+            $this->assertCount(1, $fullyPagedQuery->getResources());
+            $this->assertCount(5, $pagedQuery->getResources());
 
             // This last query is to ensure that we haven't botched the state of our connection
             // by not resetting pagination properly.
-            $final_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+            $finalQuery = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
                 'scope' => Query::SCOPE_ONE,
             ]);
 
-            $final_results = $final_query->execute();
-
-            $this->assertEquals($final_results->count(), 25);
-            $this->assertEquals(\count($final_query->getResources()), 1);
+            $this->assertCount(25, $finalQuery->execute());
+            $this->assertCount(1, $finalQuery->getResources());
         } catch (LdapException $exc) {
             $this->markTestSkipped('Test LDAP server does not support pagination');
         }
@@ -241,26 +235,23 @@ class AdapterTest extends LdapTestCase
 
         $entries = $this->setupTestUsers($ldap);
 
-        $low_max_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+        $lowMaxQuery = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
             'scope' => Query::SCOPE_ONE,
             'pageSize' => 10,
             'maxItems' => 5,
         ]);
-        $high_max_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+        $highMaxQuery = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
             'scope' => Query::SCOPE_ONE,
             'pageSize' => 10,
             'maxItems' => 13,
         ]);
 
         try {
-            $low_max_results = $low_max_query->execute();
-            $high_max_results = $high_max_query->execute();
+            $this->assertCount(5, $lowMaxQuery->execute());
+            $this->assertCount(13, $highMaxQuery->execute());
 
-            $this->assertEquals($low_max_results->count(), 5);
-            $this->assertEquals($high_max_results->count(), 13);
-
-            $this->assertEquals(\count($low_max_query->getResources()), 1);
-            $this->assertEquals(\count($high_max_query->getResources()), 2);
+            $this->assertCount(1, $lowMaxQuery->getResources());
+            $this->assertCount(2, $highMaxQuery->getResources());
         } catch (LdapException $exc) {
             $this->markTestSkipped('Test LDAP server does not support pagination');
         }

--- a/src/Symfony/Component/Messenger/Tests/Stamp/TransportNamesStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/TransportNamesStampTest.php
@@ -27,7 +27,7 @@ class TransportNamesStampTest extends TestCase
         $configuredSenders = ['first_transport', 'second_transport', 'other_transport'];
         $stamp = new TransportNamesStamp($configuredSenders);
         $stampSenders = $stamp->getTransportNames();
-        $this->assertEquals(\count($configuredSenders), \count($stampSenders));
+        $this->assertSameSize($configuredSenders, $stampSenders);
 
         foreach ($configuredSenders as $key => $sender) {
             $this->assertSame($sender, $stampSenders[$key]);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -478,7 +478,7 @@ class PropertyNormalizerTest extends TestCase
             RootDummy::class,
             'any'
         );
-        $this->assertEquals($root::class, RootDummy::class);
+        $this->assertSame(RootDummy::class, $root::class);
 
         // children (two dimension array)
         $this->assertCount(1, $root->children);

--- a/src/Symfony/Contracts/Tests/Cache/CacheTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Cache/CacheTraitTest.php
@@ -71,7 +71,7 @@ class CacheTraitTest extends TestCase
             ->method('save');
 
         $callback = function (CacheItemInterface $item) {
-            $this->assertTrue(false, 'This code should never be reached');
+            $this->fail('This code should never be reached');
         };
 
         $cache->get('key', $callback);

--- a/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
+++ b/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
@@ -372,7 +372,7 @@ class TranslatorTest extends TestCase
             if ($expectSuccess) {
                 $this->assertCount($nplural, $indexes, "Langcode '$langCode' has '$nplural' plural forms.");
             } else {
-                $this->assertNotEquals((int) $nplural, \count($indexes), "Langcode '$langCode' has '$nplural' plural forms.");
+                $this->assertNotCount($nplural, $indexes, "Langcode '$langCode' has '$nplural' plural forms.");
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Mainly missed occasions to use `assertCount()` and wrong arguments placement between expected and actual results.

Also for `AbstractDivLayoutTestCase` the abstract class references data provider only defined in the subclass. I think it's a good idea to put the data providers next to the test methods instead.