### PR TITLE
[Notifier] Make data providers static

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bandwidth/Tests/BandwidthTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bandwidth/Tests/BandwidthTransportTest.php
@@ -29,7 +29,7 @@ final class BandwidthTransportTest extends TransportTestCase
         return new BandwidthTransport('username', 'password', $from, 'account_id', 'application_id', 'priority', $client ?? new MockHttpClient());
     }
 
-    public function invalidFromProvider(): iterable
+    public static function invalidFromProvider(): iterable
     {
         yield 'no zero at start if phone number' => ['+0'];
         yield 'phone number too short' => ['+1'];

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatTransportFactoryTest.php
@@ -20,27 +20,38 @@ use Symfony\Component\Notifier\Transport\Dsn;
 
 final class FakeChatTransportFactoryTest extends TransportFactoryTestCase
 {
-    /**
-     * @dataProvider missingRequiredDependencyProvider
-     */
-    public function testMissingRequiredDependency(?MailerInterface $mailer, ?LoggerInterface $logger, string $dsn, string $message)
+    public function testMissingRequiredMailerDependency()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage($message);
+        $this->expectExceptionMessage('Cannot create a transport for scheme "fakechat+email" without providing an implementation of "Symfony\Component\Mailer\MailerInterface".');
 
-        $factory = new FakeChatTransportFactory($mailer, $logger);
-        $factory->create(new Dsn($dsn));
+        $factory = new FakeChatTransportFactory(null, $this->createStub(LoggerInterface::class));
+        $factory->create(new Dsn('fakechat+email://default?to=recipient@email.net&from=sender@email.net'));
     }
 
-    /**
-     * @dataProvider missingOptionalDependencyProvider
-     */
-    public function testMissingOptionalDependency(?MailerInterface $mailer, ?LoggerInterface $logger, string $dsn)
+    public function testMissingRequiredLoggerDependency()
     {
-        $factory = new FakeChatTransportFactory($mailer, $logger);
-        $transport = $factory->create(new Dsn($dsn));
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot create a transport for scheme "fakechat+logger" without providing an implementation of "Psr\Log\LoggerInterface".');
 
-        $this->assertSame($dsn, (string) $transport);
+        $factory = new FakeChatTransportFactory($this->createStub(MailerInterface::class));
+        $factory->create(new Dsn('fakechat+logger://default'));
+    }
+
+    public function testMissingOptionalLoggerDependency()
+    {
+        $factory = new FakeChatTransportFactory($this->createStub(MailerInterface::class));
+        $transport = $factory->create(new Dsn('fakechat+email://default?to=recipient@email.net&from=sender@email.net'));
+
+        $this->assertSame('fakechat+email://default?to=recipient@email.net&from=sender@email.net', (string) $transport);
+    }
+
+    public function testMissingOptionalMailerDependency()
+    {
+        $factory = new FakeChatTransportFactory(null, $this->createStub(LoggerInterface::class));
+        $transport = $factory->create(new Dsn('fakechat+logger://default'));
+
+        $this->assertSame('fakechat+logger://default', (string) $transport);
     }
 
     public function createFactory(): FakeChatTransportFactory
@@ -87,36 +98,5 @@ final class FakeChatTransportFactoryTest extends TransportFactoryTestCase
     public static function unsupportedSchemeProvider(): iterable
     {
         yield ['somethingElse://default?to=recipient@email.net&from=sender@email.net'];
-    }
-
-    public function missingRequiredDependencyProvider(): iterable
-    {
-        $exceptionMessage = 'Cannot create a transport for scheme "%s" without providing an implementation of "%s".';
-        yield 'missing mailer' => [
-            null,
-            $this->createMock(LoggerInterface::class),
-            'fakechat+email://default?to=recipient@email.net&from=sender@email.net',
-            sprintf($exceptionMessage, 'fakechat+email', MailerInterface::class),
-        ];
-        yield 'missing logger' => [
-            $this->createMock(MailerInterface::class),
-            null,
-            'fakechat+logger://default',
-            sprintf($exceptionMessage, 'fakechat+logger', LoggerInterface::class),
-        ];
-    }
-
-    public function missingOptionalDependencyProvider(): iterable
-    {
-        yield 'missing logger' => [
-            $this->createMock(MailerInterface::class),
-            null,
-            'fakechat+email://default?to=recipient@email.net&from=sender@email.net',
-        ];
-        yield 'missing mailer' => [
-            null,
-            $this->createMock(LoggerInterface::class),
-            'fakechat+logger://default',
-        ];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/GoIp/Tests/GoIpTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoIp/Tests/GoIpTransportTest.php
@@ -82,7 +82,7 @@ final class GoIpTransportTest extends TransportTestCase
         self::createTransport($mockClient)->send(new SmsMessage('1', 'Test'));
     }
 
-    public function goipErrorsProvider(): iterable
+    public static function goipErrorsProvider(): iterable
     {
         yield ['ERROR,L10 GSM logout'];
     }

--- a/src/Symfony/Component/Notifier/Bridge/Plivo/Tests/PlivoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Plivo/Tests/PlivoTransportTest.php
@@ -29,7 +29,7 @@ final class PlivoTransportTest extends TransportTestCase
         return new PlivoTransport('authId', 'authToken', $from, $client ?? new MockHttpClient());
     }
 
-    public function invalidFromProvider(): iterable
+    public static function invalidFromProvider(): iterable
     {
         yield 'too short' => ['a'];
         yield 'too long' => ['abcdefghijkl'];

--- a/src/Symfony/Component/Notifier/Bridge/SimpleTextin/Tests/SimpleTextinTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SimpleTextin/Tests/SimpleTextinTransportTest.php
@@ -28,7 +28,7 @@ final class SimpleTextinTransportTest extends TransportTestCase
         return new SimpleTextinTransport('test_api_key', $from, $client ?? new MockHttpClient());
     }
 
-    public function invalidFromProvider(): iterable
+    public static function invalidFromProvider(): iterable
     {
         yield 'no zero at start if phone number' => ['+0'];
         yield 'phone number too short' => ['+1'];
@@ -87,7 +87,7 @@ final class SimpleTextinTransportTest extends TransportTestCase
         yield [new DummyMessage()];
     }
 
-    public function validFromProvider(): iterable
+    public static function validFromProvider(): iterable
     {
         yield ['+11'];
         yield ['+112'];

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportTest.php
@@ -67,26 +67,26 @@ final class SpotHitTransportTest extends TransportTestCase
         $transport->send(new SmsMessage('0611223344', 'Hello!'));
     }
 
-    public function argumentsProvider(): \Generator
+    public static function argumentsProvider(): \Generator
     {
         yield [
-            function (SpotHitTransport $transport) { $transport->setSmsLong(true); },
-            function (array $bodyArguments) { $this->assertSame('1', $bodyArguments['smslong']); },
+            static function (SpotHitTransport $transport) { $transport->setSmsLong(true); },
+            static function (array $bodyArguments) { self::assertSame('1', $bodyArguments['smslong']); },
         ];
 
         yield [
-            function (SpotHitTransport $transport) { $transport->setLongNBr(3); },
-            function (array $bodyArguments) { $this->assertSame('3', $bodyArguments['smslongnbr']); },
+            static function (SpotHitTransport $transport) { $transport->setLongNBr(3); },
+            static function (array $bodyArguments) { self::assertSame('3', $bodyArguments['smslongnbr']); },
         ];
 
         yield [
-            function (SpotHitTransport $transport) {
+            static function (SpotHitTransport $transport) {
                 $transport->setSmsLong(true);
                 $transport->setLongNBr(3);
             },
-            function (array $bodyArguments) {
-                $this->assertSame('1', $bodyArguments['smslong']);
-                $this->assertSame('3', $bodyArguments['smslongnbr']);
+            static function (array $bodyArguments) {
+                self::assertSame('1', $bodyArguments['smslong']);
+                self::assertSame('3', $bodyArguments['smslongnbr']);
             },
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Data provides must be static in PHPUnit 11. For the trivial cases, I've simply added the static keyword. In two more complicated cases, we created mocks inside a data provider which is bit of a problem. Given that those providers emitted only two test sets each anyway, I've resolved the data providers by creating two separate tests.