### PR TITLE
[Notifier] Add Sweego bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2881,6 +2881,7 @@ class FrameworkExtension extends Extension
             NotifierBridge\SmsSluzba\SmsSluzbaTransportFactory::class => 'notifier.transport_factory.sms-sluzba',
             NotifierBridge\Smsense\SmsenseTransportFactory::class => 'notifier.transport_factory.smsense',
             NotifierBridge\SpotHit\SpotHitTransportFactory::class => 'notifier.transport_factory.spot-hit',
+            NotifierBridge\Sweego\SweegoTransportFactory::class => 'notifier.transport_factory.sweego',
             NotifierBridge\Telegram\TelegramTransportFactory::class => 'notifier.transport_factory.telegram',
             NotifierBridge\Telnyx\TelnyxTransportFactory::class => 'notifier.transport_factory.telnyx',
             NotifierBridge\Termii\TermiiTransportFactory::class => 'notifier.transport_factory.termii',
@@ -2948,6 +2949,7 @@ class FrameworkExtension extends Extension
             $loader->load('notifier_webhook.php');
 
             $webhookRequestParsers = [
+                NotifierBridge\Sweego\Webhook\SweegoRequestParser::class => 'notifier.webhook.request_parser.sweego',
                 NotifierBridge\Twilio\Webhook\TwilioRequestParser::class => 'notifier.webhook.request_parser.twilio',
                 NotifierBridge\Vonage\Webhook\VonageRequestParser::class => 'notifier.webhook.request_parser.vonage',
             ];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -108,6 +108,7 @@ return static function (ContainerConfigurator $container) {
         'smsense' => Bridge\Smsense\SmsenseTransportFactory::class,
         'smsmode' => Bridge\Smsmode\SmsmodeTransportFactory::class,
         'spot-hit' => Bridge\SpotHit\SpotHitTransportFactory::class,
+        'sweego' => Bridge\Sweego\SweegoTransportFactory::class,
         'telnyx' => Bridge\Telnyx\TelnyxTransportFactory::class,
         'termii' => Bridge\Termii\TermiiTransportFactory::class,
         'turbo-sms' => Bridge\TurboSms\TurboSmsTransportFactory::class,

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_webhook.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Notifier\Bridge\Sweego\Webhook\SweegoRequestParser;
 use Symfony\Component\Notifier\Bridge\Twilio\Webhook\TwilioRequestParser;
 use Symfony\Component\Notifier\Bridge\Vonage\Webhook\VonageRequestParser;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
+        ->set('notifier.webhook.request_parser.sweego', SweegoRequestParser::class)
+        ->alias(SweegoRequestParser::class, 'notifier.webhook.request_parser.sweego')
+
         ->set('notifier.webhook.request_parser.twilio', TwilioRequestParser::class)
         ->alias(TwilioRequestParser::class, 'notifier.webhook.request_parser.twilio')
 

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/README.md
@@ -1,0 +1,53 @@
+Sweego Notifier
+===============
+
+Provides [Sweego](https://www.sweego.io/) integration for Symfony Notifier.
+
+DSN example
+-----------
+
+```
+SWEEGO_DSN=sweego://API_KEY@default?region=REGION&campaign_type=CAMPAIGN_TYPE&bat=BAT&campaign_id=CAMPAIGN_ID&shorten_urls=SHORTEN_URLS&shorten_with_protocol=SHORTEN_WITH_PROTOCOL
+```
+
+where:
+ - `API_KEY` (required) is your Sweego API key
+ - `REGION` (required) is the region of the phone number (e.g. `FR`, ISO 3166-1 alpha-2 country code)
+ - `CAMPAIGN_TYPE` (required) is the type of the campaign (e.g. `transac`)
+ - `BAT` (optional) is the test mode (e.g. `true`)
+ - `CAMPAIGN_ID` (optional) is the campaign id (e.g. `string`)
+ - `SHORTEN_URLS` (optional) is the shorten urls option (e.g. `true`)
+ - `SHORTEN_WITH_PROTOCOL` (optional) is the shorten with protocol option (e.g. `true`)
+
+Advanced Message options
+------------------------
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\Sweego\SweegoOptions;
+
+$sms = new SmsMessage('+1411111111', 'My message');
+
+$options = (new SweegoOptions())
+    // False by default, set 'bat' to true enable test mode (no sms sent, only for testing purpose)
+    ->bat(true)
+    // Optional, used for tracking / filtering purpose on our platform; identity an SMS campaign and allow to see logs / stats only for this campaign
+    ->campaignId('string')
+    // True by default, we replace all url in the SMS content by a shortened url version (reduce the characters of the sms)
+    ->shortenUrls(true)
+    // True by default, add scheme to shortened url version
+    ->shortenWithProtocol(true);
+
+// Add the custom options to the sms message and send the message
+$sms->options($options);
+
+$texter->send($sms);
+```
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoOptions.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sweego;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+class SweegoOptions implements MessageOptionsInterface
+{
+    public const REGION = 'region';
+    public const BAT = 'bat';
+    public const CAMPAIGN_TYPE = 'campaign_type';
+    public const CAMPAIGN_ID = 'campaign_id';
+    public const SHORTEN_URLS = 'shorten_urls';
+    public const SHORTEN_WITH_PROTOCOL = 'shorten_with_protocol';
+
+    public function __construct(
+        private array $options = [],
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return null;
+    }
+
+    public function bat(bool $bat): self
+    {
+        $this->options[self::BAT] = $bat;
+
+        return $this;
+    }
+
+    public function campaignId(string $campaignId): self
+    {
+        $this->options[self::CAMPAIGN_ID] = $campaignId;
+
+        return $this;
+    }
+
+    public function shortenUrls(bool $shortenUrls): self
+    {
+        $this->options[self::SHORTEN_URLS] = $shortenUrls;
+
+        return $this;
+    }
+
+    public function shortenWithProtocol(bool $shortenWithProtocol): self
+    {
+        $this->options[self::SHORTEN_WITH_PROTOCOL] = $shortenWithProtocol;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransport.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sweego;
+
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ */
+final class SweegoTransport extends AbstractTransport
+{
+    protected const HOST = 'api.sweego.io';
+
+    public function __construct(
+        #[\SensitiveParameter] private readonly string $apiKey,
+        private readonly string $region,
+        private readonly string $campaignType,
+        private readonly ?bool $bat,
+        private readonly ?string $campaignId,
+        private readonly ?bool $shortenUrls,
+        private readonly ?bool $shortenWithProtocol,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+    ) {
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('sweego://%s%s', $this->getEndpoint(), '?'.http_build_query([
+            SweegoOptions::REGION => $this->region,
+            SweegoOptions::CAMPAIGN_TYPE => $this->campaignType,
+            SweegoOptions::BAT => $this->bat,
+            SweegoOptions::CAMPAIGN_ID => $this->campaignId,
+            SweegoOptions::SHORTEN_URLS => $this->shortenUrls,
+            SweegoOptions::SHORTEN_WITH_PROTOCOL => $this->shortenWithProtocol,
+        ]));
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage
+            && (null === $message->getOptions() || $message->getOptions() instanceof SweegoOptions);
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof SmsMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        $options = $message->getOptions()?->toArray() ?? [];
+
+        $body = [
+            'recipients' => [
+                [
+                    'num' => $message->getPhone(),
+                    'region' => $options[SweegoOptions::REGION] ?? $this->region,
+                ],
+            ],
+            'message-txt' => $message->getSubject(),
+            'channel' => 'sms',
+            'provider' => 'sweego',
+        ];
+
+        $body = $this->setBat($body, $options);
+        $body = $this->setCampaignType($body, $options);
+        $body = $this->setCampaignId($body, $options);
+        $body = $this->setShortenUrls($body, $options);
+        $body = $this->setShortenWithProtocol($body, $options);
+
+        $endpoint = \sprintf('https://%s/send', $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
+            'headers' => [
+                'Api-Key' => $this->apiKey,
+            ],
+            'json' => array_filter($body),
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Sweego server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
+            throw new TransportException('Unable to send the SMS.', $response);
+        }
+
+        $success = $response->toArray(false);
+
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId(array_values($success['swg_uids'])[0]);
+
+        return $sentMessage;
+    }
+
+    private function setBat(array $body, array $options): array
+    {
+        $body['bat'] = (bool) ($options[SweegoOptions::BAT] ?? $this->bat);
+
+        return $body;
+    }
+
+    private function setCampaignType(array $body, array $options): array
+    {
+        $body['campaign-type'] = $this->campaignType;
+
+        if (\array_key_exists(SweegoOptions::CAMPAIGN_TYPE, $options) && \is_string($options[SweegoOptions::CAMPAIGN_TYPE])) {
+            $body['campaign-type'] = $options[SweegoOptions::CAMPAIGN_TYPE];
+        }
+
+        return $body;
+    }
+
+    private function setCampaignId(array $body, array $options): array
+    {
+        $body['campaign-id'] = $this->campaignId;
+
+        if (\array_key_exists(SweegoOptions::CAMPAIGN_ID, $options) && \is_string($options[SweegoOptions::CAMPAIGN_ID])) {
+            $body['campaign-id'] = $options[SweegoOptions::CAMPAIGN_ID];
+        }
+
+        return $body;
+    }
+
+    private function setShortenUrls(array $body, array $options): array
+    {
+        $body['shorten_urls'] = (bool) ($options[SweegoOptions::SHORTEN_URLS] ?? $this->shortenUrls);
+
+        return $body;
+    }
+
+    private function setShortenWithProtocol(array $body, array $options): array
+    {
+        $body['shorten_with_protocol'] = (bool) ($options[SweegoOptions::SHORTEN_WITH_PROTOCOL] ?? $this->shortenWithProtocol);
+
+        return $body;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransportFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sweego;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ */
+final class SweegoTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): SweegoTransport
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('sweego' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'sweego', $this->getSupportedSchemes());
+        }
+
+        $apiKey = $this->getUser($dsn);
+        $region = $dsn->getRequiredOption(SweegoOptions::REGION);
+        $campaignType = $dsn->getRequiredOption(SweegoOptions::CAMPAIGN_TYPE);
+        $bat = $dsn->getOption(SweegoOptions::BAT);
+        $campaignId = $dsn->getOption(SweegoOptions::CAMPAIGN_ID);
+        $shortenUrls = $dsn->getOption(SweegoOptions::SHORTEN_URLS);
+        $shortenWithProtocol = $dsn->getOption(SweegoOptions::SHORTEN_WITH_PROTOCOL);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new SweegoTransport($apiKey, $region, $campaignType, $bat, $campaignId, $shortenUrls, $shortenWithProtocol, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['sweego'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sweego\Tests;
+
+use Symfony\Component\Notifier\Bridge\Sweego\SweegoTransportFactory;
+use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\MissingRequiredOptionTestTrait;
+
+final class SweegoTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use MissingRequiredOptionTestTrait;
+
+    public function createFactory(): SweegoTransportFactory
+    {
+        return new SweegoTransportFactory();
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            'sweego://host.test?region=REGION&campaign_type=CAMPAIGN_TYPE',
+            'sweego://apiKey@host.test?region=REGION&campaign_type=CAMPAIGN_TYPE',
+        ];
+    }
+
+    public static function missingRequiredOptionProvider(): iterable
+    {
+        yield 'missing option: region' => ['sweego://apiKey@default?campaign_type=CAMPAIGN_TYPE'];
+        yield 'missing option: campaign_type' => ['sweego://apiKey@default?region=REGION'];
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [true, 'sweego://apiKey@default'];
+        yield [false, 'somethingElse://apiKey@default'];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://apiKey@default'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sweego\Tests;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Notifier\Bridge\Sweego\SweegoTransport;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class SweegoTransportTest extends TransportTestCase
+{
+    public static function createTransport(?HttpClientInterface $client = null, string $from = 'from'): SweegoTransport
+    {
+        return new SweegoTransport('apiKey', 'REGION', 'CAMPAIGN_TYPE', false, 'CAMPAIGN_ID', true, false, $client ?? new MockHttpClient());
+    }
+
+    public static function toStringProvider(): iterable
+    {
+        yield ['sweego://api.sweego.io?region=REGION&campaign_type=CAMPAIGN_TYPE&bat=0&campaign_id=CAMPAIGN_ID&shorten_urls=1&shorten_with_protocol=0', self::createTransport()];
+    }
+
+    public static function supportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0611223344', 'Hello!')];
+    }
+
+    public static function unsupportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!')];
+        yield [new DummyMessage()];
+    }
+
+    public function testSupportWithNotSmsMessage()
+    {
+        $transport = new SweegoTransport('apiKey', 'REGION', 'CAMPAIGN_TYPE', false, 'CAMPAIGN_ID', true, false);
+        $message = $this->createMock(MessageInterface::class);
+        $this->assertFalse($transport->supports($message));
+    }
+
+    public function testSupportWithNotSweegoOptions()
+    {
+        $transport = new SweegoTransport('apiKey', 'REGION', 'CAMPAIGN_TYPE', false, 'CAMPAIGN_ID', true, false);
+        $message = new SmsMessage('test', 'test');
+        $options = $this->createMock(MessageOptionsInterface::class);
+        $message->options($options);
+        $this->assertFalse($transport->supports($message));
+    }
+
+    public function testSendWithInvalidMessageType()
+    {
+        $this->expectException(UnsupportedMessageTypeException::class);
+        $transport = new SweegoTransport('apiKey', 'REGION', 'CAMPAIGN_TYPE', false, 'CAMPAIGN_ID', true, false);
+        $message = $this->createMock(MessageInterface::class);
+        $transport->send($message);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/sent.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/sent.json
@@ -1,0 +1,18 @@
+{
+  "event_type": "sms_sent",
+  "timestamp": "2024-09-02T17:25:43",
+  "swg_uid": "03-f237cd16-a013-4e35-a279-c9eaa994e82b",
+  "event_id": "a5ccc627-6e43-4012-bb29-f1bfe3a3d13e",
+  "channel": "sms",
+  "client_id": "de1bbe6f-4103-47b1-8f69-94856aaba3fc",
+  "country_code": "FR",
+  "phone_number": "0033612345678",
+  "sender_id": "38082",
+  "sms_type": "transactional",
+  "sms_price": 0.04,
+  "campaign_id": null,
+  "test_mode": false,
+  "send_date": "2024-09-02T15:25:40.577165",
+  "mobile_network_code": 1,
+  "mobile_country_code": 208
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/sent.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/sent.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
+
+$wh = new SmsEvent(SmsEvent::DELIVERED, '03-f237cd16-a013-4e35-a279-c9eaa994e82b', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR));
+$wh->setRecipientPhone('0033612345678');
+
+return $wh;

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sweego\Tests\Webhook;
+
+use Symfony\Component\Notifier\Bridge\Sweego\Webhook\SweegoRequestParser;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
+
+class SweegoRequestParserTest extends AbstractRequestParserTestCase
+{
+    protected function createRequestParser(): RequestParserInterface
+    {
+        return new SweegoRequestParser();
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sweego\Webhook;
+
+use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
+use Symfony\Component\Webhook\Client\AbstractRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ *
+ * @see https://learn.sweego.io/docs/webhooks/sms_events
+ */
+final class SweegoRequestParser extends AbstractRequestParser
+{
+    protected function getRequestMatcher(): RequestMatcherInterface
+    {
+        return new ChainRequestMatcher([
+            new MethodRequestMatcher('POST'),
+            new IsJsonRequestMatcher(),
+        ]);
+    }
+
+    protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?SmsEvent
+    {
+        $payload = $request->toArray();
+
+        if (!isset($payload['event_type']) || !isset($payload['swg_uid']) || !isset($payload['phone_number'])) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        $name = match ($payload['event_type']) {
+            'sms_sent' => SmsEvent::DELIVERED,
+            default => throw new RejectWebhookException(406, \sprintf('Unsupported event "%s".', $payload['event'])),
+        };
+
+        $event = new SmsEvent($name, $payload['swg_uid'], $payload);
+        $event->setRecipientPhone($payload['phone_number']);
+
+        return $event;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "symfony/sweego-notifier",
+    "type": "symfony-notifier-bridge",
+    "description": "Symfony Sweego Notifier Bridge",
+    "keywords": ["sms", "sweego", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/http-client": "^6.4|^7.0",
+        "symfony/notifier": "^7.2"
+    },
+    "require-dev": {
+        "symfony/webhook": "^6.4|^7.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sweego\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Sweego Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -296,6 +296,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\SpotHit\SpotHitTransportFactory::class,
             'package' => 'symfony/spot-hit-notifier',
         ],
+        'sweego' => [
+            'class' => Bridge\Sweego\SweegoTransportFactory::class,
+            'package' => 'symfony/sweego-notifier',
+        ],
         'telegram' => [
             'class' => Bridge\Telegram\TelegramTransportFactory::class,
             'package' => 'symfony/telegram-notifier',

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -94,6 +94,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             Bridge\Smsmode\SmsmodeTransportFactory::class => false,
             Bridge\SmsSluzba\SmsSluzbaTransportFactory::class => false,
             Bridge\SpotHit\SpotHitTransportFactory::class => false,
+            Bridge\Sweego\SweegoTransportFactory::class => false,
             Bridge\Telegram\TelegramTransportFactory::class => false,
             Bridge\Telnyx\TelnyxTransportFactory::class => false,
             Bridge\Termii\TermiiTransportFactory::class => false,

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -96,6 +96,7 @@ final class Transport
         Bridge\Smsmode\SmsmodeTransportFactory::class,
         Bridge\SmsSluzba\SmsSluzbaTransportFactory::class,
         Bridge\SpotHit\SpotHitTransportFactory::class,
+        Bridge\Sweego\SweegoTransportFactory::class,
         Bridge\Telegram\TelegramTransportFactory::class,
         Bridge\Telnyx\TelnyxTransportFactory::class,
         Bridge\Termii\TermiiTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| Docs PR       | https://github.com/symfony/symfony-docs/pull/20338
| Recipes PR    | https://github.com/symfony/recipes/pull/1348
| License       | MIT

This PR folllows
* https://github.com/symfony/symfony/pull/57431

This Bridge brings Webhook support for `sent` event for now. Others will follow in the future.
`from` parameter is handled on Sweego side (AFAIK, it means one `from` per API Key. @pydubreucq can you confirm my words?).
