### PR TITLE
[Serializer] Deprecate `AdvancedNameConverterInterface`

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -65,6 +65,7 @@ Serializer
 
  * Deprecate the `csv_escape_char` context option of `CsvEncoder` and the `CsvEncoder::ESCAPE_CHAR_KEY` constant
  * Deprecate `CsvEncoderContextBuilder::withEscapeChar()` method
+ * Deprecate `AdvancedNameConverterInterface`, use `NameConverterInterface` instead
 
 String
 ------

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add support for configuring multiple serializer instances with different
    default contexts, name converters, sets of normalizers and encoders
  * Add support for collection profiles of multiple serializer instances
+ * Deprecate `AdvancedNameConverterInterface`, use `NameConverterInterface` instead
 
 7.1
 ---

--- a/src/Symfony/Component/Serializer/NameConverter/AdvancedNameConverterInterface.php
+++ b/src/Symfony/Component/Serializer/NameConverter/AdvancedNameConverterInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Serializer\NameConverter;
  * Gives access to the class, the format and the context in the property name converters.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since Symfony 7.2, use NameConverterInterface instead
  */
 interface AdvancedNameConverterInterface extends NameConverterInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | 
| License       | MIT

Deprecate the `AdvancedNameConverterInterface` in favor of `NameConverterInterface` as they'll have the same signature in 8.0