### PR TITLE
[Ldap] Fix deprecated signature call for `ldap_connect()`

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -39,7 +39,7 @@ class AdapterTest extends LdapTestCase
      */
     public function testSaslBind()
     {
-        $h = @ldap_connect(getenv('LDAP_HOST'), getenv('LDAP_PORT'));
+        $h = @ldap_connect('ldap://'.getenv('LDAP_HOST').':'.getenv('LDAP_PORT'));
         @ldap_set_option($h, \LDAP_OPT_PROTOCOL_VERSION, 3);
 
         if (!$h || !@ldap_bind($h)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The test is using an old signature of `ldap_connect()`. The one-argument signature should always be used.