### PR TITLE
[Runtime] Adapt test to support the `--silent` option introduced in Symfony 7.2

### DIFF
--- a/src/Symfony/Component/Runtime/Tests/phpt/command_list.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command_list.phpt
@@ -23,8 +23,8 @@ Usage:
   command [options] [arguments]
 
 Options:
-  -h, --help            Display %s
-  -q, --quiet           Do not output any message
+  -h, --help            Display %A
+  -q, --quiet           %s
   -V, --version         Display this application version
       --ansi%A
   -n, --no-interaction  Do not ask any interactive question


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Prepare tests for #53632