### PR TITLE
[PhpUnitBridge] Only allow exact matches in expectUserDeprecationMessage()

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ExpectUserDeprecationMessageTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/ExpectUserDeprecationMessageTrait.php
@@ -20,7 +20,7 @@ if (version_compare(Version::id(), '11.0.0', '<')) {
 
         final protected function expectUserDeprecationMessage(string $expectedUserDeprecationMessage): void
         {
-            $this->expectDeprecation($expectedUserDeprecationMessage);
+            $this->expectDeprecation(str_replace('%', '%%', $expectedUserDeprecationMessage));
         }
     }
 } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/54593/files#r1740953366
| License       | MIT