### PR TITLE
[Serializer] Re-add `AdvancedNameConverterInterface`

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedPropertyException;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Aurélien Pillevesse <aurelienpillevesse@hotmail.fr>
  */
-class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
+class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface, AdvancedNameConverterInterface
 {
     /**
      * Require all properties to be written in snake_case.
@@ -41,7 +41,7 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
      * @param string|null          $format
      * @param array<string, mixed> $context
      */
-    public function normalize(string $propertyName/* , ?string $class = null, ?string $format = null, array $context = [] */): string
+    public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
     {
         if (null === $this->attributes || \in_array($propertyName, $this->attributes, true)) {
             return strtolower(preg_replace('/[A-Z]/', '_\\0', lcfirst($propertyName)));
@@ -55,12 +55,8 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
      * @param string|null          $format
      * @param array<string, mixed> $context
      */
-    public function denormalize(string $propertyName/* , ?string $class = null, ?string $format = null, array $context = [] */): string
+    public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
     {
-        $class = 1 < \func_num_args() ? func_get_arg(1) : null;
-        $format = 2 < \func_num_args() ? func_get_arg(2) : null;
-        $context = 3 < \func_num_args() ? func_get_arg(3) : [];
-
         if (($context[self::REQUIRE_SNAKE_CASE_PROPERTIES] ?? false) && $propertyName !== $this->normalize($propertyName, $class, $format, $context)) {
             throw new UnexpectedPropertyException($propertyName);
         }

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 /**
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  */
-final class MetadataAwareNameConverter implements NameConverterInterface
+final class MetadataAwareNameConverter implements NameConverterInterface, AdvancedNameConverterInterface
 {
     /**
      * @var array<string, array<string, string|null>>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58294
| License       | MIT

Re-add  `AdvancedNameConverterInterface` on top of `CamelCaseToSnakeCaseNameConverter` and `MetadataAwareNameConverter`.
