### PR TITLE
[AssetMapper] Use static data providers

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapAuditorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapAuditorTest.php
@@ -119,7 +119,7 @@ class ImportMapAuditorTest extends TestCase
         $this->assertSame($expectMatch, 0 < \count($audit[0]->vulnerabilities));
     }
 
-    public function provideAuditWithVersionRange(): iterable
+    public static function provideAuditWithVersionRange(): iterable
     {
         yield [true, '1.0.0', null];
         yield [true, '1.0.0', '>= *'];

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
@@ -275,7 +275,7 @@ class ImportMapGeneratorTest extends TestCase
         $this->assertEquals($expectedData, $manager->getRawImportMapData());
     }
 
-    public function getRawImportMapDataTests(): iterable
+    public static function getRawImportMapDataTests(): iterable
     {
         yield 'it returns remote downloaded entry' => [
             [
@@ -610,7 +610,7 @@ class ImportMapGeneratorTest extends TestCase
         $this->assertEquals($expected, $manager->findEagerEntrypointImports('the_entrypoint_name'));
     }
 
-    public function getEagerEntrypointImportsTests(): iterable
+    public static function getEagerEntrypointImportsTests(): iterable
     {
         yield 'an entry with no dependencies' => [
             new MappedAsset(

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapUpdateCheckerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapUpdateCheckerTest.php
@@ -127,7 +127,7 @@ class ImportMapUpdateCheckerTest extends TestCase
         }
     }
 
-    private function provideImportMapEntry()
+    public static function provideImportMapEntry(): iterable
     {
         yield [
             [self::createRemoteEntry(

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/PackageUpdateInfoTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/PackageUpdateInfoTest.php
@@ -34,7 +34,7 @@ class PackageUpdateInfoTest extends TestCase
         $this->assertSame($updateType, $packageUpdateInfo->updateType);
     }
 
-    public function provideValidConstructorArguments()
+    public static function provideValidConstructorArguments(): iterable
     {
         return [
             ['@hotwired/stimulus', '5.2.1', 'string', 'downgrade'],
@@ -57,7 +57,7 @@ class PackageUpdateInfoTest extends TestCase
         $this->assertSame($expectUpdate, $packageUpdateInfo->hasUpdate());
     }
 
-    public function provideHasUpdateArguments()
+    public static function provideHasUpdateArguments(): iterable
     {
         return [
             ['downgrade', false],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Data provider must be public and static in PHPUnit 11.